### PR TITLE
Locale.en.canonical xcatch upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ translate:
 	@: > src/share/locale/en/LC_MESSAGES/OPNsense.pot
 	find src | xargs xgettext -j -L PHP --from-code=UTF-8 -F \
             --copyright-holder="OPNsense project." \
-            --package-name="OPNsense" \
+            --package-name="OPNsense `git describe --abbrev=0`" \
             --msgid-bugs-address="https://forum.opnsense.org/" \
 	    -o src/share/locale/en/LC_MESSAGES/OPNsense.pot
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ health:
 translate:
 	@: > src/share/locale/en/LC_MESSAGES/OPNsense.pot
 	find src | xargs xgettext -j -L PHP --from-code=UTF-8 -F \
+            --copyright-holder="OPNsense project." \
+            --package-name="OPNsense" \
+            --msgid-bugs-address="https://forum.opnsense.org/" \
 	    -o src/share/locale/en/LC_MESSAGES/OPNsense.pot
 
 clean:

--- a/src/share/locale/en/LC_MESSAGES/OPNsense.pot
+++ b/src/share/locale/en/LC_MESSAGES/OPNsense.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Copyright (C) YEAR OPNsense project.
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-11 01:30-0400\n"
+"Project-Id-Version: OPNsense\n"
+"Report-Msgid-Bugs-To: https://forum.opnsense.org/\n"
+"POT-Creation-Date: 2015-05-11 02:20-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,12 +34,12 @@ msgstr ""
 
 #: src/etc/inc/auth.inc:666 src/etc/inc/auth.inc:739 src/etc/inc/auth.inc:811
 #: src/etc/inc/auth.inc:1067
-#, c-format, php-format
+#, php-format
 msgid "ERROR!  Could not connect to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:686
-#, c-format, php-format
+#, php-format
 msgid "LDAP: Could not lookup CA by reference for host %s."
 msgstr ""
 
@@ -50,27 +50,27 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/auth.inc:825
-#, c-format, php-format
+#, php-format
 msgid "ERROR! ldap_get_user_ous() could not bind anonymously to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:830
-#, c-format, php-format
+#, php-format
 msgid "ERROR! ldap_get_user_ous() could not bind to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:927
-#, c-format, php-format
+#, php-format
 msgid "ERROR! ldap_get_groups() Could not connect to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:940
-#, c-format, php-format
+#, php-format
 msgid "ERROR! ldap_get_groups() could not bind anonymously to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:945
-#, c-format, php-format
+#, php-format
 msgid "ERROR! ldap_get_groups() could not bind to server %s."
 msgstr ""
 
@@ -85,12 +85,12 @@ msgid "ERROR! ldap_backed() called with no LDAP authentication server defined."
 msgstr ""
 
 #: src/etc/inc/auth.inc:1083
-#, c-format, php-format
+#, php-format
 msgid "ERROR! Could not bind to server %s."
 msgstr ""
 
 #: src/etc/inc/auth.inc:1117
-#, c-format, php-format
+#, php-format
 msgid "Search resulted in error: %s"
 msgstr ""
 
@@ -108,17 +108,17 @@ msgid "Local Database"
 msgstr ""
 
 #: src/etc/inc/auth.inc:1343
-#, c-format, php-format
+#, php-format
 msgid "Successful login for user '%1$s' from: %2$s"
 msgstr ""
 
 #: src/etc/inc/auth.inc:1394
-#, c-format, php-format
+#, php-format
 msgid "Session timed out for user '%1$s' from: %2$s"
 msgstr ""
 
 #: src/etc/inc/auth.inc:1396
-#, c-format, php-format
+#, php-format
 msgid "User logged out for user '%1$s' from: %2$s"
 msgstr ""
 
@@ -136,12 +136,12 @@ msgid "unknown reason"
 msgstr ""
 
 #: src/etc/inc/authgui.inc:151
-#, c-format, php-format
+#, php-format
 msgid "Invalid login (%s)."
 msgstr ""
 
 #: src/etc/inc/authgui.inc:156
-#, c-format, php-format
+#, php-format
 msgid "This device is currently being maintained by: %s."
 msgstr ""
 
@@ -170,7 +170,7 @@ msgid "Your browser must support cookies to login."
 msgstr ""
 
 #: src/etc/inc/captiveportal.inc:1061
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open '%s' in captiveportal_write_elements()%s"
 msgstr ""
 
@@ -188,13 +188,8 @@ msgstr ""
 
 #: src/etc/inc/config.console.inc:184 src/etc/inc/config.console.inc:208
 #: src/etc/inc/config.console.inc:240 src/etc/inc/config.console.inc:485
-#, c-format, php-format
+#, php-format
 msgid "%sInvalid interface name '%s'%s"
-msgstr ""
-
-#: src/etc/inc/config.console.inc:191
-#, c-format
-msgid "%sEnter the LAN interface name or 'a' for auto-detection %s"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:191
@@ -205,13 +200,8 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/config.console.inc:225
-#, c-format, php-format
+#, php-format
 msgid "%sOptional interface %s description found: %s"
-msgstr ""
-
-#: src/etc/inc/config.console.inc:227
-#, c-format
-msgid "%sEnter the Optional %s interface name or 'a' for auto-detection%s"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:227
@@ -230,12 +220,12 @@ msgid "The interfaces will be assigned as follows:"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:389
-#, c-format, php-format
+#, php-format
 msgid "%sWriting configuration..."
 msgstr ""
 
 #: src/etc/inc/config.console.inc:391
-#, c-format, php-format
+#, php-format
 msgid "done.%s"
 msgstr ""
 
@@ -248,12 +238,12 @@ msgid " done!"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:421
-#, c-format, php-format
+#, php-format
 msgid "Detected link-up on interface %s.%s"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:426
-#, c-format, php-format
+#, php-format
 msgid "No link-up detected.%s"
 msgstr ""
 
@@ -275,7 +265,7 @@ msgid "Enter the VLAN tag (1-4094):"
 msgstr ""
 
 #: src/etc/inc/config.console.inc:496
-#, c-format, php-format
+#, php-format
 msgid "%sInvalid VLAN tag '%s'%s"
 msgstr ""
 
@@ -288,7 +278,7 @@ msgid "No config.xml found, attempting to restore factory config."
 msgstr ""
 
 #: src/etc/inc/config.lib.inc:86
-#, c-format, php-format
+#, php-format
 msgid "Start Configuration upgrade at %s, set execution timeout to 15 minutes"
 msgstr ""
 
@@ -297,7 +287,7 @@ msgid "Updated bogon update frequency to 3am"
 msgstr ""
 
 #: src/etc/inc/config.lib.inc:124
-#, c-format, php-format
+#, php-format
 msgid "Ended Configuration upgrade at %s"
 msgstr ""
 
@@ -331,17 +321,21 @@ msgid "Reverted to"
 msgstr ""
 
 #: src/etc/inc/config.lib.inc:332
-#, c-format, php-format
+#, php-format
 msgid "%s made unknown change"
 msgstr ""
 
+#: src/etc/inc/crypt.inc:47
+msgid "Failed to encrypt/decrypt data!"
+msgstr ""
+
 #: src/etc/inc/dyndns.class:1222
-#, c-format, php-format
+#, php-format
 msgid "DynDNS updated IP Address on %s (%s) to %s"
 msgstr ""
 
 #: src/etc/inc/dyndns.class:1229
-#, c-format, php-format
+#, php-format
 msgid "DynDNS updated IPv6 Address on %s (%s) to %s"
 msgstr ""
 
@@ -518,19 +512,19 @@ msgid "Creating gateway group item..."
 msgstr ""
 
 #: src/etc/inc/filter.inc:677
-#, c-format, php-format
+#, php-format
 msgid ""
 "An error occurred while trying to find the interface got %s .  The rule has "
 "not been added."
 msgstr ""
 
 #: src/etc/inc/filter.inc:1003
-#, c-format, php-format
+#, php-format
 msgid "Creating reflection NAT rule for %s..."
 msgstr ""
 
 #: src/etc/inc/filter.inc:1092
-#, c-format, php-format
+#, php-format
 msgid "Creating reflection rule for %s..."
 msgstr ""
 
@@ -583,7 +577,7 @@ msgid "Creating 1:1 rules..."
 msgstr ""
 
 #: src/etc/inc/filter.inc:1670
-#, c-format, php-format
+#, php-format
 msgid "Creating advanced outbound rule %s"
 msgstr ""
 
@@ -596,32 +590,27 @@ msgid "Creating automatic outbound rules"
 msgstr ""
 
 #: src/etc/inc/filter.inc:1767
-#, c-format, php-format
+#, php-format
 msgid "Creating NAT rule %s"
 msgstr ""
 
 #: src/etc/inc/filter.inc:1973
-#, c-format, php-format
+#, php-format
 msgid "Creating filter rule %s ..."
 msgstr ""
 
-#: src/etc/inc/filter.inc:1996
-#, c-format
-msgid "filter_generate_port: %s is not a valid {$target} port."
-msgstr ""
-
 #: src/etc/inc/filter.inc:2301
-#, c-format, php-format
+#, php-format
 msgid "Setting up pass/block rules %s"
 msgstr ""
 
 #: src/etc/inc/filter.inc:2316
-#, c-format, php-format
+#, php-format
 msgid "Could not find IPv4 gateway for interface (%s)."
 msgstr ""
 
 #: src/etc/inc/filter.inc:2343
-#, c-format, php-format
+#, php-format
 msgid "Creating rule %s"
 msgstr ""
 
@@ -679,29 +668,6 @@ msgstr ""
 msgid "unread notices"
 msgstr ""
 
-#: src/etc/inc/gwlb.inc:827
-#, c-format
-msgid "MONITOR: %s is down, removing from routing group {$group['name']}"
-msgstr ""
-
-#: src/etc/inc/gwlb.inc:831
-#, c-format
-msgid ""
-"MONITOR: %s has packet loss, removing from routing group {$group['name']}"
-msgstr ""
-
-#: src/etc/inc/gwlb.inc:835
-#, c-format
-msgid ""
-"MONITOR: %s has high latency, removing from routing group {$group['name']}"
-msgstr ""
-
-#: src/etc/inc/gwlb.inc:855
-msgid ""
-"Gateways status could not be determined, considering all as up/active. "
-"(Group: {$group['name']})"
-msgstr ""
-
 #: src/etc/inc/interfaces.inc:78
 msgid "interfaces_bring_up() was called but no variable defined."
 msgstr ""
@@ -723,17 +689,17 @@ msgid "interface_vlan_configure called with if undefined."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:321 src/etc/inc/interfaces.inc:413
-#, c-format, php-format
+#, php-format
 msgid "QinQ compat VLAN: called with wrong options. Problems with config!%s"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:328
-#, c-format, php-format
+#, php-format
 msgid "interface_qinq_configure called with if undefined.%s"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:333
-#, c-format, php-format
+#, php-format
 msgid "interface_qinq_configure called with invalid if.%s"
 msgstr ""
 
@@ -742,7 +708,7 @@ msgid "Configuring QinQ interfaces..."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:421
-#, c-format, php-format
+#, php-format
 msgid "interface_qinq2_configure called with if undefined.%s"
 msgstr ""
 
@@ -751,7 +717,7 @@ msgid "Creating wireless clone interfaces..."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:511
-#, c-format, php-format
+#, php-format
 msgid "No members found on %s"
 msgstr ""
 
@@ -775,7 +741,7 @@ msgstr ""
 
 #: src/etc/inc/interfaces.inc:1107 src/etc/inc/interfaces.inc:1132
 #: src/etc/inc/interfaces.inc:1151 src/etc/inc/interfaces.inc:1164
-#, c-format, php-format
+#, php-format
 msgid "Configuring %s interface..."
 msgstr ""
 
@@ -784,7 +750,7 @@ msgid "Wrong parameters used during interface_bring_down"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:1571
-#, c-format, php-format
+#, php-format
 msgid "Can't find PPP config for %s in interface_ppps_configure()."
 msgstr ""
 
@@ -796,18 +762,18 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:1636
-#, c-format, php-format
+#, php-format
 msgid ""
 "Device %s does not exist. PPP link cannot start without the modem device."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:1641
-#, c-format, php-format
+#, php-format
 msgid "Unkown %s configured as ppp interface."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:1913
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd_%s.conf in interface_ppps_configure().%s"
 msgstr ""
 
@@ -816,43 +782,43 @@ msgid "Configuring CARP settings..."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2196
-#, c-format, php-format
+#, php-format
 msgid ""
 "Interface specified for the virtual IP address %s does not exist. Skipping "
 "this VIP."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2204
-#, c-format, php-format
+#, php-format
 msgid ""
 "Sorry but we could not find a required assigned ip address on the interface "
 "for the virtual IP address %s."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2211
-#, c-format, php-format
+#, php-format
 msgid ""
 "Sorry but we could not find a required assigned ip address on the interface "
 "for the virtual IPv6 address %s."
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2269
-#, c-format, php-format
+#, php-format
 msgid "Interface %s changed to hostap mode"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2273
-#, c-format, php-format
+#, php-format
 msgid "Interface %s changed to adhoc mode"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2277
-#, c-format, php-format
+#, php-format
 msgid "Interface %s changed to infrastructure mode"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:2290
-#, c-format, php-format
+#, php-format
 msgid "Cloning new wireless interface %s"
 msgstr ""
 
@@ -873,19 +839,19 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:3852
-#, c-format, php-format
+#, php-format
 msgid ""
 "Error: cannot open dhclient_%s.conf in interface_dhcp_configure() for "
 "writing.%s"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:3865
-#, c-format, php-format
+#, php-format
 msgid "Invalid interface \"%s\" in interface_dhcp_configure()"
 msgstr ""
 
 #: src/etc/inc/interfaces.inc:3917
-#, c-format, php-format
+#, php-format
 msgid "Could not bring up %s interface in interface_dhcp_configure()"
 msgstr ""
 
@@ -963,12 +929,12 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/notices.inc:66
-#, c-format, php-format
+#, php-format
 msgid "Could not open %s for writing"
 msgstr ""
 
 #: src/etc/inc/notices.inc:287
-#, c-format, php-format
+#, php-format
 msgid "Message sent to %s OK"
 msgstr ""
 
@@ -1010,12 +976,12 @@ msgid "establishing SSL connections requires the OpenSSL extension enabled"
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:224
-#, c-format, php-format
+#, php-format
 msgid "could not resolve host \"%s\""
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:228
-#, c-format, php-format
+#, php-format
 msgid "domain \"%s\" resolved to an address excluded to be valid"
 msgstr ""
 
@@ -1029,7 +995,7 @@ msgid "-3 socket could not be created"
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:239
-#, c-format, php-format
+#, php-format
 msgid "-4 dns lookup on hostname \"%s\" failed"
 msgstr ""
 
@@ -1094,7 +1060,7 @@ msgid "it was not specified the POP3 authentication password"
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:404
-#, c-format, php-format
+#, php-format
 msgid "Resolving POP3 authentication host \"%s\"..."
 msgstr ""
 
@@ -1115,12 +1081,12 @@ msgid "could not determine the SMTP to connect"
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:442
-#, c-format, php-format
+#, php-format
 msgid "Resolving SMTP server domain \"%s\"..."
 msgstr ""
 
 #: src/etc/inc/notices.smtp.inc:454
-#, c-format, php-format
+#, php-format
 msgid "Connected to SMTP server \"%s\"."
 msgstr ""
 
@@ -1217,22 +1183,22 @@ msgid "None (No Authentication)"
 msgstr ""
 
 #: src/etc/inc/openvpn.inc:256
-#, c-format, php-format
+#, php-format
 msgid "The field '%s' must contain a valid IP address or domain name."
 msgstr ""
 
 #: src/etc/inc/openvpn.inc:263
-#, c-format, php-format
+#, php-format
 msgid "The field '%s' must contain a valid port, ranging from 0 to 65535."
 msgstr ""
 
 #: src/etc/inc/openvpn.inc:275
-#, c-format, php-format
+#, php-format
 msgid "The field '%s' must contain a single valid %s CIDR range."
 msgstr ""
 
 #: src/etc/inc/openvpn.inc:287
-#, c-format, php-format
+#, php-format
 msgid ""
 "The field '%s' must contain only valid %s CIDR range(s) separated by commas."
 msgstr ""
@@ -1258,12 +1224,12 @@ msgid "Error creating socket!"
 msgstr ""
 
 #: src/etc/inc/pfsense-utils.inc:363
-#, c-format, php-format
+#, php-format
 msgid "Error code is '%1$s' - %2$s"
 msgstr ""
 
 #: src/etc/inc/pfsense-utils.inc:368
-#, c-format, php-format
+#, php-format
 msgid "setsockopt() failed, error: %s"
 msgstr ""
 
@@ -1273,7 +1239,7 @@ msgid "Magic Packet sent (%1$s) to {%2$s} MAC=%3$s"
 msgstr ""
 
 #: src/etc/inc/pfsense-utils.inc:437 src/etc/inc/pfsense-utils.inc:459
-#, c-format, php-format
+#, php-format
 msgid "Restored %s of config file (maybe from CARP partner)"
 msgstr ""
 
@@ -1314,22 +1280,10 @@ msgstr ""
 msgid "DNSCACHE: Found old IP %1$s and new IP %2$s"
 msgstr ""
 
-#: src/etc/inc/pfsense-utils.inc:1546
-msgid "Could not process aliases from alias: {$alias_url}"
-msgstr ""
-
 #: src/etc/inc/pfsense-utils.inc:1580
 msgid ""
 "Alias archive is a .zip file which cannot be decompressed because utility is "
 "missing!"
-msgstr ""
-
-#: src/etc/inc/pfsense-utils.inc:1590 src/etc/inc/pfsense-utils.inc:1622
-msgid "Could not open {$temp_filename}/aliases for writing!"
-msgstr ""
-
-#: src/etc/inc/pfsense-utils.inc:1596 src/etc/inc/pfsense-utils.inc:1628
-msgid "The following file could not be read {$f2p} from {$temp_filename}"
 msgstr ""
 
 #: src/etc/inc/pfsense-utils.inc:1612
@@ -1351,7 +1305,7 @@ msgid "RADIUS_ACCOUNTING_RESPONSE is unexpected for authentication"
 msgstr ""
 
 #: src/etc/inc/radius.inc:420
-#, c-format, php-format
+#, php-format
 msgid "Unexpected return value: %s"
 msgstr ""
 
@@ -1473,47 +1427,47 @@ msgid "Stopped"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:309
-#, c-format, php-format
+#, php-format
 msgid "Restart %sService"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:321
-#, c-format, php-format
+#, php-format
 msgid "Stop %sService"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:335
-#, c-format, php-format
+#, php-format
 msgid "Start %sService"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:404
-#, c-format, php-format
+#, php-format
 msgid "Could not start unknown service `%s'"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:407
-#, c-format, php-format
+#, php-format
 msgid "%s has been started."
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:480
-#, c-format, php-format
+#, php-format
 msgid "Could not stop unknown service `%s'"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:483
-#, c-format, php-format
+#, php-format
 msgid "%s has been stopped."
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:554
-#, c-format, php-format
+#, php-format
 msgid "Could not restart unknown service `%s'"
 msgstr ""
 
 #: src/etc/inc/service-utils.inc:557
-#, c-format, php-format
+#, php-format
 msgid "%s has been restarted."
 msgstr ""
 
@@ -1531,7 +1485,7 @@ msgid "Warning!  DHCP Failover setup and no CARP virtual IPs defined!"
 msgstr ""
 
 #: src/etc/inc/services.inc:890
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open dhcpd.conf in services_dhcpdv4_configure().%s"
 msgstr ""
 
@@ -1568,19 +1522,8 @@ msgid "Starting SNMP daemon... "
 msgstr ""
 
 #: src/etc/inc/services.inc:1916
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open snmpd.conf in services_snmpd_configure().%s"
-msgstr ""
-
-#: src/etc/inc/services.inc:2185
-#, c-format
-msgid "DynDNS updated IP Address (A) for {$dnsupdate['host']} on %s (%s) to %s"
-msgstr ""
-
-#: src/etc/inc/services.inc:2200
-#, c-format
-msgid ""
-"DynDNS updated IPv6 Address (AAAA) for {$dnsupdate['host']} on %s (%s) to %s"
 msgstr ""
 
 #: src/etc/inc/services.inc:2252
@@ -1605,27 +1548,27 @@ msgid "Starting UPnP service... "
 msgstr ""
 
 #: src/etc/inc/services.inc:2362
-#, c-format, php-format
+#, php-format
 msgid "Installed cron job for %s"
 msgstr ""
 
 #: src/etc/inc/services.inc:2365
-#, c-format, php-format
+#, php-format
 msgid "Updated cron job for %s"
 msgstr ""
 
 #: src/etc/inc/services.inc:2370
-#, c-format, php-format
+#, php-format
 msgid "Removed cron job for %s"
 msgstr ""
 
 #: src/etc/inc/shaper.inc:160
-#, c-format, php-format
+#, php-format
 msgid "The field '%s' contains invalid characters."
 msgstr ""
 
 #: src/etc/inc/shaper.inc:166
-#, c-format, php-format
+#, php-format
 msgid "The field '%s' is required."
 msgstr ""
 
@@ -1720,10 +1663,6 @@ msgstr ""
 
 #: src/etc/inc/shaper.inc:605
 msgid " Beware you can lose information."
-msgstr ""
-
-#: src/etc/inc/shaper.inc:643
-msgid "Adjusts the size, in bytes, of the token bucket regulator. "
 msgstr ""
 
 #: src/etc/inc/shaper.inc:643
@@ -1832,8 +1771,9 @@ msgstr ""
 #: src/www/interfaces_groups.php:102 src/www/interfaces_groups_edit.php:261
 #: src/www/interfaces_lagg.php:123 src/www/interfaces_lagg_edit.php:228
 #: src/www/interfaces_ppps.php:118 src/www/interfaces_ppps_edit.php:487
-#: src/www/interfaces_qinq.php:128 src/www/interfaces_vlan.php:125
-#: src/www/interfaces_vlan_edit.php:202 src/www/interfaces_wireless.php:116
+#: src/www/interfaces_qinq.php:128 src/www/interfaces_qinq_edit.php:334
+#: src/www/interfaces_vlan.php:125 src/www/interfaces_vlan_edit.php:202
+#: src/www/interfaces_wireless.php:116
 #: src/www/interfaces_wireless_edit.php:189
 #: src/www/load_balancer_monitor.php:125
 #: src/www/load_balancer_monitor_edit.php:77
@@ -1860,10 +1800,11 @@ msgstr ""
 #: src/www/services_dnsmasq_domainoverride_edit.php:157
 #: src/www/services_dnsmasq_edit.php:223 src/www/services_dnsmasq_edit.php:244
 #: src/www/services_dyndns.php:93 src/www/services_dyndns_edit.php:425
-#: src/www/services_igmpproxy.php:99 src/www/services_rfc2136.php:86
-#: src/www/services_rfc2136_edit.php:218 src/www/services_unbound.php:387
-#: src/www/services_unbound.php:451 src/www/services_unbound_acls.php:235
-#: src/www/services_unbound_acls.php:285 src/www/services_unbound_acls.php:310
+#: src/www/services_igmpproxy.php:99 src/www/services_igmpproxy_edit.php:175
+#: src/www/services_rfc2136.php:86 src/www/services_rfc2136_edit.php:218
+#: src/www/services_unbound.php:387 src/www/services_unbound.php:451
+#: src/www/services_unbound_acls.php:235 src/www/services_unbound_acls.php:285
+#: src/www/services_unbound_acls.php:310
 #: src/www/services_unbound_domainoverride_edit.php:151
 #: src/www/services_unbound_host_edit.php:225
 #: src/www/services_unbound_host_edit.php:246 src/www/services_wol.php:173
@@ -2026,11 +1967,6 @@ msgstr ""
 
 #: src/etc/inc/shaper.inc:1932
 msgid ""
-"The format for service curve specifications is (m1, d, m2).  m2 controls "
-msgstr ""
-
-#: src/etc/inc/shaper.inc:1932
-msgid ""
 "The format for service curve specifications is (m1, d, m2).  m2 controls the "
 "bandwidth assigned to the queue.  m1 and d are optional and can be used to "
 "control the initial bandwidth assignment.  For the first d milliseconds the "
@@ -2062,12 +1998,8 @@ msgid "Bandwidth limit for hosts to not saturate link."
 msgstr ""
 
 #: src/etc/inc/shaper.inc:2854 src/etc/inc/shaper.inc:2861
-#, c-format, php-format
+#, php-format
 msgid "Welcome to the %s Traffic Shaper."
-msgstr ""
-
-#: src/etc/inc/shaper.inc:2855 src/etc/inc/shaper.inc:2862
-msgid "The tree on the left helps you navigate through the queues <br />"
 msgstr ""
 
 #: src/etc/inc/shaper.inc:2855 src/etc/inc/shaper.inc:2862
@@ -2077,7 +2009,7 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/system.inc:473
-#, c-format, php-format
+#, php-format
 msgid "Static Routes: Gateway IP could not be found for %s"
 msgstr ""
 
@@ -2086,7 +2018,7 @@ msgid "Starting syslog..."
 msgstr ""
 
 #: src/etc/inc/system.inc:748
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open syslog.conf in system_syslogd_start().%s"
 msgstr ""
 
@@ -2099,12 +2031,12 @@ msgid "Importing HTTPS certificate"
 msgstr ""
 
 #: src/etc/inc/system.inc:1156
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open cert.pem in system_webgui_start().%s"
 msgstr ""
 
 #: src/etc/inc/system.inc:1167
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open ca.pem in system_webgui_start().%s"
 msgstr ""
 
@@ -2113,7 +2045,7 @@ msgid "ssl configuration"
 msgstr ""
 
 #: src/etc/inc/system.inc:1227
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open %s in system_generate_lighty_config().%s"
 msgstr ""
 
@@ -2127,12 +2059,6 @@ msgstr ""
 
 #: src/etc/inc/system.inc:1649 src/etc/inc/system.inc:1652
 msgid "failed!"
-msgstr ""
-
-#: src/etc/inc/upgrade_config.inc:107 src/etc/inc/upgrade_config.inc:119
-#: src/etc/inc/upgrade_config.inc:132
-#, c-format
-msgid "%sWarning: filter rule removed "
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:107
@@ -2151,12 +2077,6 @@ msgstr ""
 msgid ""
 "%sWarning: filter rule removed (destination network '%s' does not exist "
 "anymore)."
-msgstr ""
-
-#: src/etc/inc/upgrade_config.inc:152 src/etc/inc/upgrade_config.inc:164
-#: src/etc/inc/upgrade_config.inc:177
-#, c-format
-msgid "%sWarning: traffic shaper rule removed "
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:152
@@ -2181,7 +2101,7 @@ msgid ""
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:327
-#, c-format, php-format
+#, php-format
 msgid "CARP vhid %s"
 msgstr ""
 
@@ -2211,7 +2131,7 @@ msgid "Indicates whether this user is able to login for example via SSH."
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:535
-#, c-format, php-format
+#, php-format
 msgid ""
 "Indicates whether this user is allowed to copy files onto the %s appliance "
 "via SCP/SFTP. If you are going to use this privilege, you must install "
@@ -2303,32 +2223,32 @@ msgid "TCP Offload engine"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:664
-#, c-format, php-format
+#, php-format
 msgid "Interface %s Static Gateway"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:667
-#, c-format, php-format
+#, php-format
 msgid "Interface %s Dynamic Gateway"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:733
-#, c-format, php-format
+#, php-format
 msgid "Upgraded static route for %s"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:830
-#, c-format, php-format
+#, php-format
 msgid "Sitedown pool for VS: %s"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:985
-#, c-format, php-format
+#, php-format
 msgid "phase2 for %s"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:1212
-#, c-format, php-format
+#, php-format
 msgid "Upgraded Dyndns %s"
 msgstr ""
 
@@ -2337,7 +2257,7 @@ msgid "All Users"
 msgstr ""
 
 #: src/etc/inc/upgrade_config.inc:1419
-#, c-format, php-format
+#, php-format
 msgid "Converted bridged %s"
 msgstr ""
 
@@ -2346,7 +2266,7 @@ msgid "Auto added OpenVPN rule from config upgrade."
 msgstr ""
 
 #: src/etc/inc/util.inc:79
