### PR TITLE
Unify action buttons of lists

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1004,6 +1004,28 @@ function alias_expand($name) {
 	}
 }
 
+/* get description of alias */
+function get_alias_description($name)
+{
+    global $config;
+
+    if (is_alias($name))
+    {
+        if (isset($config['aliases']['alias']))
+        {
+            foreach ($config['aliases']['alias'] as $alias)
+            {
+                if ($alias['name'] == $name)
+                {
+                    return (isset($alias['descr'])) ? $alias['descr'] : "";
+                }
+            }
+
+            return null;
+        }
+    }
+}
+
 function subnet_size($subnet) {
 	if (is_subnetv4($subnet)) {
 		list ($ip, $bits) = explode("/", $subnet);

--- a/src/www/diag_confbak.php
+++ b/src/www/diag_confbak.php
@@ -321,7 +321,7 @@ $( document ).ready(function() {
                              <span class="glyphicon glyphicon-log-in"></span>
                            </a>
                            <a data-id="<?=$version['time'];?>" href="#" class="act_delete btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("Remove this backup");?>" >
-                             <span class="glyphicon glyphicon-remove"></span>
+                             <span class="fa fa-trash text-muted"></span>
                            </a>
                            <a href="diag_confbak.php?getcfg=<?=$version['time'];?>" class="btn btn-default btn-xs" title="<?=gettext("Download this backup");?>">
                            <span class="glyphicon glyphicon-download"></span>

--- a/src/www/diag_confbak.php
+++ b/src/www/diag_confbak.php
@@ -317,10 +317,10 @@ $( document ).ready(function() {
                         <td> <?= format_bytes($version['filesize']) ?></td>
                         <td> <?= "{$version['username']}: {$version['description']}" ?></td>
                         <td>
-                          <a data-id="<?=$version['time'];?>" href="#" class="act_revert btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("Revert to this configuration");?>">
+                          <a data-id="<?=$version['time'];?>" href="#" class="act_revert btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("Revert to this configuration");?>">
                              <span class="glyphicon glyphicon-log-in"></span>
                            </a>
-                           <a data-id="<?=$version['time'];?>" href="#" class="act_delete btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("Remove this backup");?>" >
+                           <a data-id="<?=$version['time'];?>" href="#" class="act_delete btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("Remove this backup");?>" >
                              <span class="fa fa-trash text-muted"></span>
                            </a>
                            <a href="diag_confbak.php?getcfg=<?=$version['time'];?>" class="btn btn-default btn-xs" title="<?=gettext("Download this backup");?>">

--- a/src/www/diag_tables.php
+++ b/src/www/diag_tables.php
@@ -182,7 +182,7 @@ $( document ).ready(function() {
                   <td><?=$entry;?></td>
                   <td>
                     <a data-address="<?=$entry;?>" title="<?=gettext("delete this entry"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </a>
                   </td>
                 </tr>

--- a/src/www/firewall_aliases.php
+++ b/src/www/firewall_aliases.php
@@ -245,7 +245,7 @@ $( document ).ready(function() {
                       </td>
                       <td>
                         <a href="firewall_aliases_edit.php?id=<?=$i;?>" title="<?=gettext("Edit alias"); ?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a id="del_<?=$i;?>" title="<?=gettext("delete alias"); ?>" class="act_delete btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a id="del_<?=$i;?>" title="<?=gettext("delete alias"); ?>" class="act_delete btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
                       </td>
                     </tr>
 <?php

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -303,7 +303,7 @@ $( document ).ready(function() {
 <?php                 endif; ?>
                       </td>
                       <td>
-                        <a href="#" class="act_toggle" id="toggle_<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
+                        <a href="#" class="act_toggle" id="toggle_<?=$nnats;?>" data-toggle="tooltip" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
 <?php                     if (!empty($natent['associated-rule-id'])): ?>
 <?php                     if(isset($natent['disabled'])):?>
                           <span class="glyphicon glyphicon-resize-horizontal text-muted"></span>
@@ -414,16 +414,16 @@ $( document ).ready(function() {
                       </td>
 
                       <td>
-                        <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_nat_edit.php?id=<?=$nnats;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_nat_edit.php?id=<?=$nnats;?>" data-toggle="tooltip" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$nnats;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash text-muted"></span>
                         </a>
-                        <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
+                        <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>
@@ -439,18 +439,18 @@ $( document ).ready(function() {
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </span>
 <?php               else: ?>
-                        <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
 <?php                   endif; ?>
 <?php                   if (count($a_nat) == 0): ?>
-                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
+                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
 <?php                   else: ?>
                         <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash text-muted"></span>
                         </a>
 <?php                   endif; ?>
-                        <a href="firewall_nat_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">
+                        <a href="firewall_nat_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("add new rule");?>">
                           <span class="glyphicon glyphicon-plus"></span>
                         </a>
                     </td>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -421,7 +421,7 @@ $( document ).ready(function() {
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$nnats;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </a>
                         <a href="firewall_nat_edit.php?dup=<?=$nnats;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
@@ -444,10 +444,10 @@ $( document ).ready(function() {
                         </a>
 <?php                   endif; ?>
 <?php                   if (count($a_nat) == 0): ?>
-                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="glyphicon glyphicon-remove" ></span></span>
+                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
 <?php                   else: ?>
                         <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </a>
 <?php                   endif; ?>
                         <a href="firewall_nat_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -323,36 +323,70 @@ $( document ).ready(function() {
                       <td>
                         <?=strtoupper($natent['protocol']);?>
                       </td>
+
                       <td class="hidden-xs hidden-sm">
-                        <?=htmlspecialchars(pprint_address($natent['source']));?>
 <?php                   if (isset($natent['source']['address']) && is_alias($natent['source']['address'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['address']);?>"><i class="fa fa-list"></i> </a>
+                          <span title="<?=htmlspecialchars(get_alias_description($natent['source']['address']));?>" data-toggle="tooltip">
+                            <?=htmlspecialchars(pprint_address($natent['source'])); ?>
+                          </span>
+                          <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['address']);?>"
+                              title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                            <i class="fa fa-list"></i>
+                          </a>
+<?php                   else: ?>
+                          <?=htmlspecialchars(pprint_address($natent['source'])); ?>
 <?php                   endif; ?>
                       </td>
+
                       <td class="hidden-xs hidden-sm">
-                        <?=htmlspecialchars(pprint_port($natent['source']['port']));?>
-<?php                   if (is_alias($natent['source']['port'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['port']);?>"><i class="fa fa-list"></i> </a>
+<?php                   if (isset($natent['source']['port']) && is_alias($natent['source']['port'])): ?>
+                          <span title="<?=htmlspecialchars(get_alias_description($natent['source']['port']));?>" data-toggle="tooltip">
+                            <?=htmlspecialchars(pprint_port($natent['source']['port'])); ?>&nbsp;
+                          </span>
+                          <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['port']);?>"
+                              title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                            <i class="fa fa-list"></i>
+                          </a>
+<?php                   else: ?>
+                          <?=htmlspecialchars(pprint_port(isset($natent['source']['port']) ? $natent['source']['port'] : null)); ?>
 <?php                   endif; ?>
                       </td>
+
                       <td class="hidden-xs hidden-sm">
-                        <?=htmlspecialchars(pprint_address($natent['destination']));?>
 <?php                   if (isset($natent['destination']['address']) && is_alias($natent['destination']['address'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"><i class="fa fa-list"></i> </a>
+                          <span title="<?=htmlspecialchars(get_alias_description($natent['destination']['address']));?>" data-toggle="tooltip">
+                            <?=htmlspecialchars(pprint_address($natent['destination'])); ?>
+                          </span>
+                          <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"
+                              title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                            <i class="fa fa-list"></i>
+                          </a>
+<?php                   else: ?>
+                          <?=htmlspecialchars(pprint_address($natent['destination'])); ?>
 <?php                   endif; ?>
                       </td>
+
                       <td class="hidden-xs hidden-sm">
-                        <?=htmlspecialchars(pprint_port($natent['destination']['port']));?>
-<?php                   if (is_alias($natent['destination']['port'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['port']);?>"><i class="fa fa-list"></i> </a>
+<?php                   if (isset($natent['destination']['port']) && is_alias($natent['destination']['port'])): ?>
+                          <span title="<?=htmlspecialchars(get_alias_description($natent['destination']['port']));?>" data-toggle="tooltip">
+                            <?=htmlspecialchars(pprint_port($natent['destination']['port'])); ?>&nbsp;
+                          </span>
+                          <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['port']);?>"
+                              title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                            <i class="fa fa-list"></i>
+                          </a>
+<?php                   else: ?>
+                          <?=htmlspecialchars(pprint_port(isset($natent['destination']['port']) ? $natent['destination']['port'] : null)); ?>
 <?php                   endif; ?>
                       </td>
+
                       <td>
                         <?=$natent['target'];?>
 <?php                   if (is_alias($natent['target'])): ?>
                         &nbsp;<a href="/firewall_aliases_edit.php?name=<?=$natent['target'];?>"><i class="fa fa-list"></i> </a>
 <?php                   endif; ?>
                       </td>
+
                       <td>
 <?php
                         $localport = $natent['local-port'];
@@ -362,14 +396,23 @@ $( document ).ready(function() {
                             $localport   .= '-' . $localendport;
                         }
 ?>
-                        <?=htmlspecialchars(pprint_port($localport));?>
-<?php                   if (is_alias($localport)): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($localport);?>"><i class="fa fa-list"></i> </a>
+<?php                   if (isset($natent['destination']['port']) && is_alias($natent['destination']['port'])): ?>
+                          <span title="<?=htmlspecialchars(get_alias_description($localport));?>" data-toggle="tooltip">
+                            <?=htmlspecialchars(pprint_port($localport));?>&nbsp;
+                          </span>
+                          <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($localport);?>"
+                              title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                            <i class="fa fa-list"></i>
+                          </a>
+<?php                   else: ?>
+                          <?=htmlspecialchars(pprint_port($localport));?>
 <?php                   endif; ?>
                       </td>
+
                       <td>
                         <?=$natent['descr'];?>
                       </td>
+
                       <td>
                         <a type="submit" id="move_<?=$nnats;?>" name="move_<?=$nnats;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
@@ -387,6 +430,7 @@ $( document ).ready(function() {
                      </tr>
 <?php $nnats++; endforeach; ?>
                     <tr>
+
                     <td colspan="8"></td>
                     <td class="hidden-xs hidden-sm" colspan="4"> </td>
                     <td>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -231,15 +231,29 @@ $main_buttons = array(
 <?php                 endif; ?>
                     </td>
                     <td>
-                      <?=pprint_address($natent['source']);?>
 <?php                 if (isset($natent['source']['address']) && is_alias($natent['source']['address'])): ?>
-                      &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['address']);?>"><i class="fa fa-list"></i> </a>
+                        <span title="<?=htmlspecialchars(get_alias_description($natent['source']['address']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_address($natent['source']));?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['address']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_address($natent['source']));?>
 <?php                 endif; ?>
                     </td>
                     <td>
-                      <?=pprint_address($natent['destination']);?>
 <?php                 if (isset($natent['destination']['address']) && is_alias($natent['destination']['address'])): ?>
-                      &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"><i class="fa fa-list"></i> </a>
+                        <span title="<?=htmlspecialchars(get_alias_description($natent['destination']['address']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_address($natent['destination']));?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_address($natent['destination']));?>
 <?php                 endif; ?>
                     </td>
                     <td>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -267,7 +267,7 @@ $main_buttons = array(
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </a>
                       <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>" class="btn btn-default btn-xs">
                         <span class="fa fa-clone text-muted"></span>
@@ -297,12 +297,12 @@ $main_buttons = array(
 <?php               if ($i == 0):
 ?>
                       <span title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip" class="btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </span>
 <?php               else:
 ?>
                       <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </a>
 <?php               endif;
 ?>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -213,7 +213,7 @@ $main_buttons = array(
                       <input type="checkbox" name="rule[]" value="<?=$i;?>" />
                     </td>
                     <td>
-                      <a href="#" type="submit" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>" class="act_toggle">
+                      <a href="#" type="submit" id="toggle_<?=$i;?>" data-toggle="tooltip" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>" class="act_toggle">
 <?php                   if(isset($natent['disabled'])):?>
                           <span class="glyphicon glyphicon-play text-muted"></span>
 <?php                   else:?>
@@ -260,16 +260,16 @@ $main_buttons = array(
                       <?=$natent['descr'];?> &nbsp;
                     </td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_nat_1to1_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule ");?>">
+                      <a href="firewall_nat_1to1_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("edit rule ");?>">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="fa fa-trash text-muted"></span>
                       </a>
-                      <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_nat_1to1_edit.php?dup=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("clone rule");?>" class="btn btn-default btn-xs">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
@@ -289,7 +289,7 @@ $main_buttons = array(
                       </span>
 <?php               else:
 ?>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
 <?php               endif;
@@ -306,7 +306,7 @@ $main_buttons = array(
                       </a>
 <?php               endif;
 ?>
-                      <a href="firewall_nat_1to1_edit.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
+                      <a href="firewall_nat_1to1_edit.php" data-toggle="tooltip" title="<?=gettext("add new rule");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plus"></span></a>
                     </td>
                   </tr>
                 </tbody>

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -211,7 +211,7 @@ $main_buttons = array(
                           <input type="checkbox" name="rule[]" value="<?=$i;?>"  />
                       </td>
                       <td>
-                        <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
+                        <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" title="<?=(!isset($natent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>">
 <?php                     if(isset($natent['disabled'])):?>
                           <span class="glyphicon glyphicon-play text-muted"></span>
 <?php                        else:?>
@@ -232,16 +232,16 @@ $main_buttons = array(
                           <?=$natent['descr'];?>
                       </td>
                       <td>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_nat_npt_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_nat_npt_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash text-muted"></span>
                         </a>
-                        <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
+                        <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>
@@ -255,18 +255,18 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </span>
 <?php               else: ?>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
 <?php                   endif; ?>
 <?php                   if (count($a_npt) == 0): ?>
-                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
+                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
 <?php                   else: ?>
                         <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash text-muted"></span>
                         </a>
 <?php                   endif; ?>
-                        <a href="firewall_nat_npt_edit.php?after=-1" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">
+                        <a href="firewall_nat_npt_edit.php?after=-1" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("add new rule");?>">
                           <span class="glyphicon glyphicon-plus"></span>
                         </a>
                         </td>

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -239,7 +239,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </a>
                         <a href="firewall_nat_npt_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                           <span class="fa fa-clone text-muted"></span>
@@ -260,10 +260,10 @@ $main_buttons = array(
                         </a>
 <?php                   endif; ?>
 <?php                   if (count($a_npt) == 0): ?>
-                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="glyphicon glyphicon-remove" ></span></span>
+                      <span class="btn btn-default btn-xs text-muted"  data-toggle="tooltip" data-placement="left" title="<?=gettext("delete selected rules");?>"><span class="fa fa-trash text-muted" ></span></span>
 <?php                   else: ?>
                         <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </a>
 <?php                   endif; ?>
                         <a href="firewall_nat_npt_edit.php?after=-1" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -363,10 +363,17 @@ include("head.inc");
                       <?=htmlspecialchars(convert_friendly_interface_to_friendly_descr($natent['interface'])); ?>
                     </td>
                     <td class="hidden-xs hidden-sm">
-                      <?= $natent['source']['network'] == "(self)" ? "This Firewall" : $natent['source']['network']; ?>
-<?php                   if (isset($natent['source']['network']) && is_alias($natent['source']['network'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['network']);?>"><i class="fa fa-list"></i> </a>
-<?php                   endif; ?>
+<?php                 if (isset($natent['source']['network']) && is_alias($natent['source']['network'])): ?>
+                        <span title="<?=htmlspecialchars(get_alias_description($natent['source']['network']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars($natent['source']['network']);?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['source']['network']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=$natent['source']['network'] == "(self)" ? gettext("This Firewall") : htmlspecialchars($natent['source']['network']); ?>&nbsp;
+<?php                 endif; ?>
                     </td>
                     <td class="hidden-xs hidden-sm">
                       <?=!empty($natent['protocol']) ? $natent['protocol'] . '/' : "" ;?>
@@ -374,10 +381,17 @@ include("head.inc");
                     </td>
                     <td class="hidden-xs hidden-sm">
                       <?=isset($natent['destination']['not']) ? "!&nbsp;" :"";?>
-                      <?=isset($natent['destination']['any']) ? "*" : $natent['destination']['address'] ;?>
-<?php                   if (isset($natent['destination']['address']) && is_alias($natent['destination']['address'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"><i class="fa fa-list"></i> </a>
-<?php                   endif; ?>
+<?php                 if (isset($natent['destination']['address']) && is_alias($natent['destination']['address'])): ?>
+                        <span title="<?=htmlspecialchars(get_alias_description($natent['destination']['address']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars($natent['destination']['address']);?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['destination']['address']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=isset($natent['destination']['any']) ? "*" : htmlspecialchars($natent['destination']['address']);?>
+<?php                 endif; ?>
                     </td>
                     <td class="hidden-xs hidden-sm">
                       <?=!empty($natent['protocol']) ? $natent['protocol'] . '/' : "" ;?>
@@ -395,10 +409,17 @@ include("head.inc");
                       else
                         $nat_address = $natent['target'];
 ?>
-                      <?=htmlspecialchars($nat_address);?>
-<?php                   if (isset($natent['target']) && is_alias($natent['target'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['target']);?>"><i class="fa fa-list"></i> </a>
-<?php                   endif; ?>
+<?php                 if (isset($natent['target']) && is_alias($natent['target'])): ?>
+                        <span title="<?=htmlspecialchars(get_alias_description($natent['target']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars($nat_address);?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($natent['target']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars($nat_address);?>
+<?php                 endif; ?>
                     </td>
                     <td class="hidden-xs hidden-sm">
                       <?=empty($natent['natport']) ? "*" : htmlspecialchars($natent['natport']);?>

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -431,16 +431,16 @@ include("head.inc");
                       <?=htmlspecialchars($natent['descr']);?>&nbsp;
                     </td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_nat_out_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_nat_out_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="fa fa-trash text-muted"></span>
                       </a>
-                      <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
+                      <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
@@ -461,7 +461,7 @@ include("head.inc");
 <?php
                 else:
 ?>
-                  <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                  <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                     <span class="glyphicon glyphicon-arrow-left"></span>
                   </a>
 <?php

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -438,7 +438,7 @@ include("head.inc");
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </a>
                       <a href="firewall_nat_out_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
@@ -470,12 +470,12 @@ include("head.inc");
 <?php
                 if ($i == 0):
 ?>
-                  <span title="<?=gettext("delete selected rules");?>"  class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></span>
+                  <span title="<?=gettext("delete selected rules");?>"  class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></span>
 <?php
                 else:
 ?>
                   <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="fa fa-trash text-muted"></span>
                   </a>
 <?php
                 endif;

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -548,9 +548,27 @@ $( document ).ready(function() {
                     </td>
                     <td class="hidden-xs hidden-sm">
 <?php
-                       if (!empty($filterent['sched'])):?>
-                      <?=htmlspecialchars($filterent['sched']);?>
-                      <a href="/firewall_schedule_edit.php?name=<?=htmlspecialchars($filterent['sched']);?>"> <span class="glyphicon glyphicon-calendar"> </span> </a>
+                      if (!empty($filterent['sched'])):?>
+<?php
+                        $schedule_descr = "";
+                        if (isset($config['schedules']['schedule']))
+                        {
+                            foreach ($config['schedules']['schedule'] as $schedule)
+                            {
+                                if ($schedule['name'] == $filterent['sched'])
+                                {
+                                    $schedule_descr = (isset($schedule['descr'])) ? $schedule['descr'] : "";
+                                }
+                            }
+                        }
+?>
+                        <span title="<?=htmlspecialchars($schedule_descr);?>" data-toggle="tooltip">
+                          <?=htmlspecialchars($filterent['sched']);?>&nbsp;
+                        </span>
+                        <a href="/firewall_schedule_edit.php?name=<?=htmlspecialchars($filterent['sched']);?>"
+                            title="<?=gettext("edit schedule");?>" data-toggle="tooltip">
+                          <i class="glyphicon glyphicon-calendar"></i>
+                        </a>
 <?php
                        endif;?>
                     </td>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -446,6 +446,7 @@ $( document ).ready(function() {
                       <span class="glyphicon glyphicon-info-sign <?=!empty($filterent['disabled']) ? "text-muted" :""?>"></span>
 <?php                 endif; ?>
                     </td>
+
                     <td>
                         <?=$record_ipprotocol;?>
 <?php
@@ -479,30 +480,63 @@ $( document ).ready(function() {
 <?php
                         endif;?>
                     </td>
+
                     <td>
-                      <?=htmlspecialchars(pprint_address($filterent['source']));?>
 <?php                 if (isset($filterent['source']['address']) && is_alias($filterent['source']['address'])): ?>
-                      &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['source']['address']);?>"><i class="fa fa-list"></i> </a>
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['address']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_address($filterent['source']));?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['source']['address']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_address($filterent['source']));?>
 <?php                 endif; ?>
                     </td>
+
                     <td class="hidden-xs hidden-sm">
-                      <?=htmlspecialchars(pprint_port(isset($filterent['source']['port']) ? $filterent['source']['port'] : null)); ?>
-<?php                   if (isset($filterent['source']['port']) && is_alias($filterent['source']['port'])): ?>
-                        &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['source']['port']);?>"><i class="fa fa-list"></i> </a>
-<?php                   endif; ?>
+<?php                 if (isset($filterent['source']['port']) && is_alias($filterent['source']['port'])): ?>
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['port']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_port($filterent['source']['port'])); ?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['source']['port']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_port(isset($filterent['source']['port']) ? $filterent['source']['port'] : null)); ?>
+<?php                 endif; ?>
                     </td>
+
                     <td class="hidden-xs hidden-sm">
-                      <?=htmlspecialchars(pprint_address($filterent['destination'])); ?>
 <?php                 if (isset($filterent['destination']['address']) && is_alias($filterent['destination']['address'])): ?>
-                      &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['destination']['address']);?>"><i class="fa fa-list"></i> </a>
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['address']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_address($filterent['destination'])); ?>
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['destination']['address']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_address($filterent['destination'])); ?>
 <?php                 endif; ?>
                     </td>
+
                     <td class="hidden-xs hidden-sm">
-                      <?=htmlspecialchars(pprint_port(isset($filterent['destination']['port']) ? $filterent['destination']['port'] : null)); ?>
 <?php                 if (isset($filterent['destination']['port']) && is_alias($filterent['destination']['port'])): ?>
-                      &nbsp;<a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['destination']['port']);?>"><i class="fa fa-list"></i> </a>
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['port']));?>" data-toggle="tooltip">
+                          <?=htmlspecialchars(pprint_port($filterent['destination']['port'])); ?>&nbsp;
+                        </span>
+                        <a href="/firewall_aliases_edit.php?name=<?=htmlspecialchars($filterent['destination']['port']);?>"
+                            title="<?=gettext("edit alias");?>" data-toggle="tooltip">
+                          <i class="fa fa-list"></i>
+                        </a>
+<?php                 else: ?>
+                        <?=htmlspecialchars(pprint_port(isset($filterent['destination']['port']) ? $filterent['destination']['port'] : null)); ?>
 <?php                 endif; ?>
                     </td>
+
                     <td class="hidden-xs hidden-sm">
 <?php
                        if (isset($filterent['gateway'])):?>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -583,7 +583,7 @@ $( document ).ready(function() {
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </a>
                       <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
@@ -620,7 +620,7 @@ $( document ).ready(function() {
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
                       <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </a>
                       <a href="firewall_rules_edit.php?if=<?=$selected_if;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">
                         <span class="glyphicon glyphicon-plus"></span>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -290,7 +290,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Block all IPv6 traffic");?></td>
                     <td>
-                      <a href="system_advanced_network.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="system_advanced_network.php" data-toggle="tooltip" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -314,7 +314,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Anti-Lockout Rule");?></td>
                     <td>
-                      <a href="system_advanced_admin.php" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="system_advanced_admin.php" data-toggle="tooltip" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -340,7 +340,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td class="hidden-xs hidden-sm"><?=gettext("Block private networks");?></td>
                     <td valign="middle" class="list nowrap">
-                        <a href="interfaces.php?if=<?=$selected_if?>#rfc1918" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="interfaces.php?if=<?=$selected_if?>#rfc1918" data-toggle="tooltip" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -365,7 +365,7 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td><?=gettext("Block bogon networks");?></td>
                     <td>
-                      <a href="interfaces.php?if=<?=htmlspecialchars($if)?>#rfc1918" data-toggle="tooltip" data-placement="left" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
+                      <a href="interfaces.php?if=<?=htmlspecialchars($if)?>#rfc1918" data-toggle="tooltip" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
@@ -424,23 +424,23 @@ $( document ).ready(function() {
                       <input type="checkbox" name="rule[]" value="<?=$i;?>"  />
                     </td>
                     <td>
-                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(empty($filterent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>"><span class="glyphicon <?=$iconfn;?>"></span></a>
+                      <a href="#" class="act_toggle" id="toggle_<?=$i;?>" data-toggle="tooltip" title="<?=(empty($filterent['disabled'])) ? gettext("disable rule") : gettext("enable rule");?>"><span class="glyphicon <?=$iconfn;?>"></span></a>
 <?php
                       if (!empty($filterent['direction']) && $filterent['direction'] == "in"):?>
-                        <i class="fa fa-long-arrow-right" data-toggle="tooltip" data-placement="left" title="<?=gettext("in");?>"></i>
+                        <i class="fa fa-long-arrow-right" data-toggle="tooltip" title="<?=gettext("in");?>"></i>
 <?php
                       elseif (!empty($filterent['direction']) && $filterent['direction'] == "out"):?>
-                        <i class="fa fa-long-arrow-left" data-toggle="tooltip" data-placement="left" title="<?=gettext("out");?>"></i>
+                        <i class="fa fa-long-arrow-left" data-toggle="tooltip" title="<?=gettext("out");?>"></i>
 <?php
                       elseif (!empty($filterent['direction']) && $filterent['direction'] == "any"):?>
-                        <i class="fa fa-arrows-h" data-toggle="tooltip" data-placement="left" title="<?=gettext("any");?>"></i>
+                        <i class="fa fa-arrows-h" data-toggle="tooltip" title="<?=gettext("any");?>"></i>
 <?php                 endif;?>
 <?php                 if ($selected_if != 'FloatingRules'):
                         ; // interfaces are always quick
                       elseif (isset($filterent['quick']) && $filterent['quick'] === 'yes'): ?>
-                        <i class="fa fa-flash text-warning" data-toggle="tooltip" data-placement="left" title="<?= gettext('first match') ?>"></i>
+                        <i class="fa fa-flash text-warning" data-toggle="tooltip" title="<?= gettext('first match') ?>"></i>
 <?php                 else: ?>
-                        <i class="fa fa-flash text-muted" data-toggle="tooltip" data-placement="left" title="<?= gettext('last match') ?>"></i>
+                        <i class="fa fa-flash text-muted" data-toggle="tooltip" title="<?= gettext('last match') ?>"></i>
 <?php                 endif; ?>
 <?php                 if (isset($filterent['log'])):?>
                       <span class="glyphicon glyphicon-info-sign <?=!empty($filterent['disabled']) ? "text-muted" :""?>"></span>
@@ -576,16 +576,16 @@ $( document ).ready(function() {
                       <?=htmlspecialchars($filterent['descr']);?>
                     </td>
                     <td>
-                      <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
+                      <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules before this rule");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
-                      <a href="firewall_rules_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
+                      <a href="firewall_rules_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit rule");?>" class="btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-pencil"></span>
                       </a>
                       <a id="del_<?=$i;?>" title="<?=gettext("delete rule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="fa fa-trash text-muted"></span>
                       </a>
-                      <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone rule");?>">
+                      <a href="firewall_rules_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone rule");?>">
                         <span class="fa fa-clone text-muted"></span>
                       </a>
                     </td>
@@ -616,13 +616,13 @@ $( document ).ready(function() {
                     <td colspan="5"></td>
                     <td colspan="5" class="hidden-xs hidden-sm"></td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected rules to end");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
                       <a id="del_x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                         <span class="fa fa-trash text-muted"></span>
                       </a>
-                      <a href="firewall_rules_edit.php?if=<?=$selected_if;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new rule");?>">
+                      <a href="firewall_rules_edit.php?if=<?=$selected_if;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("add new rule");?>">
                         <span class="glyphicon glyphicon-plus"></span>
                       </a>
                     </td>

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -236,7 +236,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$i;?>" title="<?=gettext("delete schedule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </a>
                         <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone schedule");?>">
                           <span class="fa fa-clone text-muted"></span>

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -232,13 +232,13 @@ $main_buttons = array(
                       <?=$schedule['descr'];?>
                       </td>
                       <td>
-                        <a href="firewall_schedule_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit schedule");?>" class="btn btn-default btn-xs">
+                        <a href="firewall_schedule_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit schedule");?>" class="btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <a id="del_<?=$i;?>" title="<?=gettext("delete schedule"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash text-muted"></span>
                         </a>
-                        <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone schedule");?>">
+                        <a href="firewall_schedule.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone schedule");?>">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                     </td>

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -91,6 +91,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         foreach ($a_schedules as $i => $sched) {
             if ($sched['name'] == $_GET['name']) {
               $id = $i;
+              $configId = $id;
               break;
             }
         }

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -641,7 +641,7 @@ function insertElements(tempFriendlyTime, starttimehour, starttimemin, stoptimeh
     tr.appendChild(td);
 
     td = d.createElement("td");
-    td.innerHTML = "<a onclick='removeRow(this); return false;' href='#' class=\"btn btn-default btn-xs\"><span class=\"glyphicon glyphicon-remove\"></span></\a>";
+    td.innerHTML = "<a onclick='removeRow(this); return false;' href='#' class=\"btn btn-default btn-xs\"><span class=\"fa fa-trash text-muted\"></span></\a>";
     tr.appendChild(td);
 
     td = d.createElement("td");
@@ -1140,7 +1140,7 @@ function removeRow(el) {
                                     <a onclick='editRow("<?=$tempTime; ?>",this); return false;' href='#' class="btn btn-default"><span class="glyphicon glyphicon-pencil"></span></a>
                                   </td>
                                   <td>
-                                    <a onclick='removeRow(this); return false;' href='#' class="btn btn-default"><span class="glyphicon glyphicon-remove"></span></a>
+                                    <a onclick='removeRow(this); return false;' href='#' class="btn btn-default"><span class="fa fa-trash text-muted"></span></a>
                                   </td>
                                   <td>
                                     <input type='hidden' id='schedule<?=$counter; ?>' name='schedule<?=$counter; ?>' value='<?=$tempID; ?>' />

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -306,16 +306,16 @@ $main_buttons = array(
                           <?=htmlspecialchars($vipent['descr']);?>
                         </td>
                         <td>
-                          <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected virtual IPs before this entry");?>" class="act_move btn btn-default btn-xs">
+                          <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected virtual IPs before this entry");?>" class="act_move btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-arrow-left"></span>
                           </a>
-                          <a href="firewall_virtual_ip_edit.php?id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit virtual IP");?>" class="btn btn-default btn-xs">
+                          <a href="firewall_virtual_ip_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit virtual IP");?>" class="btn btn-default btn-xs">
                             <span class="glyphicon glyphicon-pencil"></span>
                           </a>
                           <a id="del_<?=$i;?>" title="<?=gettext("delete virtual IP"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                             <span class="fa fa-trash text-muted"></span>
                           </a>
-                          <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone virtual IP");?>">
+                          <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("clone virtual IP");?>">
                             <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>
@@ -329,10 +329,10 @@ $main_buttons = array(
                     <tr>
                       <td colspan="5"></td>
                       <td>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected virtual IPs to end");?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=gettext("move selected virtual IPs to end");?>" class="act_move btn btn-default btn-xs">
                           <span class="glyphicon glyphicon-arrow-left"></span>
                         </a>
-                        <a href="firewall_virtual_ip_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("add new virtual IP");?>">
+                        <a href="firewall_virtual_ip_edit.php" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("add new virtual IP");?>">
                           <span class="glyphicon glyphicon-plus"></span>
                         </a>
                       </td>

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -313,7 +313,7 @@ $main_buttons = array(
                             <span class="glyphicon glyphicon-pencil"></span>
                           </a>
                           <a id="del_<?=$i;?>" title="<?=gettext("delete virtual IP"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                            <span class="glyphicon glyphicon-remove"></span>
+                            <span class="fa fa-trash text-muted"></span>
                           </a>
                           <a href="firewall_virtual_ip_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" title="<?=gettext("clone virtual IP");?>">
                             <span class="fa fa-clone text-muted"></span>

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -422,7 +422,7 @@ include("head.inc");
 <?php
                         if ($ifname != 'wan'):?>
                           <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$ifname;?>" class="btn btn-default act_delete" type="submit">
-                            <span class=" glyphicon glyphicon-remove"></span>
+                            <span class="fa fa-trash text-muted"></span>
                           </button>
 <?php
                         endif;?>

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -421,7 +421,7 @@ include("head.inc");
                         <td>
 <?php
                         if ($ifname != 'wan'):?>
-                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$ifname;?>" class="btn btn-default act_delete" type="submit">
+                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$ifname;?>" class="btn btn-default act_delete" type="submit">
                             <span class="fa fa-trash text-muted"></span>
                           </button>
 <?php
@@ -445,7 +445,7 @@ include("head.inc");
                           </select>
                         </td>
                         <td>
-                          <button name="add_x" type="submit" value="<?=$portname;?>" class="btn btn-primary" title="<?=gettext("add selected interface");?>" data-toggle="tooltip" data-placement="left">
+                          <button name="add_x" type="submit" value="<?=$portname;?>" class="btn btn-primary" title="<?=gettext("add selected interface");?>" data-toggle="tooltip">
                             <span class="glyphicon glyphicon-plus"></span>
                           </button>
                         </td>

--- a/src/www/interfaces_bridge.php
+++ b/src/www/interfaces_bridge.php
@@ -156,7 +156,7 @@ $main_buttons = array(
                             <span class="glyphicon glyphicon-edit"></span>
                           </a>
                           <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                            <span class=" glyphicon glyphicon-remove"></span>
+                            <span class="fa fa-trash text-muted"></span>
                           </button>
                         </td>
                       </tr>

--- a/src/www/interfaces_bridge.php
+++ b/src/www/interfaces_bridge.php
@@ -152,10 +152,10 @@ $main_buttons = array(
                         </td>
                         <td><?=$bridge['descr'];?></td>
                         <td>
-                          <a href="interfaces_bridge_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit bridge");?>">
+                          <a href="interfaces_bridge_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit bridge");?>">
                             <span class="glyphicon glyphicon-edit"></span>
                           </a>
-                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                             <span class="fa fa-trash text-muted"></span>
                           </button>
                         </td>

--- a/src/www/interfaces_gif.php
+++ b/src/www/interfaces_gif.php
@@ -135,7 +135,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                          <span class=" glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>
                     </tr>

--- a/src/www/interfaces_gif.php
+++ b/src/www/interfaces_gif.php
@@ -131,10 +131,10 @@ $main_buttons = array(
                       <td><?=$gif['remote-addr'];?></td>
                       <td><?=$gif['descr'];?></td>
                       <td>
-                        <a href="interfaces_gif_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit interface");?>">
+                        <a href="interfaces_gif_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit interface");?>">
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
-                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                           <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>

--- a/src/www/interfaces_gre.php
+++ b/src/www/interfaces_gre.php
@@ -133,10 +133,10 @@ $main_buttons = array(
                       <td><?=$gre['remote-addr'];?></td>
                       <td><?=$gre['descr'];?></td>
                       <td>
-                        <a href="interfaces_gre_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit interface");?>">
+                        <a href="interfaces_gre_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit interface");?>">
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
-                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                            <span class="fa fa-trash text-muted"></span>
                          </button>
                        </td>

--- a/src/www/interfaces_gre.php
+++ b/src/www/interfaces_gre.php
@@ -137,7 +137,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                           <span class=" glyphicon glyphicon-remove"></span>
+                           <span class="fa fa-trash text-muted"></span>
                          </button>
                        </td>
                     </tr>

--- a/src/www/interfaces_groups.php
+++ b/src/www/interfaces_groups.php
@@ -131,10 +131,10 @@ $main_buttons = array(
                     </td>
                     <td><?=$ifgroupentry['descr'];?></td>
                     <td>
-                      <a href="interfaces_groups_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit group");?>">
+                      <a href="interfaces_groups_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit group");?>">
                         <span class="glyphicon glyphicon-edit"></span>
                       </a>
-                      <button title="<?=gettext("delete ifgroupentry");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                      <button title="<?=gettext("delete ifgroupentry");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                         <span class="fa fa-trash text-muted"></span>
                       </button>
                     </td>

--- a/src/www/interfaces_groups.php
+++ b/src/www/interfaces_groups.php
@@ -135,7 +135,7 @@ $main_buttons = array(
                         <span class="glyphicon glyphicon-edit"></span>
                       </a>
                       <button title="<?=gettext("delete ifgroupentry");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                        <span class=" glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </button>
                     </td>
                   </tr>

--- a/src/www/interfaces_lagg.php
+++ b/src/www/interfaces_lagg.php
@@ -141,10 +141,10 @@ $main_buttons = array(
                         <td><?=$lagg['members'];?></td>
                         <td><?=$lagg['descr'];?></td>
                         <td>
-                          <a href="interfaces_lagg_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit interface");?>">
+                          <a href="interfaces_lagg_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit interface");?>">
                             <span class="glyphicon glyphicon-edit"></span>
                           </a>
-                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                            <span class="fa fa-trash text-muted"></span>
                          </button>
                         </td>

--- a/src/www/interfaces_lagg.php
+++ b/src/www/interfaces_lagg.php
@@ -145,7 +145,7 @@ $main_buttons = array(
                             <span class="glyphicon glyphicon-edit"></span>
                           </a>
                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                           <span class=" glyphicon glyphicon-remove"></span>
+                           <span class="fa fa-trash text-muted"></span>
                          </button>
                         </td>
                       </tr>

--- a/src/www/interfaces_ppps.php
+++ b/src/www/interfaces_ppps.php
@@ -142,7 +142,7 @@ $main_buttons = array(
                     <td><?=$ppp['descr'];?></td>
                     <td>
                       <a href="interfaces_ppps_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default"><span class="glyphicon glyphicon-edit" title="<?=gettext("edit group");?>"></span></a>
-                      <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                      <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                         <span class="fa fa-trash text-muted"></span>
                       </button>
                     </td>

--- a/src/www/interfaces_ppps.php
+++ b/src/www/interfaces_ppps.php
@@ -143,7 +143,7 @@ $main_buttons = array(
                     <td>
                       <a href="interfaces_ppps_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default"><span class="glyphicon glyphicon-edit" title="<?=gettext("edit group");?>"></span></a>
                       <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                        <span class=" glyphicon glyphicon-remove"></span>
+                        <span class="fa fa-trash text-muted"></span>
                       </button>
                     </td>
                   </tr>

--- a/src/www/interfaces_qinq.php
+++ b/src/www/interfaces_qinq.php
@@ -154,7 +154,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                          <span class=" glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>
                     </tr>

--- a/src/www/interfaces_qinq.php
+++ b/src/www/interfaces_qinq.php
@@ -150,10 +150,10 @@ $main_buttons = array(
                       <td><?=strlen($qinq['members']) > 20 ? substr($qinq['members'], 0, 20) . "..." : $qinq['members'] ;?></td>
                       <td><?=$qinq['descr'];?></td>
                       <td>
-                        <a href="interfaces_qinq_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit group");?>">
+                        <a href="interfaces_qinq_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit group");?>">
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
-                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                           <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>

--- a/src/www/interfaces_vlan.php
+++ b/src/www/interfaces_vlan.php
@@ -137,7 +137,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
                          <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                           <span class=" glyphicon glyphicon-remove"></span>
+                           <span class="fa fa-trash text-muted"></span>
                          </button>
                        </td>
                     </tr>

--- a/src/www/interfaces_vlan.php
+++ b/src/www/interfaces_vlan.php
@@ -133,10 +133,10 @@ $main_buttons = array(
                       <td><?=$vlan['tag'];?></td>
                       <td><?=$vlan['descr'];?></td>
                       <td>
-                        <a href="interfaces_vlan_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" data-placement="left"  title="<?=gettext("edit interface");?>">
+                        <a href="interfaces_vlan_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default" data-toggle="tooltip" title="<?=gettext("edit interface");?>">
                           <span class="glyphicon glyphicon-edit"></span>
                         </a>
-                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                            <span class="fa fa-trash text-muted"></span>
                          </button>
                        </td>

--- a/src/www/interfaces_wireless.php
+++ b/src/www/interfaces_wireless.php
@@ -134,7 +134,7 @@ $main_buttons = array(
                           <span class="glyphicon glyphicon-edit" title="<?=gettext("edit group");?>"></span>
                         </a>
                         <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
-                          <span class=" glyphicon glyphicon-remove"></span>
+                          <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>
                     </tr>

--- a/src/www/interfaces_wireless.php
+++ b/src/www/interfaces_wireless.php
@@ -133,7 +133,7 @@ $main_buttons = array(
                         <a href="interfaces_wireless_edit.php?id=<?=$i;?>" class="btn btn-xs btn-default">
                           <span class="glyphicon glyphicon-edit" title="<?=gettext("edit group");?>"></span>
                         </a>
-                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-placement="left" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
+                        <button title="<?=gettext("delete interface");?>" data-toggle="tooltip" data-id="<?=$i;?>" class="btn btn-default btn-xs act_delete" type="submit">
                           <span class="fa fa-trash text-muted"></span>
                         </button>
                       </td>

--- a/src/www/javascript/row_helper.js
+++ b/src/www/javascript/row_helper.js
@@ -62,7 +62,7 @@ var addRowTo = (function() {
 	td = d.createElement("td");
 	td.rowSpan = "1";
 
-	td.innerHTML = '<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>';
+	td.innerHTML = '<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="fa fa-trash"></span></a>';
 	tr.appendChild(td);
 	tbody.appendChild(tr);
 	totalrows++;

--- a/src/www/javascript/row_helper_dynamic.js
+++ b/src/www/javascript/row_helper_dynamic.js
@@ -60,7 +60,7 @@ var addRowTo = (function() {
 	}
 	td = d.createElement("td");
 	td.rowSpan = "1";
-	td.innerHTML = '<a onclick="removeRow(this); return false;" href="#"><span class="glyphicon glyphicon-remove"></span></a>';
+	td.innerHTML = '<a onclick="removeRow(this); return false;" href="#"><span class="fa fa-trash"></span></a>';
 	tr.appendChild(td);
 	tbody.appendChild(tr);
 	if(rowhelper_onAdd != '')

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -818,7 +818,7 @@ include("head.inc");
 											</td>
 											<td>
 												<a href="services_dhcp.php?if=<?=htmlspecialchars($if);?>&amp;pool=<?=$i;?>"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-pencil"></span></button></a>
-												<a href="services_dhcp.php?if=<?=htmlspecialchars($if);?>&amp;act=delpool&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this pool?");?>')"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button></a>
+												<a href="services_dhcp.php?if=<?=htmlspecialchars($if);?>&amp;act=delpool&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this pool?");?>')"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
 											</td>
 											</tr>
 											<?php endif; ?>
@@ -1067,7 +1067,7 @@ include("head.inc");
 												<input autocomplete="off" name="value<?php echo $counter; ?>" type="text" class="form-control unknown" id="value<?php echo $counter; ?>" size="40" value="<?=htmlspecialchars($value);?>" />
 											</td>
 											<td>
-												<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></a>
+												<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></a>
 											</td>
 											</tr>
 											<?php $counter++; ?>
@@ -1164,7 +1164,7 @@ include("head.inc");
 										<table border="0" cellspacing="0" cellpadding="1" summary="icons">
 										<tr>
 										<td valign="middle"><a href="services_dhcp_edit.php?if=<?=htmlspecialchars($if);?>&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a></td>
-										<td valign="middle"><a href="services_dhcp.php?if=<?=htmlspecialchars($if);?>&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this mapping?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+										<td valign="middle"><a href="services_dhcp.php?if=<?=htmlspecialchars($if);?>&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this mapping?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 										</tr>
 										</table>
 									</td>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -781,7 +781,7 @@ include("head.inc");
 													<input autocomplete="off" name="value<?php echo $counter; ?>" type="text" class="formfld" id="value<?php echo $counter; ?>" size="55" value="<?=htmlspecialchars($value);?>" />
 												</td>
 												<td>
-													<butto onclick="removeRow(this); return false;" value="<?=gettext("Delete");?>" ><span class="glyphicon glyphicon-remove"></span></button>
+													<butto onclick="removeRow(this); return false;" value="<?=gettext("Delete");?>" ><span class="fa fa-trash"></span></button>
 												</td>
 												</tr>
 												<?php $counter++; ?>
@@ -865,7 +865,7 @@ include("head.inc");
 											<table border="0" cellspacing="0" cellpadding="1" summary="icons">
 											<tr>
 											<td valign="middle"><a href="services_dhcpv6_edit.php?if=<?=$if;?>&amp;id=<?=$i;?>" alt="edit"><span class="glyphicon glyphicon-pencil"></span></a></td>
-											<td valign="middle"><a href="services_dhcpv6.php?if=<?=$if;?>&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this mapping?");?>')" alt="delete"><span class="glyphicon glyphicon-remove"></span></a></td>
+											<td valign="middle"><a href="services_dhcpv6.php?if=<?=$if;?>&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this mapping?");?>')" alt="delete"><span class="fa fa-trash"></span></a></td>
 											</tr>
 											</table>
 										</td>

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -395,7 +395,7 @@ function show_advanced_dns() {
 											<table border="0" cellspacing="0" cellpadding="1" summary="icons">
 												<tr>
 													<td valign="middle"><a href="services_dnsmasq_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a></td>
-													<td><a href="services_dnsmasq.php?type=host&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this host?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+													<td><a href="services_dnsmasq.php?type=host&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this host?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 												</tr>
 											</table>
 									</tr>
@@ -468,7 +468,7 @@ function show_advanced_dns() {
 											<?=htmlspecialchars($doment['descr']);?>&nbsp;
 										</td>
 										<td valign="middle" class="list nowrap"> <a href="services_dnsmasq_domainoverride_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-											&nbsp;<a href="services_dnsmasq.php?act=del&amp;type=doverride&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this domain override?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+											&nbsp;<a href="services_dnsmasq.php?act=del&amp;type=doverride&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this domain override?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 									</tr>
 									<?php $i++; endforeach; ?>
 									<tr style="display:none"><td></td></tr>

--- a/src/www/services_dyndns.php
+++ b/src/www/services_dyndns.php
@@ -172,7 +172,7 @@ $main_buttons = array(
 										  </td>
 										  <td valign="middle" class="list nowrap">
 											<a href="services_dyndns_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-											&nbsp;<a href="services_dyndns.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this entry?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+											&nbsp;<a href="services_dyndns.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this entry?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
 										  </td>
 										</tr>
 										<?php $i++; endforeach; ?>

--- a/src/www/services_igmpproxy.php
+++ b/src/www/services_igmpproxy.php
@@ -126,7 +126,7 @@ $main_buttons = array(
 									  </td>
 									  <td valign="middle" class="list nowrap">
 									     <a href="services_igmpproxy_edit.php?id=<?=$i;?>" title="<?=gettext("edit igmpentry"); ?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-									     <a href="services_igmpproxy.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this igmp entry? All elements that still use it will become invalid (e.g. filter rules)!");?>')" title="<?=gettext("delete igmpentry");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+									     <a href="services_igmpproxy.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this igmp entry? All elements that still use it will become invalid (e.g. filter rules)!");?>')" title="<?=gettext("delete igmpentry");?>" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
 									  </td>
 									</tr>
 										  <?php $i++; endforeach; ?>

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -302,7 +302,7 @@ include("head.inc");
 													</select>
 												</td>
 												<td>
-													<a onclick="removeRow(this); return false;" href="#" alt="" title="<?=gettext("remove this entry"); ?>"><span class="glyphicon glyphicon-remove"></span></a>
+													<a onclick="removeRow(this); return false;" href="#" alt="" title="<?=gettext("remove this entry"); ?>"><span class="fa fa-trash text-muted"></span></a>
 												</td>
 											</tr>
 						<?php

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -276,7 +276,7 @@ include("head.inc");
 																<input name="description<?=$counter;?>" type="text" class="formfld unknown" id="description<?=$counter;?>" size="40" value="<?=htmlspecialchars($description);?>" />
 															</td>
 															<td>
-																<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+																<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="fa fa-trash"></span></a>
 															</td>
 														</tr>
 													<?php $counter++; ?>
@@ -358,7 +358,7 @@ include("head.inc");
 												</td>
 												<td>
 													<a href="services_unbound_acls.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-													<a href="services_unbound_acls.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this access list?"); ?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+													<a href="services_unbound_acls.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this access list?"); ?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
 												</td>
 											</tr>
 										<?php

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -353,7 +353,7 @@ include("head.inc");
 															<input name="aliasdescription<?php echo $counter; ?>" type="text" class="formfld unknown" id="aliasdescription<?php echo $counter; ?>" size="20" value="<?=htmlspecialchars($description);?>" />
 														</td>
 														<td>
-															<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+															<a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
 														</td>
 													</tr>
 													<?php

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -179,7 +179,7 @@ include_once("head.inc");
 										<table border="0" cellspacing="0" cellpadding="1" summary="icons">
 											<tr>
 												<td valign="middle"><a href="services_unbound_host_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a></td>
-												<td><a href="services_unbound_overrides.php?type=host&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this host?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+												<td><a href="services_unbound_overrides.php?type=host&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this host?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 											</tr>
 										</table>
 								</tr>
@@ -241,7 +241,7 @@ include_once("head.inc");
 										<table border="0" cellspacing="0" cellpadding="1" summary="icons">
 											<tr>
 												<td valign="middle"><a href="services_unbound_domainoverride_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a></td>
-												<td valign="middle"><a href="services_unbound_overrides.php?act=del&amp;type=doverride&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this domain override?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+												<td valign="middle"><a href="services_unbound_overrides.php?act=del&amp;type=doverride&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this domain override?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 											</tr>
 										</table>
 									</td>

--- a/src/www/services_wol.php
+++ b/src/www/services_wol.php
@@ -198,7 +198,7 @@ include("head.inc");
 						                    <table border="0" cellspacing="0" cellpadding="1" summary="icons">
 						                      <tr>
 						                        <td valign="middle"><a href="services_wol_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a></td>
-						                        <td valign="middle"><a href="services_wol.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this entry?");?>')" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a></td>
+						                        <td valign="middle"><a href="services_wol.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('<?=gettext("Do you really want to delete this entry?");?>')" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a></td>
 						                      </tr>
 						                    </table>
 						                  </td>

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -180,7 +180,7 @@ $( document ).ready(function() {
                   </td>
                   <td>
                     <a href="system_advanced_sysctl.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs">
-                        <span data-toggle="tooltip" data-placement="left" title="<?=gettext("Edit Tunable"); ?>" class="glyphicon glyphicon-pencil"></span>
+                        <span data-toggle="tooltip" title="<?=gettext("Edit Tunable"); ?>" class="glyphicon glyphicon-pencil"></span>
                     </a>
                     <a id="del_<?=$i;?>" data-id="<?=$i;?>" title="<?=gettext("Delete Tunable"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                       <span class="fa fa-trash text-muted"></span>

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -183,7 +183,7 @@ $( document ).ready(function() {
                         <span data-toggle="tooltip" data-placement="left" title="<?=gettext("Edit Tunable"); ?>" class="glyphicon glyphicon-pencil"></span>
                     </a>
                     <a id="del_<?=$i;?>" data-id="<?=$i;?>" title="<?=gettext("Delete Tunable"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </a>
                   </td>
                 </tr>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -700,7 +700,7 @@ $i = 0;
                     </a>
                     &nbsp;
                     <a id="del_<?=$i;?>" title="<?=gettext("delete this server"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </a>
                   </td>
 <?php

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -778,7 +778,7 @@ $main_buttons = array(
 <?php
                   endif; ?>
                   <a id="del_<?=$i;?>" data-id="<?=$i;?>" title="<?=gettext("delete ca"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="fa fa-trash text-muted"></span>
                   </a>
                 </td>
               </tr>

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -764,15 +764,15 @@ $main_buttons = array(
                   </table>
                 </td>
                 <td>
-                  <a href="system_camanager.php?act=edit&amp;id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("edit CA");?>" alt="<?=gettext("edit CA");?>" class="btn btn-default btn-xs">
+                  <a href="system_camanager.php?act=edit&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit CA");?>" alt="<?=gettext("edit CA");?>" class="btn btn-default btn-xs">
                     <span class="glyphicon glyphicon-pencil"></span>
                   </a>
-                  <a href="system_camanager.php?act=exp&amp;id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("export CA cert");?>" alt="<?=gettext("export CA cert");?>" class="btn btn-default btn-xs">
+                  <a href="system_camanager.php?act=exp&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("export CA cert");?>" alt="<?=gettext("export CA cert");?>" class="btn btn-default btn-xs">
                     <span class="glyphicon glyphicon-download"></span>
                   </a>
 <?php
                   if ($ca['prv']) :?>
-                  <a href="system_camanager.php?act=expkey&amp;id=<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("export CA private key");?>" class="btn btn-default btn-xs">
+                  <a href="system_camanager.php?act=expkey&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("export CA private key");?>" class="btn btn-default btn-xs">
                     <span class="glyphicon glyphicon-download"></span>
                   </a>
 <?php

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -1294,7 +1294,7 @@ $( document ).ready(function() {
                   if (!cert_in_use($cert['refid'])) :?>
 
                   <a id="del_<?=$i;?>" data-id="<?=$i;?>" title="<?=gettext("delete cert"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="fa fa-trash text-muted"></span>
                   </a>
 <?php
                   endif;

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -534,7 +534,7 @@ include("head.inc");
                   <td><?=date("D M j G:i:s T Y", $cert["revoke_time"]); ?></td>
                   <td>
                     <a id="del_cert_<?=$thiscrl['refid'];?>" data-id="<?=$thiscrl['refid'];?>" data-certref="<?=$cert['refid'];?>" title="<?=gettext("Delete this certificate from the CRL ");?>" data-toggle="tooltip"  class="act_delete_cert btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </a>
                   </td>
                 </tr>
@@ -677,7 +677,7 @@ include("head.inc");
 <?php
                   if (!$inuse) :?>
                     <a id="del_<?=$tmpcrl['refid'];?>" data-descr="<?=htmlspecialchars($tmpcrl['descr']);?>" data-id="<?=$tmpcrl['refid'];?>" title="<?=gettext("Delete CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </a>
 <?php
                   endif; ?>

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -635,12 +635,12 @@ include("head.inc");
                   <td>
 <?php
                   if (!empty($ca['prv'])) :?>
-                    <a href="system_crlmanager.php?act=new&amp;caref=<?=$ca['refid']; ?>" data-toggle="tooltip" data-placement="left" title="<?php printf(gettext("Add or Import CRL for %s"), htmlspecialchars($ca['descr']));?>" class="btn btn-default btn-xs">
+                    <a href="system_crlmanager.php?act=new&amp;caref=<?=$ca['refid']; ?>" data-toggle="tooltip" title="<?php printf(gettext("Add or Import CRL for %s"), htmlspecialchars($ca['descr']));?>" class="btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-plus"></span>
                     </a>
 <?php
                   else :?>
-                    <a href="system_crlmanager.php?act=new&amp;caref=<?=$ca['refid']; ?>&amp;importonly=yes" data-toggle="tooltip" data-placement="left" title="<?php printf(gettext("Import CRL for %s"), htmlspecialchars($ca['descr']));?>" class="btn btn-default btn-xs">
+                    <a href="system_crlmanager.php?act=new&amp;caref=<?=$ca['refid']; ?>&amp;importonly=yes" data-toggle="tooltip" title="<?php printf(gettext("Import CRL for %s"), htmlspecialchars($ca['descr']));?>" class="btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-plus"></span>
                     </a>
 <?php
@@ -660,17 +660,17 @@ include("head.inc");
                   <td><?=$inuse ? gettext("YES") : gettext("NO"); ?></td>
                   <td>
                     <a href="system_crlmanager.php?act=exp&amp;id=<?=$tmpcrl['refid'];?>" class="btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-export" data-toggle="tooltip" data-placement="left" title="<?=gettext("Export CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
+                        <span class="glyphicon glyphicon-export" data-toggle="tooltip" title="<?=gettext("Export CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
                     </a>
 <?php
                   if ($internal) :?>
                     <a href="system_crlmanager.php?act=edit&amp;id=<?=$tmpcrl['refid'];?>" class="btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-edit" data-toggle="tooltip" data-placement="left" title="<?=gettext("Edit CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
+                      <span class="glyphicon glyphicon-edit" data-toggle="tooltip" title="<?=gettext("Edit CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
                     </a>
 <?php
                   else :?>
                     <a href="system_crlmanager.php?act=editimported&amp;id=<?=$tmpcrl['refid'];?>" class="btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-edit" data-toggle="tooltip" data-placement="left" title="<?=gettext("Edit CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
+                      <span class="glyphicon glyphicon-edit" data-toggle="tooltip" title="<?=gettext("Edit CRL") . " " . htmlspecialchars($tmpcrl['descr']);?>"></span>
                     </a>
 <?php
                   endif; ?>

--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -196,15 +196,15 @@ $( document ).ready(function() {
                       <td><?=$gateway_group['descr'];?></td>
                       <td>
                         <a href="system_gateway_groups_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"
-                            title="edit group" data-toggle="tooltip" data-placement="left">
+                            title="edit group" data-toggle="tooltip">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                         <button type="button" class="btn btn-default btn-xs act-del-group"
-                            data-id="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
-                            data-placement="left" ><span class="fa fa-trash text-muted"></span>
+                            data-id="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip">
+                          <span class="fa fa-trash text-muted"></span>
                         </button>
                         <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
-                            title="clone group" data-toggle="tooltip" data-placement="left">
+                            title="clone group" data-toggle="tooltip">
                           <span class="fa fa-clone text-muted"></span>
                         </a>
                       </td>

--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -201,7 +201,7 @@ $( document ).ready(function() {
                         </a>
                         <button type="button" class="btn btn-default btn-xs act-del-group"
                             data-id="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
-                            data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
+                            data-placement="left" ><span class="fa fa-trash text-muted"></span>
                         </button>
                         <a href="system_gateway_groups_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
                             title="clone group" data-toggle="tooltip" data-placement="left">

--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -323,15 +323,15 @@ $( document ).ready(function() {
                       <td>
 <?php
                     if (isset($gateway['inactive'])) :?>
-                        <span class="fa fa-trash text-muted" data-toggle="tooltip" data-placement="left" title="<?=gettext("Gateway is inactive because interface is missing");?>"></span>
+                        <span class="fa fa-trash text-muted" data-toggle="tooltip" title="<?=gettext("Gateway is inactive because interface is missing");?>"></span>
 <?php
                     elseif (is_numeric($gateway['attribute'])) :?>
-                        <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($gateway['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>">
+                        <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" title="<?=(!isset($gateway['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>">
                           <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>"></span>
                         </a>
 <?php
                     else :?>
-                        <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($filterent['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>"></span>
+                        <span class="glyphicon glyphicon-play <?=isset($gateway['disabled']) || isset($gateway['inactive']) ? "text-muted" : "text-success";?>" data-toggle="tooltip" title="<?=(!isset($filterent['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>"></span>
 <?php
                     endif;?>
                       </td>
@@ -353,7 +353,7 @@ $( document ).ready(function() {
                       </td>
                       <td>
                         <a href="system_gateways_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"
-                          data-toggle="tooltip" data-placement="left" title="<?=gettext("edit gateway");?>">
+                          data-toggle="tooltip" title="<?=gettext("edit gateway");?>">
                           <span class="glyphicon glyphicon-pencil"></span>
                         </a>
 <?php
@@ -365,7 +365,7 @@ $( document ).ready(function() {
 <?php
                         endif;?>
                           <a href="system_gateways_edit.php?dup=<?=$i;?>" class="btn btn-default btn-xs"
-                             data-toggle="tooltip" data-placement="left" title="<?=gettext("clone gateway");?>">
+                             data-toggle="tooltip" title="<?=gettext("clone gateway");?>">
                             <span class="fa fa-clone text-muted"></span>
                           </a>
                         </td>
@@ -379,7 +379,7 @@ $( document ).ready(function() {
 <?php
                       if ($i > 0) :
                                       ?>
-                          <button type="submit" id="btn_delete" name="del_x" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
+                          <button type="submit" id="btn_delete" name="del_x" class="btn btn-default btn-xs" data-toggle="tooltip" 
                                   title="<?=gettext("delete selected items");?>">
                               <span class="fa fa-trash text-muted"></span>
                           </button>

--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -323,7 +323,7 @@ $( document ).ready(function() {
                       <td>
 <?php
                     if (isset($gateway['inactive'])) :?>
-                        <span class="glyphicon glyphicon-remove text-muted" data-toggle="tooltip" data-placement="left" title="<?=gettext("Gateway is inactive because interface is missing");?>"></span>
+                        <span class="fa fa-trash text-muted" data-toggle="tooltip" data-placement="left" title="<?=gettext("Gateway is inactive because interface is missing");?>"></span>
 <?php
                     elseif (is_numeric($gateway['attribute'])) :?>
                         <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=(!isset($gateway['disabled'])) ? gettext("disable gateway") : gettext("enable gateway");?>">
@@ -360,7 +360,7 @@ $( document ).ready(function() {
                         if (is_numeric($gateway['attribute'])) :?>
                           <button data-id="<?=$i;?>" title="<?=gettext("delete gateway"); ?>" data-toggle="tooltip"
                                   class="act_delete btn btn-default btn-xs">
-                            <span class="glyphicon glyphicon-remove"></span>
+                            <span class="fa fa-trash text-muted"></span>
                           </button>
 <?php
                         endif;?>
@@ -381,7 +381,7 @@ $( document ).ready(function() {
                                       ?>
                           <button type="submit" id="btn_delete" name="del_x" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
                                   title="<?=gettext("delete selected items");?>">
-                              <span class="glyphicon glyphicon-remove"></span>
+                              <span class="fa fa-trash text-muted"></span>
                           </button>
 <?php
                       endif;?>

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -421,7 +421,7 @@ $( document ).ready(function() {
                       <td><?=$priv_list[$priv]['descr'];?></td>
                       <td>
                           <button type="button" data-privid="<?=$priv;?>" data-privname="<?=$priv_list[$priv]['name']?>" class="btn btn-default btn-xs act-del-priv" title="<?=gettext("delete privilege");?>" data-toggle="tooltip" data-placement="left">
-                            <span class="glyphicon glyphicon-remove"></span>
+                            <span class="fa fa-trash text-muted"></span>
                           </button>
                       </td>
                     </tr>
@@ -497,7 +497,7 @@ $( document ).ready(function() {
                     <button type="button" class="btn btn-default btn-xs act-del-group"
                         data-groupname="<?=$group['name'];?>"
                         data-groupid="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
-                        data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
+                        data-placement="left" ><span class="fa fa-trash text-muted"></span>
                     </button>
 <?php
                     endif;?>

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -368,11 +368,11 @@ $( document ).ready(function() {
                         </td>
                         <td class="text-center">
                           <br />
-                          <a href="javascript:move_selected('notmembers','members')" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"  title="<?=gettext("Add Groups"); ?>">
+                          <a href="javascript:move_selected('notmembers','members')" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("Add Groups"); ?>">
                               <span class="glyphicon glyphicon-arrow-right"></span>
                           </a>
                           <br /><br />
-                          <a href="javascript:move_selected('members','notmembers')" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"  title="<?=gettext("Remove Groups"); ?>">
+                          <a href="javascript:move_selected('members','notmembers')" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("Remove Groups"); ?>">
                               <span class="glyphicon glyphicon-arrow-left"></span>
                           </a>
                         </td>
@@ -420,7 +420,7 @@ $( document ).ready(function() {
                       <td><?=$priv_list[$priv]['name'];?></td>
                       <td><?=$priv_list[$priv]['descr'];?></td>
                       <td>
-                          <button type="button" data-privid="<?=$priv;?>" data-privname="<?=$priv_list[$priv]['name']?>" class="btn btn-default btn-xs act-del-priv" title="<?=gettext("delete privilege");?>" data-toggle="tooltip" data-placement="left">
+                          <button type="button" data-privid="<?=$priv;?>" data-privname="<?=$priv_list[$priv]['name']?>" class="btn btn-default btn-xs act-del-priv" title="<?=gettext("delete privilege");?>" data-toggle="tooltip">
                             <span class="fa fa-trash text-muted"></span>
                           </button>
                       </td>
@@ -487,8 +487,7 @@ $( document ).ready(function() {
                   </td>
                   <td>
                     <a href="system_groupmanager.php?act=edit&groupid=<?=$i?>"
-                       class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
-                       title="<?=gettext("edit group");?>">
+                       class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("edit group");?>">
                         <span class="glyphicon glyphicon-pencil"></span>
                     </a>
 
@@ -496,8 +495,8 @@ $( document ).ready(function() {
                     if ($group['scope'] != "system") :?>
                     <button type="button" class="btn btn-default btn-xs act-del-group"
                         data-groupname="<?=$group['name'];?>"
-                        data-groupid="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip"
-                        data-placement="left" ><span class="fa fa-trash text-muted"></span>
+                        data-groupid="<?=$i?>" title="<?=gettext("delete group");?>" data-toggle="tooltip">
+                      <span class="fa fa-trash text-muted"></span>
                     </button>
 <?php
                     endif;?>
@@ -513,7 +512,7 @@ $( document ).ready(function() {
                   <td class="hidden-xs"> </td>
                   <td class="list">
                     <a href="system_groupmanager.php?act=new" class="btn btn-default btn-xs"
-                       title="<?=gettext("add user");?>" data-toggle="tooltip" data-placement="left">
+                       title="<?=gettext("add user");?>" data-toggle="tooltip">
                       <span class="glyphicon glyphicon-plus"></span>
                     </a>
                   </td>

--- a/src/www/system_routes.php
+++ b/src/www/system_routes.php
@@ -254,7 +254,7 @@ endif; ?>
                     </td>
                     <td>
                       <a href="#" class="act_toggle" data-id="<?=$i;?>">
-                        <span class="glyphicon glyphicon-play <?=isset($route['disabled']) ? "text-muted" : "text-success" ;?>" data-toggle="tooltip" data-placement="left"
+                        <span class="glyphicon glyphicon-play <?=isset($route['disabled']) ? "text-muted" : "text-success" ;?>" data-toggle="tooltip"
                               title="<?=(!isset($route['disabled'])) ? gettext("disable route") : gettext("enable route");?>" alt="icon">
                         </span>
                       </a>
@@ -272,19 +272,19 @@ endif; ?>
                       <?=$route['descr'];?>
                     </td>
                     <td>
-                      <a data-id="<?=$i;?>" data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected routes before this route");?>" class="act_move btn btn-default btn-xs">
+                      <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("move selected routes before this route");?>" class="act_move btn btn-default btn-xs">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                       </a>
                       <a class="btn btn-default btn-xs" href="system_routes_edit.php?id=<?=$i;?>"
-                          title="<?=gettext("edit route");?>" data-toggle="tooltip" data-placement="left">
+                          title="<?=gettext("edit route");?>" data-toggle="tooltip">
                         <span class="glyphicon glyphicon-pencil" alt="edit" ></span>
                       </a>
                       <button type="button" class="btn btn-default btn-xs act-del-route"
-                          data-id="<?=$i?>" title="<?=gettext("delete route");?>" data-toggle="tooltip"
-                          data-placement="left" ><span class="fa fa-trash text-muted"></span>
+                          data-id="<?=$i?>" title="<?=gettext("delete route");?>" data-toggle="tooltip">
+                        <span class="fa fa-trash text-muted"></span>
                       </button>
                       <a class="btn btn-default btn-xs" href="system_routes_edit.php?dup=<?=$i;?>"
-                          title="<?=gettext("clone route");?>" data-toggle="tooltip" data-placement="left">
+                          title="<?=gettext("clone route");?>" data-toggle="tooltip">
                         <span class="fa fa-clone text-muted" alt="duplicate"></span>
                       </a>
                     </td>
@@ -302,7 +302,7 @@ endif; ?>
                             title="<?=gettext("move selected routes to end");?>" alt="move" />
 <?php
                     else :?>
-                    <button type="submit" data-id="<?=$i;?>"  data-toggle="tooltip" data-placement="left" title="<?=gettext("move selected routes to end");?>" class="act_move btn btn-default btn-xs">
+                    <button type="submit" data-id="<?=$i;?>"  data-toggle="tooltip" title="<?=gettext("move selected routes to end");?>" class="act_move btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-arrow-left"></span>
                     </button>
 <?php
@@ -315,10 +315,10 @@ endif; ?>
 
 <?php
                     else :?>
-                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"><span class="fa fa-trash text-muted"></span></button>
+                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs" data-toggle="tooltip"><span class="fa fa-trash text-muted"></span></button>
 <?php
                     endif;?>
-                    <a href="system_routes_edit.php" class="btn btn-default btn-xs" title="<?=gettext("add route");?>" data-toggle="tooltip" data-placement="left">
+                    <a href="system_routes_edit.php" class="btn btn-default btn-xs" title="<?=gettext("add route");?>" data-toggle="tooltip">
                       <span class="glyphicon glyphicon-plus"></span>
                     </a>
                     </td>

--- a/src/www/system_routes.php
+++ b/src/www/system_routes.php
@@ -281,7 +281,7 @@ endif; ?>
                       </a>
                       <button type="button" class="btn btn-default btn-xs act-del-route"
                           data-id="<?=$i?>" title="<?=gettext("delete route");?>" data-toggle="tooltip"
-                          data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
+                          data-placement="left" ><span class="fa fa-trash text-muted"></span>
                       </button>
                       <a class="btn btn-default btn-xs" href="system_routes_edit.php?dup=<?=$i;?>"
                           title="<?=gettext("clone route");?>" data-toggle="tooltip" data-placement="left">
@@ -310,12 +310,12 @@ endif; ?>
 <?php
                     if ($i == 0) :?>
                     <span class="btn btn-default btn-xs">
-                        <span class="glyphicon glyphicon-remove text-muted"></span>
+                        <span class="fa fa-trash text-muted"></span>
                     </span>
 
 <?php
                     else :?>
-                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"><span class="glyphicon glyphicon-remove"></span></button>
+                    <button id="del_x" title="<?=gettext("delete selected routes");?>" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"><span class="fa fa-trash text-muted"></span></button>
 <?php
                     endif;?>
                     <a href="system_routes_edit.php" class="btn btn-default btn-xs" title="<?=gettext("add route");?>" data-toggle="tooltip" data-placement="left">

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -759,7 +759,7 @@ $( document ).ready(function() {
                             if (empty($priv['group'])) :?>
                               <button type="button" data-priv="<?=$priv['id']?>" class="btn btn-default btn-xs act-del-priv"
                                   title="<?=gettext("revoke privilege");?>" data-toggle="tooltip" data-placement="left">
-                                <span class="glyphicon glyphicon-remove"></span>
+                                <span class="fa fa-trash text-muted"></span>
                               </button>
 <?php
                             endif;?>
@@ -815,7 +815,7 @@ $( document ).ready(function() {
                             </a>
                             <button type="submit" data-certid="<?=$i;?>" class="btn btn-default btn-xs act-del-cert"
                                 title="<?=gettext("unlink certificate");?>" data-toggle="tooltip" data-placement="left" >
-                                <span class="glyphicon glyphicon-remove"></span>
+                                <span class="fa fa-trash text-muted"></span>
                             </button>
                           </td>
                         </tr>
@@ -973,7 +973,7 @@ $( document ).ready(function() {
                         <button type="button" class="btn btn-default btn-xs act-del-user"
                             data-username="<?=$userent['name'];?>"
                             data-userid="<?=$i?>" title="<?=gettext("delete user");?>" data-toggle="tooltip"
-                            data-placement="left" ><span class="glyphicon glyphicon-remove"></span>
+                            data-placement="left" ><span class="fa fa-trash text-muted"></span>
                         </button>
 <?php
                         endif;?>

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -758,7 +758,7 @@ $( document ).ready(function() {
 <?php
                             if (empty($priv['group'])) :?>
                               <button type="button" data-priv="<?=$priv['id']?>" class="btn btn-default btn-xs act-del-priv"
-                                  title="<?=gettext("revoke privilege");?>" data-toggle="tooltip" data-placement="left">
+                                  title="<?=gettext("revoke privilege");?>" data-toggle="tooltip">
                                 <span class="fa fa-trash text-muted"></span>
                               </button>
 <?php
@@ -771,7 +771,7 @@ $( document ).ready(function() {
                           <td colspan="3"></td>
                           <td>
                             <a href="system_usermanager_addprivs.php?userid=<?=$id?>" class="btn btn-xs btn-default"
-                                title="<?=gettext("assign privileges");?>" data-toggle="tooltip" data-placement="left">
+                                title="<?=gettext("assign privileges");?>" data-toggle="tooltip">
                               <span class="glyphicon glyphicon-plus"></span>
                             </a>
                           </td>
@@ -804,18 +804,16 @@ $( document ).ready(function() {
                           </td>
                           <td>
                             <a href="system_usermanager.php?act=expckey&amp;certid=<?=$i?>&amp;userid=<?=$id?>"
-                               class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
-                               title="<?=gettext("export private key");?>">
-                                <span class="glyphicon glyphicon-arrow-down"></span>
+                                class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("export private key");?>">
+                              <span class="glyphicon glyphicon-arrow-down"></span>
                             </a>
                             <a href="system_usermanager.php?act=expcert&amp;certid=<?=$i?>&amp;userid=<?=$id?>"
-                               class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
-                               title="<?=gettext("export certificate");?>">
-                                <span class="glyphicon glyphicon-arrow-down"></span>
+                                class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("export certificate");?>">
+                              <span class="glyphicon glyphicon-arrow-down"></span>
                             </a>
                             <button type="submit" data-certid="<?=$i;?>" class="btn btn-default btn-xs act-del-cert"
-                                title="<?=gettext("unlink certificate");?>" data-toggle="tooltip" data-placement="left" >
-                                <span class="fa fa-trash text-muted"></span>
+                                title="<?=gettext("unlink certificate");?>" data-toggle="tooltip">
+                              <span class="fa fa-trash text-muted"></span>
                             </button>
                           </td>
                         </tr>
@@ -827,7 +825,7 @@ $( document ).ready(function() {
                           <td colspan="2"></td>
                           <td>
                             <a href="system_certmanager.php?act=new&amp;userid=<?=$id?>" class="btn btn-default btn-xs"
-                                title="<?=gettext("create or link user certificate");?>" data-toggle="tooltip" data-placement="left" >
+                                title="<?=gettext("create or link user certificate");?>" data-toggle="tooltip">
                               <span class="glyphicon glyphicon-plus"></span>
                             </a>
                           </td>
@@ -863,8 +861,8 @@ $( document ).ready(function() {
                                       </td>
                                       <td>
                                         <button data-key="<?=$userApiKey['key'][0];?>" type="button" class="btn btn-default btn-xs act-del-api-key"
-                                            title="<?=gettext("delete API key");?>" data-toggle="tooltip" data-placement="left" >
-                                            <span class="glyphicon glyphicon-trash"></span>
+                                            title="<?=gettext("delete API key");?>" data-toggle="tooltip">
+                                          <span class="glyphicon glyphicon-trash"></span>
                                         </button>
                                       </td>
                                   </tr>
@@ -877,8 +875,8 @@ $( document ).ready(function() {
                                     <td></td>
                                     <td>
                                       <button type="button" class="btn btn-default btn-xs" id="newApiKey"
-                                          title="<?=gettext("create API key");?>" data-toggle="tooltip" data-placement="left" >
-                                          <span class="glyphicon glyphicon-plus"></span>
+                                          title="<?=gettext("create API key");?>" data-toggle="tooltip">
+                                        <span class="glyphicon glyphicon-plus"></span>
                                       </button>
                                     </td>
                                   </tr>
@@ -964,16 +962,15 @@ $( document ).ready(function() {
                       </td>
                       <td>
                         <a href="system_usermanager.php?act=edit&userid=<?=$i?>"
-                           class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left"
-                           title="<?=gettext("edit user");?>">
-                            <span class="glyphicon glyphicon-pencil"></span>
+                            class="btn btn-default btn-xs" data-toggle="tooltip" title="<?=gettext("edit user");?>">
+                          <span class="glyphicon glyphicon-pencil"></span>
                         </a>
 <?php
                         if ($userent['scope'] != "system") :?>
                         <button type="button" class="btn btn-default btn-xs act-del-user"
                             data-username="<?=$userent['name'];?>"
-                            data-userid="<?=$i?>" title="<?=gettext("delete user");?>" data-toggle="tooltip"
-                            data-placement="left" ><span class="fa fa-trash text-muted"></span>
+                            data-userid="<?=$i?>" title="<?=gettext("delete user");?>" data-toggle="tooltip">
+                          <span class="fa fa-trash text-muted"></span>
                         </button>
 <?php
                         endif;?>
@@ -989,7 +986,7 @@ $( document ).ready(function() {
                       <td colspan="3"></td>
                       <td>
                         <a href="system_usermanager.php?act=new" class="btn btn-default btn-xs"
-                           title="<?=gettext("add user");?>" data-toggle="tooltip" data-placement="left">
+                           title="<?=gettext("add user");?>" data-toggle="tooltip">
                           <span class="glyphicon glyphicon-plus"></span>
                         </a>
 <?php

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -404,7 +404,7 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase1 and all associated phase2 entries?"); ?>')"
           class="btn btn-default btn-xs">
-          <span class="glyphicon glyphicon-remove"></span>
+          <span class="fa fa-trash text-muted"></span>
       </button>
 <?php                 if (!isset($ph1ent['mobile'])) :
 ?>
@@ -532,7 +532,7 @@ if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase2 entry?"); ?>')"
           class="btn btn-default btn-xs">
-          <span class="glyphicon glyphicon-remove"><span>
+          <span class="fa fa-trash text-muted"><span>
         </button>
         <a href="vpn_ipsec_phase2.php?dup=<?=$ph2ent['uniqid']; ?>"
             title="<?=gettext("clone phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left"
@@ -563,7 +563,7 @@ endforeach;
                                 <button name="delp2_x" type="submit" title="<?=gettext("delete selected phase 2 entries");?>" data-toggle="tooltip" data-placement="left"
                                   onclick="return confirm('<?=gettext("Do you really want to delete the selected phase2 entries?");?>')"
                                   class="btn btn-default btn-xs">
-                                  <span class="glyphicon glyphicon-remove"></span>
+                                  <span class="fa fa-trash text-muted"></span>
                                 </button>
 <?php                                 endif;
 ?>
@@ -599,7 +599,7 @@ endforeach;  // $a_phase1 as $ph1ent
                       data-toggle="tooltip" data-placement="left"
                       onclick="return confirm('<?=gettext("Do you really want to delete the selected phase1 entries?");?>')"
                       class="btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-remove"></span>
+                      <span class="fa fa-trash text-muted"></span>
                     </button>
                       <a href="vpn_ipsec_phase1.php" title="<?=gettext("add new phase 1 entry");?>" data-toggle="tooltip" data-placement="left"
                           alt="add" class="btn btn-default btn-xs">

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -392,15 +392,15 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
     </td>
     <td>
       <button name="move_<?=$i; ?>_x" type="submit" class="btn btn-default btn-xs"
-          title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip" data-placement="left">
+          title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip">
         <span class="glyphicon glyphicon-arrow-left"></span>
       </button>
       <a href="vpn_ipsec_phase1.php?p1index=<?=$i; ?>" class="btn btn-default btn-xs" alt="edit"
-          title="<?=gettext("edit phase1 entry"); ?>" data-toggle="tooltip" data-placement="left">
+          title="<?=gettext("edit phase1 entry"); ?>" data-toggle="tooltip">
         <span class="glyphicon glyphicon-pencil"></span>
       </a><br/>
       <button name="del_<?=$i;?>_x"
-          title="<?=gettext("delete phase1 entry");?>" data-toggle="tooltip" data-placement="left"
+          title="<?=gettext("delete phase1 entry");?>" data-toggle="tooltip"
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase1 and all associated phase2 entries?"); ?>')"
           class="btn btn-default btn-xs">
@@ -409,7 +409,7 @@ if (!empty($ph1ent['encryption-algorithm']['keylen'])) {
 <?php                 if (!isset($ph1ent['mobile'])) :
 ?>
                       <a href="vpn_ipsec_phase1.php?dup=<?=$i; ?>" class="btn btn-default btn-xs" alt="add"
-                          title="<?=gettext("clone phase1 entry"); ?>" data-toggle="tooltip" data-placement="left">
+                          title="<?=gettext("clone phase1 entry"); ?>" data-toggle="tooltip">
                                       <span class="fa fa-clone text-muted"></span>
                       </a>
 <?php                 endif;
@@ -517,25 +517,25 @@ if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm
     </td>
     <td>
         <button name="movep2_<?=$j;?>_x"
-            title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip" data-placement="left"
+            title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip"
             type="submit"
             class="btn btn-default btn-xs">
             <span class="glyphicon glyphicon-arrow-left"></span>
         </button>
         <a href="vpn_ipsec_phase2.php?p2index=<?=$ph2ent['uniqid']; ?>"
-            title="<?=gettext("edit phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left"
+            title="<?=gettext("edit phase 2 entry"); ?>" data-toggle="tooltip"
             alt="edit" class="btn btn-default btn-xs">
           <span class="glyphicon glyphicon-pencil"></span>
         </a>
         <button name="delp2_<?=$ph2index; ?>_x"
-          title="<?=gettext("delete phase 2 entry");?>" data-toggle="tooltip" data-placement="left"
+          title="<?=gettext("delete phase 2 entry");?>" data-toggle="tooltip"
           type="submit"
           onclick="return confirm('<?=gettext("Do you really want to delete this phase2 entry?"); ?>')"
           class="btn btn-default btn-xs">
           <span class="fa fa-trash text-muted"><span>
         </button>
         <a href="vpn_ipsec_phase2.php?dup=<?=$ph2ent['uniqid']; ?>"
-            title="<?=gettext("clone phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left"
+            title="<?=gettext("clone phase 2 entry"); ?>" data-toggle="tooltip"
             alt="add" class="btn btn-default btn-xs">
           <span class="fa fa-clone text-muted"></span>
         </a>
@@ -552,23 +552,23 @@ endforeach;
 ?>
 
                                 <button name="movep2_<?=$j;?>_x" type="submit"
-                                  title="<?=gettext("move selected phase 2 entries to end");?>" data-toggle="tooltip" data-placement="left"
-                                  class="btn btn-default btn-xs">
+                                    title="<?=gettext("move selected phase 2 entries to end");?>" data-toggle="tooltip"
+                                    class="btn btn-default btn-xs">
                                   <span class="glyphicon glyphicon-arrow-down"></span>
                                 </button>
 <?php                                 endif;
 ?>
 <?php                                 if ($j > 0) :
 ?>
-                                <button name="delp2_x" type="submit" title="<?=gettext("delete selected phase 2 entries");?>" data-toggle="tooltip" data-placement="left"
-                                  onclick="return confirm('<?=gettext("Do you really want to delete the selected phase2 entries?");?>')"
-                                  class="btn btn-default btn-xs">
+                                <button name="delp2_x" type="submit" title="<?=gettext("delete selected phase 2 entries");?>" data-toggle="tooltip"
+                                    onclick="return confirm('<?=gettext("Do you really want to delete the selected phase2 entries?");?>')"
+                                    class="btn btn-default btn-xs">
                                   <span class="fa fa-trash text-muted"></span>
                                 </button>
 <?php                                 endif;
 ?>
                 <a href="vpn_ipsec_phase2.php?ikeid=<?=$ph1ent['ikeid']; ?><?= isset($ph1ent['mobile'])?"&amp;mobile=true":"";?>" class="btn btn-default btn-xs"
-                    title="<?=gettext("add phase 2 entry"); ?>" data-toggle="tooltip" data-placement="left">
+                    title="<?=gettext("add phase 2 entry"); ?>" data-toggle="tooltip">
                   <span alt="add" class="glyphicon glyphicon-plus"></span>
                 </a>
               </td>
@@ -586,22 +586,22 @@ endforeach;  // $a_phase1 as $ph1ent
                     <td colspan="8"> </td>
                     <td>
                       <button name="move_<?=$i;?>_x"
-                      type="submit"
-                      title="<?=gettext("move selected phase 1 entries to end");?>"
-                      data-toggle="tooltip" data-placement="left"
-                      class="btn btn-default btn-xs">
-                      <span class="glyphicon glyphicon-arrow-down"></span>
-                    </button>
+                          type="submit"
+                          title="<?=gettext("move selected phase 1 entries to end");?>"
+                          data-toggle="tooltip"
+                          class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-arrow-down"></span>
+                      </button>
                       <button
                       name="del_x"
                       type="submit"
                       title="<?=gettext("delete selected phase 1 entries");?>"
-                      data-toggle="tooltip" data-placement="left"
+                      data-toggle="tooltip"
                       onclick="return confirm('<?=gettext("Do you really want to delete the selected phase1 entries?");?>')"
                       class="btn btn-default btn-xs">
                       <span class="fa fa-trash text-muted"></span>
                     </button>
-                      <a href="vpn_ipsec_phase1.php" title="<?=gettext("add new phase 1 entry");?>" data-toggle="tooltip" data-placement="left"
+                      <a href="vpn_ipsec_phase1.php" title="<?=gettext("add new phase 1 entry");?>" data-toggle="tooltip"
                           alt="add" class="btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-plus"></span>
                     </a>

--- a/src/www/vpn_ipsec_keys.php
+++ b/src/www/vpn_ipsec_keys.php
@@ -169,7 +169,7 @@ foreach ($config['ipsec']['mobilekey'] as $secretent) :
     <a href="vpn_ipsec_keys_edit.php?id=<?=$i;
 ?>" title="<?=gettext("edit key"); ?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
     <a id="del_<?=$i;
-?>" title="<?=gettext("delete key"); ?>" class="act_delete btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+?>" title="<?=gettext("delete key"); ?>" class="act_delete btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
   </td>
 </tr>
 <?php           $i++;

--- a/src/www/vpn_l2tp_users.php
+++ b/src/www/vpn_l2tp_users.php
@@ -123,7 +123,7 @@ endif; ?>
 
                                         <a href="vpn_l2tp_users.php?act=del&amp;id=<?=$i;
 ?>" class="btn btn-default" onclick="return confirm('<?=gettext("Do you really want to delete this user?");
-?>')"title="<?=gettext("delete user"); ?>"><span class="glyphicon glyphicon-remove"></span></a>
+?>')"title="<?=gettext("delete user"); ?>"><span class="fa fa-trash text-muted"></span></a>
 
 					                 </td>
 								</tr>

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -1079,7 +1079,7 @@ else :
                 <td>
                     <a href="vpn_openvpn_client.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
 										<a id="del_<?=$i;
-?>" title="<?=gettext("delete client"); ?>" class="act_delete btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+?>" title="<?=gettext("delete client"); ?>" class="act_delete btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
                 </td>
 				</tr>
 				<?php

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -635,7 +635,7 @@ else :
                                     <td valign="middle" class="list nowrap">
 																			<a href="vpn_openvpn_csc.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
 																			<a id="del_<?=$i;
-?>" title="<?=gettext("delete csc"); ?>" class="act_delete btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+?>" title="<?=gettext("delete csc"); ?>" class="act_delete btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
                                     </td>
 									</tr>
 									<?php

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1743,7 +1743,7 @@ else :
                         <a href="vpn_openvpn_server.php?act=edit&amp;id=<?=$i;
 ?>" title="<?=gettext("edit server"); ?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                         <a id="del_<?=$i;
-?>" title="<?=gettext("delete server"); ?>" class="act_delete btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+?>" title="<?=gettext("delete server"); ?>" class="act_delete btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
                                     </td>
                   </tr>
                     <?php

--- a/src/www/vpn_pppoe.php
+++ b/src/www/vpn_pppoe.php
@@ -142,7 +142,7 @@ $main_buttons = array(
 
 											<a href="vpn_pppoe.php?act=del&amp;id=<?=$i;
 ?>" onclick="return confirm('<?=gettext("Do you really want to delete this entry? All elements that still use it will become invalid (e.g. filter rules)!");
-?>')" title="<?=gettext("delete pppoe instance");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+?>')" title="<?=gettext("delete pppoe instance");?>" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
 										  </td>
 										</tr>
                                                 <?php $i++;

--- a/src/www/vpn_pppoe_edit.php
+++ b/src/www/vpn_pppoe_edit.php
@@ -622,7 +622,7 @@ function enable_change(enable_over) {
 ?>" size="10" value="<?=htmlspecialchars($ip);?>" />
                                     </td>
                                     <td>
-                                        <a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-remove"></span></a>
+                                        <a onclick="removeRow(this); return false;" href="#" class="btn btn-default btn-xs"><span class="fa fa-trash text-muted"></span></a>
                                     </td>
                                 </tr>
 						<?php

--- a/src/www/vpn_pptp_users.php
+++ b/src/www/vpn_pptp_users.php
@@ -117,7 +117,7 @@ endif; ?>
 
                                         <a href="vpn_pptp_users.php?act=del&amp;id=<?=$i;
 ?>" class="btn btn-default" onclick="return confirm('<?=gettext("Do you really want to delete this user?");
-?>')"title="<?=gettext("delete user"); ?>"><span class="glyphicon glyphicon-remove"></span></a></td>
+?>')"title="<?=gettext("delete user"); ?>"><span class="fa fa-trash text-muted"></span></a></td>
 										</tr>
                                         <?php $i++;
 


### PR DESCRIPTION
* Changed "X" icon for delete action to "trash bin" for all delete actions, which modify the config (e.g. remove firewall rule). This means, e.g. removing a DHCP lease or a state from the pf state table still has an "X" and not a "trash bin" icon. #616

* Moved position of most tooltips from left (most) to top. Not moved were tooltips of horizontal button rows (e.g. user manager: add/remove groups) and the services table. #616 

_Unfortunately this PR depends on #626._