### PR TITLE
CARP virtual IP: make sure to save a value for advskew

### DIFF
--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -182,6 +182,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         // defaults
         $vipent['type'] = "single";
         $vipent['subnet_bits'] = "32";
+        $vipent['advskew'] = "0";
         // 1-on-1 copy attributes
         foreach (array('mode', 'interface', 'descr', 'type', 'subnet_bits', 'subnet', 'vhid'
                       ,'advskew','advbase','password') as $fieldname) {


### PR DESCRIPTION
Currently if we add a CARP virtual IP and leave "advskew" at the default value of "0", then this value will not be saved to the config.xml. This is problematic, because the CARP configuration will be synced with the *same* value of "0" to the secondary node, instead of automatically adding +100 to it.

This leads to some serious issues, because the secondary node will easily become the master. And besides that, the master node will not become the CARP MASTER after a reboot (for example).

I'm not sure if there is a better place to fix this. Maybe something else should be changed to allow saving of the value "0".