-#, c-format, php-format
+#, php-format
 msgid "WARNING: Could not mark subsystem: %s dirty"
 msgstr ""
 
@@ -2359,7 +2279,7 @@ msgid "WARNING: You must give a name as parameter to try_lock() function."
 msgstr ""
 
 #: src/etc/inc/util.inc:1023
-#, c-format, php-format
+#, php-format
 msgid "The command '%s' returned exit code '%d', the output was '%s'"
 msgstr ""
 
@@ -2373,7 +2293,7 @@ msgid "Access denied!"
 msgstr ""
 
 #: src/etc/inc/voucher.inc:225
-#, c-format, php-format
+#, php-format
 msgid "Access granted for %d Minutes in total."
 msgstr ""
 
@@ -2392,7 +2312,7 @@ msgid "Can't read %s"
 msgstr ""
 
 #: src/etc/inc/voucher.inc:480
-#, c-format, php-format
+#, php-format
 msgid "Voucher: %s"
 msgstr ""
 
@@ -2401,37 +2321,37 @@ msgid "Configuring IPsec VPN... "
 msgstr ""
 
 #: src/etc/inc/vpn.inc:394
-#, c-format, php-format
+#, php-format
 msgid "Error: Invalid certificate info for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:400
-#, c-format, php-format
+#, php-format
 msgid "Error: Invalid certificate hash info for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:405
-#, c-format, php-format
+#, php-format
 msgid "Error: Cannot write IPsec CA file for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:427
-#, c-format, php-format
+#, php-format
 msgid "Error: Invalid phase1 certificate reference for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:435
-#, c-format, php-format
+#, php-format
 msgid "Error: Cannot write phase1 key file for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:442
-#, c-format, php-format
+#, php-format
 msgid "Error: Cannot write phase1 certificate file for %s"
 msgstr ""
 
 #: src/etc/inc/vpn.inc:869
-#, c-format, php-format
+#, php-format
 msgid "Ignoring IPsec reload since there are no tunnels on interface %s"
 msgstr ""
 
@@ -2448,17 +2368,17 @@ msgid "Could not kill mpd within 3 seconds.   Trying again."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:949
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.conf in vpn_pptpd_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1068
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.links in vpn_pptpd_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1093
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.secret in vpn_pptpd_configure()."
 msgstr ""
 
@@ -2467,17 +2387,17 @@ msgid "Configuring PPPoE VPN service... "
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1174
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.conf in vpn_pppoe_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1283
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.links in vpn_pppoe_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1310
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.secret in vpn_pppoe_configure()."
 msgstr ""
 
@@ -2490,17 +2410,17 @@ msgid "Configuring l2tp VPN service... "
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1379
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.conf in vpn_l2tp_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1478
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.links in vpn_l2tp_configure()."
 msgstr ""
 
 #: src/etc/inc/vpn.inc:1504
-#, c-format, php-format
+#, php-format
 msgid "Error: cannot open mpd.secret in vpn_l2tp_configure()."
 msgstr ""
 
@@ -2519,7 +2439,7 @@ msgid "XML error: %1$s at line %2$d in %3$s"
 msgstr ""
 
 #: src/etc/inc/xmlparse.inc:182 src/etc/inc/xmlparse_attr.inc:208
-#, c-format, php-format
+#, php-format
 msgid "XML error: no %s object found!"
 msgstr ""
 
@@ -2529,7 +2449,7 @@ msgid "XML error: %1$s at line %2$d"
 msgstr ""
 
 #: src/etc/inc/xmlrpc/legacy.inc:145 src/etc/inc/xmlrpc/legacy.inc:210
-#, c-format, php-format
+#, php-format
 msgid "Merged in config (%s sections) from XMLRPC client."
 msgstr ""
 
@@ -2547,10 +2467,6 @@ msgstr ""
 msgid ""
 "\n"
 "The User manager authentication server is set to \""
-msgstr ""
-
-#: src/etc/rc.initial.password:49
-msgid "' . $config['system']['webgui']['authmode'] . '"
 msgstr ""
 
 #: src/etc/rc.initial.password:50
@@ -2572,17 +2488,17 @@ msgid "Please change the password as soon as you log in!"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:106
-#, c-format, php-format
+#, php-format
 msgid "Do you want to enable the %s server on %s?"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:249
-#, c-format, php-format
+#, php-format
 msgid "Configure %s address %s interface via %s?"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:263
-#, c-format, php-format
+#, php-format
 msgid "Enter the new %s %s address.  Press <ENTER> for none:"
 msgstr ""
 
@@ -2591,12 +2507,12 @@ msgid "This IP address conflicts with another interface or a VIP"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:274
-#, c-format, php-format
+#, php-format
 msgid "Subnet masks are entered as bit counts (as in CIDR notation) in %s."
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:289
-#, c-format, php-format
+#, php-format
 msgid "Enter the new %s %s subnet bit count (1 to %s):"
 msgstr ""
 
@@ -2609,7 +2525,7 @@ msgid "You cannot set broadcast address to an interface"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:314
-#, c-format, php-format
+#, php-format
 msgid "For a WAN, enter the new %s %s upstream gateway address."
 msgstr ""
 
@@ -2618,7 +2534,7 @@ msgid "For a LAN, press <ENTER> for none:"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:321
-#, c-format, php-format
+#, php-format
 msgid "not an %s IP address!"
 msgstr ""
 
@@ -2627,7 +2543,7 @@ msgid "not in subnet!"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:367
-#, c-format, php-format
+#, php-format
 msgid "Enter the start address of the %s client address range:"
 msgstr ""
 
@@ -2636,7 +2552,7 @@ msgid "This IP address must be in the interface's subnet"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:380
-#, c-format, php-format
+#, php-format
 msgid "Enter the end address of the %s client address range:"
 msgstr ""
 
@@ -2645,7 +2561,7 @@ msgid "The end address of the DHCP range must be >= the start address"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:403
-#, c-format, php-format
+#, php-format
 msgid "Disabling %s DHCPD..."
 msgstr ""
 
@@ -2654,22 +2570,22 @@ msgid "Do you want to revert to HTTP as the webConfigurator protocol?"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:423
-#, c-format, php-format
+#, php-format
 msgid "Note: the anti-lockout rule on %s has been re-enabled."
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:454
-#, c-format, php-format
+#, php-format
 msgid "%s IP configuration from console menu"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:469 src/etc/rc.initial.setlanip:472
-#, c-format, php-format
+#, php-format
 msgid "The IPv4 %s address has been set to %s"
 msgstr ""
 
 #: src/etc/rc.initial.setlanip:478 src/etc/rc.initial.setlanip:481
-#, c-format, php-format
+#, php-format
 msgid "The IPv6 %s address has been set to %s"
 msgstr ""
 
@@ -2778,6 +2694,14 @@ msgstr ""
 
 #: src/etc/rc.restore_config_backup:103
 msgid "quit"
+msgstr ""
+
+#: src/etc/rc.sshd:133
+msgid "Started creating your SSH keys. SSH startup is being delayed a wee bit."
+msgstr ""
+
+#: src/etc/rc.sshd:140
+msgid "Completed creating your SSH keys. SSH will now be started."
 msgstr ""
 
 #: src/sbin/gmirror_status_check.php:51
@@ -3033,14 +2957,15 @@ msgstr ""
 #: src/www/interfaces_qinq.php:125 src/www/interfaces_vlan.php:123
 #: src/www/interfaces_wireless.php:114 src/www/services_captiveportal.php:199
 #: src/www/services_dhcp_relay.php:61 src/www/services_dhcpv6_relay.php:62
-#: src/www/services_dyndns.php:89 src/www/services_wol.php:136
-#: src/www/services_wol.php:171 src/www/services_wol_edit.php:75
-#: src/www/services_wol_edit.php:136 src/www/status_graph.php:205
-#: src/www/system_gateways.php:217 src/www/system_gateways_edit.php:104
-#: src/www/system_gateways_edit.php:660 src/www/system_routes.php:236
-#: src/www/vpn_ipsec_phase1.php:596 src/www/vpn_l2tp.php:310
-#: src/www/vpn_openvpn_client.php:532 src/www/vpn_openvpn_server.php:852
-#: src/www/vpn_pppoe.php:116 src/www/vpn_pppoe_edit.php:386
+#: src/www/services_dyndns.php:89 src/www/services_igmpproxy_edit.php:161
+#: src/www/services_wol.php:136 src/www/services_wol.php:171
+#: src/www/services_wol_edit.php:75 src/www/services_wol_edit.php:136
+#: src/www/status_graph.php:205 src/www/system_gateways.php:217
+#: src/www/system_gateways_edit.php:104 src/www/system_gateways_edit.php:660
+#: src/www/system_routes.php:236 src/www/vpn_ipsec_phase1.php:596
+#: src/www/vpn_l2tp.php:310 src/www/vpn_openvpn_client.php:532
+#: src/www/vpn_openvpn_server.php:852 src/www/vpn_pppoe.php:116
+#: src/www/vpn_pppoe_edit.php:386
 #: src/www/widgets/widgets/wake_on_lan.widget.php:44
 msgid "Interface"
 msgstr ""
@@ -3171,8 +3096,9 @@ msgstr ""
 #: src/www/interfaces_groups.php:53 src/www/interfaces_groups_edit.php:33
 #: src/www/interfaces_lagg.php:73 src/www/interfaces_lagg_edit.php:124
 #: src/www/interfaces_ppps_edit.php:379 src/www/interfaces_qinq.php:77
-#: src/www/interfaces_vlan.php:76 src/www/interfaces_vlan_edit.php:143
-#: src/www/interfaces_wireless.php:66 src/www/interfaces_wireless_edit.php:139
+#: src/www/interfaces_qinq_edit.php:30 src/www/interfaces_vlan.php:76
+#: src/www/interfaces_vlan_edit.php:143 src/www/interfaces_wireless.php:66
+#: src/www/interfaces_wireless_edit.php:139
 #: src/www/services_captiveportal.php:516
 #: src/www/services_captiveportal_zones.php:89
 #: src/www/services_dnsmasq.php:276 src/www/status_interfaces.php:45
@@ -3585,7 +3511,8 @@ msgstr ""
 #: src/www/interfaces_assign.php:559 src/www/interfaces_bridge_edit.php:612
 #: src/www/interfaces_gif_edit.php:243 src/www/interfaces_gre_edit.php:248
 #: src/www/interfaces_groups_edit.php:333 src/www/interfaces_lagg_edit.php:238
-#: src/www/interfaces_ppps_edit.php:800 src/www/interfaces_vlan_edit.php:212
+#: src/www/interfaces_ppps_edit.php:800 src/www/interfaces_qinq_edit.php:387
+#: src/www/interfaces_vlan_edit.php:212
 #: src/www/interfaces_wireless_edit.php:200
 #: src/www/load_balancer_monitor_edit.php:358
 #: src/www/load_balancer_pool_edit.php:334
@@ -3603,9 +3530,10 @@ msgstr ""
 #: src/www/services_dnsmasq.php:325
 #: src/www/services_dnsmasq_domainoverride_edit.php:166
 #: src/www/services_dnsmasq_edit.php:289 src/www/services_dyndns_edit.php:433
-#: src/www/services_igmpproxy.php:135 src/www/services_ntpd.php:399
-#: src/www/services_ntpd_gps.php:571 src/www/services_ntpd_pps.php:211
-#: src/www/services_opendns.php:205 src/www/services_rfc2136_edit.php:226
+#: src/www/services_igmpproxy.php:135 src/www/services_igmpproxy_edit.php:275
+#: src/www/services_ntpd.php:399 src/www/services_ntpd_gps.php:571
+#: src/www/services_ntpd_pps.php:211 src/www/services_opendns.php:205
+#: src/www/services_rfc2136_edit.php:226
 #: src/www/services_router_advertisements.php:369
 #: src/www/services_snmp.php:480 src/www/services_unbound.php:344
 #: src/www/services_unbound_acls.php:105 src/www/services_unbound_acls.php:296
@@ -4422,6 +4350,7 @@ msgstr ""
 #: src/www/firewall_schedule_edit.php:48 src/www/firewall_shaper.php:43
 #: src/www/firewall_shaper_wizards.php:62 src/www/firewall_virtual_ip.php:178
 #: src/www/firewall_virtual_ip_edit.php:234
+#: src/www/services_igmpproxy_edit.php:31
 msgid "Firewall"
 msgstr ""
 
@@ -5802,6 +5731,10 @@ msgid ""
 "Logs page"
 msgstr ""
 
+#: src/www/fbegin.inc:132
+msgid "Help for items on this page"
+msgstr ""
+
 #: src/www/fbegin.inc:207
 msgid "Save Settings"
 msgstr ""
@@ -5882,13 +5815,14 @@ msgstr ""
 #: src/www/interfaces_bridge_edit.php:233 src/www/interfaces_gif_edit.php:123
 #: src/www/interfaces_gre_edit.php:117 src/www/interfaces_groups_edit.php:33
 #: src/www/interfaces_lagg_edit.php:124 src/www/interfaces_ppps_edit.php:379
-#: src/www/interfaces_vlan_edit.php:143
+#: src/www/interfaces_qinq_edit.php:30 src/www/interfaces_vlan_edit.php:143
 #: src/www/interfaces_wireless_edit.php:139
 #: src/www/load_balancer_monitor_edit.php:182
 #: src/www/load_balancer_pool_edit.php:157
 #: src/www/load_balancer_relay_action_edit.php:170
 #: src/www/load_balancer_relay_protocol_edit.php:127
 #: src/www/load_balancer_virtual_server_edit.php:132 src/www/pkg_edit.php:255
+#: src/www/services_igmpproxy_edit.php:31
 #: src/www/services_rfc2136_edit.php:113 src/www/services_wol_edit.php:105
 #: src/www/vpn_l2tp_users_edit.php:29 src/www/vpn_pppoe_edit.php:231
 #: src/www/vpn_pptp_users_edit.php:128
@@ -5979,7 +5913,9 @@ msgstr ""
 msgid "Network(s)"
 msgstr ""
 
-#: src/www/firewall_aliases_edit.php:462 src/www/services_unbound_acls.php:234
+#: src/www/firewall_aliases_edit.php:462
+#: src/www/services_igmpproxy_edit.php:224
+#: src/www/services_unbound_acls.php:234
 msgid "CIDR"
 msgstr ""
 
@@ -6098,11 +6034,13 @@ msgstr ""
 #: src/www/firewall_schedule_edit.php:985
 #: src/www/firewall_virtual_ip_edit.php:463
 #: src/www/interfaces_gif_edit.php:236 src/www/interfaces_gre_edit.php:241
-#: src/www/interfaces_groups_edit.php:266 src/www/interfaces_vlan_edit.php:205
+#: src/www/interfaces_groups_edit.php:266 src/www/interfaces_qinq_edit.php:339
+#: src/www/interfaces_vlan_edit.php:205
 #: src/www/interfaces_wireless_edit.php:192 src/www/services_dhcp_edit.php:415
 #: src/www/services_dhcpv6_edit.php:238
 #: src/www/services_dnsmasq_domainoverride_edit.php:160
 #: src/www/services_dnsmasq_edit.php:226
+#: src/www/services_igmpproxy_edit.php:180
 #: src/www/services_unbound_domainoverride_edit.php:155
 #: src/www/services_unbound_host_edit.php:228
 #: src/www/services_wol_edit.php:161
@@ -6123,11 +6061,12 @@ msgstr ""
 #: src/www/load_balancer_relay_protocol_edit.php:69
 #: src/www/load_balancer_relay_protocol_edit.php:203
 #: src/www/services_captiveportal.php:869 src/www/services_dhcp.php:1084
-#: src/www/services_igmpproxy.php:97 src/www/status_ntpd.php:178
-#: src/www/system_authservers.php:156 src/www/system_authservers.php:179
-#: src/www/system_authservers.php:474 src/www/system_authservers.php:815
-#: src/www/system_certmanager.php:775 src/www/vpn_ipsec_phase2.php:539
-#: src/www/vpn_ipsec_phase2.php:574 src/www/vpn_ipsec_phase2.php:616
+#: src/www/services_igmpproxy.php:97 src/www/services_igmpproxy_edit.php:185
+#: src/www/status_ntpd.php:178 src/www/system_authservers.php:156
+#: src/www/system_authservers.php:179 src/www/system_authservers.php:474
+#: src/www/system_authservers.php:815 src/www/system_certmanager.php:775
+#: src/www/vpn_ipsec_phase2.php:539 src/www/vpn_ipsec_phase2.php:574
+#: src/www/vpn_ipsec_phase2.php:616
 msgid "Type"
 msgstr ""
 
@@ -6141,7 +6080,8 @@ msgstr ""
 #: src/www/firewall_nat_edit.php:658 src/www/firewall_nat_out_edit.php:539
 #: src/www/firewall_nat_out_edit.php:598 src/www/firewall_rules_edit.php:996
 #: src/www/firewall_rules_edit.php:1099
-#: src/www/firewall_virtual_ip_edit.php:383 src/www/services_opendns.php:167
+#: src/www/firewall_virtual_ip_edit.php:383
+#: src/www/services_igmpproxy_edit.php:223 src/www/services_opendns.php:167
 #: src/www/services_unbound_acls.php:233 src/www/system_routes.php:234
 #: src/www/vpn_ipsec_mobile.php:443 src/www/vpn_ipsec_phase2.php:544
 #: src/www/vpn_ipsec_phase2.php:579 src/www/vpn_ipsec_phase2.php:621
@@ -6165,7 +6105,7 @@ msgstr ""
 #: src/www/interfaces_bridge_edit.php:613 src/www/interfaces_gif_edit.php:244
 #: src/www/interfaces_gre_edit.php:249 src/www/interfaces_groups_edit.php:334
 #: src/www/interfaces_lagg_edit.php:239 src/www/interfaces_ppps_edit.php:801
-#: src/www/interfaces_vlan_edit.php:213
+#: src/www/interfaces_qinq_edit.php:388 src/www/interfaces_vlan_edit.php:213
 #: src/www/interfaces_wireless_edit.php:201
 #: src/www/load_balancer_monitor_edit.php:359
 #: src/www/load_balancer_pool_edit.php:335
@@ -6177,6 +6117,7 @@ msgstr ""
 #: src/www/services_dhcp_edit.php:532 src/www/services_dhcpv6_edit.php:245
 #: src/www/services_dnsmasq_domainoverride_edit.php:167
 #: src/www/services_dnsmasq_edit.php:290 src/www/services_dyndns_edit.php:438
+#: src/www/services_igmpproxy_edit.php:276
 #: src/www/services_rfc2136_edit.php:227 src/www/services_unbound_acls.php:297
 #: src/www/services_unbound_domainoverride_edit.php:163
 #: src/www/services_unbound_host_edit.php:292
@@ -8742,12 +8683,12 @@ msgid "Cannot get CPU load"
 msgstr ""
 
 #: src/www/guiconfig.inc:246
-#, c-format
+#, php-format
 msgid "The field %s contains invalid characters."
 msgstr ""
 
 #: src/www/guiconfig.inc:252
-#, c-format
+#, php-format
 msgid "The field %s is required."
 msgstr ""
 
@@ -8792,8 +8733,16 @@ msgstr ""
 msgid "Currently viewing: "
 msgstr ""
 
+#: src/www/guiconfig.inc:974
+msgid "move mouse out this alias to hide"
+msgstr ""
+
 #: src/www/guiconfig.inc:1014
 msgid "listing only first 10k items"
+msgstr ""
+
+#: src/www/guiconfig.inc:1038
+msgid "edit this alias"
 msgstr ""
 
 #: src/www/index.php:94
@@ -11018,7 +10967,8 @@ msgstr ""
 
 #: src/www/interfaces_gif_edit.php:154 src/www/interfaces_gre_edit.php:64
 #: src/www/interfaces_gre_edit.php:150 src/www/interfaces_lagg_edit.php:155
-#: src/www/interfaces_vlan_edit.php:71 src/www/interfaces_vlan_edit.php:176
+#: src/www/interfaces_qinq_edit.php:297 src/www/interfaces_vlan_edit.php:71
+#: src/www/interfaces_vlan_edit.php:176
 #: src/www/interfaces_wireless_edit.php:78
 #: src/www/interfaces_wireless_edit.php:162
 msgid "Parent interface"
@@ -11232,7 +11182,7 @@ msgstr ""
 msgid "No numbers or spaces are allowed. Only characters in a-zA-Z"
 msgstr ""
 
-#: src/www/interfaces_groups_edit.php:271
+#: src/www/interfaces_groups_edit.php:271 src/www/interfaces_qinq_edit.php:344
 msgid "Member (s)"
 msgstr ""
 
@@ -11700,11 +11650,11 @@ msgstr ""
 msgid "QinQ interface does not exist"
 msgstr ""
 
-#: src/www/interfaces_qinq.php:77
+#: src/www/interfaces_qinq.php:77 src/www/interfaces_qinq_edit.php:30
 msgid "QinQ"
 msgstr ""
 
-#: src/www/interfaces_qinq.php:126
+#: src/www/interfaces_qinq.php:126 src/www/interfaces_qinq_edit.php:353
 msgid "Tag"
 msgstr ""
 
@@ -11722,6 +11672,90 @@ msgid ""
 "Not all drivers/NICs support 802.1Q QinQ tagging properly. On cards that do "
 "not explicitly support it, QinQ tagging will still work, but the reduced MTU "
 "may cause problems. See the %s handbook for information on supported cards."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:77
+msgid "First level tag cannot be empty."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:79
+msgid ""
+"You are editing an existing entry and modifying the first level tag is not "
+"allowed."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:81
+msgid ""
+"You are editing an existing entry and modifying the interface is not allowed."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:85
+msgid "QinQ level already exists for this interface, edit it!"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:89
+msgid ""
+"A normal VLAN exists with this tag please remove it to use this tag for QinQ "
+"first level."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:116 src/www/interfaces_qinq_edit.php:126
+msgid "Tags can contain only numbers or a range in format #-#."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:189
+msgid "QinQ VLANs group"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:263
+msgid "members"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:267
+msgid "detail"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:289
+msgid "Interface QinQ Edit"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:314
+msgid "Only QinQ capable interfaces will be shown."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:317
+msgid "First level tag"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:322
+msgid ""
+"This is the first level VLAN tag. On top of this are stacked the member "
+"VLANs defined below."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:327
+#: src/www/load_balancer_relay_action.php:140
+#: src/www/load_balancer_relay_action_edit.php:516
+#: src/www/load_balancer_relay_action_edit.php:536
+#: src/www/load_balancer_relay_protocol.php:134
+msgid "Options"
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:330
+msgid ""
+"Adds interface to QinQ interface groups so you can write filter rules easily."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:347
+msgid ""
+"You can specify ranges in the input below. The format is pretty simple i.e "
+"9-100 or 10 20..."
+msgstr ""
+
+#: src/www/interfaces_qinq_edit.php:380 src/www/services_dhcpv6.php:789
+#: src/www/services_router_advertisements.php:326
+#: src/www/system_certmanager.php:806
+msgid "add another entry"
 msgstr ""
 
 #: src/www/interfaces_vlan.php:61
@@ -12202,13 +12236,6 @@ msgstr ""
 #: src/www/load_balancer_relay_action.php:124
 #: src/www/load_balancer_relay_protocol.php:118
 msgid "Relay Protocols"
-msgstr ""
-
-#: src/www/load_balancer_relay_action.php:140
-#: src/www/load_balancer_relay_action_edit.php:516
-#: src/www/load_balancer_relay_action_edit.php:536
-#: src/www/load_balancer_relay_protocol.php:134
-msgid "Options"
 msgstr ""
 
 #: src/www/load_balancer_relay_action_edit.php:55
@@ -14712,12 +14739,6 @@ msgstr ""
 msgid "Enter the Bootfile URL"
 msgstr ""
 
-#: src/www/services_dhcpv6.php:789
-#: src/www/services_router_advertisements.php:326
-#: src/www/system_certmanager.php:806
-msgid "add another entry"
-msgstr ""
-
 #: src/www/services_dhcpv6.php:819
 msgid "Status: DHCPv6 leases"
 msgstr ""
@@ -15369,7 +15390,7 @@ msgid ""
 "work."
 msgstr ""
 
-#: src/www/services_igmpproxy.php:65
+#: src/www/services_igmpproxy.php:65 src/www/services_igmpproxy_edit.php:31
 msgid "IGMP Proxy"
 msgstr ""
 
@@ -15400,6 +15421,55 @@ msgid ""
 "Please add the interface for upstream, the allowed subnets, and the "
 "downstream interfaces you would like the proxy to allow. Only one 'upstream' "
 "interface can be configured."
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:65
+msgid "Only one 'upstream' interface can be configured."
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:158
+msgid "IGMP Proxy Edit"
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:188
+msgid "Upstream Interface"
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:189
+msgid "Downstream Interface"
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:193
+msgid ""
+"The <b>upstream</b> network interface is the outgoing interface which is "
+"responsible for communicating to available multicast data sources. There can "
+"only be one upstream interface."
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:199
+msgid "Downstream"
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:199
+msgid ""
+"network interfaces are the distribution  interfaces  to  the destination  "
+"networks,  where  multicast  clients  can  join groups and receive multicast "
+"data. One or more downstream interfaces must be configured."
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:206
+msgid "Threshold"
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:211
+msgid ""
+"Defines the TTL threshold for  the  network  interface.  Packets with  a "
+"lower TTL than the threshold value will be ignored. This setting is "
+"optional, and by default the threshold is 1."
+msgstr ""
+
+#: src/www/services_igmpproxy_edit.php:218
+msgid "Network (s)"
 msgstr ""
 
 #: src/www/services_ntpd.php:198 src/www/services_ntpd.php:294
@@ -16489,4 +16559,7312 @@ msgid "Number of Hosts to cache"
 msgstr ""
 
 #: src/www/services_unbound_advanced.php:373
