### PR TITLE
firewall: extend pfInfo by active rules

### DIFF
--- a/src/opnsense/scripts/filter/pfinfo.py
+++ b/src/opnsense/scripts/filter/pfinfo.py
@@ -37,7 +37,7 @@ import ujson
 
 if __name__ == '__main__':
     result = collections.OrderedDict()
-    for stattype in ['info', 'memory', 'timeouts', 'Interfaces']:
+    for stattype in ['info', 'memory', 'timeouts', 'Interfaces', 'rules']:
         with tempfile.NamedTemporaryFile() as output_stream:
             subprocess.call(['/sbin/pfctl', '-vvs'+stattype], stdout=output_stream, stderr=open(os.devnull, 'wb'))
             output_stream.seek(0)

--- a/src/www/diag_pf_info.php
+++ b/src/www/diag_pf_info.php
@@ -29,7 +29,7 @@
 require_once("guiconfig.inc");
 
 $pgtitle = gettext("Diagnostics: pfInfo");
-$data_tabs = array("info", "memory", "timeouts", "interfaces");
+$data_tabs = array("info", "memory", "timeouts", "interfaces", "rules");
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['getactivity'])) {


### PR DESCRIPTION
Extends pfInfo by showing active rules incl. match statistics.

Especially for troubleshooting the generated rules by OPNsense are quite useful.