### PR TITLE
CA Generation: fix internal intermediate CA creation

### DIFF
--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -121,6 +121,7 @@ function ca_inter_create(&$ca, $keylen, $lifetime, $dn, $caref, $digest_alg = 's
 
     // return our ca information
     $ca['crt'] = base64_encode($str_crt);
+    $ca['caref'] = $caref;
     $ca['prv'] = base64_encode($str_key);
     $ca['serial'] = 0;
 


### PR DESCRIPTION
Found a bug while working on something else: Internal intermediate CAs were not correctly referred back to the signing CA.