-msgid "Number of hos
+msgid "Number of hosts for which information is cached. The default is 10,000."
+msgstr ""
+
+#: src/www/services_unbound_advanced.php:378
+msgid "Unwanted Reply Threshold"
+msgstr ""
+
+#: src/www/services_unbound_advanced.php:389
+msgid ""
+"If enabled, a total number of unwanted replies is kept track of in every "
+"thread. When it reaches the threshold, a defensive action is taken and a "
+"warning is printed to the log file. This defensive action is to clear the "
+"RRSet and message caches, hopefully flushing away any poison. The default is "
+"disabled, but if enabled a value of 10 million is suggested."
+msgstr ""
+
+#: src/www/services_unbound_advanced.php:394
+msgid "Log level verbosity"
+msgstr ""
+
+#: src/www/services_unbound_advanced.php:408
+msgid "Select the log verbosity."
+msgstr ""
+
+#: src/www/services_unbound_domainoverride_edit.php:76
+msgid ""
+"A valid IP address and port must be specified, for example "
+"192.168.100.10@5353."
+msgstr ""
+
+#: src/www/services_unbound_domainoverride_edit.php:78
+msgid "A valid IP address must be specified, for example 192.168.100.10."
+msgstr ""
+
+#: src/www/services_unbound_domainoverride_edit.php:146
+msgid ""
+"To use a nondefault port for communication, append an '@' with the port "
+"number."
+msgstr ""
+
+#: src/www/services_unbound_host_edit.php:198
+msgid "Edit DNS Resolver entry"
+msgstr ""
+
+#: src/www/services_wol.php:53
+#, php-format
+msgid "Sent magic packet to %1$s (%2$s)%3$s"
+msgstr ""
+
+#: src/www/services_wol.php:55
+#, php-format
+msgid ""
+"Please check the %1$ssystem log%2$s, the wol command for %3$s (%4$s) did not "
+"complete successfully%5$s"
+msgstr ""
+
+#: src/www/services_wol.php:78
+msgid "A valid interface must be specified."
+msgstr ""
+
+#: src/www/services_wol.php:84
+msgid "A valid ip could not be found!"
+msgstr ""
+
+#: src/www/services_wol.php:89
+#, php-format
+msgid "Sent magic packet to %s."
+msgstr ""
+
+#: src/www/services_wol.php:91
+#, php-format
+msgid ""
+"Please check the %1$ssystem log%2$s, the wol command for %3$s did not "
+"complete successfully%4$s"
+msgstr ""
+
+#: src/www/services_wol.php:147
+msgid "Choose which interface the host to be woken up is connected to."
+msgstr ""
+
+#: src/www/services_wol.php:154
+msgid "Enter a MAC address "
+msgstr ""
+
+#: src/www/services_wol.php:154
+msgid "in the following format: xx:xx:xx:xx:xx:xx"
+msgstr ""
+
+#: src/www/services_wol.php:165
+msgid "Or Click the MAC address to wake up an individual device:"
+msgstr ""
+
+#: src/www/services_wol.php:165
+msgid "Wake all clients at once: "
+msgstr ""
+
+#: src/www/services_wol.php:213
+msgid "Magic Packets"
+msgstr ""
+
+#: src/www/services_wol.php:213
+msgid ""
+"The NIC in the computer that is to be woken up must support Wake on LAN and "
+"has to be configured properly (WOL cable, BIOS settings). "
+msgstr ""
+
+#: src/www/services_wol.php:213
+msgid ""
+"This service can be used to wake up (power on) computers by sending special"
+msgstr ""
+
+#: src/www/services_wol_edit.php:126
+msgid "Edit WOL entry"
+msgstr ""
+
+#: src/www/services_wol_edit.php:147
+msgid "Choose which interface this host is connected to."
+msgstr ""
+
+#: src/www/services_wol_edit.php:154
+msgid "Enter a MAC address  in the following format: xx:xx:xx:xx:xx:xx"
+msgstr ""
+
+#: src/www/shortcuts.inc:91 src/www/shortcuts.inc:93
+msgid "Main page for this section"
+msgstr ""
+
+#: src/www/shortcuts.inc:118 src/www/shortcuts.inc:120
+msgid "Status of items on this page"
+msgstr ""
+
+#: src/www/shortcuts.inc:128 src/www/shortcuts.inc:130
+msgid "Log entries for items on this page"
+msgstr ""
+
+#: src/www/status.php:93
+msgid "This status page includes the following information"
+msgstr ""
+
+#: src/www/status.php:210
+msgid ""
+"Note: make sure to remove any sensitive information (passwords, maybe also "
+"IP addresses) before posting information from this page in public places "
+"(like mailing lists)"
+msgstr ""
+
+#: src/www/status.php:213
+msgid "Passwords in config.xml have been automatically removed"
+msgstr ""
+
+#: src/www/status_captiveportal.php:45
+msgid "Status: Captive portal"
+msgstr ""
+
+#: src/www/status_captiveportal.php:115
+#: src/www/status_captiveportal_expire.php:68
+#: src/www/status_captiveportal_test.php:69
+#: src/www/status_captiveportal_voucher_rolls.php:73
+#: src/www/status_captiveportal_vouchers.php:108
+msgid "Active Users"
+msgstr ""
+
+#: src/www/status_captiveportal.php:116
+#: src/www/status_captiveportal_expire.php:69
+#: src/www/status_captiveportal_test.php:70
+#: src/www/status_captiveportal_voucher_rolls.php:74
+#: src/www/status_captiveportal_vouchers.php:109
+msgid "Active Vouchers"
+msgstr ""
+
+#: src/www/status_captiveportal.php:118
+#: src/www/status_captiveportal_expire.php:71
+#: src/www/status_captiveportal_test.php:50
+#: src/www/status_captiveportal_test.php:72
+#: src/www/status_captiveportal_voucher_rolls.php:76
+#: src/www/status_captiveportal_vouchers.php:111
+msgid "Test Vouchers"
+msgstr ""
+
+#: src/www/status_captiveportal.php:119
+#: src/www/status_captiveportal_expire.php:50
+#: src/www/status_captiveportal_expire.php:72
+#: src/www/status_captiveportal_test.php:73
+#: src/www/status_captiveportal_voucher_rolls.php:77
+#: src/www/status_captiveportal_vouchers.php:112
+msgid "Expire Vouchers"
+msgstr ""
+
+#: src/www/status_captiveportal.php:134
+msgid "Captive Portal Zone"
+msgstr ""
+
+#: src/www/status_captiveportal.php:158
+msgid "Captiveportal status"
+msgstr ""
+
+#: src/www/status_captiveportal.php:165 src/www/status_captiveportal.php:168
+#: src/www/widgets/widgets/captive_portal_status.widget.php:78
+msgid "Session start"
+msgstr ""
+
+#: src/www/status_captiveportal.php:166
+#: src/www/widgets/widgets/captive_portal_status.widget.php:79
+msgid "Last activity"
+msgstr ""
+
+#: src/www/status_captiveportal.php:196 src/www/status_interfaces.php:129
+#: src/www/status_interfaces.php:142 src/www/status_interfaces.php:155
+#: src/www/status_interfaces.php:169
+msgid "Disconnect"
+msgstr ""
+
+#: src/www/status_captiveportal.php:196
+msgid "Do you really want to disconnect this client?"
+msgstr ""
+
+#: src/www/status_captiveportal.php:210
+msgid "Don't show last activity"
+msgstr ""
+
+#: src/www/status_captiveportal.php:213
+msgid "Show last activity"
+msgstr ""
+
+#: src/www/status_captiveportal_expire.php:86
+#: src/www/status_captiveportal_test.php:86
+msgid "Voucher(s)"
+msgstr ""
+
+#: src/www/status_captiveportal_expire.php:90
+msgid ""
+"Enter multiple vouchers separated by space or newline. All valid vouchers "
+"will be marked as expired"
+msgstr ""
+
+#: src/www/status_captiveportal_test.php:90
+msgid ""
+"Enter multiple vouchers separated by space or newline. The remaining time, "
+"if valid, will be shown for each voucher"
+msgstr ""
+
+#: src/www/status_captiveportal_voucher_rolls.php:90
+msgid "Roll#"
+msgstr ""
+
+#: src/www/status_captiveportal_voucher_rolls.php:92
+msgid "# of Tickets"
+msgstr ""
+
+#: src/www/status_captiveportal_voucher_rolls.php:94
+msgid "used"
+msgstr ""
+
+#: src/www/status_captiveportal_voucher_rolls.php:95
+msgid "active"
+msgstr ""
+
+#: src/www/status_captiveportal_voucher_rolls.php:96
+msgid "ready"
+msgstr ""
+
+#: src/www/status_captiveportal_vouchers.php:125
+msgid "Voucher"
+msgstr ""
+
+#: src/www/status_captiveportal_vouchers.php:127
+msgid "Activated at"
+msgstr ""
+
+#: src/www/status_captiveportal_vouchers.php:128
+msgid "Expires in"
+msgstr ""
+
+#: src/www/status_captiveportal_vouchers.php:129
+msgid "Expires at"
+msgstr ""
+
+#: src/www/status_captiveportal_vouchers.php:137
+msgid "min"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:33
+msgid "DHCP leases"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:301 src/www/status_dhcpv6_leases.php:382
+msgid "Failover Group"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:302 src/www/status_dhcpv6_leases.php:383
+msgid "My State"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:303 src/www/status_dhcp_leases.php:305
+#: src/www/status_dhcpv6_leases.php:384 src/www/status_dhcpv6_leases.php:386
+msgid "Since"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:304 src/www/status_dhcpv6_leases.php:385
+msgid "Peer State"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:340 src/www/status_dhcpv6_leases.php:422
+#: src/www/status_dhcpv6_leases.php:518
+msgid "End"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:341 src/www/status_dhcpv6_leases.php:423
+#: src/www/status_gateway_groups.php:141 src/www/status_gateways.php:131
+#: src/www/status_gateways.php:135
+#: src/www/widgets/widgets/wake_on_lan.widget.php:59
+msgid "Online"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:342 src/www/status_dhcpv6_leases.php:424
+msgid "Lease Type"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:395
+msgid "send Wake on LAN packet to this MAC address"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:417 src/www/status_dhcpv6_leases.php:483
+msgid "add a static mapping for this MAC address"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:423
+msgid "add a Wake on LAN mapping for this MAC address"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:428 src/www/status_dhcpv6_leases.php:492
+msgid "delete this DHCP lease"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:447 src/www/status_dhcpv6_leases.php:579
+msgid "Show active and static leases only"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:450 src/www/status_dhcpv6_leases.php:582
+msgid "Show all configured leases"
+msgstr ""
+
+#: src/www/status_dhcp_leases.php:454 src/www/status_dhcpv6_leases.php:586
+msgid "No leases file found. Is the DHCP server active"
+msgstr ""
+
+#: src/www/status_dhcpv6_leases.php:34
+msgid "DHCPv6 leases"
+msgstr ""
+
+#: src/www/status_dhcpv6_leases.php:418 src/www/status_dhcpv6_leases.php:515
+msgid "IAID"
+msgstr ""
+
+#: src/www/status_dhcpv6_leases.php:420
+msgid "Hostname/MAC"
+msgstr ""
+
+#: src/www/status_dhcpv6_leases.php:514
+msgid "IPv6 Prefix"
+msgstr ""
+
+#: src/www/status_filter_reload.php:33
+msgid "Filter Reload Status"
+msgstr ""
+
+#: src/www/status_filter_reload.php:94
+msgid ""
+"This page will automatically refresh every 3 seconds until the filter is "
+"done reloading"
+msgstr ""
+
+#: src/www/status_gateway_groups.php:109
+#, php-format
+msgid "Tier %s"
+msgstr ""
+
+#: src/www/status_gateway_groups.php:135 src/www/status_gateways.php:125
+msgid "Warning, Packetloss"
+msgstr ""
+
+#: src/www/status_gateway_groups.php:138 src/www/status_gateways.php:128
+msgid "Warning, Latency"
+msgstr ""
+
+#: src/www/status_gateway_groups.php:144
+msgid "Gathering data"
+msgstr ""
+
+#: src/www/status_gateways.php:74
+#: src/www/widgets/widgets/gateways.widget.php:47
+msgid "RTT"
+msgstr ""
+
+#: src/www/status_gateways.php:75
+#: src/www/widgets/widgets/gateways.widget.php:48
+msgid "Loss"
+msgstr ""
+
+#: src/www/status_gateways.php:101 src/www/status_gateways.php:109
+#: src/www/status_gateways.php:138
+#: src/www/widgets/widgets/gateways.widget.php:84
+#: src/www/widgets/widgets/gateways.widget.php:93
+msgid "Pending"
+msgstr ""
+
+#: src/www/status_gateways.php:119
+msgid "Offline (forced)"
+msgstr ""
+
+#: src/www/status_gateways.php:144
+msgid "Last check:"
+msgstr ""
+
+#: src/www/status_graph.php:95
+msgid "Traffic Graph"
+msgstr ""
+
+#: src/www/status_graph.php:263
+msgid "Host IP"
+msgstr ""
+
+#: src/www/status_graph.php:263
+msgid "Host Name or IP"
+msgstr ""
+
+#: src/www/status_graph.php:264
+msgid "Bandwidth In"
+msgstr ""
+
+#: src/www/status_graph.php:265
+msgid "Bandwidth Out"
+msgstr ""
+
+#: src/www/status_graph.php:352
+msgid "Adobe SVG Viewer"
+msgstr ""
+
+#: src/www/status_graph.php:352
+msgid ""
+"Firefox 1.5 or later or other browser supporting SVG is required to view the "
+"graph"
+msgstr ""
+
+#: src/www/status_graph.php:352
+msgid "the"
+msgstr ""
+
+#: src/www/status_graph_cpu.php:29
+msgid "CPU load"
+msgstr ""
+
+#: src/www/status_graph_cpu.php:34
+msgid "Status: CPU Graph"
+msgstr ""
+
+#: src/www/status_graph_cpu.php:41
+msgid "Adobe SVG viewer"
+msgstr ""
+
+#: src/www/status_graph_cpu.php:41
+msgid "if you can't see the graph, you may have to install the"
+msgstr ""
+
+#: src/www/status_interfaces.php:77
+msgid "interface"
+msgstr ""
+
+#: src/www/status_interfaces.php:100 src/www/status_interfaces.php:116
+msgid "Release"
+msgstr ""
+
+#: src/www/status_interfaces.php:100 src/www/status_interfaces.php:116
+msgid "Renew"
+msgstr ""
+
+#: src/www/status_interfaces.php:129 src/www/status_interfaces.php:142
+#: src/www/status_interfaces.php:155 src/www/status_interfaces.php:172
+msgid "Connect"
+msgstr ""
+
+#: src/www/status_interfaces.php:180
+msgid "Uptime "
+msgstr ""
+
+#: src/www/status_interfaces.php:187
+msgid "Cell Signal (RSSI)"
+msgstr ""
+
+#: src/www/status_interfaces.php:194
+msgid "Cell Mode"
+msgstr ""
+
+#: src/www/status_interfaces.php:201
+msgid "Cell SIM State"
+msgstr ""
+
+#: src/www/status_interfaces.php:208
+msgid "Cell Service"
+msgstr ""
+
+#: src/www/status_interfaces.php:215
+msgid "Cell Upstream"
+msgstr ""
+
+#: src/www/status_interfaces.php:222
+msgid "Cell Downstream"
+msgstr ""
+
+#: src/www/status_interfaces.php:229
+msgid "Cell Current Up"
+msgstr ""
+
+#: src/www/status_interfaces.php:236
+msgid "Cell Current Down"
+msgstr ""
+
+#: src/www/status_interfaces.php:265
+msgid "Subnet mask IPv4"
+msgstr ""
+
+#: src/www/status_interfaces.php:272
+msgid "Gateway IPv4"
+msgstr ""
+
+#: src/www/status_interfaces.php:280
+msgid "IPv6 Link Local"
+msgstr ""
+
+#: src/www/status_interfaces.php:296
+msgid "Subnet mask IPv6"
+msgstr ""
+
+#: src/www/status_interfaces.php:303
+msgid "Gateway IPv6"
+msgstr ""
+
+#: src/www/status_interfaces.php:311
+msgid "ISP DNS servers"
+msgstr ""
+
+#: src/www/status_interfaces.php:323
+msgid "Media"
+msgstr ""
+
+#: src/www/status_interfaces.php:330
+msgid "LAGG Protocol"
+msgstr ""
+
+#: src/www/status_interfaces.php:337
+msgid "LAGG Ports"
+msgstr ""
+
+#: src/www/status_interfaces.php:360
+msgid "BSSID"
+msgstr ""
+
+#: src/www/status_interfaces.php:374
+msgid "RSSI"
+msgstr ""
+
+#: src/www/status_interfaces.php:381
+msgid "In/out packets"
+msgstr ""
+
+#: src/www/status_interfaces.php:390
+msgid "In/out packets (pass)"
+msgstr ""
+
+#: src/www/status_interfaces.php:399
+msgid "In/out packets (block)"
+msgstr ""
+
+#: src/www/status_interfaces.php:409
+msgid "In/out errors"
+msgstr ""
+
+#: src/www/status_interfaces.php:417
+#: src/www/widgets/widgets/interface_statistics.widget.php:100
+msgid "Collisions"
+msgstr ""
+
+#: src/www/status_interfaces.php:426
+#, php-format
+msgid "Bridge (%s)"
+msgstr ""
+
+#: src/www/status_interfaces.php:450
+msgid "Interrupts/Second"
+msgstr ""
+
+#: src/www/status_interfaces.php:453
+msgid "total"
+msgstr ""
+
+#: src/www/status_interfaces.php:455
+msgid "rate"
+msgstr ""
+
+#: src/www/status_interfaces.php:467
+#, php-format
+msgid ""
+"Using dial-on-demand will bring the connection up again if any packet "
+"triggers it. To substantiate this point: disconnecting manually will %snot%s "
+"prevent dial-on-demand from making connections to the outside! Don't use "
+"dial-on-demand if you want to make sure that the line is kept disconnected."
+msgstr ""
+
+#: src/www/status_ntpd.php:176
+msgid "Ref ID"
+msgstr ""
+
+#: src/www/status_ntpd.php:177
+msgid "Stratum"
+msgstr ""
+
+#: src/www/status_ntpd.php:179
+msgid "When"
+msgstr ""
+
+#: src/www/status_ntpd.php:180
+msgid "Poll"
+msgstr ""
+
+#: src/www/status_ntpd.php:181
+msgid "Reach"
+msgstr ""
+
+#: src/www/status_ntpd.php:182
+msgid "Delay"
+msgstr ""
+
+#: src/www/status_ntpd.php:183
+msgid "Offset"
+msgstr ""
+
+#: src/www/status_ntpd.php:184
+msgid "Jitter"
+msgstr ""
+
+#: src/www/status_ntpd.php:241
+msgid "Clock Latitude"
+msgstr ""
+
+#: src/www/status_ntpd.php:242
+msgid "Clock Longitude"
+msgstr ""
+
+#: src/www/status_ntpd.php:243
+msgid "Clock Altitude"
+msgstr ""
+
+#: src/www/status_ntpd.php:244
+msgid "Satellites"
+msgstr ""
+
+#: src/www/status_openvpn.php:154
+msgid "Client connections"
+msgstr ""
+
+#: src/www/status_openvpn.php:161 src/www/status_openvpn.php:231
+#: src/www/system_camanager.php:564 src/www/system_certmanager.php:756
+#: src/www/system_certmanager.php:928 src/www/vpn_openvpn_csc.php:751
+msgid "Common Name"
+msgstr ""
+
+#: src/www/status_openvpn.php:162 src/www/status_openvpn.php:232
+msgid "Real Address"
+msgstr ""
+
+#: src/www/status_openvpn.php:163
+msgid "Virtual Address"
+msgstr ""
+
+#: src/www/status_openvpn.php:164 src/www/status_openvpn.php:282
+#: src/www/status_openvpn.php:345
+msgid "Connected Since"
+msgstr ""
+
+#: src/www/status_openvpn.php:165 src/www/status_openvpn.php:285
+#: src/www/status_openvpn.php:348
+msgid "Bytes Sent"
+msgstr ""
+
+#: src/www/status_openvpn.php:166
+msgid "Bytes Received"
+msgstr ""
+
+#: src/www/status_openvpn.php:193
+msgid "Kill client connection from"
+msgstr ""
+
+#: src/www/status_openvpn.php:218
+msgid "Display OpenVPN's internal routing table for this server."
+msgstr ""
+
+#: src/www/status_openvpn.php:218
+msgid "Show Routing Table"
+msgstr ""
+
+#: src/www/status_openvpn.php:224
+msgid "Routing Table"
+msgstr ""
+
+#: src/www/status_openvpn.php:233
+msgid "Target Network"
+msgstr ""
+
+#: src/www/status_openvpn.php:234
+msgid "Last Used"
+msgstr ""
+
+#: src/www/status_openvpn.php:256
+msgid ""
+"An IP address followed by C indicates a host currently connected through the "
+"VPN."
+msgstr ""
+
+#: src/www/status_openvpn.php:273
+msgid "Peer to Peer Server Instance Statistics"
+msgstr ""
+
+#: src/www/status_openvpn.php:283 src/www/status_openvpn.php:346
+msgid "Virtual Addr"
+msgstr ""
+
+#: src/www/status_openvpn.php:284 src/www/status_openvpn.php:347
+msgid "Remote Host"
+msgstr ""
+
+#: src/www/status_openvpn.php:286 src/www/status_openvpn.php:349
+msgid "Bytes Rcvd"
+msgstr ""
+
+#: src/www/status_openvpn.php:336
+msgid "Client Instance Statistics"
+msgstr ""
+
+#: src/www/status_openvpn.php:397
+msgid ""
+"If you have custom options that override the management features of OpenVPN "
+"on a client or server, they will cause that OpenVPN instance to not work "
+"correctly with this status page."
+msgstr ""
+
+#: src/www/status_openvpn.php:401
+msgid "No OpenVPN instance defined"
+msgstr ""
+
+#: src/www/status_queues.php:113 src/www/status_rrd_graph_settings.php:44
+#: src/www/status_rrd_graph_tabs.inc:13
+msgid "Queues"
+msgstr ""
+
+#: src/www/status_queues.php:113
+msgid "Traffic shaper"
+msgstr ""
+
+#: src/www/status_queues.php:131
+msgid "Traffic shaping is not configured."
+msgstr ""
+
+#: src/www/status_queues.php:169
+msgid "Statistics"
+msgstr ""
+
+#: src/www/status_queues.php:177
+msgid "Borrows"
+msgstr ""
+
+#: src/www/status_queues.php:178
+msgid "Suspends"
+msgstr ""
+
+#: src/www/status_queues.php:179
+msgid "Drops"
+msgstr ""
+
+#: src/www/status_queues.php:180
+msgid "Length"
+msgstr ""
+
+#: src/www/status_queues.php:191
+msgid "Queue graphs take 5 seconds to sample data"
+msgstr ""
+
+#: src/www/status_queues.php:192
+msgid "You can configure the Traffic Shaper"
+msgstr ""
+
+#: src/www/status_queues.php:262
+msgid "Loading"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:147
+msgid "Invalid start date/time:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:160
+msgid "Invalid end date/time:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:175 src/www/status_rrd_graph_settings.php:51
+msgid "Inverse"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:176 src/www/status_rrd_graph_settings.php:52
+msgid "Absolute"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:237 src/www/status_rrd_graph_settings.php:53
+msgid "Absolute Timespans"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:237 src/www/status_rrd_graph_settings.php:54
+msgid "Current Period"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:237 src/www/status_rrd_graph_settings.php:55
+msgid "Previous Period"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:247 src/www/status_rrd_graph_img.php:38
+#: src/www/status_rrd_graph_settings.php:106
+#: src/www/status_rrd_graph_settings.php:136
+msgid "RRD Graphs"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:396
+msgid ""
+"Note: Change of color and/or style may not take effect until the next refresh"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:404
+msgid "Graphs:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:470
+msgid "Style:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:486
+msgid "Period:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:502
+msgid "Enter date and/or time. Current timezone:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:506
+msgid "Start:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:511
+msgid "End:"
+msgstr ""
+
+#: src/www/status_rrd_graph.php:517
+msgid "Go"
+msgstr ""
+
+#: src/www/status_rrd_graph_img.php:38
+msgid "Image viewer"
+msgstr ""
+
+#: src/www/status_rrd_graph_img.php:1214
+#, php-format
+msgid "Sorry we do not have data to graph for %s"
+msgstr ""
+
+#: src/www/status_rrd_graph_img.php:1236
+#, php-format
+msgid "Failed to create graph with error code %1$s, the error is: %2$s"
+msgstr ""
+
+#: src/www/status_rrd_graph_img.php:1238 src/www/status_rrd_graph_img.php:1245
+#, php-format
+msgid "failed to create graph from %s%s, removing database"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:41
+#: src/www/status_rrd_graph_tabs.inc:6
+msgid "Traffic"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:42
+#: src/www/status_rrd_graph_tabs.inc:8
+msgid "Packets"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:43
+#: src/www/status_rrd_graph_tabs.inc:10
+msgid "Quality"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:140
+msgid "Enables the RRD graphing backend."
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:145
+msgid "Default category"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:156
+msgid "This selects default category."
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:160
+msgid "Default style"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:171
+msgid "This selects the default style."
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:175
+msgid "Default period"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:186
+msgid "This selects the default period."
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:193
+msgid ""
+"Do you really want to reset the RRD graphs? This will erase all graph data."
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:193
+msgid "Reset RRD Data"
+msgstr ""
+
+#: src/www/status_rrd_graph_settings.php:200
+msgid ""
+"Graphs will not be allowed to be recreated within a 1 minute interval, "
+"please take this into account after changing the style."
+msgstr ""
+
+#: src/www/status_rrd_graph_tabs.inc:15
+msgid "QueueDrops"
+msgstr ""
+
+#: src/www/status_rrd_graph_tabs.inc:23
+msgid "Cellular"
+msgstr ""
+
+#: src/www/status_services.php:111
+#: src/www/widgets/widgets/services_status.widget.php:86
+msgid "No services found"
+msgstr ""
+
+#: src/www/status_upnp.php:34
+msgid "Rules have been cleared and the daemon restarted"
+msgstr ""
+
+#: src/www/status_upnp.php:44
+msgid "UPnP &amp; NAT-PMP Status"
+msgstr ""
+
+#: src/www/status_upnp.php:65
+msgid "UPnP is currently disabled."
+msgstr ""
+
+#: src/www/status_upnp.php:77
+msgid "Int. Port"
+msgstr ""
+
+#: src/www/status_upnp.php:110
+msgid "Clear"
+msgstr ""
+
+#: src/www/status_upnp.php:110
+msgid "all currently connected sessions"
+msgstr ""
+
+#: src/www/status_wireless.php:74
+msgid ""
+"Rescan has been initiated in the background. Refresh this page in 10 seconds "
+"to see the results."
+msgstr ""
+
+#: src/www/status_wireless.php:89
+msgid "Nearby access points or ad-hoc peers"
+msgstr ""
+
+#: src/www/status_wireless.php:141
+msgid "Associated or ad-hoc peers"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:76
+msgid "You must specify a valid webConfigurator port number"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:80
+msgid "Max Processes must be a number 1 or greater"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:86
+#, php-format
+msgid "Alternate hostname %s is not a valid hostname."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:247
+#, php-format
+msgid "One moment...redirecting to %s in 20 seconds."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:273 src/www/system_advanced_tabs.inc:7
+msgid "Admin Access"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:310
+msgid "webConfigurator"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:332
+msgid "No Certificates have been defined. You must"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:333
+msgid "Create or Import"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:334
+msgid "a Certificate before SSL can be enabled."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:358
+msgid "TCP port"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:363
+msgid ""
+"Enter a custom port number for the webConfigurator above if you want to "
+"override the default (80 for HTTP, 443 for HTTPS). Changes will take effect "
+"immediately after save."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:370
+msgid "Max Processes"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:375
+msgid ""
+"Enter the number of webConfigurator processes you want to run. This defaults "
+"to 2. Increasing this will allow more users/browsers to access the GUI "
+"concurrently."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:382
+msgid "WebGUI redirect"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:385
+msgid "Disable webConfigurator redirect rule"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:387
+msgid ""
+"When this is unchecked, access to the webConfigurator is always permitted "
+"even on port 80, regardless of the listening port configured. Check this box "
+"to disable this automatically added redirect rule. "
+msgstr ""
+
+#: src/www/system_advanced_admin.php:394
+msgid "WebGUI Login Autocomplete"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:397
+msgid "Enable webConfigurator login autocomplete"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:399
+msgid ""
+"When this is checked, login credentials for the webConfigurator may be saved "
+"by the browser. While convenient, some security standards require this to be "
+"disabled. Check this box to enable autocomplete on the login form so that "
+"browsers will prompt to save credentials (NOTE: Some browsers do not respect "
+"this option). "
+msgstr ""
+
+#: src/www/system_advanced_admin.php:406
+msgid "WebGUI login messages"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:409
+msgid "Disable logging of webConfigurator successful logins"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:411
+msgid ""
+"When this is checked, successful logins to the webConfigurator will not be "
+"logged."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:417
+msgid "Anti-lockout"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:426
+msgid "Disable webConfigurator anti-lockout rule"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:428
+#, php-format
+msgid ""
+"When this is unchecked, access to the webConfigurator on the %s interface is "
+"always permitted, regardless of the user-defined firewall rule set. Check "
+"this box to disable this automatically added rule, so access to the "
+"webConfigurator is controlled by the user-defined firewall rules (ensure you "
+"have a firewall rule in place that allows you in, or you will lock yourself "
+"out!)"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:434
+msgid ""
+"Hint: the &quot;Set interface(s) IP address&quot; option in the console menu "
+"resets this setting as well."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:438
+msgid "DNS Rebind Check"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:441
+msgid "Disable DNS Rebinding Checks"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:443
+msgid ""
+"When this is unchecked, your system is protected against <a href=\"http://en."
+"wikipedia.org/wiki/DNS_rebinding\">DNS Rebinding attacks</a>. This blocks "
+"private IP responses from your configured DNS servers. Check this box to "
+"disable this protection if it interferes with webConfigurator access or name "
+"resolution in your environment. "
+msgstr ""
+
+#: src/www/system_advanced_admin.php:450
+msgid "Alternate Hostnames"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:454
+msgid "Alternate Hostnames for DNS Rebinding and HTTP_REFERER Checks"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:456
+msgid ""
+"Here you can specify alternate hostnames by which the router may be queried, "
+"to bypass the DNS Rebinding Attack checks. Separate hostnames with spaces."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:461
+msgid "Browser HTTP_REFERER enforcement"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:464
+msgid "Disable HTTP_REFERER enforcement check"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:466
+msgid ""
+"When this is unchecked, access to the webConfigurator is protected against "
+"HTTP_REFERER redirection attempts. Check this box to disable this protection "
+"if you find that it interferes with webConfigurator access in certain corner "
+"cases such as using external scripts to interact with this system. More "
+"information on HTTP_REFERER is available from <a target='_blank' "
+"href='http://en.wikipedia.org/wiki/HTTP_referrer'>Wikipedia</a>."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:473
+msgid "BEAST Attack Protection"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:476
+msgid "Mitigate the BEAST SSL Attack"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:478
+msgid ""
+"When this is checked, the webConfigurator can mitigate BEAST SSL attacks. "
+msgstr ""
+
+#: src/www/system_advanced_admin.php:481
+#, php-format
+msgid ""
+"This option has been automatically disabled because a conflicting "
+"cryptographic accelerator card has been detected (%s)."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:483
+msgid ""
+"This option is off by default because Hifn accelerators do NOT work with "
+"this option, and the GUI will not function. It is possible that other "
+"accelerators have a similar problem that is not yet known/documented. More "
+"information on BEAST is available from <a target='_blank' href='https://en."
+"wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack'>Wikipedia</a>."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:489
+msgid "Enable XDebug"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:492
+msgid ""
+"Enable debugger / profiler (developer mode, do not enable in production "
+"environment)"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:494
+msgid ""
+"When this is checked, php XDebug will be enabled and profiling output can be "
+"analysed using webgrind which will be available at [this-url]/webgrind/"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:496
+msgid ""
+"For more information about XDebug profiling and how to enable it for your "
+"requests, please visit http://www.xdebug.org/docs/"
+"all_settings#profiler_enable_trigger"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:501
+msgid "Secure Shell"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:505
+msgid "Secure Shell Server"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:508
+msgid "Enable Secure Shell"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:512
+msgid "Root Login"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:515
+msgid "Enable root user login"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:517
+msgid "Root login is generally discouraged. It is advised "
+msgstr ""
+
+#: src/www/system_advanced_admin.php:518
+msgid "to log in via another user and switch to root afterwards."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:522
+msgid "Authentication Method"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:525
+msgid "Enable password login for Secure Shell"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:527
+msgid "When disabled, authorized keys need to be configured for each"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:528
+msgid "user"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:529
+msgid "that has been granted secure shell access."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:533
+msgid "SSH port"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:536
+msgid "Leave this blank for the default of 22."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:544
+msgid "Serial Communications"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:547
+msgid "Serial Terminal"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:550
+msgid ""
+"Enables the first serial port with 115200/8/N/1 by default, or another speed "
+"selectable below."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:551
+msgid ""
+"Note:  This will redirect the console output and messages to the serial "
+"port. You can still access the console menu from the internal video card/"
+"keyboard. A <b>null modem</b> serial cable or adapter is required to use the "
+"serial console."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:555
+msgid "Serial Speed"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:565
+msgid "Allows selection of different speeds for the serial console port."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:569
+msgid "Primary Console"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:575
+msgid ""
+"Select the preferred console if multiple consoles are present. The preferred "
+"console will show OPNsense boot script output. All consoles display OS boot "
+"messages, console messages, and the console menu."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:579
+msgid "Console Options"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:583
+msgid "Console menu"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:586
+msgid "Password protect the console menu"
+msgstr ""
+
+#: src/www/system_advanced_admin.php:588
+msgid "Changes to this option will take effect after a reboot."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:624
+msgid "secure shell configuration has changed. Stopping sshd."
+msgstr ""
+
+#: src/www/system_advanced_admin.php:627
+msgid "secure shell configuration has changed. Restarting sshd."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:67
+msgid "The Firewall Adaptive values must be set together."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:69
+msgid "The Firewall Adaptive Start value must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:72
+msgid "The Firewall Adaptive End value must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:75
+msgid "The Firewall Maximum States value must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:78
+msgid "The Aliases Hostname Resolve Interval value must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:81
+msgid "The Firewall Maximum Table Entries value must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:84
+msgid "The TCP idle timeout must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:87
+msgid "The Reflection timeout must be an integer."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:219
+msgid "Firewall and NAT"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:231
+msgid "as the name says, it is the normal optimization algorithm"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:232
+msgid ""
+"used for high latency links, such as satellite links.  Expires idle "
+"connections later than default"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:233
+msgid ""
+"expires idle connections quicker. More efficient use of CPU and memory but "
+"can drop legitimate idle connections"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:234
+msgid ""
+"tries to avoid dropping any legitimate idle connections at the expense of "
+"increased memory usage and CPU utilization."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:261
+msgid "Firewall Advanced"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:266
+msgid "IP Do-Not-Fragment compatibility"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:269
+msgid "Clear invalid DF bits instead of dropping the packets"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:270
+msgid ""
+"This allows for communications with hosts that generate fragmented packets "
+"with the don't fragment (DF) bit set. Linux NFS is known to do this. This "
+"will cause the filter to not drop such packets but instead clear the don't "
+"fragment bit."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:277
+msgid "IP Random id generation"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:280
+msgid ""
+"Insert a stronger id into IP header of packets passing through the filter."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:281
+msgid ""
+"Replaces the IP identification field of packets with random values to "
+"compensate for operating systems that use predictable values. This option "
+"only applies to packets that are not fragmented after the optional packet "
+"reassembly."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:288
+msgid "Firewall Optimization Options"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:291
+msgid "normal"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:292
+msgid "high-latency"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:293
+msgid "aggressive"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:294
+msgid "conservative"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:304
+msgid "Select the type of state table optimization to use"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:308
+msgid "Disable Firewall"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:311
+msgid "Disable all packet filtering."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:313
+#, php-format
+msgid "Note:  This converts %s into a routing only platform!"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:314
+msgid "Note:  This will also turn off NAT!"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:315
+msgid "If you only want to disable NAT, and not firewall rules, visit the"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:315
+msgid "Outbound NAT"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:320
+msgid "Disable Firewall Scrub"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:323
+msgid ""
+"Disables the PF scrubbing option which can sometimes interfere with NFS and "
+"PPTP traffic."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:328
+msgid "Firewall Adaptive Timeouts"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:330
+msgid ""
+"Timeouts for states can be scaled adaptively as the number of state table "
+"entries grows."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:333
+msgid ""
+"When the number of state entries exceeds this value, adaptive scaling "
+"begins.  All timeout values are scaled linearly with factor (adaptive.end - "
+"number of states) / (adaptive.end - adaptive.start)."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:337
+msgid ""
+"When reaching this number of state entries, all timeout values become zero, "
+"effectively purging all state entries immediately.  This value is used to "
+"define the scale factor, it should not actually be reached (set a lower "
+"state limit, see below)."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:339
+msgid "Note:  Leave this blank for the default(0)."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:343
+msgid "Firewall Maximum States"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:347
+msgid "Maximum number of connections to hold in the firewall state table."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:349
+msgid ""
+"Note:  Leave this blank for the default.  On your system the default size is:"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:353
+msgid "Firewall Maximum Table Entries"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:357
+msgid ""
+"Maximum number of table entries for systems such as aliases, sshlockout, "
+"snort, etc, combined."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:360
+msgid "Note:  Leave this blank for the default."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:362
+msgid "On your system the default size is:"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:368
+msgid "Static route filtering"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:371
+msgid "Bypass firewall rules for traffic on the same interface"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:373
+msgid ""
+"This option only applies if you have defined one or more static routes. If "
+"it is enabled, traffic that enters and leaves through the same interface "
+"will not be checked by the firewall. This may be desirable in some "
+"situations where multiple subnets are connected to the same interface."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:383
+msgid "Disable all auto-added VPN rules."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:385
+msgid "Note: This disables automatically added rules for IPsec, PPTP."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:393
+msgid "Disable reply-to on WAN rules"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:395
+msgid ""
+"With Multi-WAN you generally want to ensure traffic leaves the same "
+"interface it arrives on, hence reply-to is added automatically by default. "
+"When using bridging, you must disable this behavior if the WAN gateway IP is "
+"different from the gateway IP of the hosts behind the bridged interface."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:404
+msgid "Disable Negate rule on policy routing rules"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:406
+msgid ""
+"With Multi-WAN you generally want to ensure traffic reaches directly "
+"connected networks and VPN networks when using policy routing. You can "
+"disable this for special purposes but it requires manually creating rules "
+"for these networks"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:411
+msgid "Aliases Hostnames Resolve Interval"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:415
+msgid ""
+"Interval, in seconds, that will be used to resolve hostnames configured on "
+"aliases."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:417
+msgid "Note:  Leave this blank for the default (300s)."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:421
+msgid "Check certificate of aliases URLs"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:424
+msgid "Verify HTTPS certificates when downloading alias URLs"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:426
+msgid ""
+"Make sure the certificate is valid for all HTTPS addresses on aliases. If "
+"it's not valid or is revoked, do not download it."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:432
+msgid "Bogon Networks"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:436
+msgid "Update Frequency"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:439
+msgid "Monthly"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:440
+msgid "Weekly"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:441
+msgid "Daily"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:444
+msgid ""
+"The frequency of updating the lists of IP addresses that are reserved (but "
+"not RFC 1918) or not yet assigned by IANA."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:452
+msgid "Network Address Translation"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:456
+msgid "NAT Reflection mode for port forwards"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:464
+msgid ""
+"When enabled, this automatically creates additional NAT redirect rules for "
+"access to port forwards on your external IP addresses from within your "
+"internal networks."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:466
+msgid ""
+"The NAT + proxy mode uses a helper program to send packets to the target of "
+"the port forward.  It is useful in setups where the interface and/or gateway "
+"IP used for communication with the target cannot be accurately determined at "
+"the time the rules are loaded.  Reflection rules are not created for ranges "
+"larger than 500 ports and will not be used for more than 1000 ports total "
+"between all port forwards.  Only TCP and UDP protocols are supported."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:468
+msgid ""
+"The pure NAT mode uses a set of NAT rules to direct packets to the target of "
+"the port forward.  It has better scalability, but it must be possible to "
+"accurately determine the interface and gateway IP used for communication "
+"with the target at the time the rules are loaded.  There are no inherent "
+"limits to the number of ports other than the limits of the protocols.  All "
+"protocols available for port forwards are supported."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:470
+#: src/www/system_advanced_firewall.php:490
+msgid ""
+"Individual rules may be configured to override this system setting on a per-"
+"rule basis."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:474
+msgid "Reflection Timeout"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:477
+msgid "Enter value for Reflection timeout in seconds."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:479
+msgid "Note: Only applies to Reflection on port forwards in NAT + proxy mode."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:483
+msgid "Enable NAT Reflection for 1:1 NAT"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:486
+msgid ""
+"Enables the automatic creation of additional NAT redirect rules for access "
+"to 1:1 mappings of your external IP addresses from within your internal "
+"networks."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:488
+msgid ""
+"Note: Reflection on 1:1 mappings is only for the inbound component of the "
+"1:1 mappings.  This functions the same as the pure NAT mode for port "
+"forwards.  For more details, refer to the pure NAT mode description above."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:494
+msgid "Enable automatic outbound NAT for Reflection"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:497
+msgid ""
+"Automatically create outbound NAT rules which assist inbound NAT rules that "
+"direct traffic back out to the same subnet it originated from."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:499
+msgid ""
+"Required for full functionality of the pure NAT mode of NAT Reflection for "
+"port forwards or NAT Reflection for 1:1 NAT."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:501
+msgid ""
+"Note: This only works for assigned interfaces.  Other interfaces require "
+"manually creating the outbound NAT rules that direct the reply packets back "
+"through the router."
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:505
+msgid "FTP Proxy"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:508
+msgid "Enable FTP proxy for clients"
+msgstr ""
+
+#: src/www/system_advanced_firewall.php:510
+msgid ""
+"Configures the FTP proxy to allow for client connections behind the firewall "
+"using active file transfer mode."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:66
+msgid "AMD Geode LX Security Block"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:67
+msgid "AES-NI CPU-based Acceleration"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:69
+msgid "Intel Core* CPU on-die thermal sensor"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:70
+msgid "AMD K8, K10 and K11 CPU on-die thermal sensor"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:81
+msgid "Please select a valid Cryptographic Accelerator."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:84
+msgid "Please select a valid Thermal Hardware Sensor."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:87
+msgid "/tmp Size must be numeric and should not be less than 40MB."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:90
+msgid "/var Size must be numeric and should not be less than 60MB."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:220 src/www/system_advanced_tabs.inc:10
+msgid "Miscellaneous"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:272
+msgid "Proxy support"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:278
+msgid "Proxy URL"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:282
+#, php-format
+msgid "Proxy url for allowing %s to use this proxy to connect outside."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:286
+msgid "Proxy Port"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:290
+#, php-format
+msgid ""
+"Proxy port to use when %s connects to the proxy URL configured above. "
+"Default is 8080 for http protocol or 443 for ssl."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:294
+msgid "Proxy Username"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:298
+#, php-format
+msgid "Proxy username for allowing %s to use this proxy to connect outside"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:302
+msgid "Proxy Pass"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:306
+#, php-format
+msgid "Proxy password for allowing %s to use this proxy to connect outside"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:311 src/www/system_advanced_misc.php:314
+#: src/www/system_advanced_misc.php:335
+msgid "Load Balancing"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:317
+msgid "Use sticky connections"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:318
+msgid ""
+"Successive connections will be redirected to the servers in a round-robin "
+"manner with connections from the same source being sent to the same web "
+"server. This 'sticky connection' will exist as long as there are states that "
+"refer to this connection. Once the states expire, so will the sticky "
+"connection. Further connections from that host will be redirected to the "
+"next web server in the round robin. Changing this option will restart the "
+"Load Balancing service."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:329
+msgid ""
+"Set the source tracking timeout for sticky connections. By default this is "
+"0, so source tracking is removed as soon as the state expires. Setting this "
+"timeout higher will cause the source/destination relationship to persist for "
+"longer periods of time."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:338
+msgid "Allow default gateway switching"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:339
+msgid ""
+"If the link where the default gateway resides fails switch the default "
+"gateway to another available one."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:344
+msgid "Power savings"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:347
+msgid "PowerD"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:350
+msgid "Use PowerD"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:352
+msgid "On AC Power Mode"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:354 src/www/system_advanced_misc.php:362
+msgid "Hiadaptive"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:355 src/www/system_advanced_misc.php:363
+msgid "Adaptive"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:356 src/www/system_advanced_misc.php:364
+msgid "Minimum"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:357 src/www/system_advanced_misc.php:365
+msgid "Maximum"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:360
+msgid "On Battery Power Mode"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:368
+msgid ""
+"The powerd utility monitors the system state and sets various power control "
+"options accordingly.  It offers four modes (maximum, minimum, adaptive and "
+"hiadaptive) that can be individually selected while on AC power or "
+"batteries. The modes maximum, minimum, adaptive and hiadaptive may be "
+"abbreviated max, min, adp, hadp.  Maximum mode chooses the highest "
+"performance values.  Minimum mode selects the lowest performance values to "
+"get the most power savings. Adaptive mode attempts to strike a balance by "
+"degrading performance when the system appears idle and increasing it when "
+"the system is busy.  It offers a good balance between a small performance "
+"loss for greatly increased power savings.  Hiadaptive mode is alike adaptive "
+"mode, but tuned for systems where performance and interactivity are more "
+"important than power consumption.  It raises frequency faster, drops slower "
+"and keeps twice lower CPU load."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:384
+msgid "Cryptographic Hardware Acceleration"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:387
+msgid "Cryptographic Hardware"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:396
+msgid ""
+"A cryptographic accelerator module will use hardware support to speed up "
+"some cryptographic functions on systems which have the chip. Do not enable "
+"this option if you have a Hifn cryptographic acceleration card, as this will "
+"take precedence and the Hifn card will not be used. Acceleration should be "
+"automatic for IPsec when using a cipher supported by your chip, such as "
+"AES-128. OpenVPN should be set for AES-128-CBC and have cryptodev enabled "
+"for hardware acceleration."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:404
+msgid ""
+"If you do not have a crypto chip in your system, this option will have no "
+"effect. To unload the selected module, set this option to 'none' and then "
+"reboot."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:409 src/www/system_advanced_misc.php:412
+msgid "Thermal Sensors"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:415
+msgid "None/ACPI"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:421
+msgid ""
+"If you have a supported CPU, selecting a themal sensor will load the "
+"appropriate driver to read its temperature. Setting this to 'None' will "
+"attempt to read the temperature from an ACPI-compliant motherboard sensor "
+"instead, if one is present."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:425
+msgid ""
+"If you do not have a supported thermal sensor chip in your system, this "
+"option will have no effect. To unload the selected module, set this option "
+"to 'none' and then reboot."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:430
+msgid "IP Security"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:435
+msgid ""
+"These settings have moved to <a href=\"vpn_ipsec_settings.php\">VPN &gt; "
+"IPsec on the Advanced Settings tab</a>."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:442
+msgid "Schedule States"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:446
+msgid ""
+"By default schedules clear the states of existing connections when the "
+"expiration time has come. This option overrides that behavior by not "
+"clearing states for existing connections."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:451
+msgid "Gateway Monitoring"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:454
+msgid "State Killing on Gateway Failure"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:458
+msgid ""
+"The monitoring process will flush states for a gateway that goes down if "
+"this box is not checked. Check this box to disable this behavior."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:462
+msgid "Skip rules when gateway is down"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:466
+msgid ""
+"By default, when a rule has a specific gateway set, and this gateway is "
+"down, rule is created and traffic is sent to default gateway.This option "
+"overrides that behavior and the rule is not created when gateway is down"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:472
+msgid "Enable debugging messages of gateway monitoring daemon"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:476
+msgid ""
+"By default, gateway monitoring does not log its error messages, by toggling "
+"this setting the daemon would enable logging its messages to syslog."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:481
+msgid "RAM Disk Settings (Reboot to Apply Changes)"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:484
+msgid "Use RAM Disks"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:487
+msgid "Use memory file system for /tmp and /var"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:488
+msgid ""
+"Set this if you wish to use /tmp and /var as RAM disks (memory file system "
+"disks) on a full install rather than use the hard disk. Setting this will "
+"cause the data in /tmp and /var to be lost at reboot, including log data. "
+"RRD and DHCP Leases will be retained."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:493
+msgid "/tmp RAM Disk Size"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:497
+msgid ""
+"Set the size, in MB, for the /tmp RAM disk. Leave blank for 40MB. Do not set "
+"lower than 40."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:502
+msgid "/var RAM Disk Size"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:506
+msgid ""
+"Set the size, in MB, for the /var RAM disk. Leave blank for 60MB. Do not set "
+"lower than 60."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:511
+msgid "Periodic RRD Backup"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:513 src/www/system_advanced_misc.php:529
+msgid "Frequency:"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:517 src/www/system_advanced_misc.php:533
+msgid "hour"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:521
+msgid ""
+"This will periodically backup the RRD data so it can be restored "
+"automatically on the next boot. Keep in mind that the more frequent the "
+"backup, the more writes will happen to your media."
+msgstr ""
+
+#: src/www/system_advanced_misc.php:527
+msgid "Periodic DHCP Leases Backup"
+msgstr ""
+
+#: src/www/system_advanced_misc.php:537
+msgid ""
+"This will periodically backup the DHCP leases data so it can be restored "
+"automatically on the next boot. Keep in mind that the more frequent the "
+"backup, the more writes will happen to your media."
+msgstr ""
+
+#: src/www/system_advanced_network.php:55
+msgid "You must specify an IP address to NAT IPv6 packets."
+msgstr ""
+
+#: src/www/system_advanced_network.php:144 src/www/system_advanced_tabs.inc:9
+msgid "Networking"
+msgstr ""
+
+#: src/www/system_advanced_network.php:182
+msgid "IPv6 Options"
+msgstr ""
+
+#: src/www/system_advanced_network.php:187
+#: src/www/system_advanced_network.php:190
+msgid "Allow IPv6"
+msgstr ""
+
+#: src/www/system_advanced_network.php:191
+msgid ""
+"All IPv6 traffic will be blocked by the firewall unless this box is checked."
+msgstr ""
+
+#: src/www/system_advanced_network.php:192
+msgid ""
+"NOTE: This does not disable any IPv6 features on the firewall, it only "
+"blocks traffic."
+msgstr ""
+
+#: src/www/system_advanced_network.php:197
+msgid "IPv6 over IPv4 Tunneling"
+msgstr ""
+
+#: src/www/system_advanced_network.php:200
+msgid "Enable IPv4 NAT encapsulation of IPv6 packets"
+msgstr ""
+
+#: src/www/system_advanced_network.php:201
+msgid ""
+"This provides an RFC 2893 compatibility mechanism that can be used to "
+"tunneling IPv6 packets over IPv4 routing infrastructures. If enabled, don't "
+"forget to add a firewall rule to permit IPv6 packets."
+msgstr ""
+
+#: src/www/system_advanced_network.php:211
+msgid "Prefer IPv4 over IPv6"
+msgstr ""
+
+#: src/www/system_advanced_network.php:214
+msgid "Prefer to use IPv4 even if IPv6 is available"
+msgstr ""
+
+#: src/www/system_advanced_network.php:215
+msgid ""
+"By default, if a hostname resolves IPv6 and IPv4 addresses IPv6 will be "
+"used, if you check this option, IPv4 will be used instead of IPv6."
+msgstr ""
+
+#: src/www/system_advanced_network.php:224
+msgid "Device polling"
+msgstr ""
+
+#: src/www/system_advanced_network.php:227
+msgid "Enable device polling"
+msgstr ""
+
+#: src/www/system_advanced_network.php:228
+#, php-format
+msgid ""
+"Device polling is a technique that lets the system periodically poll network "
+"devices for new data instead of relying on interrupts. This prevents your "
+"webConfigurator, SSH, etc. from being inaccessible due to interrupt floods "
+"when under extreme load. Generally this is not recommended. Not all NICs "
+"support polling; see the %s homepage for a list of supported cards."
+msgstr ""
+
+#: src/www/system_advanced_network.php:232
+msgid "Hardware Checksum Offloading"
+msgstr ""
+
+#: src/www/system_advanced_network.php:235
+msgid "Disable hardware checksum offload"
+msgstr ""
+
+#: src/www/system_advanced_network.php:236
+msgid ""
+"Checking this option will disable hardware checksum offloading. Checksum "
+"offloading is broken in some hardware, particularly some Realtek cards. "
+"Rarely, drivers may have problems with checksum offloading and some specific "
+"NICs."
+msgstr ""
+
+#: src/www/system_advanced_network.php:239
+#: src/www/system_advanced_network.php:250
+#: src/www/system_advanced_network.php:261
+msgid ""
+"This will take effect after you reboot the machine or re-configure each "
+"interface."
+msgstr ""
+
+#: src/www/system_advanced_network.php:243
+msgid "Hardware TCP Segmentation Offloading"
+msgstr ""
+
+#: src/www/system_advanced_network.php:246
+msgid "Disable hardware TCP segmentation offload"
+msgstr ""
+
+#: src/www/system_advanced_network.php:247
+msgid ""
+"Checking this option will disable hardware TCP segmentation offloading (TSO, "
+"TSO4, TSO6). This offloading is broken in some hardware drivers, and may "
+"impact performance with some specific NICs."
+msgstr ""
+
+#: src/www/system_advanced_network.php:254
+msgid "Hardware Large Receive Offloading"
+msgstr ""
+
+#: src/www/system_advanced_network.php:257
+msgid "Disable hardware large receive offload"
+msgstr ""
+
+#: src/www/system_advanced_network.php:258
+msgid ""
+"Checking this option will disable hardware large receive offloading (LRO). "
+"This offloading is broken in some hardware drivers, and may impact "
+"performance with some specific NICs."
+msgstr ""
+
+#: src/www/system_advanced_network.php:265
+msgid "ARP Handling"
+msgstr ""
+
+#: src/www/system_advanced_network.php:268
+msgid "Suppress ARP messages"
+msgstr ""
+
+#: src/www/system_advanced_network.php:269
+msgid ""
+"This option will suppress ARP log messages when multiple interfaces reside "
+"on the same broadcast domain"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:135
+#: src/www/system_advanced_notifications.php:224
+msgid "Test Growl"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:141
+#: src/www/system_advanced_notifications.php:147
+#, php-format
+msgid "This is a test message from %s.  It is safe to ignore this message."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:144
+#: src/www/system_advanced_notifications.php:293
+msgid "Test SMTP"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:151
+#: src/www/system_advanced_tabs.inc:12
+msgid "Notifications"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:181
+msgid "Growl"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:185
+msgid "Disable Growl Notifications"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:188
+msgid ""
+"Check this option to disable growl notifications but preserve the settings "
+"below."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:192
+msgid "Registration Name"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:195
+msgid "Enter the name to register with the Growl server (default: PHP-Growl)."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:199
+msgid "Notification Name"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:202
+#, php-format
+msgid "Enter a name for the Growl notifications (default: %s growl alert)."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:209
+msgid ""
+"This is the IP address that you would like to send growl notifications to."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:216
+msgid "Enter the password of the remote growl notification device."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:225
+msgid ""
+"NOTE: A test notification will be sent even if the service is marked as "
+"disabled."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:230
+msgid "SMTP E-Mail"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:233
+msgid "Disable SMTP Notifications"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:236
+msgid ""
+"Check this option to disable SMTP notifications but preserve the settings "
+"below. Some other mechanisms, such as packages, may need these settings in "
+"place to function."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:240
+msgid "E-Mail server"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:243
+msgid ""
+"This is the FQDN or IP address of the SMTP E-Mail server to which "
+"notifications will be sent."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:247
+msgid "SMTP Port of E-Mail server"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:250
+msgid ""
+"This is the port of the SMTP E-Mail server, typically 25, 587 (submission) "
+"or 465 (smtps)"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:254
+msgid "Secure SMTP Connection"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:261
+msgid "From e-mail address"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:264
+msgid "This is the e-mail address that will appear in the from field."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:268
+msgid "Notification E-Mail address"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:271
+msgid ""
+"Enter the e-mail address that you would like email notifications sent to."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:275
+msgid "Notification E-Mail auth username (optional)"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:278
+msgid "Enter the e-mail address username for SMTP authentication."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:282
+msgid "Notification E-Mail auth password"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:285
+msgid "Enter the e-mail address password for SMTP authentication."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:294
+msgid ""
+"NOTE: A test message will be sent even if the service is marked as disabled."
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:302
+msgid "System Sounds"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:305
+msgid "Startup/Shutdown Sound"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:308
+msgid "Disable the startup/shutdown beep"
+msgstr ""
+
+#: src/www/system_advanced_notifications.php:310
+msgid "When this is checked, startup and shutdown sounds will no longer play."
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:114 src/www/system_advanced_tabs.inc:11
+msgid "System Tunables"
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:132
+msgid ""
+"The firewall tunables have changed.  You must apply the configuration to "
+"take affect."
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:143
+msgid "Tunable Name"
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:171
+msgid "Edit Tunable"
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:176
+msgid "Delete Tunable"
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:199
+msgid "Edit system tunable"
+msgstr ""
+
+#: src/www/system_advanced_sysctl.php:204
+msgid "Tunable"
+msgstr ""
+
+#: src/www/system_advanced_tabs.inc:8
+msgid "Firewall / NAT"
+msgstr ""
+
+#: src/www/system_authservers.php:34
+msgid "Authentication Servers"
+msgstr ""
+
+#: src/www/system_authservers.php:75
+msgid "deleted"
+msgstr ""
+
+#: src/www/system_authservers.php:155 src/www/system_authservers.php:178
+#: src/www/system_authservers.php:463 src/www/system_camanager.php:159
+#: src/www/system_camanager.php:171 src/www/system_camanager.php:186
+#: src/www/system_camanager.php:375 src/www/system_certmanager.php:191
+#: src/www/system_certmanager.php:203 src/www/system_certmanager.php:220
+#: src/www/system_certmanager.php:404 src/www/system_certmanager.php:607
+#: src/www/system_certmanager.php:1001 src/www/system_crlmanager.php:183
+#: src/www/system_crlmanager.php:190 src/www/system_crlmanager.php:310
+#: src/www/system_crlmanager.php:406 src/www/system_usermanager.php:176
+#: src/www/system_usermanager.php:749
+msgid "Descriptive name"
+msgstr ""
+
+#: src/www/system_authservers.php:158 src/www/system_authservers.php:513
+msgid "Port value"
+msgstr ""
+
+#: src/www/system_authservers.php:159 src/www/system_authservers.php:519
+msgid "Transport"
+msgstr ""
+
+#: src/www/system_authservers.php:160 src/www/system_authservers.php:555
+msgid "Protocol version"
+msgstr ""
+
+#: src/www/system_authservers.php:161
+msgid "Search level"
+msgstr ""
+
+#: src/www/system_authservers.php:162
+msgid "User naming Attribute"
+msgstr ""
+
+#: src/www/system_authservers.php:163
+msgid "Group naming Attribute"
+msgstr ""
+
+#: src/www/system_authservers.php:164 src/www/system_authservers.php:701
+msgid "Group member attribute"
+msgstr ""
+
+#: src/www/system_authservers.php:165
+msgid "Authentication container"
+msgstr ""
+
+#: src/www/system_authservers.php:170
+msgid "Bind user DN"
+msgstr ""
+
+#: src/www/system_authservers.php:171
+msgid "Bind Password"
+msgstr ""
+
+#: src/www/system_authservers.php:186 src/www/system_authservers.php:773
+msgid "Authentication port value"
+msgstr ""
+
+#: src/www/system_authservers.php:192 src/www/system_authservers.php:779
+msgid "Accounting port value"
+msgstr ""
+
+#: src/www/system_authservers.php:197 src/www/system_authservers.php:752
+msgid "Shared Secret"
+msgstr ""
+
+#: src/www/system_authservers.php:204
+msgid "The host name contains invalid characters."
+msgstr ""
+
+#: src/www/system_authservers.php:207
+msgid "An authentication server with the same name already exists."
+msgstr ""
+
+#: src/www/system_authservers.php:210
+msgid "RADIUS Timeout value must be numeric and positive."
+msgstr ""
+
+#: src/www/system_authservers.php:400
+msgid "Please fill the required values."
+msgstr ""
+
+#: src/www/system_authservers.php:406
+msgid "Please fill the bind username/password."
+msgstr ""
+
+#: src/www/system_authservers.php:428
+#: src/www/system_usermanager_settings.php:87
+msgid "Popup blocker detected.  Action aborted."
+msgstr ""
+
+#: src/www/system_authservers.php:499
+msgid "LDAP Server Settings"
+msgstr ""
+
+#: src/www/system_authservers.php:506 src/www/system_authservers.php:746
+msgid "Hostname or IP address"
+msgstr ""
+
+#: src/www/system_authservers.php:509
+msgid ""
+"NOTE: When using SSL, this hostname MUST match the Common Name (CN) of the "
+"LDAP server's SSL Certificate."
+msgstr ""
+
+#: src/www/system_authservers.php:534 src/www/vpn_openvpn_client.php:750
+#: src/www/vpn_openvpn_server.php:950
+msgid "Peer Certificate Authority"
+msgstr ""
+
+#: src/www/system_authservers.php:547
+msgid "This option is used if 'SSL Encrypted' option is choosen."
+msgstr ""
+
+#: src/www/system_authservers.php:548
+msgid "It must match with the CA in the AD otherwise problems will arise."
+msgstr ""
+
+#: src/www/system_authservers.php:570
+msgid "Search scope"
+msgstr ""
+
+#: src/www/system_authservers.php:574
+msgid "Level:"
+msgstr ""
+
+#: src/www/system_authservers.php:589
+msgid "Base DN:"
+msgstr ""
+
+#: src/www/system_authservers.php:599
+msgid "Authentication containers"
+msgstr ""
+
+#: src/www/system_authservers.php:603
+msgid "Containers:"
+msgstr ""
+
+#: src/www/system_authservers.php:614
+msgid ""
+"Note: Semi-Colon separated. This will be prepended to the search base dn "
+"above or you can specify full container path containing a dc= component."
+msgstr ""
+
+#: src/www/system_authservers.php:615 src/www/system_authservers.php:616
+#: src/www/system_authservers.php:633
+msgid "Example:"
+msgstr ""
+
+#: src/www/system_authservers.php:623
+msgid "Extended Query"
+msgstr ""
+
+#: src/www/system_authservers.php:640
+msgid "Bind credentials"
+msgstr ""
+
+#: src/www/system_authservers.php:648
+msgid "Use anonymous binds to resolve distinguished names"
+msgstr ""
+
+#: src/www/system_authservers.php:657
+msgid "User DN:"
+msgstr ""
+
+#: src/www/system_authservers.php:673
+msgid "Initial Template"
+msgstr ""
+
+#: src/www/system_authservers.php:689
+msgid "User naming attribute"
+msgstr ""
+
+#: src/www/system_authservers.php:695
+msgid "Group naming attribute"
+msgstr ""
+
+#: src/www/system_authservers.php:707
+msgid "UTF8 Encode"
+msgstr ""
+
+#: src/www/system_authservers.php:715
+msgid ""
+"UTF8 encode LDAP parameters before sending them to the server. Required to "
+"support international characters, but may not be supported by every LDAP "
+"server."
+msgstr ""
+
+#: src/www/system_authservers.php:722
+msgid "Username Alterations"
+msgstr ""
+
+#: src/www/system_authservers.php:730
+msgid ""
+"Do not strip away parts of the username after the @ symbol, e.g. user@host "
+"becomes user when unchecked."
+msgstr ""
+
+#: src/www/system_authservers.php:743
+msgid "Radius Server Settings"
+msgstr ""
+
+#: src/www/system_authservers.php:758
+msgid "Services offered"
+msgstr ""
+
+#: src/www/system_authservers.php:785
+msgid "Authentication Timeout"
+msgstr ""
+
+#: src/www/system_authservers.php:788
+msgid ""
+"This value controls how long, in seconds, that the RADIUS server may take to "
+"respond to an authentication request."
+msgstr ""
+
+#: src/www/system_authservers.php:789
+msgid "If left blank, the default value is 5 seconds."
+msgstr ""
+
+#: src/www/system_authservers.php:790
+msgid ""
+"NOTE: If you are using an interactive two-factor authentication system, "
+"increase this timeout to account for how long it will take the user to "
+"receive and enter a token."
+msgstr ""
+
+#: src/www/system_authservers.php:814
+msgid "Server Name"
+msgstr ""
+
+#: src/www/system_authservers.php:825
+msgid "Additional authentication servers can be added here."
+msgstr ""
+
+#: src/www/system_authservers.php:848
+msgid "Do you really want to delete this Server?"
+msgstr ""
+
+#: src/www/system_camanager.php:34
+msgid "Import an existing Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:35
+msgid "Create an internal Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:36
+msgid "Create an intermediate Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:41
+msgid "Certificate Authority Manager"
+msgstr ""
+
+#: src/www/system_camanager.php:87
+#, php-format
+msgid "Certificate Authority %s and its CRLs (if any) successfully deleted"
+msgstr ""
+
+#: src/www/system_camanager.php:160 src/www/system_camanager.php:410
+#: src/www/system_certmanager.php:192 src/www/system_certmanager.php:623
+msgid "Certificate data"
+msgstr ""
+
+#: src/www/system_camanager.php:162 src/www/system_certmanager.php:195
+msgid "This certificate does not appear to be valid."
+msgstr ""
+
+#: src/www/system_camanager.php:164
+msgid "Encrypted private keys are not yet supported."
+msgstr ""
+
+#: src/www/system_camanager.php:172 src/www/system_camanager.php:188
+#: src/www/system_camanager.php:466 src/www/system_certmanager.php:205
+#: src/www/system_certmanager.php:221 src/www/system_certmanager.php:679
+#: src/www/system_certmanager.php:835 src/www/system_usermanager.php:178
+#: src/www/system_usermanager.php:775
+msgid "Key length"
+msgstr ""
+
+#: src/www/system_camanager.php:173 src/www/system_camanager.php:189
+#: src/www/system_camanager.php:498 src/www/system_certmanager.php:206
+#: src/www/system_certmanager.php:711 src/www/system_crlmanager.php:367
+#: src/www/system_usermanager.php:179 src/www/system_usermanager.php:793
+#: src/www/vpn_ipsec_phase1.php:854 src/www/vpn_ipsec_phase2.php:764
+msgid "Lifetime"
+msgstr ""
+
+#: src/www/system_camanager.php:174 src/www/system_camanager.php:190
+#: src/www/system_certmanager.php:207 src/www/system_certmanager.php:222
+msgid "Distinguished name Country Code"
+msgstr ""
+
+#: src/www/system_camanager.php:175 src/www/system_camanager.php:191
+#: src/www/system_certmanager.php:208 src/www/system_certmanager.php:223
+msgid "Distinguished name State or Province"
+msgstr ""
+
+#: src/www/system_camanager.php:176 src/www/system_camanager.php:192
+#: src/www/system_certmanager.php:209 src/www/system_certmanager.php:224
+msgid "Distinguished name City"
+msgstr ""
+
+#: src/www/system_camanager.php:177 src/www/system_camanager.php:193
+#: src/www/system_certmanager.php:210 src/www/system_certmanager.php:225
+msgid "Distinguished name Organization"
+msgstr ""
+
+#: src/www/system_camanager.php:178 src/www/system_camanager.php:194
+#: src/www/system_certmanager.php:211 src/www/system_certmanager.php:226
+msgid "Distinguished name Email Address"
+msgstr ""
+
+#: src/www/system_camanager.php:179 src/www/system_camanager.php:195
+#: src/www/system_certmanager.php:212 src/www/system_certmanager.php:227
+msgid "Distinguished name Common Name"
+msgstr ""
+
+#: src/www/system_camanager.php:187 src/www/system_camanager.php:449
+msgid "Signing Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:212 src/www/system_certmanager.php:295
+#: src/www/system_certmanager.php:300
+msgid "Please select a valid Key Length."
+msgstr ""
+
+#: src/www/system_camanager.php:214 src/www/system_certmanager.php:297
+#: src/www/system_certmanager.php:302
+msgid "Please select a valid Digest Algorithm."
+msgstr ""
+
+#: src/www/system_camanager.php:297
+msgid "add or import ca"
+msgstr ""
+
+#: src/www/system_camanager.php:383 src/www/system_certmanager.php:587
+#: src/www/system_crlmanager.php:287
+msgid "Method"
+msgstr ""
+
+#: src/www/system_camanager.php:404
+msgid "Existing Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:414 src/www/system_certmanager.php:627
+msgid "Paste a certificate in X.509 PEM format here."
+msgstr ""
+
+#: src/www/system_camanager.php:418
+msgid "(optional)"
+msgstr ""
+
+#: src/www/system_camanager.php:418
+msgid "Certificate Private Key"
+msgstr ""
+
+#: src/www/system_camanager.php:422
+msgid ""
+"Paste the private key for the above certificate here. This is optional in "
+"most cases, but required if you need to generate a Certificate Revocation "
+"List (CRL)."
+msgstr ""
+
+#: src/www/system_camanager.php:428
+msgid "Serial for next certificate"
+msgstr ""
+
+#: src/www/system_camanager.php:431
+msgid ""
+"Enter a decimal number to be used as the serial number for the next "
+"certificate to be created using this CA."
+msgstr ""
+
+#: src/www/system_camanager.php:443
+msgid "Internal Certificate Authority"
+msgstr ""
+
+#: src/www/system_camanager.php:478 src/www/system_certmanager.php:691
+#: src/www/vpn_ipsec.php:334 src/www/vpn_ipsec.php:501
+#: src/www/vpn_ipsec_phase2.php:714 src/www/vpn_openvpn_server.php:1036
+msgid "bits"
+msgstr ""
+
+#: src/www/system_camanager.php:482 src/www/system_certmanager.php:695
+#: src/www/system_certmanager.php:853
+msgid "Digest Algorithm"
+msgstr ""
+
+#: src/www/system_camanager.php:494 src/www/system_certmanager.php:707
+#: src/www/system_certmanager.php:865
+msgid ""
+"NOTE: It is recommended to use an algorithm stronger than SHA1 when possible."
+msgstr ""
+
+#: src/www/system_camanager.php:501 src/www/system_certmanager.php:714
+#: src/www/system_crlmanager.php:370
+msgid "days"
+msgstr ""
+
+#: src/www/system_camanager.php:509 src/www/system_certmanager.php:722
+#: src/www/system_certmanager.php:873
+msgid "Country Code"
+msgstr ""
+
+#: src/www/system_camanager.php:524 src/www/system_certmanager.php:728
+#: src/www/system_certmanager.php:888
+msgid "State or Province"
+msgstr ""
+
+#: src/www/system_camanager.php:528 src/www/system_camanager.php:538
+#: src/www/system_camanager.php:548 src/www/system_camanager.php:558
+#: src/www/system_camanager.php:568
+msgid "ex:"
+msgstr ""
+
+#: src/www/system_camanager.php:530 src/www/system_certmanager.php:894
+msgid "Sachsen"
+msgstr ""
+
+#: src/www/system_camanager.php:534 src/www/system_certmanager.php:734
+#: src/www/system_certmanager.php:898
+msgid "City"
+msgstr ""
+
+#: src/www/system_camanager.php:540 src/www/system_certmanager.php:904
+msgid "Leipzig"
+msgstr ""
+
+#: src/www/system_camanager.php:544 src/www/system_certmanager.php:740
+#: src/www/system_certmanager.php:908
+msgid "Organization"
+msgstr ""
+
+#: src/www/system_camanager.php:550
+msgid "My Company Inc"
+msgstr ""
+
+#: src/www/system_camanager.php:560
+msgid "admin@mycompany.com"
+msgstr ""
+
+#: src/www/system_camanager.php:570
+msgid "internal-ca"
+msgstr ""
+
+#: src/www/system_camanager.php:599 src/www/system_crlmanager.php:548
+msgid "Internal"
+msgstr ""
+
+#: src/www/system_camanager.php:600 src/www/system_certmanager.php:1056
+msgid "Issuer"
+msgstr ""
+
+#: src/www/system_camanager.php:601 src/www/system_certificates_tabs.inc:6
+#: src/www/system_crlmanager.php:549
+msgid "Certificates"
+msgstr ""
+
+#: src/www/system_camanager.php:602 src/www/system_certmanager.php:1057
+msgid "Distinguished Name"
+msgstr ""
+
+#: src/www/system_camanager.php:616 src/www/system_certmanager.php:1073
+msgid "self-signed"
+msgstr ""
+
+#: src/www/system_camanager.php:618 src/www/system_certmanager.php:1075
+msgid "external"
+msgstr ""
+
+#: src/www/system_camanager.php:655 src/www/system_certmanager.php:1117
+msgid "Valid From"
+msgstr ""
+
+#: src/www/system_camanager.php:660 src/www/system_certmanager.php:1122
+msgid "Valid Until"
+msgstr ""
+
+#: src/www/system_camanager.php:666
+msgid "edit CA"
+msgstr ""
+
+#: src/www/system_camanager.php:667
+msgid "export CA cert"
+msgstr ""
+
+#: src/www/system_camanager.php:669
+msgid "export CA private key"
+msgstr ""
+
+#: src/www/system_camanager.php:671
+msgid ""
+"Do you really want to delete this Certificate Authority and its CRLs, and "
+"unreference any associated certificates?"
+msgstr ""
+
+#: src/www/system_camanager.php:671
+msgid "delete ca"
+msgstr ""
+
+#: src/www/system_certificates_tabs.inc:7 src/www/system_crlmanager.php:191
+#: src/www/system_crlmanager.php:316 src/www/vpn_ipsec_phase1.php:177
+#: src/www/vpn_openvpn_client.php:250 src/www/vpn_openvpn_server.php:325
+msgid "Certificate Authority"
+msgstr ""
+
+#: src/www/system_certificates_tabs.inc:8
+msgid "Certificate Revocation"
+msgstr ""
+
+#: src/www/system_certmanager.php:34
+msgid "Import an existing Certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:35
+msgid "Create an internal Certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:36
+msgid "Create a Certificate Signing Request"
+msgstr ""
+
+#: src/www/system_certmanager.php:44
+msgid "Certificate Manager"
+msgstr ""
+
+#: src/www/system_certmanager.php:52
+msgid "Choose an existing certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:92
+#, php-format
+msgid "Certificate %s successfully deleted"
+msgstr ""
+
+#: src/www/system_certmanager.php:193
+msgid "Key data"
+msgstr ""
+
+#: src/www/system_certmanager.php:204 src/www/system_certmanager.php:662
+#: src/www/system_usermanager.php:177 src/www/system_usermanager.php:755
+msgid "Certificate authority"
+msgstr ""
+
+#: src/www/system_certmanager.php:232
+msgid "Existing Certificate Choice"
+msgstr ""
+
+#: src/www/system_certmanager.php:405
+msgid "Final Certificate data"
+msgstr ""
+
+#: src/www/system_certmanager.php:425
+#, php-format
+msgid "The certificate modulus does not match the signing request modulus."
+msgstr ""
+
+#: src/www/system_certmanager.php:456
+msgid "add or import certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:617
+msgid "Import Certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:631
+msgid "Private key data"
+msgstr ""
+
+#: src/www/system_certmanager.php:635
+msgid "Paste a private key in X.509 PEM format here."
+msgstr ""
+
+#: src/www/system_certmanager.php:644
+msgid "Internal Certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:653
+msgid "No internal Certificate Authorities have been defined. You must"
+msgstr ""
+
+#: src/www/system_certmanager.php:655
+msgid "an internal CA before creating an internal certificate."
+msgstr ""
+
+#: src/www/system_certmanager.php:752 src/www/system_certmanager.php:924
+msgid "webadmin@mycompany.com"
+msgstr ""
+
+#: src/www/system_certmanager.php:766 src/www/system_certmanager.php:934
+msgid "www.example.com"
+msgstr ""
+
+#: src/www/system_certmanager.php:770
+msgid "Alternative Names"
+msgstr ""
+
+#: src/www/system_certmanager.php:830
+msgid "External Signing Request"
+msgstr ""
+
+#: src/www/system_certmanager.php:914
+msgid "My Company Inc."
+msgstr ""
+
+#: src/www/system_certmanager.php:946
+msgid "Choose an Existing Certificate"
+msgstr ""
+
+#: src/www/system_certmanager.php:951
+msgid "Existing Certificates"
+msgstr ""
+
+#: src/www/system_certmanager.php:1010
+msgid "Complete Signing Request"
+msgstr ""
+
+#: src/www/system_certmanager.php:1014
+msgid "Signing request data"
+msgstr ""
+
+#: src/www/system_certmanager.php:1018
+msgid ""
+"Copy the certificate signing data from here and forward it to your "
+"certificate authority for signing."
+msgstr ""
+
+#: src/www/system_certmanager.php:1022
+msgid "Final certificate data"
+msgstr ""
+
+#: src/www/system_certmanager.php:1026
+msgid "Paste the certificate received from your certificate authority here."
+msgstr ""
+
+#: src/www/system_certmanager.php:1058 src/www/system_crlmanager.php:550
+msgid "In Use"
+msgstr ""
+
+#: src/www/system_certmanager.php:1081
+msgid "external - signature pending"
+msgstr ""
+
+#: src/www/system_certmanager.php:1151
+msgid "export ca"
+msgstr ""
+
+#: src/www/system_certmanager.php:1155
+msgid "export key"
+msgstr ""
+
+#: src/www/system_certmanager.php:1159
+msgid "export ca cert+user cert+user cert key in .p12 format"
+msgstr ""
+
+#: src/www/system_certmanager.php:1164
+msgid "Do you really want to delete this Certificate?"
+msgstr ""
+
+#: src/www/system_certmanager.php:1164 src/www/system_usermanager.php:703
+msgid "delete cert"
+msgstr ""
+
+#: src/www/system_certmanager.php:1171
+msgid "update csr"
+msgstr ""
+
+#: src/www/system_certmanager.php:1181
+msgid "Note: You can only delete a certificate if it is not currently in use."
+msgstr ""
+
+#: src/www/system_crlmanager.php:35
+msgid "Certificate Revocation List Manager"
+msgstr ""
+
+#: src/www/system_crlmanager.php:38
+msgid "Create an internal Certificate Revocation List"
+msgstr ""
+
+#: src/www/system_crlmanager.php:39
+msgid "Import an existing Certificate Revocation List"
+msgstr ""
+
+#: src/www/system_crlmanager.php:76
+msgid "Invalid CRL reference."
+msgstr ""
+
+#: src/www/system_crlmanager.php:82
+#, php-format
+msgid "Certificate Revocation List %s is in use and cannot be deleted"
+msgstr ""
+
+#: src/www/system_crlmanager.php:88
+#, php-format
+msgid "Certificate Revocation List %s successfully deleted"
+msgstr ""
+
+#: src/www/system_crlmanager.php:127
+msgid "Both the Certificate and CRL must be specified."
+msgstr ""
+
+#: src/www/system_crlmanager.php:131
+msgid "CA mismatch between the Certificate and CRL. Unable to Revoke."
+msgstr ""
+
+#: src/www/system_crlmanager.php:134
+msgid "Cannot revoke certificates for an imported/external CRL."
+msgstr ""
+
+#: src/www/system_crlmanager.php:166 src/www/system_crlmanager.php:168
+#, php-format
+msgid "Deleted Certificate %s from CRL %s"
+msgstr ""
+
+#: src/www/system_crlmanager.php:170
+#, php-format
+msgid "Failed to delete Certificate %s from CRL %s"
+msgstr ""
+
+#: src/www/system_crlmanager.php:184
+msgid "Certificate Revocation List data"
+msgstr ""
+
+#: src/www/system_crlmanager.php:340
+msgid "Existing Certificate Revocation List"
+msgstr ""
+
+#: src/www/system_crlmanager.php:347 src/www/system_crlmanager.php:412
+msgid "CRL data"
+msgstr ""
+
+#: src/www/system_crlmanager.php:351 src/www/system_crlmanager.php:416
+msgid "Paste a Certificate Revocation List in X.509 CRL format here."
+msgstr ""
+
+#: src/www/system_crlmanager.php:361
+msgid "Internal Certificate Revocation List"
+msgstr ""
+
+#: src/www/system_crlmanager.php:371
+msgid "Default: 9999"
+msgstr ""
+
+#: src/www/system_crlmanager.php:375
+msgid "Serial"
+msgstr ""
+
+#: src/www/system_crlmanager.php:379
+msgid "Default: 0"
+msgstr ""
+
+#: src/www/system_crlmanager.php:403
+msgid "Edit Imported Certificate Revocation List"
+msgstr ""
+
+#: src/www/system_crlmanager.php:437
+msgid "Currently Revoked Certificates for CRL"
+msgstr ""
+
+#: src/www/system_crlmanager.php:440 src/www/vpn_openvpn_export.php:882
+msgid "Certificate Name"
+msgstr ""
+
+#: src/www/system_crlmanager.php:441
+msgid "Revocation Reason"
+msgstr ""
+
+#: src/www/system_crlmanager.php:442
+msgid "Revoked At"
+msgstr ""
+
+#: src/www/system_crlmanager.php:451
+msgid "No Certificates Found for this CRL."
+msgstr ""
+
+#: src/www/system_crlmanager.php:469
+msgid "Delete this certificate from the CRL "
+msgstr ""
+
+#: src/www/system_crlmanager.php:469
+msgid "Do you really want to delete this Certificate from the CRL?"
+msgstr ""
+
+#: src/www/system_crlmanager.php:487
+msgid "No Certificates Found for this CA."
+msgstr ""
+
+#: src/www/system_crlmanager.php:493
+msgid "Revoke a Certificate"
+msgstr ""
+
+#: src/www/system_crlmanager.php:498
+msgid "Choose a Certificate to Revoke"
+msgstr ""
+
+#: src/www/system_crlmanager.php:514
+msgid "Reason"
+msgstr ""
+
+#: src/www/system_crlmanager.php:558
+msgid "Additional Certificate Revocation Lists can be added here."
+msgstr ""
+
+#: src/www/system_crlmanager.php:585
+#, php-format
+msgid "Add or Import CRL for %s"
+msgstr ""
+
+#: src/www/system_crlmanager.php:587
+#, php-format
+msgid "Import CRL for %s"
+msgstr ""
+
+#: src/www/system_crlmanager.php:606
+msgid "Export CRL"
+msgstr ""
+
+#: src/www/system_crlmanager.php:610 src/www/system_crlmanager.php:614
+msgid "Edit CRL"
+msgstr ""
+
+#: src/www/system_crlmanager.php:618
+msgid "Do you really want to delete this Certificate Revocation List?"
+msgstr ""
+
+#: src/www/system_crlmanager.php:619
+msgid "Delete CRL"
+msgstr ""
+
+#: src/www/system_firmware_check.php:78 src/www/system_firmware_check.php:80
+#: src/www/widgets/widgets/system_information.widget.php:57
+#: src/www/widgets/widgets/system_information.widget.php:59
+msgid "Click to retry now"
+msgstr ""
+
+#: src/www/system_firmware_check.php:78
+#: src/www/widgets/widgets/system_information.widget.php:57
+msgid "Connection Error"
+msgstr ""
+
+#: src/www/system_firmware_check.php:80
+#: src/www/widgets/widgets/system_information.widget.php:59
+msgid "Repository Problem"
+msgstr ""
+
+#: src/www/system_firmware_check.php:82
+#: src/www/widgets/widgets/system_information.widget.php:61
+msgid " no updates found."
+msgstr ""
+
+#: src/www/system_firmware_check.php:82
+#: src/www/widgets/widgets/system_information.widget.php:61
+msgid "At"
+msgstr ""
+
+#: src/www/system_firmware_check.php:82 src/www/system_firmware_check.php:93
+#: src/www/widgets/widgets/system_information.widget.php:66
+msgid "Click to check now"
+msgstr ""
+
+#: src/www/system_firmware_check.php:84
+msgid "There is a mandatory update for the package manager."
+msgstr ""
+
+#: src/www/system_firmware_check.php:86
+msgid "Upgrade pkg and recheck, there maybe other updates available."
+msgstr ""
+
+#: src/www/system_firmware_check.php:87 src/www/system_firmware_check.php:90
+msgid "Upgrade Now"
+msgstr ""
+
+#: src/www/system_firmware_check.php:88 src/www/system_firmware_check.php:90
+msgid "Re-Check Now"
+msgstr ""
+
+#: src/www/system_firmware_check.php:90
+#: src/www/widgets/widgets/system_information.widget.php:63
+msgid " update(s) are available."
+msgstr ""
+
+#: src/www/system_firmware_check.php:90
+#: src/www/widgets/widgets/system_information.widget.php:63
+msgid "A total of "
+msgstr ""
+
+#: src/www/system_firmware_check.php:93
+msgid "Current status is unknown"
+msgstr ""
+
+#: src/www/system_firmware_check.php:98 src/www/system_firmware_tabs.inc:33
+msgid "Auto Update"
+msgstr ""
+
+#: src/www/system_firmware_check.php:98
+#: src/www/system_firmware_settings.php:46
+msgid "Firmware"
+msgstr ""
+
+#: src/www/system_firmware_settings.php:76
+msgid "Updates"
+msgstr ""
+
+#: src/www/system_firmware_settings.php:82
+msgid "Dashboard check"
+msgstr ""
+
+#: src/www/system_firmware_settings.php:86
+msgid "Disable the automatic dashboard auto-update check."
+msgstr ""
+
+#: src/www/system_firmware_tabs.inc:34
+msgid "Updater Settings"
+msgstr ""
+
+#: src/www/system_gateway_groups.php:85
+msgid "removed gateway group"
+msgstr ""
+
+#: src/www/system_gateway_groups.php:119
+#, php-format
+msgid ""
+"The gateway configuration has been changed.%sYou must apply the changes in "
+"order for them to take effect."
+msgstr ""
+
+#: src/www/system_gateway_groups.php:177
+msgid "Do you really want to delete this gateway group?"
+msgstr ""
+
+#: src/www/system_gateway_groups.php:191
+msgid ""
+"Remember to use these Gateway Groups in firewall rules in order to enable "
+"load balancing, failover, or policy-based routing. Without rules directing "
+"traffic into the Gateway Groups, they will not be used."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:47
+msgid "Member Down"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:48
+msgid "Packet Loss"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:49
+msgid "High Latency"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:50
+msgid "Packet Loss or High Latency"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:82
+msgid "A valid gateway group name must be specified."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:85
+#: src/www/system_gateways_edit.php:112
+msgid "The gateway name must not contain invalid characters."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:94
+msgid "Changing name on a gateway group is not allowed."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:99
+#, php-format
+msgid "A gateway group with this name \"%s\" already exists."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:116
+#, php-format
+msgid ""
+"A gateway group cannot have the same name with a gateway \"%s\" please "
+"choose another name."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:120
+msgid "No gateway(s) have been selected to be used in this group"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:144
+msgid "Edit gateway group"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:226
+msgid "Edit gateway group entry"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:239
+msgid "Gateway Priority"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:273
+msgid "Never"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:274
+msgid "Tier 1"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:275
+msgid "Tier 2"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:276
+msgid "Tier 3"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:277
+msgid "Tier 4"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:278
+msgid "Tier 5"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:294
+msgid "Interface Address"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:312
+msgid "Link Priority"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:313
+msgid ""
+"The priority selected here defines in what order failover and balancing of "
+"links will be done. Multiple links of the same priority will balance "
+"connections until all links in the priority will be exhausted. If all links "
+"in a priority level are exhausted we will use the next available link(s) in "
+"the next priority level."
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:318
+msgid ""
+"The virtual IP field selects what (virtual) IP should be used when this "
+"group applies to a local Dynamic DNS, IPsec or OpenVPN endpoint"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:323
+msgid "Trigger Level"
+msgstr ""
+
+#: src/www/system_gateway_groups_edit.php:334
+msgid "When to trigger exclusion of a member"
+msgstr ""
+
+#: src/www/system_gateways.php:82
+#, php-format
+msgid ""
+"Gateway '%s' cannot be deleted because it is in use on Gateway Group '%s'"
+msgstr ""
+
+#: src/www/system_gateways.php:92
+#, php-format
+msgid ""
+"Gateway '%s' cannot be deleted because it is in use on Static Route '%s'"
+msgstr ""
+
+#: src/www/system_gateways.php:200
+msgid "The gateway configuration has been changed."
+msgstr ""
+
+#: src/www/system_gateways.php:219 src/www/system_gateways_edit.php:724
+msgid "Monitor IP"
+msgstr ""
+
+#: src/www/system_gateways.php:259
+msgid "This gateway is inactive because interface is missing"
+msgstr ""
+
+#: src/www/system_gateways.php:323
+msgid "Edit Gateway"
+msgstr ""
+
+#: src/www/system_gateways.php:331
+msgid "Delete Gateway"
+msgstr ""
+
+#: src/www/system_gateways.php:331
+msgid "Do you really want to delete this gateway?"
+msgstr ""
+
+#: src/www/system_gateways.php:339
+msgid "Add Gateway based on this one"
+msgstr ""
+
+#: src/www/system_gateways.php:359
+msgid "delete selected items"
+msgstr ""
+
+#: src/www/system_gateways.php:360
+msgid "Do you really want to delete the selected gateway items?"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:116
+msgid "A valid gateway IP address must be specified."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:124
+msgid ""
+"Cannot add IPv4 Gateway Address because no IPv4 address could be found on "
+"the interface."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:143 src/www/system_gateways_edit.php:171
+#, php-format
+msgid ""
+"The gateway address %1$s does not lie within one of the chosen interface's "
+"subnets."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:152
+msgid ""
+"Cannot add IPv6 Gateway Address because no IPv6 address could be found on "
+"the interface."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:178
+msgid ""
+"Dynamic gateway values cannot be specified for interfaces with a static IPv4 "
+"configuration."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:182
+msgid ""
+"Dynamic gateway values cannot be specified for interfaces with a static IPv6 "
+"configuration."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:186
+msgid "A valid monitor IP address must be specified."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:212
+msgid "Changing name on a gateway is not allowed."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:217
+#, php-format
+msgid "The gateway name \"%s\" already exists."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:223
+#, php-format
+msgid "The gateway IP address \"%s\" already exists."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:229
+#, php-format
+msgid ""
+"The monitor IP address \"%s\" is already in use. You must choose a different "
+"monitor IP."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:239
+msgid "The low latency threshold needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:242
+msgid "The low latency threshold needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:249
+msgid "The high latency threshold needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:252
+msgid "The high latency threshold needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:259
+msgid "The low Packet Loss threshold needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:262
+msgid "The low Packet Loss threshold needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:265
+msgid "The low Packet Loss threshold needs to be less than 100."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:272
+msgid "The high Packet Loss threshold needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:275
+msgid "The high Packet Loss threshold needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:278
+msgid "The high Packet Loss threshold needs to be 100 or less."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:286
+msgid ""
+"The high latency threshold needs to be higher than the low latency threshold"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:309
+msgid ""
+"The high Packet Loss threshold needs to be higher than the low Packet Loss "
+"threshold"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:331
+msgid "The probe interval needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:334
+msgid "The probe interval needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:341
+msgid "The down time setting needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:344
+msgid "The down time setting needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:352
+msgid "The probe interval needs to be less than the down time setting."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:374
+msgid "The average delay replies qty needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:377
+msgid "The average delay replies qty needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:384
+msgid "The average packet loss probes qty needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:387
+msgid "The average packet loss probes qty needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:394
+msgid "The lost probe delay needs to be a numeric value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:397
+msgid "The lost probe delay needs to be positive."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:513 src/www/system_gateways_edit.php:636
+msgid "Edit gateway"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:655
+msgid "Disable this gateway"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:656
+msgid ""
+"Set this option to disable this gateway without removing it from the list."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:673
+msgid "Choose which interface this gateway applies to."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:690
+msgid "Choose the Internet Protocol this gateway uses."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:697
+msgid "Gateway name"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:704
+msgid "Gateway IP address"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:708 src/www/system_gateways_edit.php:711
+msgid "Default Gateway"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:712
+msgid "This will select the above gateway as the default gateway"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:716 src/www/system_gateways_edit.php:719
+msgid "Disable Gateway Monitoring"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:720
+msgid "This will consider this gateway as always being up"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:733
+msgid "Alternative monitor IP"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:734
+msgid ""
+"Enter an alternative address here to be used to monitor the link. This is "
+"used for the quality RRD graphs as well as the load balancer entries. Use "
+"this if the gateway does not respond to ICMP echo requests (pings)"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:741 src/www/system_gateways_edit.php:744
+msgid "Mark Gateway as Down"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:745
+msgid "This will force this gateway to be considered Down"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:753
+msgid " - Show advanced option"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:758
+msgid "Weight"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:770
+msgid "Weight for this gateway when used in a Gateway Group."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:774
+msgid "Latency thresholds"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:776 src/www/system_gateways_edit.php:788
+msgid "From"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:779 src/www/system_gateways_edit.php:791
+msgid "To"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:786
+msgid "Packet Loss thresholds"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:798
+msgid "Probe Interval"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:804
+msgid ""
+"NOTE: The quality graph is averaged over seconds, not intervals, so as the "
+"probe interval is increased the accuracy of the quality graph is decreased."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:809
+msgid "Down"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:817
+msgid "Average Delay Replies Qty"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:822 src/www/system_gateways_edit.php:832
+#: src/www/system_gateways_edit.php:842
+msgid "Use calculated value."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:827
+msgid "Average Packet Loss Probes Qty"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:837
+msgid "Lost Probe Delay"
+msgstr ""
+
+#: src/www/system_gateways_edit.php:848
+msgid ""
+"The probe interval must be less than the down time, otherwise the gateway "
+"will seem to go down then come up again at the next probe."
+msgstr ""
+
+#: src/www/system_gateways_edit.php:849
+msgid ""
+"The down time defines the length of time before the gateway is marked as "
+"down, but the accuracy is controlled by the probe interval. For example, if "
+"your down time is 40 seconds but on a 30 second probe interval, only one "
+"probe would have to fail before the gateway is marked down at the 40 second "
+"mark. By default, the gateway is considered down after 10 seconds, and the "
+"probe interval is 1 second, so 10 probes would have to fail before the "
+"gateway is marked down."
+msgstr ""
+
+#: src/www/system_gateways_tabs.inc:7
+msgid "Routes"
+msgstr ""
+
+#: src/www/system_general.php:37
+msgid "English"
+msgstr ""
+
+#: src/www/system_general.php:104
+msgid "The hostname may only contain the characters a-z, 0-9 and '-'."
+msgstr ""
+
+#: src/www/system_general.php:107
+msgid "The domain may only contain the characters a-z, 0-9, '-' and '.'."
+msgstr ""
+
+#: src/www/system_general.php:143
+#, php-format
+msgid ""
+"You can not assign a gateway to DNS '%s' server which is on a directly "
+"connected network."
+msgstr ""
+
+#: src/www/system_general.php:152
+msgid ""
+"The time update interval must be either 0 (disabled) or between 6 and 1440."
+msgstr ""
+
+#: src/www/system_general.php:159
+msgid ""
+"A NTP Time Server name may only contain the characters a-z, 0-9, '-' and '.'."
+msgstr ""
+
+#: src/www/system_general.php:306
+msgid "Name of the firewall host, without domain part"
+msgstr ""
+
+#: src/www/system_general.php:317
+msgid ""
+"Do not use 'local' as a domain name. It will cause local hosts running mDNS "
+"(avahi, bonjour, etc.) to be unable to resolve local hosts not running mDNS."
+msgstr ""
+
+#: src/www/system_general.php:319
+msgid "mycorp.com, home, office, private, etc."
+msgstr ""
+
+#: src/www/system_general.php:330
+msgid "DNS Server"
+msgstr ""
+
+#: src/www/system_general.php:332
+msgid "Use gateway"
+msgstr ""
+
+#: src/www/system_general.php:382
+msgid ""
+"Enter IP addresses to be used by the system for DNS resolution. These are "
+"also used for the DHCP service, DNS forwarder and for PPTP VPN clients."
+msgstr ""
+
+#: src/www/system_general.php:387
+msgid ""
+"In addition, optionally select the gateway for each DNS server. When using "
+"multiple WAN connections there should be at least one unique DNS server per "
+"gateway."
+msgstr ""
+
+#: src/www/system_general.php:394
+msgid "Allow DNS server list to be overridden by DHCP/PPP on WAN"
+msgstr ""
+
+#: src/www/system_general.php:397
+#, php-format
+msgid ""
+"If this option is set, %s will use DNS servers assigned by a DHCP/PPP server "
+"on WAN for its own purposes (including the DNS forwarder). However, they "
+"will not be assigned to DHCP and PPTP VPN clients."
+msgstr ""
+
+#: src/www/system_general.php:406
+msgid "Do not use the DNS Forwarder as a DNS server for the firewall"
+msgstr ""
+
+#: src/www/system_general.php:409
+msgid ""
+"By default localhost (127.0.0.1) will be used as the first DNS server where "
+"the DNS Forwarder or DNS Resolver is enabled and set to listen on Localhost, "
+"so system can use the local DNS service to perform lookups. Checking this "
+"box omits localhost from the list of DNS servers."
+msgstr ""
+
+#: src/www/system_general.php:416
+msgid "Time zone"
+msgstr ""
+
+#: src/www/system_general.php:428
+msgid "Select the location closest to you"
+msgstr ""
+
+#: src/www/system_general.php:446
+msgid "NTP time server"
+msgstr ""
+
+#: src/www/system_general.php:451
+msgid ""
+"Use a space to separate multiple hosts (only one required). Remember to set "
+"up at least one DNS server if you enter a host name here!"
+msgstr ""
+
+#: src/www/system_general.php:458
+msgid "Language"
+msgstr ""
+
+#: src/www/system_general.php:471
+msgid "Choose a language for the webConfigurator"
+msgstr ""
+
+#: src/www/system_general.php:476
+msgid "Theme"
+msgstr ""
+
+#: src/www/system_general.php:493
+msgid "This will change the look and feel of"
+msgstr ""
+
+#: src/www/system_groupmanager.php:33
+#: src/www/system_groupmanager_addprivs.php:44
+msgid "Group manager"
+msgstr ""
+
+#: src/www/system_groupmanager.php:57 src/www/vpn_ipsec_mobile.php:627
+msgid "Group"
+msgstr ""
+
+#: src/www/system_groupmanager.php:58 src/www/system_groupmanager.php:82
+#: src/www/system_usermanager.php:77 src/www/system_usermanager.php:92
+msgid "successfully deleted"
+msgstr ""
+
+#: src/www/system_groupmanager.php:81 src/www/system_usermanager.php:91
+msgid "Privilege"
+msgstr ""
+
+#: src/www/system_groupmanager.php:108
+msgid "The group name contains invalid characters."
+msgstr ""
+
+#: src/www/system_groupmanager.php:111
+msgid "The group name is longer than 16 characters."
+msgstr ""
+
+#: src/www/system_groupmanager.php:117
+msgid "Another entry with the same group name already exists."
+msgstr ""
+
+#: src/www/system_groupmanager.php:267 src/www/system_usermanager.php:459
+msgid "Defined by"
+msgstr ""
+
+#: src/www/system_groupmanager.php:274 src/www/system_groupmanager.php:435
+msgid "Group name"
+msgstr ""
+
+#: src/www/system_groupmanager.php:284
+msgid "Group description, for your own information only"
+msgstr ""
+
+#: src/www/system_groupmanager.php:291 src/www/system_usermanager.php:505
+msgid "Group Memberships"
+msgstr ""
+
+#: src/www/system_groupmanager.php:296
+msgid "Not Members"
+msgstr ""
+
+#: src/www/system_groupmanager.php:351
+#: src/www/system_groupmanager_addprivs.php:181
+#: src/www/system_usermanager.php:581
+#: src/www/system_usermanager_addprivs.php:163
+msgid "Hold down CTRL (pc)/COMMAND (mac) key to select multiple items"
+msgstr ""
+
+#: src/www/system_groupmanager.php:358
+msgid "Assigned Privileges"
+msgstr ""
+
+#: src/www/system_groupmanager.php:385 src/www/system_usermanager.php:627
+msgid "Do you really want to delete this privilege?"
+msgstr ""
+
+#: src/www/system_groupmanager.php:386 src/www/system_usermanager.php:628
+msgid "delete privilege"
+msgstr ""
+
+#: src/www/system_groupmanager.php:437
+msgid "Member Count"
+msgstr ""
+
+#: src/www/system_groupmanager.php:448
+msgid "add group"
+msgstr ""
+
+#: src/www/system_groupmanager.php:454
+msgid ""
+"Additional webConfigurator groups can be added here.\n"
+"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tGroup permissions can be assigned which are "
+"inherited by users who are members of the group.\n"
+"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tAn icon that appears grey indicates that it is "
+"a system defined object.\n"
+"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tSome system object properties can be modified "
+"but they cannot be deleted."
+msgstr ""
+
+#: src/www/system_groupmanager.php:510
+msgid "Do you really want to delete this group?"
+msgstr ""
+
+#: src/www/system_groupmanager_addprivs.php:44
+msgid "Add privileges"
+msgstr ""
+
+#: src/www/system_groupmanager_addprivs.php:68
+#: src/www/system_usermanager_addprivs.php:58
+msgid "Selected priveleges"
+msgstr ""
+
+#: src/www/system_groupmanager_addprivs.php:169
+#: src/www/system_usermanager_addprivs.php:151
+msgid "System Privileges"
+msgstr ""
+
+#: src/www/system_groupmanager_addprivs.php:200
+#: src/www/system_usermanager_addprivs.php:169
+msgid "Select a privilege from the list above for a description"
+msgstr ""
+
+#: src/www/system_hasync.php:86
+msgid "High Availability"
+msgstr ""
+
+#: src/www/system_routes.php:45 src/www/system_routes.php:191
+#: src/www/system_routes_edit.php:207
+msgid "Static Routes"
+msgstr ""
+
+#: src/www/system_routes.php:106 src/www/system_routes.php:118
+msgid "removed route to"
+msgstr ""
+
+#: src/www/system_routes.php:133
+msgid "enabled route to"
+msgstr ""
+
+#: src/www/system_routes.php:137
+msgid "disabled route to"
+msgstr ""
+
+#: src/www/system_routes.php:214
+#, php-format
+msgid ""
+"The static route configuration has been changed.%sYou must apply the changes "
+"in order for them to take effect."
+msgstr ""
+
+#: src/www/system_routes.php:322 src/www/system_routes.php:327
+msgid "move selected routes to end"
+msgstr ""
+
+#: src/www/system_routes.php:348
+msgid "delete selected routes"
+msgstr ""
+
+#: src/www/system_routes.php:349
+msgid "Do you really want to delete the selected routes?"
+msgstr ""
+
+#: src/www/system_routes.php:360
+msgid ""
+"Do not enter static routes for networks assigned on any interface of this "
+"firewall.  Static routes are only used for networks reachable via a "
+"different router, and not reachable via your default gateway."
+msgstr ""
+
+#: src/www/system_routes_edit.php:78 src/www/system_routes_edit.php:238
+msgid "Destination network"
+msgstr ""
+
+#: src/www/system_routes_edit.php:79
+msgid "Destination network bit count"
+msgstr ""
+
+#: src/www/system_routes_edit.php:85
+msgid "A valid IPv4 or IPv6 destination network must be specified."
+msgstr ""
+
+#: src/www/system_routes_edit.php:88
+msgid "A valid destination network bit count must be specified."
+msgstr ""
+
+#: src/www/system_routes_edit.php:106
+msgid "A IPv4 subnet can not be over 32 bits."
+msgstr ""
+
+#: src/www/system_routes_edit.php:148
+msgid "A route to these destination networks already exists"
+msgstr ""
+
+#: src/www/system_routes_edit.php:158 src/www/system_routes_edit.php:165
+#, php-format
+msgid "This network conflicts with address configured on interface %s."
+msgstr ""
+
+#: src/www/system_routes_edit.php:207
+msgid "Edit route"
+msgstr ""
+
+#: src/www/system_routes_edit.php:235
+msgid "Edit route entry"
+msgstr ""
+
+#: src/www/system_routes_edit.php:256
+msgid "Destination network for this static route"
+msgstr ""
+
+#: src/www/system_routes_edit.php:274
+msgid "Choose which gateway this route applies to or"
+msgstr ""
+
+#: src/www/system_routes_edit.php:284
+msgid "Add new gateway:"
+msgstr ""
+
+#: src/www/system_routes_edit.php:290
+msgid "Interface:"
+msgstr ""
+
+#: src/www/system_routes_edit.php:304
+msgid "Gateway IP:"
+msgstr ""
+
+#: src/www/system_routes_edit.php:328
+msgid "Disable this static route"
+msgstr ""
+
+#: src/www/system_routes_edit.php:329
+msgid ""
+"Set this option to disable this static route without removing it from the "
+"list."
+msgstr ""
+
+#: src/www/system_routes_edit.php:413
+#, php-format
+msgid "You can manage Gateways %shere%s."
+msgstr ""
+
+#: src/www/system_routes_edit.php:417
+msgid "Sorry, we could not create your gateway at this time."
+msgstr ""
+
+#: src/www/system_usermanager.php:144 src/www/system_usermanager.php:735
+#: src/www/system_usermanager.php:745 src/www/vpn_ipsec_phase1.php:177
+#: src/www/vpn_openvpn_server.php:325
+msgid "Certificate"
+msgstr ""
+
+#: src/www/system_usermanager.php:145
+msgid "association removed."
+msgstr ""
+
+#: src/www/system_usermanager.php:189
+msgid "The username is longer than 16 characters."
+msgstr ""
+
+#: src/www/system_usermanager.php:192
+#: src/www/system_usermanager_passwordmg.php:44
+#: src/www/vpn_l2tp_users_edit.php:88 src/www/vpn_pptp_users_edit.php:87
+msgid "The passwords do not match."
+msgstr ""
+
+#: src/www/system_usermanager.php:202 src/www/vpn_l2tp_users_edit.php:98
+#: src/www/vpn_pptp_users_edit.php:97
+msgid "Another entry with the same username already exists."
+msgstr ""
+
+#: src/www/system_usermanager.php:213
+msgid "That username is reserved by the system."
+msgstr ""
+
+#: src/www/system_usermanager.php:233
+msgid "Invalid expiration date format; use MM/DD/YYYY instead."
+msgstr ""
+
+#: src/www/system_usermanager.php:240
+msgid "Invalid internal Certificate Authority"
+msgstr ""
+
+#: src/www/system_usermanager.php:486
+msgid "(confirmation)"
+msgstr ""
+
+#: src/www/system_usermanager.php:490 src/www/system_usermanager.php:858
+msgid "Full name"
+msgstr ""
+
+#: src/www/system_usermanager.php:494
+msgid "User's full name, for your own information only"
+msgstr ""
+
+#: src/www/system_usermanager.php:498
+msgid "Expiration date"
+msgstr ""
+
+#: src/www/system_usermanager.php:502
+msgid ""
+"Leave blank if the account shouldn't expire, otherwise enter the expiration "
+"date in the following format: mm/dd/yyyy"
+msgstr ""
+
+#: src/www/system_usermanager.php:512
+msgid "Not Member Of"
+msgstr ""
+
+#: src/www/system_usermanager.php:514
+msgid "Member Of"
+msgstr ""
+
+#: src/www/system_usermanager.php:546
+msgid "Add Groups"
+msgstr ""
+
+#: src/www/system_usermanager.php:550
+msgid "Remove Groups"
+msgstr ""
+
+#: src/www/system_usermanager.php:589
+msgid "Effective Privileges"
+msgstr ""
+
+#: src/www/system_usermanager.php:596
+msgid "Inherited From"
+msgstr ""
+
+#: src/www/system_usermanager.php:654
+msgid "User Certificates"
+msgstr ""
+
+#: src/www/system_usermanager.php:659
+msgid "CA"
+msgstr ""
+
+#: src/www/system_usermanager.php:690
+msgid "export private key"
+msgstr ""
+
+#: src/www/system_usermanager.php:696
+msgid "export cert"
+msgstr ""
+
+#: src/www/system_usermanager.php:702
+msgid "(Certificate will not be deleted)"
+msgstr ""
+
+#: src/www/system_usermanager.php:702
+msgid "Do you really want to remove this certificate association?"
+msgstr ""
+
+#: src/www/system_usermanager.php:737
+msgid "Click to create a user certificate."
+msgstr ""
+
+#: src/www/system_usermanager.php:807 src/www/system_usermanager.php:813
+msgid "Authorized keys"
+msgstr ""
+
+#: src/www/system_usermanager.php:809
+msgid "Click to paste an authorized key."
+msgstr ""
+
+#: src/www/system_usermanager.php:824
+msgid "Paste an authorized keys file here."
+msgstr ""
+
+#: src/www/system_usermanager.php:828
+msgid "IPsec Pre-Shared Key"
+msgstr ""
+
+#: src/www/system_usermanager.php:870 src/www/vpn_l2tp_users.php:71
+#: src/www/vpn_pptp_users.php:68
+msgid "add user"
+msgstr ""
+
+#: src/www/system_usermanager.php:877
+msgid ""
+"Additional users can be added here. User permissions for accessing the "
+"webConfigurator can be assigned directly or inherited from group "
+"memberships. An icon that appears grey indicates that it is a system defined "
+"object. Some system object properties can be modified but they cannot be "
+"deleted."
+msgstr ""
+
+#: src/www/system_usermanager.php:882
+msgid ""
+"Accounts created here are also used for other parts of the system such as "
+"OpenVPN, IPsec, and Captive Portal."
+msgstr ""
+
+#: src/www/system_usermanager.php:928
+msgid "edit user"
+msgstr ""
+
+#: src/www/system_usermanager.php:938 src/www/vpn_l2tp_users.php:125
+#: src/www/vpn_pptp_users.php:120
+msgid "Do you really want to delete this user?"
+msgstr ""
+
+#: src/www/system_usermanager.php:939 src/www/vpn_l2tp_users.php:125
+#: src/www/vpn_pptp_users.php:120
+msgid "delete user"
+msgstr ""
+
+#: src/www/system_usermanager_passwordmg.php:33
+msgid "User Password"
+msgstr ""
+
+#: src/www/system_usermanager_passwordmg.php:57
+msgid "Password successfully changed"
+msgstr ""
+
+#: src/www/system_usermanager_passwordmg.php:93
+msgid "Sorry, you cannot change the password for a non-local user."
+msgstr ""
+
+#: src/www/system_usermanager_passwordmg.php:122
+msgid "Confirmation"
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:37
+msgid "User manager settings"
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:47
+msgid "Session timeout must be an integer value."
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:57
+msgid ""
+"The test was not performed because it is supported only for ldap based "
+"backends."
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:123
+msgid "Session Timeout"
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:127
+msgid ""
+"Time in minutes to expire idle management sessions. The default is 4 hours "
+"(240 minutes)."
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:128
+msgid "Enter 0 to never expire sessions. NOTE: This is a security risk!"
+msgstr ""
+
+#: src/www/system_usermanager_settings.php:155
+msgid "Save and Test"
+msgstr ""
+
+#: src/www/system_usermanager_settings_ldapacpicker.php:67
+msgid ""
+"Could not connect to the LDAP server. Please check your LDAP configuration."
+msgstr ""
+
+#: src/www/system_usermanager_settings_ldapacpicker.php:74
+msgid "Please select which containers to Authenticate against:"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:47
+#, php-format
+msgid "Could not find settings for %s%s"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:52
+#, php-format
+msgid "Testing %s LDAP settings... One moment please..."
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:53
+msgid "Attempting connection to"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:57
+msgid "Attempting bind to"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:61
+msgid "Attempting to fetch Organizational Units from"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:66
+msgid "Organization units found"
+msgstr ""
+
+#: src/www/system_usermanager_settings_test.php:72
+#: src/www/system_usermanager_settings_test.php:75
+#: src/www/system_usermanager_settings_test.php:78
+msgid "failed"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:232 src/www/vpn_ipsec_keys.php:90
+#: src/www/vpn_ipsec_mobile.php:332
+msgid "The IPsec tunnel configuration has been changed"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:247
+msgid "IKE"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:248
+msgid "Remote Gateway"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:250
+msgid "P1 Protocol"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:251
+msgid "P1 Transforms"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:252
+msgid "P1 Description"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:332 src/www/vpn_ipsec.php:499
+#: src/www/vpn_ipsec_phase2.php:703
+msgid "auto"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:355 src/www/vpn_ipsec.php:523
+msgid "move selected entries before this"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:362
+msgid "edit phase1 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:370
+msgid "delete phase1 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:372
+msgid ""
+"Do you really want to delete this phase1 and all associated phase2 entries?"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:382
+msgid "copy phase1 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:415
+#, php-format
+msgid "Show %s Phase-2 entries"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:423
+msgid "Local Subnet"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:424
+msgid "Remote Subnet"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:425
+msgid "P2 Protocol"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:426
+msgid "P2 Transforms"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:427
+msgid "P2 Auth Methods"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:528
+msgid "edit phase2 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:532
+msgid "delete phase2 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:534
+msgid "Do you really want to delete this phase2 entry?"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:538
+msgid "add a new Phase 2 based on this one"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:553 src/www/vpn_ipsec.php:559
+msgid "move selected phase2 entries to end"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:567
+msgid "add phase2 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:572 src/www/vpn_ipsec.php:578
+msgid "delete selected phase2 entries"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:579
+msgid "Do you really want to delete the selected phase2 entries?"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:605 src/www/vpn_ipsec.php:612
+msgid "move selected phase1 entries to end"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:621
+msgid "add new phase1"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:631 src/www/vpn_ipsec.php:638
+msgid "delete selected phase1 entries"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:639
+msgid "Do you really want to delete the selected phase1 entries?"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:658
+msgid "Status:IPsec"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:658
+msgid "You can check your IPsec status at"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:659
+msgid "IPsec Debug Mode can be enabled at"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:659 src/www/vpn_ipsec.php:660
+msgid "VPN:IPsec:Advanced Settings"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:660
+msgid "IPsec can be set to prefer older SAs at"
+msgstr ""
+
+#: src/www/vpn_ipsec.php:680
+msgid "Enable IPsec"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:64
+msgid "Deleted IPsec Pre-Shared Key"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:71
+msgid "VPN: IPsec: Keys"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:107 src/www/vpn_ipsec_keys_edit.php:65
+#: src/www/vpn_ipsec_keys_edit.php:137
+msgid "Identifier"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:123
+msgid "ANY USER"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:137
+msgid "edit"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:151
+msgid "edit key"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:152
+msgid "Do you really want to delete this Pre-Shared Key?"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:152
+msgid "delete key"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys.php:176 src/www/vpn_ipsec_keys_edit.php:167
+msgid "PSK for any user can be set by using an identifier of any/ANY"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:70
+msgid "The identifier contains invalid characters."
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:73
+msgid "A user with this name already exists. Add the key to the user instead."
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:80
+msgid "Another entry with the same identifier already exists."
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:97
+msgid "Edited"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:100
+msgid "Added"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:111
+msgid "VPN: IPsec: Edit Pre-Shared Key"
+msgstr ""
+
+#: src/www/vpn_ipsec_keys_edit.php:141
+msgid ""
+"This can be either an IP address, fully qualified domain name or an e-mail "
+"address"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:130
+msgid "Group Authentication Source"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:130
+msgid "User Authentication Source"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:136
+msgid ""
+"A valid IP address for 'Virtual Address Pool Network' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:140
+msgid "A valid value for 'DNS Default Domain' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:147
+msgid "A valid split DNS domain list must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:157
+msgid ""
+"At least one DNS server must be specified to enable the DNS Server option."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:159
+msgid "A valid IP address for 'DNS Server #1' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:161
+msgid "A valid IP address for 'DNS Server #2' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:163
+msgid "A valid IP address for 'DNS Server #3' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:165
+msgid "A valid IP address for 'DNS Server #4' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:170
+msgid ""
+"At least one WINS server must be specified to enable the DNS Server option."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:172
+msgid "A valid IP address for 'WINS Server #1' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:174
+msgid "A valid IP address for 'WINS Server #2' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:179
+msgid "A valid value for 'Login Banner' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:238
+msgid "Mobile"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:337
+msgid "Create Phase1"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:337
+msgid "Please click Create to define one."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:337
+msgid ""
+"Support for IPsec Mobile clients is enabled but a Phase1 definition was not "
+"found"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:357
+msgid "IKE Extensions"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:366
+msgid "Enable IPsec Mobile Client Support"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:379
+msgid "Extended Authentication (Xauth)"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:386
+msgid "User Authentication"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:404
+msgid "Group Authentication"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:409
+msgid "system"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:420
+msgid "Client Configuration (mode-cfg)"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:427
+msgid "Virtual Address Pool"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:436
+msgid "Provide a virtual IP address to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:459
+msgid "Network List"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:468
+msgid "Provide a list of accessible networks to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:475
+msgid "Save Xauth Password"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:484
+msgid "Allow clients to save Xauth passwords (Cisco VPN client only)."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:485
+msgid ""
+"NOTE: With iPhone clients, this does not work when deployed via the iPhone "
+"configuration utility, only by manual entry."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:492 src/www/vpn_openvpn_csc.php:510
+#: src/www/vpn_openvpn_server.php:1511
+msgid "DNS Default Domain"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:501 src/www/vpn_openvpn_csc.php:520
+#: src/www/vpn_openvpn_server.php:1521
+msgid "Provide a default domain name to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:515
+msgid "Split DNS"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:524
+msgid ""
+"Provide a list of split DNS domain names to clients. Enter a comma separated "
+"list."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:525
+msgid ""
+"NOTE: If left blank, and a default domain is set, it will be used for this "
+"value."
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:539 src/www/vpn_openvpn_csc.php:535
+#: src/www/vpn_openvpn_server.php:1536
+msgid "DNS Servers"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:548 src/www/vpn_openvpn_csc.php:545
+#: src/www/vpn_openvpn_server.php:1546
+msgid "Provide a DNS server list to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:581 src/www/vpn_openvpn_csc.php:682
+#: src/www/vpn_openvpn_server.php:1704
+msgid "WINS Servers"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:590 src/www/vpn_openvpn_csc.php:692
+#: src/www/vpn_openvpn_server.php:1714
+msgid "Provide a WINS server list to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:611
+msgid "Phase2 PFS Group"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:620
+msgid ""
+"Provide the Phase2 PFS group to clients ( overrides all mobile phase2 "
+"settings )"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:641
+msgid "Login Banner"
+msgstr ""
+
+#: src/www/vpn_ipsec_mobile.php:650
+msgid "Provide a login banner to clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:162
+msgid "EAP-TLS can only be used with IKEv2 type VPNs."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:182 src/www/vpn_ipsec_phase1.php:635
+msgid "Remote gateway"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:188
+msgid "The P1 lifetime must be an integer."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:192
+msgid "A valid remote gateway address or host name must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:194
+msgid ""
+"A valid remote gateway IPv4 address must be specified or you need to change "
+"protocol to IPv6"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:196
+msgid ""
+"A valid remote gateway IPv6 address must be specified or you need to change "
+"protocol to IPv4"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:205
+#, php-format
+msgid "The remote gateway \"%1$s\" is already used by phase1 \"%2$s\"."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:216
+msgid "There is a Phase 2 using IPv6, you cannot use IPv4."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:220
+msgid "There is a Phase 2 using IPv4, you cannot use IPv6."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:233
+msgid "Please enter an address for 'My Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:236
+msgid "Please enter a keyid tag for 'My Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:239
+msgid "Please enter a fully qualified domain name for 'My Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:242
+msgid "Please enter a user and fully qualified domain name for 'My Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:245
+msgid "Please enter a dynamic domain name for 'My Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:248
+msgid "A valid IP address for 'My identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:251
+msgid "A valid domain name for 'My identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:255
+msgid "A valid FQDN for 'My identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:260
+msgid ""
+"A valid User FQDN in the form of user@my.domain.com for 'My identifier' must "
+"be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:265
+msgid "A valid Dynamic DNS address for 'My identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:275
+msgid "Please enter an address for 'Peer Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:278
+msgid "Please enter a keyid tag for 'Peer Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:281
+msgid "Please enter a fully qualified domain name for 'Peer Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:284
+msgid ""
+"Please enter a user and fully qualified domain name for 'Peer Identifier'"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:287
+msgid "A valid IP address for 'Peer identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:290
+msgid "A valid domain name for 'Peer identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:294
+msgid "A valid FQDN for 'Peer identifier' must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:299
+msgid ""
+"A valid User FQDN in the form of user@my.domain.com for 'Peer identifier' "
+"must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:305
+msgid "A numeric value must be specified for DPD delay."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:308
+msgid "A numeric value must be specified for DPD retries."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:312
+msgid "Valid arguments for IKE type is v1 or v2"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:386 src/www/vpn_ipsec_phase1.php:388
+msgid "Edit Phase 1"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:532 src/www/vpn_ipsec_phase2.php:492
+#: src/www/vpn_ipsec_tabs.inc:3
+msgid "Tunnels"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:533 src/www/vpn_ipsec_phase2.php:493
+#: src/www/vpn_ipsec_tabs.inc:4
+msgid "Mobile clients"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:534 src/www/vpn_ipsec_phase2.php:494
+#: src/www/vpn_ipsec_tabs.inc:5
+msgid "Pre-Shared Keys"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:535 src/www/vpn_ipsec_phase2.php:495
+#: src/www/vpn_ipsec_tabs.inc:6
+msgid "Advanced Settings"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:548 src/www/vpn_openvpn_client.php:464
+#: src/www/vpn_openvpn_csc.php:343 src/www/vpn_openvpn_server.php:762
+msgid "General information"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:558
+msgid "Disable this phase1 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:560
+msgid ""
+"Set this option to disable this phase1 without removing it from the list"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:566
+msgid "Key Exchange version"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:577
+msgid ""
+"Select the KeyExchange Protocol version to be used. Usually known as IKEv1 "
+"or IKEv2."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:581
+msgid "Internet Protocol"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:592
+msgid "Select the Internet Protocol family from this dropdown"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:628
+msgid "Select the interface for the local endpoint of this phase1 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:639
+msgid "Enter the public IP address or host name of the remote gateway"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:666
+msgid "Phase 1 proposal (Authentication)"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:673 src/www/vpn_openvpn_client.php:605
+msgid "Authentication method"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:688 src/www/vpn_ipsec_phase1.php:833
+#: src/www/vpn_ipsec_phase1.php:849
+msgid "Must match the setting chosen on the remote side"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:693
+msgid "Negotiation mode"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:704
+msgid "Aggressive is more flexible, but less secure"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:708
+msgid "My identifier"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:721
+msgid "Peer identifier"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:736
+msgid ""
+"NOTE: This is known as the \"group\" setting on some VPN client "
+"implementations"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:747
+msgid "Input your Pre-Shared Key string"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:752
+msgid "My Certificate"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:766
+msgid "Select a certificate previously configured in the Certificate Manager"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:771
+msgid "My Certificate Authority"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:785
+msgid ""
+"Select a certificate authority previously configured in the Certificate "
+"Manager"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:796
+msgid "Phase 1 proposal (Algorithms)"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:803 src/www/vpn_openvpn_client.php:826
+#: src/www/vpn_openvpn_server.php:1070
+msgid "Encryption algorithm"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:822
+msgid "Hash algorithm"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:838
+msgid "DH key group"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:873
+msgid "Disable Rekey"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:876
+msgid "Whether a connection should be renegotiated when it is about to expire."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:880
+msgid "Disable Reauth"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:883
+msgid ""
+"Whether rekeying of an IKE_SA should also reauthenticate the peer. In IKEv1, "
+"reauthentication is always done."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:887
+msgid "NAT Traversal"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:892
+msgid "Force"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:896
+msgid ""
+"Set this option to enable the use of NAT-T (i.e. the encapsulation of ESP in "
+"UDP packets) if needed, which can help with clients that are behind "
+"restrictive firewalls"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:902
+msgid "Dead Peer Detection"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:905
+msgid "Enable DPD"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:911
+msgid "Delay between requesting peer acknowledgement"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:915
+msgid "retries"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase1.php:917
+msgid "Number of consecutive failures allowed before disconnect"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:123
+msgid "A valid ikeid must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:127
+msgid "Local network type"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:127
+msgid "Unique Identifier"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:130
+msgid "Remote network type"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:140
+msgid "A valid local network bit count must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:143
+msgid "A valid local network IP address must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:145
+msgid ""
+"A valid local network IPv4 address must be specified or you need to change "
+"Mode to IPv6"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:147
+msgid ""
+"A valid local network IPv6 address must be specified or you need to change "
+"Mode to IPv4"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:157 src/www/vpn_ipsec_phase2.php:183
+msgid "Invalid Local Network."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:157 src/www/vpn_ipsec_phase2.php:183
+msgid "has no subnet."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:164
+msgid "A valid NAT local network bit count must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:166
+msgid ""
+"You cannot configure a network type address for NAT while only an address "
+"type is selected for local source."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:169
+msgid "A valid NAT local network IP address must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:171
+msgid ""
+"A valid NAT local network IPv4 address must be specified or you need to "
+"change Mode to IPv6"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:173
+msgid ""
+"A valid NAT local network IPv6 address must be specified or you need to "
+"change Mode to IPv4"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:190
+msgid "A valid remote network bit count must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:193
+msgid "A valid remote network IP address must be specified."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:195
+msgid ""
+"A valid remote network IPv4 address must be specified or you need to change "
+"Mode to IPv6"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:197
+msgid ""
+"A valid remote network IPv6 address must be specified or you need to change "
+"Mode to IPv4"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:215
+msgid "Phase2 with this Local Network is already defined for mobile clients."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:240
+msgid ""
+"Phase2 with this Local/Remote networks combination is already defined for "
+"this Phase1."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:252
+msgid "At least one encryption algorithm must be selected."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:257
+msgid "At least one hashing algorithm needs to be selected."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:266
+msgid "The P2 lifetime must be an integer."
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:313 src/www/vpn_ipsec_phase2.php:315
+msgid "Edit Phase 2"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:512
+msgid "Disable this phase2 entry"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:514
+msgid ""
+"Set this option to disable this phase2 entry without removing it from the "
+"list"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:535
+msgid "Local Network"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:549 src/www/vpn_ipsec_phase2.php:584
+#, php-format
+msgid "%s subnet"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:571
+msgid ""
+"In case you need NAT/BINAT on this network specify the address to be "
+"translated"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:612
+msgid "Remote Network"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:663
+msgid "Phase 2 proposal (SA/Key Exchange)"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:678
+msgid "ESP is encryption, AH is authentication only"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:683
+msgid "Encryption algorithms"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:725
+msgid ""
+"Hint: use 3DES for best compatibility or if you have a hardware crypto "
+"accelerator card. Blowfish is usually the fastest in software encryption"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:731
+msgid "Hash algorithms"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:741
+msgid "PFS key group"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:759
+msgid "Set globally in mobile client options"
+msgstr ""
+
+#: src/www/vpn_ipsec_phase2.php:777
+msgid "Automatically ping host"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:158
+msgid "IPSec Advanced Settings"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:165
+msgid "LAN security associsations"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:168
+msgid "Do not install LAN SPD"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:170
+msgid ""
+"By default, if IPSec is enabled negating SPD are inserted to provide "
+"protection. This behaviour can be changed by enabling this setting which "
+"will prevent installing these SPDs."
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:175
+msgid "Security Associations"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:178
+msgid "Prefer older IPsec SAs"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:180
+msgid ""
+"By default, if several SAs match, the newest one is preferred if it's at "
+"least 30 seconds old. Select this option to always prefer old SAs over new "
+"ones."
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:186
+msgid "IPsec Debug"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:188
+msgid "Start IPSec in debug mode based on sections selected"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:209
+msgid ""
+"Launches IPSec in debug mode so that more verbose logs will be generated to "
+"aid in troubleshooting."
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:214
+msgid "IPsec Reload on Failover"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:217
+msgid "Force IPsec Reload on Failover"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:219
+msgid ""
+"In some circumstances using a gateway group as the interface for an IPsec "
+"tunnel does not function properly, and IPsec must be forcefully reloaded "
+"when a failover occurs. Because this will disrupt all IPsec tunnels, this "
+"behavior is disabled by default. Check this box to force IPsec to fully "
+"reload on failover."
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:226
+msgid "Maximum MSS"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:229
+msgid "Enable MSS clamping on VPN traffic"
+msgstr ""
+
+#: src/www/vpn_ipsec_settings.php:233
+msgid ""
+"Enable MSS clamping on TCP flows over VPN. This helps overcome problems with "
+"PMTUD on IPsec VPN links. If left blank, the default value is 1400 bytes. "
+msgstr ""
+
+#: src/www/vpn_l2tp.php:65 src/www/vpn_pppoe_edit.php:105
+#: src/www/vpn_pptp.php:74
+msgid "Remote start address"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:65 src/www/vpn_pppoe_edit.php:105
+#: src/www/vpn_pppoe_edit.php:439 src/www/vpn_pptp.php:74
+#: src/www/vpn_pptp.php:361
+msgid "Server address"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:70 src/www/vpn_pppoe_edit.php:110
+#: src/www/vpn_pptp.php:79
+msgid "RADIUS server address"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:70 src/www/vpn_pppoe_edit.php:110
+#: src/www/vpn_pptp.php:79 src/www/vpn_pptp.php:441
+msgid "RADIUS shared secret"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:76 src/www/vpn_pppoe_edit.php:116
+#: src/www/vpn_pptp.php:85
+msgid "A valid server address must be specified."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:79 src/www/vpn_pptp.php:88
+msgid ""
+"'Server address' parameter should NOT be set to any IP address currently in "
+"use on this firewall."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:82 src/www/vpn_pppoe_edit.php:118
+#: src/www/vpn_pptp.php:91
+msgid "A valid remote start address must be specified."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:85 src/www/vpn_pppoe_edit.php:120
+#: src/www/vpn_pptp.php:94
+msgid "A valid RADIUS server address must be specified."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:101 src/www/vpn_pppoe_edit.php:127
+#: src/www/vpn_pptp.php:103
+msgid "The specified server address lies in the remote subnet."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:104 src/www/vpn_pptp.php:107
+msgid "The specified server address is equal to the LAN interface address."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:284 src/www/vpn_l2tp_users.php:97
+#: src/www/vpn_l2tp_users_edit.php:156 src/www/vpn_pptp.php:303
+#: src/www/vpn_pptp_users.php:91 src/www/vpn_pptp_users_edit.php:148
+msgid "Configuration"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:306
+msgid "Enable L2TP server"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:327
+msgid "Server Address"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:331
+msgid ""
+"Enter the IP address the L2TP server should give to clients for use as their "
+"\"gateway\""
+msgstr ""
+
+#: src/www/vpn_l2tp.php:333 src/www/vpn_pppoe_edit.php:445
+#: src/www/vpn_pptp.php:367
+msgid "Typically this is set to an unused IP just outside of the client range"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:336 src/www/vpn_pppoe_edit.php:448
+#: src/www/vpn_pptp.php:370
+msgid ""
+"NOTE: This should NOT be set to any IP address currently in use on this "
+"firewall"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:339
+msgid "Remote Address Range"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:342
+msgid "Specify the starting address for the client IP address subnet."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:359 src/www/vpn_pppoe_edit.php:418
+msgid "is"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:363
+msgid "Number of L2TP users"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:376
+msgid "is ten L2TP clients"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:380
+msgid "Secret"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:384
+msgid ""
+"Specify optional secret shared between peers. Required on some devices/"
+"setups."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:388
+msgid "Authentication Type"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:391
+msgid "CHAP"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:395
+msgid "Specifies which protocol to use for authentication."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:399
+msgid "L2TP DNS Servers"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:405
+msgid "primary and secondary DNS servers assigned to L2TP clients"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:409 src/www/vpn_pptp.php:392
+msgid "WINS Server"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:415 src/www/vpn_pppoe_edit.php:476
+#: src/www/vpn_pptp.php:398
+msgid "RADIUS"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:418 src/www/vpn_pppoe_edit.php:479
+#: src/www/vpn_pptp.php:401
+msgid "Use a RADIUS server for authentication"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:419
+msgid ""
+"When set, all users will be authenticated using the RADIUS server specified "
+"below. The local user database will not be used."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:422 src/www/vpn_pppoe_edit.php:485
+#: src/www/vpn_pptp.php:407
+msgid "Enable RADIUS accounting"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:423
+msgid "Sends accounting packets to the RADIUS server."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:426 src/www/vpn_pptp.php:432
+msgid "RADIUS Server"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:430
+msgid "Enter the IP address of the RADIUS server."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:433
+msgid "RADIUS Shared Secret"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:437
+msgid ""
+"Enter the shared secret that will be used to authenticate to the RADIUS "
+"server."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:440
+msgid "RADIUS Issued IP's"
+msgstr ""
+
+#: src/www/vpn_l2tp.php:444
+msgid "Issue IP Addresses via RADIUS server."
+msgstr ""
+
+#: src/www/vpn_l2tp.php:457
+msgid ""
+"Don't forget to add a firewall rule to permit traffic from L2TP clients!"
+msgstr ""
+
+#: src/www/vpn_l2tp_users.php:85 src/www/vpn_pptp_users.php:82
+msgid "Warning: RADIUS is enabled. The local user database will not be used."
+msgstr ""
+
+#: src/www/vpn_l2tp_users.php:87
+msgid "The l2tp user list has been modified"
+msgstr ""
+
+#: src/www/vpn_l2tp_users.php:87
+msgid "Warning: this will terminate all current l2tp sessions!"
+msgstr ""
+
+#: src/www/vpn_l2tp_users.php:87 src/www/vpn_pptp_users.php:84
+msgid "You must apply the changes in order for them to take effect"
+msgstr ""
+
+#: src/www/vpn_l2tp_users_edit.php:85 src/www/vpn_pptp_users_edit.php:84
+msgid "The password contains invalid characters."
+msgstr ""
+
+#: src/www/vpn_l2tp_users_edit.php:91 src/www/vpn_pptp_users_edit.php:90
+msgid "The IP address entered is not valid."
+msgstr ""
+
+#: src/www/vpn_l2tp_users_edit.php:178 src/www/vpn_pptp_users_edit.php:170
+msgid "confirmation"
+msgstr ""
+
+#: src/www/vpn_l2tp_users_edit.php:179
+msgid "If you want to change the users password, enter it here twice."
+msgstr ""
+
+#: src/www/vpn_l2tp_users_edit.php:186 src/www/vpn_pptp_users_edit.php:178
+msgid ""
+"If you want the user to be assigned a specific IP address, enter it here."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:33 src/www/vpn_openvpn_client.php:447
+#: src/www/vpn_openvpn_csc.php:326 src/www/vpn_openvpn_export.php:586
+#: src/www/vpn_openvpn_export_shared.php:287
+#: src/www/vpn_openvpn_server.php:746
+msgid "Client"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:80
+msgid "Client successfully deleted"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:172 src/www/vpn_openvpn_server.php:224
+msgid ""
+"Protocol and IP address families do not match. You cannot select an IPv6 "
+"protocol and an IPv4 IP address."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:174 src/www/vpn_openvpn_server.php:226
+msgid ""
+"Protocol and IP address families do not match. You cannot select an IPv4 "
+"protocol and an IPv6 IP address."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:176 src/www/vpn_openvpn_server.php:228
+msgid ""
+"An IPv4 protocol was selected, but the selected interface has no IPv4 "
+"address."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:178 src/www/vpn_openvpn_server.php:230
+msgid ""
+"An IPv6 protocol was selected, but the selected interface has no IPv6 "
+"address."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:194 src/www/vpn_openvpn_server.php:265
+msgid "The specified 'Local port' is in use. Please select another value"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:213
+msgid "User name and password are required for proxy with authentication."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:232
+msgid "The bandwidth limit must be a positive numeric value."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:240 src/www/vpn_openvpn_server.php:273
+msgid "The field 'Shared Key' does not appear to be valid"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:245 src/www/vpn_openvpn_server.php:278
+msgid "The field 'TLS Authentication Key' does not appear to be valid"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:254 src/www/vpn_openvpn_server.php:329
+msgid "Shared key"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:260
+msgid ""
+"If no Client Certificate is selected, a username and password must be "
+"entered."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:337
+msgid "add client"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:448 src/www/vpn_openvpn_csc.php:327
+#: src/www/vpn_openvpn_export.php:587
+#: src/www/vpn_openvpn_export_shared.php:288
+#: src/www/vpn_openvpn_server.php:747
+msgid "Client Specific Overrides"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:450 src/www/vpn_openvpn_csc.php:329
+#: src/www/vpn_openvpn_export.php:589
+#: src/www/vpn_openvpn_export_shared.php:290
+#: src/www/vpn_openvpn_server.php:749
+msgid "Client Export"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:451 src/www/vpn_openvpn_csc.php:330
+#: src/www/vpn_openvpn_export.php:590
+#: src/www/vpn_openvpn_export_shared.php:291
+#: src/www/vpn_openvpn_server.php:750
+msgid "Shared Key Export"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:478
+msgid "Disable this client"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:483
+msgid ""
+"Set this option to disable this client without removing it from the list"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:487 src/www/vpn_openvpn_server.php:785
+msgid "Server Mode"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:517
+msgid "Device mode"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:568 src/www/vpn_openvpn_server.php:888
+msgid "Local port"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:571
+msgid ""
+"Set this option if you would like to bind to a specific port. Leave this "
+"blank or enter 0 for a random dynamic port."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:575
+msgid "Server host or address"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:581
+msgid "Server port"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:587
+msgid "Proxy host or address"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:593
+msgid "Proxy port"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:599
+msgid "Proxy authentication extra options"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:611
+msgid "basic"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:612
+msgid "ntlm"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:643
+msgid "Server host name resolution"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:653
+msgid "Infinitely resolve server"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:658
+msgid ""
+"Continuously attempt to resolve the server host name. Useful when "
+"communicating with a server that is not permanently connected to the Internet"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:674
+msgid "User Authentication Settings"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:677
+msgid "User name/pass"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:679
+msgid "Leave empty when no user name and password are needed."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:706 src/www/vpn_openvpn_server.php:905
+msgid "Cryptographic Settings"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:709 src/www/vpn_openvpn_server.php:908
+msgid "TLS Authentication"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:719 src/www/vpn_openvpn_server.php:918
+msgid "Enable authentication of TLS packets"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:733 src/www/vpn_openvpn_server.php:932
+msgid "Automatically generate a shared TLS authentication key"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:743 src/www/vpn_openvpn_client.php:819
+#: src/www/vpn_openvpn_server.php:943 src/www/vpn_openvpn_server.php:1063
+msgid "Paste your shared key here"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:769
+msgid "Client Certificate"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:798 src/www/vpn_openvpn_server.php:1041
+msgid "Shared Key"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:809 src/www/vpn_openvpn_server.php:1052
+msgid "Automatically generate a shared key"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:844 src/www/vpn_openvpn_server.php:1088
+msgid "Auth Digest Algorithm"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:859
+msgid ""
+"NOTE: Leave this set to SHA1 unless the server is set to match. SHA1 is the "
+"default for OpenVPN."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:863 src/www/vpn_openvpn_server.php:1107
+msgid "Hardware Crypto"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:884 src/www/vpn_openvpn_csc.php:404
+#: src/www/vpn_openvpn_server.php:1171
+msgid "Tunnel Settings"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:887 src/www/vpn_openvpn_server.php:1174
+msgid "IPv4 Tunnel Network"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:890 src/www/vpn_openvpn_csc.php:410
+msgid ""
+"This is the virtual network used for private communications between this "
+"client and the server expressed using CIDR (eg. 10.0.8.0/24). The first "
+"network address is assumed to be the server address and the second network "
+"address will be assigned to the client virtual interface"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:900 src/www/vpn_openvpn_server.php:1188
+msgid "IPv6 Tunnel Network"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:903
+msgid ""
+"This is the IPv6 virtual network used for private communications between "
+"this client and the server expressed using CIDR (eg. fe80::/64). The first "
+"network address is assumed to be the server address and the second network "
+"address will be assigned to the client virtual interface"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:913 src/www/vpn_openvpn_csc.php:440
+#: src/www/vpn_openvpn_server.php:1315
+msgid "IPv4 Remote Network/s"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:916
+msgid ""
+"These are the IPv4 networks that will be routed through the tunnel, so that "
+"a site-to-site VPN can be established without manually changing the routing "
+"tables. Expressed as a comma-separated list of one or more CIDR ranges. If "
+"this is a site-to-site VPN, enter the remote LAN/s here. You may leave this "
+"blank to only communicate with other clients"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:926 src/www/vpn_openvpn_csc.php:454
+#: src/www/vpn_openvpn_server.php:1329
+msgid "IPv6 Remote Network/s"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:929
+msgid ""
+"These are the IPv6 networks that will be routed through the tunnel, so that "
+"a site-to-site VPN can be established without manually changing the routing "
+"tables. Expressed as a comma-separated list of one or more IP/PREFIX. If "
+"this is a site-to-site VPN, enter the remote LAN/s here. You may leave this "
+"blank to only communicate with other clients"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:939
+msgid "Limit outgoing bandwidth"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:942
+msgid ""
+"Maximum outgoing bandwidth for this tunnel. Leave empty for no limit. The "
+"input value has to be something between 100 bytes/sec and 100 Mbytes/sec "
+"(entered as bytes per second)"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:961
+msgid ""
+"Compress tunnel packets using the LZO algorithm. Adaptive compression will "
+"dynamically disable compression for a period of time if OpenVPN detects that "
+"the data in the packets is not being compressed efficiently."
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:965 src/www/vpn_openvpn_server.php:1368
+msgid "Type-of-Service"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:975 src/www/vpn_openvpn_server.php:1378
+msgid ""
+"Set the TOS IP header value of tunnel packets to match the encapsulated "
+"packet value"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:984 src/www/vpn_openvpn_server.php:1423
+msgid "Disable IPv6"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:994 src/www/vpn_openvpn_server.php:1433
+msgid "Don't forward IPv6 traffic"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1003
+msgid "Don't pull routes"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1013
+msgid "Don't add or remove routes automatically. Instead pass routes to "
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1013
+msgid "script using environmental variables"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1022
+msgid "Don't add/remove routes"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1032
+msgid ""
+"This option effectively bars the server from adding routes to the client's "
+"routing table, however note that this option still allows the server to set "
+"the TCP/IP properties of the client's TUN/TAP interface"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1046 src/www/vpn_openvpn_server.php:1771
+msgid "Advanced configuration"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1055
+msgid ""
+"Enter any additional options you would like to add to the OpenVPN client "
+"configuration here, separated by a semicolon"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1056
+msgid "EXAMPLE:"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1064 src/www/vpn_openvpn_server.php:1789
+msgid "Verbosity level"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1076 src/www/vpn_openvpn_server.php:1802
+msgid ""
+"Each level shows all info from the previous levels. Level 3 is recommended "
+"if you want a good summary of what's happening without being swamped by "
+"output"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1077 src/www/vpn_openvpn_server.php:1803
+msgid "No output except fatal errors"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1078 src/www/vpn_openvpn_server.php:1804
+msgid "Normal usage range"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1079 src/www/vpn_openvpn_server.php:1805
+msgid ""
+"Output R and W characters to the console for each packet read and write, "
+"uppercase is used for TCP/UDP packets and lowercase is used for TUN/TAP "
+"packets"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1080 src/www/vpn_openvpn_server.php:1806
+msgid "Debug info range"
+msgstr ""
+
+#: src/www/vpn_openvpn_client.php:1140
+msgid "delete client"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:32
+msgid "Client Specific Override"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:59
+msgid "Client Specific Override successfully deleted"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:139 src/www/vpn_openvpn_server.php:282
+msgid "The field 'DNS Server #1' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:141 src/www/vpn_openvpn_server.php:284
+msgid "The field 'DNS Server #2' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:143 src/www/vpn_openvpn_server.php:286
+msgid "The field 'DNS Server #3' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:145 src/www/vpn_openvpn_server.php:288
+msgid "The field 'DNS Server #4' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:150 src/www/vpn_openvpn_server.php:293
+msgid "The field 'NTP Server #1' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:152 src/www/vpn_openvpn_server.php:295
+msgid "The field 'NTP Server #2' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:154 src/www/vpn_openvpn_server.php:297
+msgid "The field 'NTP Server #3' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:156 src/www/vpn_openvpn_server.php:299
+msgid "The field 'NTP Server #4' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:162 src/www/vpn_openvpn_server.php:305
+msgid "The field 'WINS Server #1' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:164 src/www/vpn_openvpn_server.php:307
+msgid "The field 'WINS Server #2' must contain a valid IP address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:168 src/www/vpn_openvpn_server.php:311
+msgid ""
+"The field 'NetBIOS Data Distribution Server #1' must contain a valid IP "
+"address"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:301
+msgid "add csc"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:357
+msgid "Disable this override"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:362
+msgid ""
+"Set this option to disable this client-specific override without removing it "
+"from the list"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:366
+msgid "Common name"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:369
+msgid "Enter the client's X.509 common name here"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:380
+msgid "Connection blocking"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:390
+msgid "Block this client connection based on its common name"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:395
+msgid ""
+"Don't use this option to permanently disable a client due to a compromised "
+"key or password. Use a CRL (certificate revocation list) instead"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:407 src/www/vpn_openvpn_server.php:1832
+msgid "Tunnel Network"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:420 src/www/vpn_openvpn_server.php:1289
+msgid "IPv4 Local Network/s"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:423
+msgid ""
+"These are the IPv4 networks that will be accessible from this particular "
+"client. Expressed as a comma-separated list of one or more CIDR ranges."
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:425 src/www/vpn_openvpn_csc.php:435
+msgid ""
+"NOTE: You do not need to specify networks here if they have already been "
+"defined on the main server configuration."
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:430 src/www/vpn_openvpn_server.php:1302
+msgid "IPv6 Local Network/s"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:433
+msgid ""
+"These are the IPv6 networks that will be accessible from this particular "
+"client. Expressed as a comma-separated list of one or more IP/PREFIX "
+"networks."
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:443
+msgid ""
+"These are the IPv4 networks that will be routed to this client specifically "
+"using iroute, so that a site-to-site VPN can be established. Expressed as a "
+"comma-separated list of one or more CIDR ranges. You may leave this blank if "
+"there are no client-side networks to be routed"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:449
+msgid ""
+"NOTE: Remember to add these subnets to the IPv4 Remote Networks list on the "
+"corresponding OpenVPN server settings."
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:457
+msgid ""
+"These are the IPv6 networks that will be routed to this client specifically "
+"using iroute, so that a site-to-site VPN can be established. Expressed as a "
+"comma-separated list of one or more IP/PREFIX networks. You may leave this "
+"blank if there are no client-side networks to be routed"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:463
+msgid ""
+"NOTE: Remember to add these subnets to the IPv6 Remote Networks list on the "
+"corresponding OpenVPN server settings."
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:468 src/www/vpn_openvpn_server.php:1271
+msgid "Redirect Gateway"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:478 src/www/vpn_openvpn_server.php:1281
+msgid "Force all client generated traffic through the tunnel"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:489 src/www/vpn_openvpn_server.php:1447
+msgid "Client Settings"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:492
+msgid "Server Definitions"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:502
+msgid "Prevent this client from receiving any server-defined client settings"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:587 src/www/vpn_openvpn_server.php:1608
+msgid "NTP Servers"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:597 src/www/vpn_openvpn_server.php:1618
+msgid "Provide a NTP server list to clients"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:623 src/www/vpn_openvpn_server.php:1644
+msgid "NetBIOS Options"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:633 src/www/vpn_openvpn_server.php:1654
+msgid "Enable NetBIOS over TCP/IP"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:638 src/www/vpn_openvpn_server.php:1659
+msgid ""
+"If this option is not set, all NetBIOS-over-TCP/IP options (including WINS) "
+"will be disabled"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:645 src/www/vpn_openvpn_server.php:1666
+msgid "Node Type"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:657 src/www/vpn_openvpn_server.php:1679
+msgid ""
+"Possible options: b-node (broadcasts), p-node (point-to-point name queries "
+"to a WINS server), m-node (broadcast then query name server), and h-node "
+"(query name server, then broadcast)"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:671 src/www/vpn_openvpn_server.php:1693
+msgid ""
+"A NetBIOS Scope\tID provides an extended naming service for\tNetBIOS over "
+"TCP/IP. The NetBIOS scope ID isolates NetBIOS traffic on a single network to "
+"only those nodes with the same NetBIOS scope ID"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:723
+msgid ""
+"Enter any additional options you would like to add for this client specific "
+"override, separated by a semicolon"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:724 src/www/vpn_openvpn_server.php:1781
+msgid "EXAMPLE: push \"route 10.0.0.0 255.255.255.0\""
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:774
+msgid "edit csc"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:777
+msgid "Do you really want to delete this csc?"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:778
+msgid "delete csc"
+msgstr ""
+
+#: src/www/vpn_openvpn_csc.php:790
+msgid "Additional OpenVPN client specific overrides can be added here."
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:871
+msgid ""
+"Enter any additional options you would like to add to the OpenVPN client "
+"export configuration here, separated by a line break or semicolon"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:872
+msgid "EXAMPLE: remote-random"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:883
+#: src/www/vpn_openvpn_export_shared.php:449
+msgid "Export"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:888
+msgid "NOTES:"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:889
+msgid ""
+"The &quot;XP&quot; Windows installers work on Windows XP and later versions. "
+"The &quot;win6&quot; Windows installers include a new tap-windows6 driver "
+"that works only on Windows Vista and later."
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:893
+msgid ""
+"If you expect to see a certain client in the list but it is not there, it is "
+"usually due to a CA mismatch between the OpenVPN server instance and the "
+"client certificates found in the User Manager."
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:896
+msgid "Links to OpenVPN clients for various platforms:"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:901
+msgid ""
+"Binaries for Windows, Source for other platforms. Packaged above in the "
+"Windows Installers"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:901
+msgid "OpenVPN Community Client"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:902
+msgid "OpenVPN For Android"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:902
+msgid "Recommended client for Android"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:903
+msgid "FEAT VPN For Android"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:903
+msgid "For older versions of Android"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:904
+msgid "Android (Google Play)"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:904
+msgid "OpenVPN Connect"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:904
+msgid "Recommended client for iOS"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:904
+msgid "iOS (App Store)"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:905
+msgid "Recommended client for Mac OSX"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:905
+msgid "Viscosity"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:906
+msgid "Free client for OSX"
+msgstr ""
+
+#: src/www/vpn_openvpn_export.php:906
+msgid "Tunnelblick"
+msgstr ""
+
+#: src/www/vpn_openvpn_export_shared.php:448
+msgid "Client Type"
+msgstr ""
+
+#: src/www/vpn_openvpn_export_shared.php:455
+msgid ""
+"These are shared key configurations for use in site-to-site tunnels with "
+"other routers. Shared key tunnels are not normally used for remote access "
+"connections to end users."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:81
+msgid "Server successfully deleted"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:239
+msgid ""
+"You must select a Backend for Authentication if the server mode requires "
+"User Auth."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:320
+msgid "The field 'Concurrent connections' must be numeric."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:334
+msgid "Tunnel network"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:337
+msgid ""
+"Using a tunnel network and server bridge settings together is not allowed."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:340
+msgid "Server Bridge DHCP Start and End must both be empty, or defined."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:342
+msgid "Server Bridge DHCP Start must be an IPv4 address."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:344
+msgid "Server Bridge DHCP End must be an IPv4 address."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:346
+msgid "The Server Bridge DHCP range is invalid (start higher than end)."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:477
+msgid "add server"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:776
+msgid "Disable this server"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:781
+msgid ""
+"Set this option to disable this server without removing it from the list"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:800
+msgid "Backend for authentication"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:832
+msgid "Device Mode"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:969
+msgid "Peer Certificate Revocation List"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:994
+msgid "Server Certificate"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1023
+msgid "DH Parameters Length"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1103
+msgid ""
+"NOTE: Leave this set to SHA1 unless all clients are set to match. SHA1 is "
+"the default for OpenVPN."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1125
+msgid "Certificate Depth"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1143
+msgid ""
+"When a certificate-based client logs in, do not accept certificates below "
+"this depth. Useful for denying certificates made with intermediate CAs "
+"generated from the same CA as the server."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1150
+msgid "Strict User/CN Matching"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1160
+msgid ""
+"When authenticating users, enforce a match between the common name of the "
+"client certificate and the username given at login."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1178
+msgid ""
+"This is the IPv4 virtual network used for private communications between "
+"this server and client hosts expressed using CIDR (eg. 10.0.8.0/24). The "
+"first network address will be assigned to the\tserver virtual interface. The "
+"remaining network addresses can optionally be assigned to connecting "
+"clients. (see Address Pool)"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1192
+msgid ""
+"This is the IPv6 virtual network used for private communications between "
+"this server and client hosts expressed using CIDR (eg. fe80::/64). The first "
+"network address will be assigned to the server virtual interface. The "
+"remaining network addresses can optionally be assigned to connecting "
+"clients. (see Address Pool)"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1202
+msgid "Bridge DHCP"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1212
+msgid "Allow clients on the bridge to obtain DHCP."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1220
+msgid "Bridge Interface"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1242
+msgid ""
+"The interface to which this tap instance will be bridged. This is not done "
+"automatically. You must assign this interface and create the bridge "
+"separately. This setting controls which existing IP address and subnet mask "
+"are used by OpenVPN for the bridge. Setting this to 'none' will cause the "
+"Server Bridge DHCP settings below to be ignored."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1251
+msgid "Server Bridge DHCP Start"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1255
+msgid ""
+"When using tap mode as a multi-point server, you may optionally supply a "
+"DHCP range to use on the interface to which this tap instance is bridged. If "
+"these settings are left blank, DHCP will be passed through to the LAN, and "
+"the interface setting above will be ignored."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1264
+msgid "Server Bridge DHCP End"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1293
+msgid ""
+"These are the IPv4 networks that will be accessible from the remote "
+"endpoint. Expressed as a comma-separated list of one or more CIDR ranges. "
+"You may leave this blank if you don't want to add a route to the local "
+"network through this tunnel on the remote machine. This is generally set to "
+"your LAN network"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1306
+msgid ""
+"These are the IPv6 networks that will be accessible from the remote "
+"endpoint. Expressed as a comma-separated list of one or more IP/PREFIX. You "
+"may leave this blank if you don't want to add a route to the local network "
+"through this tunnel on the remote machine. This is generally set to your LAN "
+"network"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1319
+msgid ""
+"These are the IPv4 networks that will be routed through the tunnel, so that "
+"a site-to-site VPN can be established without manually changing the routing "
+"tables. Expressed as a comma-separated list of one or more CIDR ranges. If "
+"this is a site-to-site VPN, enter the remote LAN/s here. You may leave this "
+"blank if you don't want a site-to-site VPN"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1333
+msgid ""
+"These are the IPv6 networks that will be routed through the tunnel, so that "
+"a site-to-site VPN can be established without manually changing the routing "
+"tables. Expressed as a comma-separated list of one or more IP/PREFIX. If "
+"this is a site-to-site VPN, enter the remote LAN/s here. You may leave this "
+"blank if you don't want a site-to-site VPN"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1343
+msgid "Concurrent connections"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1347
+msgid ""
+"Specify the maximum number of clients allowed to concurrently connect to "
+"this server"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1364
+msgid ""
+"Compress tunnel packets using the LZO algorithm. Adaptive compression will "
+"dynamically disable compression for a period of time if OpenVPN detects that "
+"the data in the packets is not being compressed efficiently"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1386
+msgid "Inter-client communication"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1396
+msgid "Allow communication between clients connected to this server"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1404
+msgid "Duplicate Connections"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1414
+msgid ""
+"Allow multiple concurrent connections from clients using the same Common "
+"Name.<br />NOTE: This is not generally recommended, but may be needed for "
+"some scenarios."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1450
+msgid "Dynamic IP"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1460
+msgid ""
+"Allow connected clients to retain their connections if their IP address "
+"changes"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1468
+msgid "Address Pool"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1478
+msgid "Provide a virtual adapter IP address to clients (see Tunnel Network)"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1486
+msgid "Topology"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1496
+msgid ""
+"Allocate only one IP per client (topology subnet), rather than an isolated "
+"subnet per client (topology net30)."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1503
+msgid ""
+"Relevant when supplying a virtual adapter IP address to clients when using "
+"tun mode on IPv4."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1504
+msgid ""
+"Some clients may require this even for IPv6, such as OpenVPN Connect (iOS/"
+"Android). Others may break if it is present, such as older versions of "
+"OpenVPN or clients such as Yealink phones."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1589
+msgid "Force DNS cache update"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1599
+msgid ""
+"Run ''net stop dnscache'', ''net start dnscache'', ''ipconfig /flushdns'' "
+"and ''ipconfig /registerdns'' on connection initiation. This is known to "
+"kick Windows into recognizing pushed DNS servers."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1689
+msgid "Scope ID"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1740
+msgid "Client Management Port"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1750
+msgid ""
+"Use a different management port on clients. The default port is 166. Specify "
+"a different port if the client machines need to select from multiple OpenVPN "
+"links."
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1780
+msgid ""
+"Enter any additional options you would like to add to the OpenVPN server "
+"configuration here, separated by a semicolon"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1831
+msgid "Protocol / Port"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1861
+msgid "edit server"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1863
+msgid "Do you really want to delete this server?"
+msgstr ""
+
+#: src/www/vpn_openvpn_server.php:1863
+msgid "delete server"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:87
+msgid "add a new pppoe instance"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:100
+msgid "The PPPoE entry list has been changed"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:118
+msgid "Number of users"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:138
+msgid "edit pppoe instance"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:140
+msgid ""
+"Do you really want to delete this entry? All elements that still use it will "
+"become invalid (e.g. filter rules)!"
+msgstr ""
+
+#: src/www/vpn_pppoe.php:140
+msgid "delete pppoe instance"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:129
+msgid "The specified server address is equal to an interface ip address."
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:134
+#, php-format
+msgid "No password specified for username %s"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:136
+#, php-format
+msgid "Incorrect ip address  specified for username %s"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:142
+msgid "Wrong data submitted"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:231
+msgid "PPPoE Server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:369
+msgid "PPPoE server configuration"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:382
+msgid "Enable PPPoE server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:405
+msgid "Subnet netmask"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:418
+msgid "Hint"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:422
+msgid "No. PPPoE users"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:435
+msgid "Hint: 10 is ten PPPoE clients"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:443
+msgid ""
+"Enter the IP address the PPPoE server should give to clients for use as "
+"their \"gateway\""
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:451 src/www/vpn_pptp.php:373
+msgid "Remote address range"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:455
+msgid "Specify the starting address for the client IP address subnet"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:472
+msgid ""
+"If entered they will be given to all PPPoE clients, else LAN DNS and one WAN "
+"DNS will go to all clients"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:480 src/www/vpn_pptp.php:402
+msgid ""
+"When set, all users will be authenticated using the RADIUS server specified "
+"below. The local user database will not be used"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:487 src/www/vpn_pptp.php:408
+msgid "Sends accounting packets to the RADIUS server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:489
+msgid "Use Backup RADIUS Server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:490
+msgid ""
+"When set, if primary server fails all requests will be sent via backup server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:493
+msgid "NAS IP Address"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:496
+msgid "RADIUS server NAS IP Address"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:500 src/www/vpn_pptp.php:426
+msgid "RADIUS Accounting Update"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:503
+msgid "RADIUS accounting update period in seconds"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:507 src/www/vpn_pptp.php:415
+msgid "RADIUS issued IPs"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:510
+msgid "Issue IP Addresses via RADIUS server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:513
+msgid "RADIUS server Primary"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:518
+msgid ""
+"Enter the IP address, authentication port and accounting port (optional) of "
+"the RADIUS server."
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:519 src/www/vpn_pppoe_edit.php:535
+msgid "standard port 1812 and 1813 accounting"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:522
+msgid "RADIUS primary shared secret"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:525 src/www/vpn_pppoe_edit.php:542
+#: src/www/vpn_pptp.php:445
+msgid ""
+"Enter the shared secret that will be used to authenticate to the RADIUS "
+"server"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:529
+msgid "RADIUS server Secondary"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:534
+msgid ""
+"Enter the IP address, authentication port and accounting port (optional) of "
+"the backup RADIUS server."
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:538
+msgid "RADIUS secondary shared secret"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:546
+msgid "User (s)"
+msgstr ""
+
+#: src/www/vpn_pppoe_edit.php:612
+msgid ""
+"don't forget to add a firewall rule to permit traffic from PPPoE clients"
+msgstr ""
+
+#: src/www/vpn_pptp.php:112
+msgid "PPTP redirection target address"
+msgstr ""
+
+#: src/www/vpn_pptp.php:117
+msgid "A valid target address must be specified."
+msgstr ""
+
+#: src/www/vpn_pptp.php:188 src/www/vpn_pptp_users.php:63
+#: src/www/vpn_pptp_users_edit.php:128
+msgid "VPN PPTP"
+msgstr ""
+
+#: src/www/vpn_pptp.php:297
+msgid ""
+"PPTP is no longer considered a secure VPN technology because it relies upon "
+"MS-CHAPv2 which has been compromised. If you continue to use PPTP be aware "
+"that intercepted traffic can be decrypted by a third party, so it should be "
+"considered unencrypted. We advise migrating to another VPN type such as "
+"OpenVPN or IPsec.<br /><br /><a href=\"https://isc.sans.edu/diary/End+of+Days"
+"+for+MS-CHAPv2/13807\">Read More</a>"
+msgstr ""
+
+#: src/www/vpn_pptp.php:326
+msgid "Redirect incoming PPTP connections to"
+msgstr ""
+
+#: src/www/vpn_pptp.php:329
+msgid "PPTP redirection"
+msgstr ""
+
+#: src/www/vpn_pptp.php:333
+msgid ""
+"Enter the IP address of a host which will accept incoming PPTP connections"
+msgstr ""
+
+#: src/www/vpn_pptp.php:340
+msgid "Enable PPTP server"
+msgstr ""
+
+#: src/www/vpn_pptp.php:343
+msgid "No. PPTP users"
+msgstr ""
+
+#: src/www/vpn_pptp.php:357
+msgid "Hint: 10 is ten PPTP clients"
+msgstr ""
+
+#: src/www/vpn_pptp.php:365
+msgid ""
+"Enter the IP address the PPTP server should give to clients for use as their "
+"\"gateway\""
+msgstr ""
+
+#: src/www/vpn_pptp.php:378
+msgid "Specify the starting address for the client IP subnet"
+msgstr ""
+
+#: src/www/vpn_pptp.php:382
+msgid "PPTP DNS Servers"
+msgstr ""
+
+#: src/www/vpn_pptp.php:388
+msgid "primary and secondary DNS servers assigned to PPTP clients"
+msgstr ""
+
+#: src/www/vpn_pptp.php:411
+msgid "Secondary RADIUS server for failover authentication"
+msgstr ""
+
+#: src/www/vpn_pptp.php:412
+msgid ""
+"When set, all requests will go to the secondary server when primary fails"
+msgstr ""
+
+#: src/www/vpn_pptp.php:416
+msgid "Issue IP addresses via RADIUS server"
+msgstr ""
+
+#: src/www/vpn_pptp.php:420
+msgid "RADIUS NAS IP"
+msgstr ""
+
+#: src/www/vpn_pptp.php:438 src/www/vpn_pptp.php:455
+msgid ""
+"Enter the IP address, RADIUS port, and RADIUS accounting port of the RADIUS "
+"server"
+msgstr ""
+
+#: src/www/vpn_pptp.php:458
+msgid "Secondary RADIUS shared secret"
+msgstr ""
+
+#: src/www/vpn_pptp.php:462
+msgid ""
+"Enter the shared secret that will be used to authenticate to the secondary "
+"RADIUS server"
+msgstr ""
+
+#: src/www/vpn_pptp.php:472
+msgid "Require 128-bit encryption"
+msgstr ""
+
+#: src/www/vpn_pptp.php:473
+msgid ""
+"When set, only 128-bit encryption will be accepted. Otherwise 40-bit and 56-"
+"bit encryption will be accepted as well. Note that encryption will always be "
+"forced on PPTP connections (i.e. unencrypted connections will not be "
+"accepted)"
+msgstr ""
+
+#: src/www/vpn_pptp.php:487
+msgid "add a firewall rule"
+msgstr ""
+
+#: src/www/vpn_pptp.php:487
+msgid "don't forget to "
+msgstr ""
+
+#: src/www/vpn_pptp.php:487
+msgid "to permit traffic from PPTP clients"
+msgstr ""
+
+#: src/www/vpn_pptp_users.php:84
+msgid "The PPTP user list has been modified"
+msgstr ""
+
+#: src/www/vpn_pptp_users.php:84
+msgid "Warning: this will terminate all current PPTP sessions"
+msgstr ""
+
+#: src/www/vpn_pptp_users_edit.php:81
+msgid "The password cannot start with '!'."
+msgstr ""
+
+#: src/www/vpn_pptp_users_edit.php:171
+msgid "If you want to change the users' password, enter it here twice."
+msgstr ""
+
+#: src/www/widgets/widgets/dyn_dns_status.widget.php:74
+msgid "Int."
+msgstr ""
+
+#: src/www/widgets/widgets/dyn_dns_status.widget.php:125
+msgid "Checking ..."
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:82
+msgid "Packets In"
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:85
+msgid "Packets Out"
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:88
+msgid "Bytes In"
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:91
+msgid "Bytes Out"
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:94
+msgid "Errors In"
+msgstr ""
+
+#: src/www/widgets/widgets/interface_statistics.widget.php:97
+msgid "Errors Out"
+msgstr ""
+
+#: src/www/widgets/widgets/ipsec.widget.php:94
+msgid "Active Tunnels"
+msgstr ""
+
+#: src/www/widgets/widgets/ipsec.widget.php:95
+msgid "Inactive Tunnels"
+msgstr ""
+
+#: src/www/widgets/widgets/ipsec.widget.php:96
+msgid "Mobile Users"
+msgstr ""
+
+#: src/www/widgets/widgets/log.widget.php:199
+msgid "IF"
+msgstr ""
+
+#: src/www/widgets/widgets/smart_status.widget.php:39
+msgid "Drive"
+msgstr ""
+
+#: src/www/widgets/widgets/smart_status.widget.php:40
+msgid "Ident"
+msgstr ""
+
+#: src/www/widgets/widgets/smart_status.widget.php:41
+msgid "SMART Status"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:63
+msgid "Click to upgrade"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:106
+msgid "Versions"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:128
+msgid "CPU Type"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:143
+msgid "Hardware crypto"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:148
+msgid "Uptime"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:152
+msgid "Current date/time"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:158
+msgid "DNS server(s)"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:170
+msgid "Last config change"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:175
+msgid "State table size"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:188
+msgid "Show states"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:192
+msgid "MBUF Usage"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:209
+msgid "Temperature"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:223
+msgid "Load average"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:229
+msgid "CPU usage"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:241
+msgid "Memory usage"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:254
+msgid "SWAP usage"
+msgstr ""
+
+#: src/www/widgets/widgets/system_information.widget.php:267
+msgid "Disk usage"
+msgstr ""
+
+#: src/www/widgets/widgets/traffic_graphs.widget.php:132
+msgid "Scale up"
+msgstr ""
+
+#: src/www/widgets/widgets/traffic_graphs.widget.php:137
+msgid "Scale follow"
+msgstr ""
+
+#: src/www/widgets/widgets/wake_on_lan.widget.php:43
+msgid "Computer / Device"
+msgstr ""
+
+#: src/www/widgets/widgets/wake_on_lan.widget.php:69
+msgid "Wake Up"
+msgstr ""
+
+#: src/www/widgets/widgets/wake_on_lan.widget.php:74
+msgid "No saved WoL addresses"
+msgstr ""
+
+#: src/www/wizard.php:52 src/www/wizard.php:60
+#, php-format
+msgid "ERROR:  Could not open %s."
+msgstr ""
+
+#: src/www/wizard.php:66
+#, php-format
+msgid "ERROR: Could not parse /usr/local/www/wizards/%s file."
+msgstr ""
+
+#: src/www/wizards/openvpn_wizard.inc:625
+#: src/www/wizards/openvpn_wizard.inc:642
+#, php-format
+msgid "OpenVPN %s wizard"
+msgstr ""
+
+#: src/www/wizards/openvpn_wizard.inc:637
+#: src/www/wizards/openvpn_wizard.inc:652
+msgid "OpenVPN Wizard"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:58
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:61
+msgid "You need to specify the number of connections."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:63
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:66
+msgid "The number of connections should be greater than 1."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:88
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:102
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:109
+msgid "You have less interfaces than number of connections!"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:300
+msgid "You cannot specify bandwidth smaller than 1!"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:311
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:334
+msgid "You cannot select the same interface for local and outside."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:493
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:589
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:536
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:639
+msgid ""
+"Address must be a valid IP address or Firewall Alias.  Please correct this "
+"value to continue."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:577
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:606
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:627
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:654
+msgid "Only percentage bandwidth specification is allowed."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:760
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1144
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:809
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1207
+msgid ""
+"Custom Bandwidths are greater than 30%. Please lower them for the wizard to "
+"continue."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1446
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1515
+msgid "Penalty Box"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1453
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1473
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1487
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1504
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1523
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1547
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1626
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1522
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1543
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1557
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1574
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1593
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1617
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1644
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1697
+msgid "Traffic Shaper Wizard"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1465
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1535
+msgid "Connections From Upstream SIP Server"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_dedicated.inc:1479
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:1549
+msgid "Connections To Upstream SIP Server"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:72
+msgid "You need to specify the number of LAN type interfaces."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:77
+msgid "The number of LAN type interfaces should be greater than 1."
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:321
+msgid "You cannot specify 0 bandwidth!"
+msgstr ""
+
+#: src/www/wizards/traffic_shaper_wizard_multi_all.inc:343
+msgid "You cannot select the same interface twice on local interfaces."
+msgstr ""

--- a/src/share/locale/en/LC_MESSAGES/OPNsense.pot
+++ b/src/share/locale/en/LC_MESSAGES/OPNsense.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OPNsense\n"
+"Project-Id-Version: OPNsense 15.1.10.1\n"
 "Report-Msgid-Bugs-To: https://forum.opnsense.org/\n"
-"POT-Creation-Date: 2015-05-11 02:20-0400\n"
+"POT-Creation-Date: 2015-05-11 02:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
Adding a few lines to ensure the .pot file isn't so confusing/daunting.

Ostensibly, language translators will start by precisely copying this file- so a bit of OPNsense is good in the header IMHO.