### PR TITLE
Firewall log not dispalaying intentionally logged IGMP packets

### DIFF
--- a/src/etc/inc/filter_log.inc
+++ b/src/etc/inc/filter_log.inc
@@ -254,6 +254,9 @@ function parse_filter_line($line)
 			}
 			break;
 		}
+	} elseif ($flent['protoid'] == '2') { // IGMP 
+		$flent['src'] = $flent['srcip'];
+		$flent['dst'] = $flent['dstip'];
 	} elseif ($flent['protoid'] == '112') { // CARP
 		$flent['type'] = $rule_data[$field++];
 		$flent['ttl'] = $rule_data[$field++];


### PR DESCRIPTION
Intentional IGMP log messages dropped because the packets did not have source and destination set.

Signed-off-by: Isaac (.ike) Levy <ike@blackskyresearch.net>