### PR TITLE
fix CARP support for OpenVPN client

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -29,6 +29,8 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
+require_once('pfsense-utils.inc');
+
 global $openvpn_verbosity_level;
 $openvpn_verbosity_level = array(
 	0 => gettext('0 (none)'),


### PR DESCRIPTION
This fixes the crash report I've just submitted. The function `get_carp_interface_status()` cannot be found otherwise...