### PR TITLE
Update authgui.inc

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -261,7 +261,7 @@ function display_login_form()
 
 			  <div class="form-group">
 			    <label for="usernamefld"><?=gettext("Username:"); ?></label>
-			    <input id="usernamefld" type="text" name="usernamefld" class="form-control user" tabindex="1" autofocus="autofocus" />
+			    <input id="usernamefld" type="text" name="usernamefld" class="form-control user" tabindex="1" autofocus="autofocus" autocapitalize="off" autocorrect="off" />
 			  </div>
 
 			  <div class="form-group">


### PR DESCRIPTION
Added autocapitalize="off" autocorrect="off" to the input for the logon form usernamefld. When using from an iPhone/iPad the first character of the username is capitalized automatically.