### PR TITLE
add new form input type "header"

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -46,9 +46,13 @@ allownew    :   allow new items (for list) if applicable
             {% if help|default(false) %}
                 <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>
             {% elseif help|default(false) == false %}
-                <i class="fa fa-info-circle text-muted"></i>
+                <i class="fa fa-info-circle text-muted{% if type == "header" %} hidden{% endif %}"></i>
             {% endif %}
-            <b>{{label}}</b>
+            {% if type == "header" %}
+                <h4 class="modal-title __mb __mt">{{label}}</h4>
+            {% else %}
+                <b>{{label}}</b>
+            {% endif %}
         </div>
     </td>
     <td >


### PR DESCRIPTION
If I'm not mistaken there is currently no (easy) way to add a proper header for forms. This makes long forms rather confusing:

![forms_info](https://cloud.githubusercontent.com/assets/909706/14107353/e92f74e2-f5b7-11e5-889c-3293391ac6d7.png)

This patch adds the new input type "header" to allow headers in forms:

```
    <field>
        <label>Tuning Options</label>
        <type>header</type>
    </field>
```

![forms_header](https://cloud.githubusercontent.com/assets/909706/14107357/f80dd026-f5b7-11e5-9173-db7fb986bdba.png)

(I'd be more happy to have a margin of just 10px instead of 15px, but I don't wanted to add a new css class just for this.)