### PR TITLE
firewall: raise usability for normal log view

### DIFF
--- a/src/www/diag_logs_filter.php
+++ b/src/www/diag_logs_filter.php
@@ -727,7 +727,7 @@ include("head.inc");
 									$rowIndex++;?>
 									<tr class="<?=$evenRowClass?>">
 									  <td class="listMRlr nowrap" align="center" sorttable_customkey="<?=$filterent['act']?>">
-									  <a onclick="javascript:getURL('diag_logs_filter.php?getrulenum=<?php echo "{$filterent['rulenum']},{$filterent['act']}"; ?>', outputrule);" title="<?php echo $filterent['act'];?>"><span class="glyphicon glyphicon-<?php switch ($filterent['act']) {
+									  <a href="#" onclick="javascript:getURL('diag_logs_filter.php?getrulenum=<?php echo "{$filterent['rulenum']},{$filterent['act']}"; ?>', outputrule);" title="<?php echo $filterent['act'];?>"><span class="glyphicon glyphicon-<?php switch ($filterent['act']) {
 									    case 'pass':
                                                                                 echo "play";  /* icon triangle */
                                                                                 break;


### PR DESCRIPTION
Change cursor when hoovering over symbol within "Act" column of
normal firewall log to indicate that icon may be clicked.

Addresses #487 