### PR TITLE
service status: added references to service config pages

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2473,7 +2473,7 @@ function get_services() {
 	if (isset($config['unbound']['enable'])) {
 		$pconfig = array();
 		$pconfig['name'] = "unbound";
-		$pconfig['description'] = gettext("Unbound DNS Forwarder");
+		$pconfig['description'] = gettext("Unbound DNS Resolver");
 		$services[] = $pconfig;
 	}
 

--- a/src/www/shortcuts.inc
+++ b/src/www/shortcuts.inc
@@ -143,18 +143,28 @@ $shortcuts['dhcp6']['log'] = "diag_logs_dhcp.php";
 $shortcuts['dhcp6']['status'] = "status_dhcpv6_leases.php";
 
 $shortcuts['ipsec'] = array();
+$shortcuts['ipsec']['main'] = "vpn_ipsec.php";
+$shortcuts['ipsec']['log'] = "diag_logs_ipsec.php";
+$shortcuts['ipsec']['status'] = "diag_ipsec.php";
 $shortcuts['ipsec']['service'] = "ipsec";
 
 $shortcuts['openvpn'] = array();
+$shortcuts['openvpn']['log'] = "diag_logs_openvpn.php";
+$shortcuts['openvpn']['status'] = "status_openvpn.php";
 $shortcuts['openvpn']['service'] = "openvpn";
 
 $shortcuts['forwarder'] = array();
+$shortcuts['forwarder']['main'] = 'services_dnsmasq.php';
 $shortcuts['forwarder']['service'] = 'dnsmasq';
 
 $shortcuts['resolver'] = array();
+$shortcuts['resolver']['main'] = "services_unbound.php";
 $shortcuts['resolver']['service'] = 'unbound';
 
 $shortcuts['ntp'] = array();
+$shortcuts['ntp']['main'] = "services_ntpd.php";
+$shortcuts['ntp']['status'] = "status_ntpd.php";
+$shortcuts['ntp']['log'] = "diag_logs_ntpd.php";
 $shortcuts['ntp']['service'] = 'ntpd';
 
 $shortcuts['firewall'] = array();
@@ -190,3 +200,11 @@ $shortcuts['squid'] = array();
 $shortcuts['squid']['main'] = "ui/proxy/";
 $shortcuts['squid']['log'] = "diag_logs_proxy.php";
 $shortcuts['squid']['service'] = "squid";
+
+$shortcuts['sshd'] = array();
+$shortcuts['sshd']['main'] = 'system_advanced_admin.php';
+$shortcuts['sshd']['service'] = 'sshd';
+
+$shortcuts['radvd'] = array();
+$shortcuts['radvd']['main'] = 'services_dhcpv6.php';
+$shortcuts['radvd']['service'] = 'radvd';


### PR DESCRIPTION
- Added links to main pages, log pages, and status pages of services shown in the System: Diagnosics: Services page.

- Changed incorrect name of unbound service from "Unbound DNS Forwarder" to "Unbound DNS Resolver"