### PR TITLE
Reworked action buttons for list operations

### DIFF
--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -303,7 +303,7 @@ $( document ).ready(function() {
 <?php                 endif; ?>
                       </td>
                       <td>
-                        <a href="#" class="act_toggle" id="toggle_<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>">
+                        <a href="#" class="act_toggle" id="toggle_<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
 <?php                     if (!empty($natent['associated-rule-id'])): ?>
 <?php                     if(isset($natent['disabled'])):?>
                           <span class="glyphicon glyphicon-resize-horizontal text-muted"></span>
@@ -374,13 +374,13 @@ $( document ).ready(function() {
                         <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_nat_edit.php?id=<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this rule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_nat_edit.php?id=<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
-                        <a id="del_<?=$nnats;?>" title="<?=gettext("delete this rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                        <a id="del_<?=$nnats;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
-                        <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
+                        <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -381,7 +381,7 @@ $( document ).ready(function() {
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
                         <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
-                          <span class="glyphicon glyphicon-plus"></span>
+                          <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>
                      </tr>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -251,7 +251,7 @@ $main_buttons = array(
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
                       <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new mapping based on this one");?>" class="btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-plus"></span>
+                        <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
                   </tr>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -135,7 +135,7 @@ $main_buttons = array(
         BootstrapDialog.show({
             type:BootstrapDialog.TYPE_DANGER,
             title: "<?= gettext("1:1");?>",
-            message: "<?=gettext("Do you really want to delete the selected mappings?");?>",
+            message: "<?=gettext("Do you really want to delete the selected rules?");?>",
             buttons: [{
                     label: "<?= gettext("No");?>",
                     action: function(dialogRef) {
@@ -213,7 +213,12 @@ $main_buttons = array(
                       <input type="checkbox" name="rule[]" value="<?=$i;?>" />
                     </td>
                     <td>
-                      <a href="#" type="submit" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>" class="act_toggle glyphicon glyphicon glyphicon-play <?=isset($natent['disabled']) ? "text-muted" : "text-success";?>">
+                      <a href="#" type="submit" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>" class="act_toggle">
+<?php                   if(isset($natent['disabled'])):?>
+                          <span class="glyphicon glyphicon-play text-muted"></span>
+<?php                   else:?>
+                          <span class="glyphicon glyphicon-play text-success"></span>
+<?php                   endif; ?>
                       </a>
                     </td>
                     <td>
@@ -241,16 +246,16 @@ $main_buttons = array(
                       <?=$natent['descr'];?> &nbsp;
                     </td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected mapping before this rule");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_nat_1to1_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this mapping");?>">
+                      <a href="firewall_nat_1to1_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule ");?>">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
-                      <a id="del_<?=$i;?>" title="<?=gettext("delete this mapping"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                      <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
-                      <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new mapping based on this one");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>" class="btn btn-default btn-xs">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
@@ -264,30 +269,30 @@ $main_buttons = array(
                     <td>
 <?php               if ($i == 0):
 ?>
-                      <span title="<?=gettext("move selected mappings to end");?>" class="btn btn-default btn-xs">
+                      <span title="<?=gettext("move selected rules to end");?>" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left">
                         </span>
                       </span>
 <?php               else:
 ?>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected mappings to end");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
 <?php               endif;
 ?>
 <?php               if ($i == 0):
 ?>
-                      <span title="<?=gettext("delete selected mappings"); ?>" data-toggle="tooltip" class="btn btn-default btn-xs">
+                      <span title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-remove"></span>
                       </span>
 <?php               else:
 ?>
-                      <a id="del_x" title="<?=gettext("delete selected mappings"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                      <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
 <?php               endif;
 ?>
-                      <a href="firewall_nat_1to1_edit.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new mapping");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
+                      <a href="firewall_nat_1to1_edit.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
                     </td>
                   </tr>
                 </tbody>

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -211,7 +211,7 @@ $main_buttons = array(
                           <input type="checkbox" name="rule[]" value="<?=$i;?>"  />
                       </td>
                       <td>
-                        <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>">
+                        <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
 <?php                     if(isset($natent['disabled'])):?>
                           <span class="glyphicon glyphicon-play text-muted"></span>
 <?php                        else:?>
@@ -235,13 +235,13 @@ $main_buttons = array(
                         <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_nat_npt_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this rule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_nat_npt_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
-                        <a id="del_<?=$i;?>" title="<?=gettext("delete this rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                        <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
-                        <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
+                        <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -242,7 +242,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
                         <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
-                          <span class="glyphicon glyphicon-plus"></span>
+                          <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>
                     </tr>

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -319,7 +319,7 @@ include("head.inc");
           <div class="table-responsive content-box ">
             <table class="table table-striped table-sort">
               <thead>
-                <tr><th colspan="12"><?=gettext("Mappings:"); ?></th></tr>
+                <tr><th colspan="12"><?=gettext("Manual rules:"); ?></th></tr>
                 <tr>
                     <th>&nbsp;</th>
                     <th>&nbsp;</th>
@@ -348,11 +348,11 @@ include("head.inc");
 <?php
                     if ($mode == "disabled" || $mode == "automatic"):
 ?>
-                      <span data-toggle="tooltip" title="<?=gettext("This rule is being ignored");?>" class="glyphicon glyphicon-play <?=$mode == "disabled" || $mode == "automatic" || isset($natent['disabled']) ? "text-muted" : "text-success";?>"></span>
+                      <span data-toggle="tooltip" title="<?=gettext("All manual rules are being ignored");?>" class="glyphicon glyphicon-play <?=$mode == "disabled" || $mode == "automatic" || isset($natent['disabled']) ? "text-muted" : "text-success";?>"></span>
 <?php
                     else:
 ?>
-                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" title="<?=gettext("click to toggle enabled/disabled status");?>" class="btn btn-default btn-xs <?=isset($natent['disabled']) ? "text-muted" : "text-success";?>">
+                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>" class="btn btn-default btn-xs <?=isset($natent['disabled']) ? "text-muted" : "text-success";?>">
                         <span class="glyphicon glyphicon-play <?=isset($natent['disabled']) ? "text-muted" : "text-success";?>  "></span>
                       </a>
 <?php
@@ -413,13 +413,13 @@ include("head.inc");
                       <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_nat_out_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit mapping");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_nat_out_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
-                      <a id="del_<?=$i;?>" title="<?=gettext("delete this rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                      <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
-                      <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add a new NAT based on this one");?>">
+                      <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
@@ -459,7 +459,7 @@ include("head.inc");
 <?php
                 endif;
 ?>
-                  <a href="firewall_nat_out_edit.php" title="<?=gettext("add new mapping");?>" alt="add"  class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
+                  <a href="firewall_nat_out_edit.php" title="<?=gettext("add new rule");?>" alt="add"  class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
                   </td>
                 </tr>
               </tbody>

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -420,7 +420,7 @@ include("head.inc");
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
                       <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add a new NAT based on this one");?>">
-                        <span class="glyphicon glyphicon-plus"></span>
+                        <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
                   </tr>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -290,7 +290,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Block all IPv6 traffic");?></td>
                     <td>
-                      <a href="system_advanced_network.php" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="system_advanced_network.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -314,7 +314,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Anti-Lockout Rule");?></td>
                     <td>
-                      <a href="system_advanced_admin.php" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="system_advanced_admin.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -340,7 +340,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td class="hidden-xs hidden-sm"><?=gettext("Block private networks");?></td>
                     <td valign="middle" class="list nowrap">
-                        <a href="interfaces.php?if=<?=$selected_if?>#rfc1918" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="interfaces.php?if=<?=$selected_if?>#rfc1918" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -365,7 +365,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Block bogon networks");?></td>
                     <td>
-                      <a href="interfaces.php?if=<?=htmlspecialchars($if)?>#rfc1918" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="interfaces.php?if=<?=htmlspecialchars($if)?>#rfc1918" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -424,9 +424,7 @@ $( document ).ready(function() {
                       <input type="checkbox" name="rule[]" value="<?=$i;?>"  />
                     </td>
                     <td>
-                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>">
-                        <span class="glyphicon <?=$iconfn;?>"></span>
-                      </a>
+                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(empty($filterent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>"><span class="glyphicon <?=$iconfn;?>"></span></a>
 <?php
                       if (!empty($filterent['direction']) && $filterent['direction'] == "in"):?>
                         <i class="fa fa-long-arrow-right" data-toggle="tooltip" data-placement="left" title="<?=gettext("in");?>"></i>
@@ -525,13 +523,13 @@ $( document ).ready(function() {
                       <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_rules_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this rule");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_rules_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
-                      <a id="del_<?=$i;?>" title="<?=gettext("delete this rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                      <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
-                      <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
+                      <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -532,7 +532,7 @@ $( document ).ready(function() {
                         <span class="glyphicon glyphicon-remove"></span>
                       </a>
                       <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
-                        <span class="glyphicon glyphicon-plus"></span>
+                        <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
                   </tr>

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -232,13 +232,13 @@ $main_buttons = array(
                       <?=$schedule['descr'];?>
                       </td>
                       <td>
-                        <a href="firewall_schedule_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this schedule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_schedule_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit schedule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
-                        <a id="del_<?=$i;?>" title="<?=gettext("delete this schedule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                        <a id="del_<?=$i;?>" title="<?=gettext("delete schedule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
-                        <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new schedule based on this one");?>">
+                        <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone schedule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                     </td>

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -239,7 +239,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-remove"></span>
                         </a>
                         <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new schedule based on this one");?>">
-                          <span class="glyphicon glyphicon-plus"></span>
+                          <span class="fa fa-clone text-muted"></span>
                         </a>
                     </td>
                   </tr>

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -316,7 +316,7 @@ $main_buttons = array(
                             <span class="glyphicon glyphicon-remove"></span>
                           </a>
                           <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
-                            <span class="glyphicon glyphicon-plus"></span>
+                            <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>
                       </tr>

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -306,16 +306,16 @@ $main_buttons = array(
                           <?=htmlspecialchars($vipent['descr']);?>
                         </td>
                         <td>
-                          <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected virtual ip before this rule");?>" class="act_move btn btn-default btn-xs">
+                          <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected virtual IPs before this entry");?>" class="act_move btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-arrow-left"></span>
                           </a>
-                          <a href="firewall_virtual_ip_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit this virtual ip");?>" class="btn btn-default btn-xs">
+                          <a href="firewall_virtual_ip_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit virtual IP");?>" class="btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-pencil"></span>
                           </a>
-                          <a id="del_<?=$i;?>" title="<?=gettext("delete this virtual ip"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
+                          <a id="del_<?=$i;?>" title="<?=gettext("delete virtual IP"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-remove"></span>
                           </a>
-                          <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule based on this one");?>">
+                          <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone virtual IP");?>">
                             <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>
@@ -329,10 +329,10 @@ $main_buttons = array(
                     <tr>
                       <td colspan="5"></td>
                       <td>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected virtual IPs to end");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_virtual_ip_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">
+                        <a href="firewall_virtual_ip_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new virtual IP");?>">
                           <span class="glyphicon glyphicon-plus"></span>
                         </a>
                       </td>

--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -195,12 +195,18 @@ $( document ).ready(function() {
                       </td>
                       <td><?=$gateway_group['descr'];?></td>
                       <td>
-                        <a href="system_gateway_groups_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="system_gateway_groups_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"
+                            title="edit group" data-toggle="tooltip" data-placement="left">
+                          <span class="glyphicon glyphicon-pencil"></span>
+                        </a>
                         <button type="button" class="btn btn-default btn-xs act-del-group"
                             data-id="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
                             data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
                         </button>
-                        <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"><span class="fa fa-clone text-muted"></span></a>
+                        <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
+                            title="clone group" data-toggle="tooltip" data-placement="left">
+                          <span class="fa fa-clone text-muted"></span>
+                        </a>
                       </td>
                     </tr>
 <?php $i++;

--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -200,7 +200,7 @@ $( document ).ready(function() {
                             data-id="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
                             data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
                         </button>
-                        <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
+                        <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"><span class="fa fa-clone text-muted"></span></a>
                       </td>
                     </tr>
 <?php $i++;

--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -366,7 +366,7 @@ $( document ).ready(function() {
                         endif;?>
                           <a href="system_gateways_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
                              data-toggle="tooltip" data-placement="left" title="<?=gettext("Add Gateway based on this one");?>">
-                            <span class="glyphicon glyphicon-plus"></span>
+                            <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>
                       </tr>

--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -323,15 +323,15 @@ $( document ).ready(function() {
                       <td>
 <?php
                     if (isset($gateway['inactive'])) :?>
-                        <span class="glyphicon glyphicon-remove text-muted" data-toggle="tooltip" data-placement="left" title="<?=gettext("This gateway is inactive because interface is missing");?>"></span>
+                        <span class="glyphicon glyphicon-remove text-muted" data-toggle="tooltip" data-placement="left" title="<?=gettext("Gateway is inactive because interface is missing");?>"></span>
 <?php
                     elseif (is_numeric($gateway['attribute'])) :?>
-                        <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>" >
+                        <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($gateway['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>">
                           <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>"></span>
                         </a>
 <?php
                     else :?>
-                        <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("click to toggle enabled/disabled status");?>"></span>
+                        <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($filterent['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>"></span>
 <?php
                     endif;?>
                       </td>
@@ -353,19 +353,19 @@ $( document ).ready(function() {
                       </td>
                       <td>
                         <a href="system_gateways_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"
-                          data-toggle="tooltip" data-placement="left" title="<?=gettext("Edit Gateway");?>">
+                          data-toggle="tooltip" data-placement="left" title="<?=gettext("edit gateway");?>">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
 <?php
                         if (is_numeric($gateway['attribute'])) :?>
-                          <button data-id="<?=$i;?>" title="<?=gettext("Delete Gateway"); ?>" data-toggle="tooltip"
+                          <button data-id="<?=$i;?>" title="<?=gettext("delete gateway"); ?>" data-toggle="tooltip"
                                   class="act_delete btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-remove"></span>
                           </button>
 <?php
                         endif;?>
                           <a href="system_gateways_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
-                             data-toggle="tooltip" data-placement="left" title="<?=gettext("Add Gateway based on this one");?>">
+                             data-toggle="tooltip" data-placement="left" title="<?=gettext("clone gateway");?>">
                             <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>

--- a/src/www/system_routes.php
+++ b/src/www/system_routes.php
@@ -254,8 +254,8 @@ endif; ?>
                     </td>
                     <td>
                       <a href="#" class="act_toggle" data-id="<?=$i;?>">
-                        <span class="glyphicon glyphicon-play <?=isset($route['disabled']) ? "text-muted" : "text-success" ;?>"
-                              title="<?=gettext("click to toggle enabled/disabled status");?>" alt="icon">
+                        <span class="glyphicon glyphicon-play <?=isset($route['disabled']) ? "text-muted" : "text-success" ;?>" data-toggle="tooltip" data-placement="left"
+                              title="<?=(!isset($route['disabled'])) ? gettext("disable route") : gettext("enable route");?>" alt="icon">
                         </span>
                       </a>
                     </td>
@@ -272,18 +272,20 @@ endif; ?>
                       <?=$route['descr'];?>
                     </td>
                     <td>
-                      <a data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                      <a data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected routes before this route");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a class="btn btn-default btn-xs" href="system_routes_edit.php?id=<?=$i;?>">
-                        <span class="glyphicon glyphicon-pencil" title="<?=gettext("edit rule");?>" alt="edit"></span>
+                      <a class="btn btn-default btn-xs" href="system_routes_edit.php?id=<?=$i;?>"
+                          title="<?=gettext("edit route");?>" data-toggle="tooltip" data-placement="left">
+                        <span class="glyphicon glyphicon-pencil" alt="edit" ></span>
                       </a>
                       <button type="button" class="btn btn-default btn-xs act-del-route"
                           data-id="<?=$i?>" title="<?=gettext("delete route");?>" data-toggle="tooltip"
                           data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
                       </button>
-                      <a class="btn btn-default btn-xs" href="system_routes_edit.php?dup=<?=$i;?>">
-                        <span class="fa fa-clone text-muted" title="<?=gettext("add a new rule based on this one");?>" alt="duplicate"></span>
+                      <a class="btn btn-default btn-xs" href="system_routes_edit.php?dup=<?=$i;?>"
+                          title="<?=gettext("clone route");?>" data-toggle="tooltip" data-placement="left">
+                        <span class="fa fa-clone text-muted" alt="duplicate"></span>
                       </a>
                     </td>
                   </tr>
@@ -300,12 +302,11 @@ endif; ?>
                             title="<?=gettext("move selected routes to end");?>" alt="move" />
 <?php
                     else :?>
-                    <button type="submit" data-id="<?=$i;?>"  data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                    <button type="submit" data-id="<?=$i;?>"  data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected routes to end");?>" class="act_move btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-arrow-left"></span>
                     </button>
 <?php
                     endif;?>
-                    <a href="system_routes_edit.php" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
 <?php
                     if ($i == 0) :?>
                     <span class="btn btn-default btn-xs">
@@ -314,9 +315,12 @@ endif; ?>
 
 <?php
                     else :?>
-                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></button>
+                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"><span class="glyphicon glyphicon-remove"></span></button>
 <?php
                     endif;?>
+                    <a href="system_routes_edit.php" class="btn btn-default btn-xs" title="<?=gettext("add route");?>" data-toggle="tooltip" data-placement="left">
+                      <span class="glyphicon glyphicon-plus"></span>
+                    </a>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/system_routes.php
+++ b/src/www/system_routes.php
@@ -283,7 +283,7 @@ endif; ?>
                           data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
                       </button>
                       <a class="btn btn-default btn-xs" href="system_routes_edit.php?dup=<?=$i;?>">
-                        <span class="glyphicon glyphicon-plus" title="<?=gettext("add a new rule based on this one");?>" alt="duplicate"></span>
+                        <span class="fa fa-clone text-muted" title="<?=gettext("add a new rule based on this one");?>" alt="duplicate"></span>
                       </a>
                     </td>
                   </tr>

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -298,8 +298,8 @@ foreach ($pconfig['phase1'] as $ph1ent) :
       <input type="checkbox" name="p1entry[]" value="<?=$i;?>"/>
     </td>
     <td>
-      <button name="toggle_<?=$i;
-?>_x" title="<?=gettext("click to toggle enabled/disabled status");?>" type="submit" class="btn btn-<?= isset($ph1ent['disabled'])? "default":"success"?> btn-xs">
+      <button name="toggle_<?=$i; ?>_x" type="submit" class="btn btn-<?= isset($ph1ent['disabled'])? "default":"success"?> btn-xs"
+          title="<?=(isset($ph1ent['disabled'])) ? gettext("enable phase 1 entry") : gettext("disable phase 1 entry");?>" data-toggle="tooltip">
         <span class="glyphicon glyphicon-play"></span>
       </button>
     </td>
@@ -362,16 +362,16 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
         <?=$ph1ent['descr'];?>&nbsp;
     </td>
     <td>
-      <button name="move_<?=$i;
-?>_x" title="<?=gettext("move selected entries before this");?>" type="submit" class="btn btn-default btn-xs">
-          <span class="glyphicon glyphicon-arrow-left"></span>
+      <button name="move_<?=$i; ?>_x" type="submit" class="btn btn-default btn-xs"
+          title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip" data-placement="left">
+        <span class="glyphicon glyphicon-arrow-left"></span>
       </button>
-      <a href="vpn_ipsec_phase1.php?p1index=<?=$i;
-?>" title="<?=gettext("edit phase1 entry"); ?>" class="btn btn-default btn-xs" alt="edit">
-          <span class="glyphicon glyphicon-pencil"></span>
+      <a href="vpn_ipsec_phase1.php?p1index=<?=$i; ?>" class="btn btn-default btn-xs" alt="edit"
+          title="<?=gettext("edit phase1 entry"); ?>" data-toggle="tooltip" data-placement="left">
+        <span class="glyphicon glyphicon-pencil"></span>
       </a><br/>
       <button name="del_<?=$i;?>_x"
-          title="<?=gettext("delete phase1 entry");?>"
+          title="<?=gettext("delete phase1 entry");?>" data-toggle="tooltip" data-placement="left"
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase1 and all associated phase2 entries?"); ?>')"
           class="btn btn-default btn-xs">
@@ -379,8 +379,8 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
       </button>
 <?php                 if (!isset($ph1ent['mobile'])) :
 ?>
-                      <a href="vpn_ipsec_phase1.php?dup=<?=$i;
-?>" title="<?=gettext("copy phase1 entry"); ?>" class="btn btn-default btn-xs" alt="add">
+                      <a href="vpn_ipsec_phase1.php?dup=<?=$i; ?>" class="btn btn-default btn-xs" alt="add"
+                          title="<?=gettext("clone phase1 entry"); ?>" data-toggle="tooltip" data-placement="left">
                                       <span class="fa fa-clone text-muted"></span>
                       </a>
 <?php                 endif;
@@ -434,9 +434,9 @@ foreach ($pconfig['phase2'] as $ph2index => $ph2ent) :
       <input type="checkbox" name="p2entry[]" value="<?=$ph2index;?>"/>
     </td>
     <td>
-      <button name="togglep2_<?=$ph2index;
-?>_x" title="<?=gettext("click to toggle enabled/disabled status");
-?>" type="submit" class="btn btn-<?= isset($ph2ent['disabled'])?"default":"success";?> btn-xs">
+      <button name="togglep2_<?=$ph2index; ?>_x"
+          title="<?=(isset($ph2ent['disabled'])) ? gettext("enable phase 2 entry") : gettext("disable phase 2 entry"); ?>" data-toggle="tooltip"
+          type="submit" class="btn btn-<?= isset($ph2ent['disabled'])?"default":"success";?> btn-xs">
         <span class="glyphicon glyphicon-play"></span>
       </button>
     </td>
@@ -488,24 +488,26 @@ if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm
     </td>
     <td>
         <button name="movep2_<?=$j;?>_x"
-            title="<?=gettext("move selected entries before this");?>"
+            title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip" data-placement="left"
             type="submit"
             class="btn btn-default btn-xs">
             <span class="glyphicon glyphicon-arrow-left"></span>
         </button>
-        <a href="vpn_ipsec_phase2.php?p2index=<?=$ph2ent['uniqid'];
-?>" title="<?=gettext("edit phase2 entry"); ?>" alt="edit" class="btn btn-default btn-xs">
+        <a href="vpn_ipsec_phase2.php?p2index=<?=$ph2ent['uniqid']; ?>"
+            title="<?=gettext("edit phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left"
+            alt="edit" class="btn btn-default btn-xs">
           <span class="glyphicon glyphicon-pencil"></span>
         </a>
-        <button name="delp2_<?=$ph2index;
-?>_x" title="<?=gettext("delete phase2 entry");?>"
+        <button name="delp2_<?=$ph2index; ?>_x"
+          title="<?=gettext("delete phase 2 entry");?>" data-toggle="tooltip" data-placement="left"
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase2 entry?"); ?>')"
           class="btn btn-default btn-xs">
           <span class="glyphicon glyphicon-remove"><span>
         </button>
-        <a href="vpn_ipsec_phase2.php?dup=<?=$ph2ent['uniqid'];
-?>" title="<?=gettext("add a new Phase 2 based on this one"); ?>" alt="add" class="btn btn-default btn-xs">
+        <a href="vpn_ipsec_phase2.php?dup=<?=$ph2ent['uniqid']; ?>"
+            title="<?=gettext("clone phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left"
+            alt="add" class="btn btn-default btn-xs">
           <span class="fa fa-clone text-muted"></span>
         </a>
     </td>
@@ -521,25 +523,25 @@ endforeach;
 ?>
 
                                 <button name="movep2_<?=$j;?>_x" type="submit"
-                                  title="<?=gettext("move selected phase2 entries to end");?>"
+                                  title="<?=gettext("move selected phase 2 entries to end");?>" data-toggle="tooltip" data-placement="left"
                                   class="btn btn-default btn-xs">
                                   <span class="glyphicon glyphicon-arrow-down"></span>
                                 </button>
 <?php                                 endif;
 ?>
-                <a href="vpn_ipsec_phase2.php?ikeid=<?=$ph1ent['ikeid'];
-?><?= isset($ph1ent['mobile'])?"&amp;mobile=true":"";?>" class="btn btn-default btn-xs">
-                  <span title="<?=gettext("add phase2 entry"); ?>" alt="add" class="glyphicon glyphicon-plus"></span>
-                </a>
 <?php                                 if ($j > 0) :
 ?>
-                                <button name="delp2_x" type="submit" title="<?=gettext("delete selected phase2 entries");?>"
+                                <button name="delp2_x" type="submit" title="<?=gettext("delete selected phase 2 entries");?>" data-toggle="tooltip" data-placement="left"
                                   onclick="return confirm('<?=gettext("Do you really want to delete the selected phase2 entries?");?>')"
                                   class="btn btn-default btn-xs">
                                   <span class="glyphicon glyphicon-remove"></span>
                                 </button>
 <?php                                 endif;
 ?>
+                <a href="vpn_ipsec_phase2.php?ikeid=<?=$ph1ent['ikeid']; ?><?= isset($ph1ent['mobile'])?"&amp;mobile=true":"";?>" class="btn btn-default btn-xs"
+                    title="<?=gettext("add phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left">
+                  <span alt="add" class="glyphicon glyphicon-plus"></span>
+                </a>
               </td>
             </tr>
           </tbody>
@@ -556,21 +558,24 @@ endforeach;  // $a_phase1 as $ph1ent
                     <td>
                       <button name="move_<?=$i;?>_x"
 											type="submit"
-											title="<?=gettext("move selected phase1 entries to end");?>"
+											title="<?=gettext("move selected phase 1 entries to end");?>"
+											data-toggle="tooltip" data-placement="left"
 											class="btn btn-default btn-xs">
 											<span class="glyphicon glyphicon-arrow-down"></span>
 										</button>
-                      <a href="vpn_ipsec_phase1.php" title="<?=gettext("add new phase1");?>" alt="add" class="btn btn-default btn-xs">
-											<span class="glyphicon glyphicon-plus"></span>
-										</a>
                       <button
 											name="del_x"
 											type="submit"
-											title="<?=gettext("delete selected phase1 entries");?>"
+											title="<?=gettext("delete selected phase 1 entries");?>"
+											data-toggle="tooltip" data-placement="left"
 											onclick="return confirm('<?=gettext("Do you really want to delete the selected phase1 entries?");?>')"
 											class="btn btn-default btn-xs">
 											<span class="glyphicon glyphicon-remove"></span>
 										</button>
+                      <a href="vpn_ipsec_phase1.php" title="<?=gettext("add new phase 1 entry");?>" data-toggle="tooltip" data-placement="left"
+                          alt="add" class="btn btn-default btn-xs">
+											<span class="glyphicon glyphicon-plus"></span>
+										</a>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -381,7 +381,7 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
 ?>
                       <a href="vpn_ipsec_phase1.php?dup=<?=$i;
 ?>" title="<?=gettext("copy phase1 entry"); ?>" class="btn btn-default btn-xs" alt="add">
-                                      <span class="glyphicon glyphicon-plus"></span>
+                                      <span class="fa fa-clone text-muted"></span>
                       </a>
 <?php                 endif;
 ?>
@@ -506,7 +506,7 @@ if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm
         </button>
         <a href="vpn_ipsec_phase2.php?dup=<?=$ph2ent['uniqid'];
 ?>" title="<?=gettext("add a new Phase 2 based on this one"); ?>" alt="add" class="btn btn-default btn-xs">
-          <span class="glyphicon glyphicon-plus"></span>
+          <span class="fa fa-clone text-muted"></span>
         </a>
     </td>
   </tr>


### PR DESCRIPTION
Reworked action buttons of several lists:
* IPsec phase 1 and phase 2 entries
* Firewall rules
* NAT rules (all 4 pages)
* Firewall schedules
* Virtual IPs
* Gateways
* Gateway groups
* Routes

Changes applied (to each page):
* Changed plus icon of "add new item based on this one" to a clone icon; changed text to "clone item" (#606)
* Applied consistent button order of move, remove, add, clone
* Changed tooltips "click to toggle enable/disable rule" to "disable rule" and "enable rule" corresponding to the current state, respectively
* Added missing tooltips for buttons


Additionally the title of the manual NAT rules table was changed from "Mappings" to "Manual rules", since the automatically generated rules are called "Automatic rules" and also the NAT mode only uses the word "rules" and never "mapping".