### PR TITLE
firewall: show warning banner if firewall disabled

### DIFF
--- a/src/www/diag_logs_filter.php
+++ b/src/www/diag_logs_filter.php
@@ -606,6 +606,10 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
+                                <?php if (isset($config['system']['disablefilter'])): ?>
+                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+                                <?php endif; ?>
+
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			    <section class="col-xs-12">

--- a/src/www/diag_logs_filter.php
+++ b/src/www/diag_logs_filter.php
@@ -606,10 +606,7 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
-                                <?php if (isset($config['system']['disablefilter'])): ?>
-                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
-                                <?php endif; ?>
-
+				<?php print_service_disabled_banner('firewall'); ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			    <section class="col-xs-12">

--- a/src/www/diag_logs_filter_dynamic.php
+++ b/src/www/diag_logs_filter_dynamic.php
@@ -87,10 +87,7 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
-                                <?php if (isset($config['system']['disablefilter'])): ?>
-                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
-                                <?php endif; ?>
-
+				<?php print_service_disabled_banner('firewall'); ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			    <section class="col-xs-12">

--- a/src/www/diag_logs_filter_dynamic.php
+++ b/src/www/diag_logs_filter_dynamic.php
@@ -87,6 +87,10 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
+                                <?php if (isset($config['system']['disablefilter'])): ?>
+                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+                                <?php endif; ?>
+
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			    <section class="col-xs-12">

--- a/src/www/diag_logs_filter_plain.php
+++ b/src/www/diag_logs_filter_plain.php
@@ -63,10 +63,7 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
-                                <?php if (isset($config['system']['disablefilter'])): ?>
-                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
-                                <?php endif; ?>
-
+				<?php print_service_disabled_banner('firewall'); ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			     <section class="col-xs-12">

--- a/src/www/diag_logs_filter_plain.php
+++ b/src/www/diag_logs_filter_plain.php
@@ -63,6 +63,10 @@ include("head.inc");
 		<div class="container-fluid">
 			<div class="row">
 
+                                <?php if (isset($config['system']['disablefilter'])): ?>
+                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+                                <?php endif; ?>
+
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			     <section class="col-xs-12">

--- a/src/www/diag_logs_filter_summary.php
+++ b/src/www/diag_logs_filter_summary.php
@@ -114,9 +114,7 @@ include("head.inc"); ?>
 	<section class="page-content-main">
 		<div class="container-fluid">
 			<div class="row">
-                                <?php if (isset($config['system']['disablefilter'])): ?>
-                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
-                                <?php endif; ?>
+				<?php print_service_disabled_banner('firewall'); ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 			    <section class="col-xs-12">
 						<div class="tab-content content-box col-xs-12">

--- a/src/www/diag_logs_filter_summary.php
+++ b/src/www/diag_logs_filter_summary.php
@@ -114,6 +114,9 @@ include("head.inc"); ?>
 	<section class="page-content-main">
 		<div class="container-fluid">
 			<div class="row">
+                                <?php if (isset($config['system']['disablefilter'])): ?>
+                                <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+                                <?php endif; ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 			    <section class="col-xs-12">
 						<div class="tab-content content-box col-xs-12">

