### PR TITLE
fix relayd startup/restart (ref #780)

### DIFF
--- a/src/www/status_services.php
+++ b/src/www/status_services.php
@@ -119,6 +119,7 @@ function service_control_start($name, $extras) {
             break;
         case 'relayd':
             relayd_configure();
+            filter_configure();
             break;
         case 'squid':
             configd_run("proxy start");
@@ -269,6 +270,7 @@ function service_control_restart($name, $extras) {
             break;
         case 'relayd':
             relayd_configure(true);
+            filter_configure();
             break;
         case 'squid':
             configd_run("proxy restart");


### PR DESCRIPTION
@fichtner In contrast to my original report in #780, a manual start/restart of the relayd service will disrupt network traffic too. Maybe this is a very specific edge case in my OPNsense setup/configuration, but adding a filter_configure() fixes this too.