### PR TITLE
tiny bugfix: unbound: fix JS to enable/disable interface selectors

### DIFF
--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -175,6 +175,7 @@ function enable_change(enable_over) {
 	var endis;
 	endis = !(jQuery('#enable').is(":checked") || enable_over);
 	jQuery("#active_interface,#outgoing_interface,#dnssec,#forwarding,#regdhcp,#regdhcpstatic,#dhcpfirst,#port,#txtsupport,#custom_options").prop('disabled', endis);
+	jQuery("#active_interface,#outgoing_interface").selectpicker("refresh");
 }
 function show_advanced_dns() {
 	jQuery("#showadv").show();


### PR DESCRIPTION
If unbound is enabled/disabled globally, the interface selectors should be
enabled/disabled as well.