### PR TITLE
bring back loadbalancer descriptions

### DIFF
--- a/src/etc/inc/load_balancer_maintable.inc
+++ b/src/etc/inc/load_balancer_maintable.inc
@@ -115,7 +115,7 @@ class MainTable {
 				echo "  </td>\n";
 			}
 			echo "  <td class=\"listbg\" onclick=\"fr_toggle({$cur_row})\" id=\"frd{$cur_row}\" ondblclick=\"document.location='{$this->edit_uri}?id={$cur_row}'\">\n";
-			echo "    <font color=\"#FFFFFF\">{$row[$this->cname[$this->columns - 1]]}</font>\n";
+			echo "    {$row[$this->cname[$this->columns - 1]]}\n";
 			echo "  </td>\n";
 			echo "  <td class=\"list nowrap\">\n";
 			$this->display_buttons($cur_row);

--- a/src/www/widgets/widgets/load_balancer_status.widget.php
+++ b/src/www/widgets/widgets/load_balancer_status.widget.php
@@ -140,7 +140,7 @@ if (!$nentries) {
 		</table>
 		</td>
 		<td class="listbg" >
-			<font color="#FFFFFF"><?=$vsent['descr'];?></font>
+			<?=$vsent['descr'];?>
 		</td>
 	</tr>
 	<?php $i++;


### PR DESCRIPTION
Currently loadbalancer descriptions are configured with white (#FFFFFF) font. :-) This patch removes the `<font>` tags and relies on CSS to provide the required font color.