### PR TITLE
adding 1999 BSD license for Whistle Communications

### DIFF
--- a/src/sbin/mpd.script
+++ b/src/sbin/mpd.script
@@ -1,9 +1,38 @@
 #################################################################
 #
-# $Id: mpd.script.sample,v 1.9 2009/10/04 19:36:04 amotin Exp $
-#
 # Copyright (c) 1995-1999 Whistle Communications, Inc. All rights reserved.
-# See ``COPYRIGHT.whistle''
+#
+# Subject to the following obligations and disclaimer of warranty,
+# use and redistribution of this software, in source or object code
+# forms, with or without modifications are expressly permitted by
+# Whistle Communications; provided, however, that:   (i) any and
+# all reproductions of the source or object code must include the
+# copyright notice above and the following disclaimer of warranties;
+# and (ii) no rights are granted, in any manner or form, to use
+# Whistle Communications, Inc. trademarks, including the mark "WHISTLE
+# COMMUNICATIONS" on advertising, endorsements, or otherwise except
+# as such appears in the above copyright notice or in the software.
+# 
+# THIS SOFTWARE IS BEING PROVIDED BY WHISTLE COMMUNICATIONS "AS IS",
+# AND TO THE MAXIMUM EXTENT PERMITTED BY LAW, WHISTLE COMMUNICATIONS
+# MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
+# REGARDING THIS SOFTWARE, INCLUDING WITHOUT LIMITATION, ANY AND
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE, OR NON-INFRINGEMENT.  WHISTLE COMMUNICATIONS DOES NOT
+# WARRANT, GUARANTEE, OR MAKE ANY REPRESENTATIONS REGARDING THE USE
+# OF, OR THE RESULTS OF THE USE OF THIS SOFTWARE IN TERMS OF ITS
+# CORRECTNESS, ACCURACY, RELIABILITY OR OTHERWISE.  IN NO EVENT
+# SHALL WHISTLE COMMUNICATIONS BE LIABLE FOR ANY DAMAGES RESULTING
+# FROM OR ARISING OUT OF ANY USE OF THIS SOFTWARE, INCLUDING WITHOUT
+# LIMITATION, ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# PUNITIVE, OR CONSEQUENTIAL DAMAGES, PROCUREMENT OF SUBSTITUTE
+# GOODS OR SERVICES, LOSS OF USE, DATA OR PROFITS, HOWEVER CAUSED
+# AND UNDER ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF WHISTLE COMMUNICATIONS
+# IS ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This BSD compatable licence re-added for clarity.
 #
 #################################################################
 
@@ -19,7 +48,7 @@
 ##  $InitString		External initialization string
 ##  $LoginScript	If "yes", look for script login
 ##
-## pfSense specific variables:
+## OPNsense specific variables:
 ##	$APN			Access Point (host)Name for 3G connections
 ##	$APNum			Access Point Number, typically "1", might not matter
 ##	$SimPin			SIM card PIN number


### PR DESCRIPTION
Signed-off-by: Isaac (.ike) Levy <ike@blackskyresearch.net>

I passed this missing licence file while splunking the codebase, appears it got dropped in FreeBSD at some point, (and then the code apparently got dropped).

Their licence is just a somewhat modified BSD style 2-clause.