--- a/src/www/diag_pf_info.php
+++ b/src/www/diag_pf_info.php
@@ -69,6 +69,7 @@ $( document ).ready(function() {
 <section class="page-content-main">
   <div class="container-fluid col-xs-12">
     <div class="row">
+        <?php print_service_disabled_banner('firewall'); ?>
         <section class="col-xs-12">
           <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
 <?php

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -225,6 +225,9 @@ $( document ).ready(function() {
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
+        <?php if (isset($config['system']['disablefilter'])): ?>
+        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+        <?php endif; ?>
 <?php   if (isset($savemsg)) print_info_box($savemsg); ?>
 <?php   if (is_subsystem_dirty('natconf')): ?>
 <?php     print_info_box_apply(gettext("The NAT configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));?><br />

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -175,6 +175,9 @@ $main_buttons = array(
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
+        <?php if (isset($config['system']['disablefilter'])): ?>
+        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+        <?php endif; ?>
 <?php
         if (isset($savemsg))
           print_info_box($savemsg);

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -178,6 +178,9 @@ $main_buttons = array(
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
+        <?php if (isset($config['system']['disablefilter'])): ?>
+        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+        <?php endif; ?>
         <?php if (isset($savemsg)) print_info_box($savemsg); ?>
         <?php if (is_subsystem_dirty('natconf')): ?>
         <?php print_info_box_apply(gettext("The NAT configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));?><br />

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -246,6 +246,9 @@ include("head.inc");
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
+        <?php if (isset($config['system']['disablefilter'])): ?>
+        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+        <?php endif; ?>
 <?php
         if (isset($savemsg))
             print_info_box($savemsg);

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -200,9 +200,7 @@ $( document ).ready(function() {
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
-        <?php if (isset($config['system']['disablefilter'])): ?>
-        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
-        <?php endif; ?>
+        <?php print_service_disabled_banner('firewall'); ?>
         <?php if (isset($savemsg)) print_info_box($savemsg); ?>
         <?php if (is_subsystem_dirty('filter')): ?><p>
         <?php print_info_box_apply(gettext("The firewall rule configuration has been changed.<br />You must apply the changes in order for them to take effect."));?>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -200,6 +200,9 @@ $( document ).ready(function() {
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
+        <?php if (isset($config['system']['disablefilter'])): ?>
+        <?php print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));?>
+        <?php endif; ?>
         <?php if (isset($savemsg)) print_info_box($savemsg); ?>
         <?php if (is_subsystem_dirty('filter')): ?><p>
         <?php print_info_box_apply(gettext("The firewall rule configuration has been changed.<br />You must apply the changes in order for them to take effect."));?>

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -264,7 +264,10 @@ function print_service_disabled_banner($service) {
 		switch ($service) {
 			case 'firewall':
 			case 'filter':
-				print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));
+				print_warning_box(gettext(
+					"The firewall has globally been disabled and configured rules are currently not enforced. " .
+					"It can be enabled in the <a href=\"system_advanced_firewall.php\">Firewall and NAT settings</a> page."
+				));
 				break;
 		}
 	}

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -237,6 +237,17 @@ function print_info_box($msg)
 EOFnp;
 }
 
+function print_warning_box($msg)
+{
+	echo <<<EOFnp
+<div class="col-xs-12">
+	<div class="alert alert-warning alert-dismissible" role="alert">
+		<p>{$msg}</p>
+	</div>
+</div>
+EOFnp;
+}
+
 function get_std_save_message() {
 	global $d_sysrebootreqd_path;
 	$filter_related = false;

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -237,8 +237,7 @@ function print_info_box($msg)
 EOFnp;
 }
 
-function print_warning_box($msg)
-{
+function print_warning_box($msg) {
 	echo <<<EOFnp
 <div class="col-xs-12">
 	<div class="alert alert-warning alert-dismissible" role="alert">
@@ -246,6 +245,29 @@ function print_warning_box($msg)
 	</div>
 </div>
 EOFnp;
+}
+
+function is_service_enabled($service) {
+	global $config;
+
+	switch ($service) {
+		case 'firewall':
+		case 'filter':
+			return !isset($config['system']['disablefilter']);
+		default:
+			return false;
+	}
+}
+
+function print_service_disabled_banner($service) {
+	if (!is_service_enabled($service)) {
+		switch ($service) {
+			case 'firewall':
+			case 'filter':
+				print_warning_box(gettext("The firewall has globally been disabled. Configured rules are currently not enforced."));
+				break;
+		}
+	}
 }
 
 function get_std_save_message() {

--- a/src/www/status_filter_reload.php
+++ b/src/www/status_filter_reload.php
@@ -65,7 +65,7 @@ include("head.inc");
 	<section class="page-content-main">
 		<div class="container-fluid">
 			<div class="row">
-
+				<?php print_service_disabled_banner('firewall'); ?>
 				<?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
 
 			    <section class="col-xs-12">


### PR DESCRIPTION
If firewall is globally disabled, show a warning banner in all relevant
firewall configuration and diagnostic screens (filter and NAT).