### PR TITLE
fixes #485: make NAT type configurable for IPsec

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1766,10 +1766,21 @@ function filter_nat_rules_generate(&$FilterIflist)
                   if ($remote_subnet == "0.0.0.0/0") {
                       $remote_subnet = "any";
                   }
-                  if (is_ipaddr($natlocal_subnet) && !is_ipaddr($local_subnet)) {
-                      $nattype = "nat";
-                  } else {
-                      $nattype = "binat";
+                  /* Try to enforce a specific NAT type or choose automatically. */
+                  switch(isset($ph2ent['natlocalid']['nattype']) ? $ph2ent['natlocalid']['nattype'] : null) {
+                      case "binat":
+                          $nattype = "binat";
+                          break;
+                      case "nat":
+                          $nattype = "nat";
+                          break;
+                      default:
+                          if (is_ipaddr($natlocal_subnet) && !is_ipaddr($local_subnet)) {
+                              $nattype = "nat";
+                          } else {
+                              $nattype = "binat";
+                          }
+                          break;
                   }
                   $natrules .= "{$nattype} on enc0 from {$local_subnet} to {$remote_subnet} -> {$natlocal_subnet}\n";
                 }


### PR DESCRIPTION
This PR adds an option to manually configure the NAT type for IPsec. It's fallback is to use the "auto" mode (to match the previous behaviour), so it shouldn't break anything for existing configurations.

This resolves issue #485.