### PR TITLE
unbound: Fix "register DHCP leases in DNS" config option

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -549,18 +549,20 @@ function unbound_add_host_entries() {
     }
 
     // Handle DHCPLeases added host entries
-    $dhcplcfg = read_hosts();
-    $host_entries = "";
-    if (is_array($dhcplcfg)) {
-        foreach($dhcplcfg as $key=>$host) {
-            $host_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
-            $host_entries .= "local-data: \"{$host['fqdn']} IN A {$host['ipaddr']}\"\n";
-            if (!empty($host['name'])) {
-                $host_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['name']}\"\n";
-                $host_entries .= "local-data: \"{$host['name']} IN A {$host['ipaddr']}\"\n";
+    if (isset($config['unbound']['regdhcp'])) {
+        $dhcplcfg = read_hosts();
+        $host_entries = "";
+        if (is_array($dhcplcfg)) {
+            foreach($dhcplcfg as $key=>$host) {
+                $host_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
+                $host_entries .= "local-data: \"{$host['fqdn']} IN A {$host['ipaddr']}\"\n";
+                if (!empty($host['name'])) {
+                    $host_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['name']}\"\n";
+                    $host_entries .= "local-data: \"{$host['name']} IN A {$host['ipaddr']}\"\n";
+                }
             }
+            $unbound_entries .= $host_entries;
         }
-        $unbound_entries .= $host_entries;
     }
 
     // Write out entries


### PR DESCRIPTION
The option to register DHCP leases within unbound DNS was configurable via
DNS Resolver GUI, but the setting was ignored. DHCP leases were always applied.

There is still a bug in the "register DHCP leases in DNS" feature which might be related to this, but I'm not yet sure if it's a bug in the dhcpd or in unbound config generators: #624