### PR TITLE
bring back gateway descriptions

### DIFF
--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -349,11 +349,7 @@ $( document ).ready(function() {
                         <?=$gateway['monitor'];?>
                       </td>
                       <td>
-<?php
-                      if (!is_numeric($gateway['attribute'])) :?>
                         <?=$gateway['descr'];?>
-<?php
-                      endif;?>
                       </td>
                       <td>
                         <a href="system_gateways_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"


### PR DESCRIPTION
Currently the descriptions for gateways are not visible in `System -> Gateways -> All`, but can still be seen when editing a gateway. This patch brings back the gateway descriptions.

I think they got lost during [a code cleanup](https://github.com/opnsense/core/commit/a453828f3abd249892cf980eed1f62456973e71f#diff-a544724430f51cdfcf966a33f5b8549f).