### PR TITLE
Fixes 376: add description for status DHCP leases

### DIFF
--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -283,6 +283,7 @@ foreach($config['interfaces'] as $ifname => $ifarr) {
 			$slease['start'] = "";
 			$slease['end'] = "";
 			$slease['hostname'] = htmlentities($static['hostname']);
+			$slease['descr'] = htmlentities($static['descr']);
 			$slease['act'] = "static";
 			$slease['online'] = in_array(strtolower($slease['mac']), $arpdata_mac) ? 'online' : 'offline';
 			$leases[] = $slease;
@@ -339,6 +340,7 @@ if(count($pools) > 0) {
 							    <td class="listhdrr"><?=gettext("IP address"); ?></td>
 							    <td class="listhdrr"><?=gettext("MAC address"); ?></td>
 							    <td class="listhdrr"><?=gettext("Hostname"); ?></td>
+							    <td class="listhdrr"><?=gettext("Description"); ?></td>
 							    <td class="listhdrr"><?=gettext("Start"); ?></td>
 							    <td class="listhdrr"><?=gettext("End"); ?></td>
 							    <td class="listhdrr"><?=gettext("Online"); ?></td>
@@ -405,6 +407,11 @@ if(count($pools) > 0) {
 										}
 							                }
 							                echo "<td class=\"listr\">{$fspans}"  . htmlentities($data['hostname']) . "{$fspane}</td>\n";
+									if (isset($data['descr'])) {
+										echo "<td class=\"listr\">{$fspans}"  . htmlentities($data['descr']) . "{$fspane}</td>\n";
+									} else {
+										echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
+									}
 											if ($data['type'] != "static") {
 												echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['start']) . "{$fspane}</td>\n";
 												echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['end']) . "{$fspane}</td>\n";

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -391,18 +391,18 @@ if(count($pools) > 0) {
 							                }
 									echo "<tr>\n";
 							                echo "<td class=\"listlr\">{$fspans}{$data['ip']}{$fspane}</td>\n";
-									$mac=$data['mac'];
+									$mac = $data['mac'];
 									$mac_hi = strtoupper($mac[0] . $mac[1] . $mac[3] . $mac[4] . $mac[6] . $mac[7]);
 							                if ($data['online'] != "online") {
-										if(isset($mac_man[$mac_hi])){ // Manufacturer for this MAC is defined
+										if (isset($mac_man[$mac_hi])) { // Manufacturer for this MAC is defined
 								                        echo "<td class=\"listr\">{$fspans}<a href=\"services_wol.php?if={$data['if']}&amp;mac=$mac\" title=\"" . gettext("$mac - send Wake on LAN packet to this MAC address") ."\">{$mac}</a><br /><font size=\"-2\"><i>{$mac_man[$mac_hi]}</i></font>{$fspane}</td>\n";
-										}else{
+										} else {
 											echo "<td class=\"listr\">{$fspans}<a href=\"services_wol.php?if={$data['if']}&amp;mac={$data['mac']}\" title=\"" . gettext("send Wake on LAN packet to this MAC address") ."\">{$data['mac']}</a>{$fspane}</td>\n";
 										}
-							                }else{
-										if(isset($mac_man[$mac_hi])){ // Manufacturer for this MAC is defined
+							                } else {
+										if (isset($mac_man[$mac_hi])) { // Manufacturer for this MAC is defined
 											echo "<td class=\"listr\">{$fspans}{$mac}<br /><font size=\"-2\"><i>{$mac_man[$mac_hi]}</i></font>{$fspane}</td>\n";
-								                }else{
+								                } else {
 											echo "<td class=\"listr\">{$fspans}{$data['mac']}{$fspane}</td>\n";
 										}
 							                }
@@ -412,13 +412,13 @@ if(count($pools) > 0) {
 									} else {
 										echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
 									}
-											if ($data['type'] != "static") {
-												echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['start']) . "{$fspane}</td>\n";
-												echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['end']) . "{$fspane}</td>\n";
-											} else {
-												echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
-												echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
-											}
+									if ($data['type'] != "static") {
+										echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['start']) . "{$fspane}</td>\n";
+										echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['end']) . "{$fspane}</td>\n";
+									} else {
+										echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
+										echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
+									}
 							                echo "<td class=\"listr\">{$fspans}{$data['online']}{$fspane}</td>\n";
 							                echo "<td class=\"listr\">{$fspans}{$data['act']}{$fspane}</td>\n";
 							                echo "<td valign=\"middle\">&nbsp;";

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -352,6 +352,7 @@ foreach($config['interfaces'] as $ifname => $ifarr) {
 			$slease['start'] = "";
 			$slease['end'] = "";
 			$slease['hostname'] = htmlentities($static['hostname']);
+			$slease['descr'] = htmlentities($static['descr']);
 			$slease['act'] = "static";
 			if (in_array($slease['ip'], array_keys($ndpdata))) {
 				$slease['online'] = 'online';
@@ -419,6 +420,7 @@ if(count($pools) > 0) {
 							    <td class="listhdrr"><?=gettext("IAID"); ?></td>
 							    <td class="listhdrr"><?=gettext("DUID"); ?></td>
 							    <td class="listhdrr"><?=gettext("Hostname/MAC"); ?></td>
+							    <td class="listhdrr"><?=gettext("Description"); ?></td>
 							    <td class="listhdrr"><?=gettext("Start"); ?></td>
 							    <td class="listhdrr"><?=gettext("End"); ?></td>
 							    <td class="listhdrr"><?=gettext("Online"); ?></td>
@@ -460,8 +462,13 @@ if(count($pools) > 0) {
 									if (!empty($data['hostname'])) {
 										echo htmlentities($data['hostname']) . "<br />";
 									}
+									if (isset($data['descr'])) {
+										echo "<td class=\"listr\">{$fspans}"  . htmlentities($data['descr']) . "{$fspane}</td>\n";
+									} else {
+										echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
+									}
 
-									$mac=trim($ndpdata[$data['ip']]['mac']);
+									$mac = trim($ndpdata[$data['ip']]['mac']);
 									if (!empty($mac)) {
 										$mac_hi = strtoupper($mac[0] . $mac[1] . $mac[3] . $mac[4] . $mac[6] . $mac[7]);
 										print htmlentities($mac);


### PR DESCRIPTION
This PR enhances the `Status->DHCP IPv4 Leases` and `Status->DHCP IPv6 Leases` pages by adding the description of the static lease (if available).