### PR TITLE
Language correction: more generic expression

### DIFF
--- a/src/www/diag_defaults.php
+++ b/src/www/diag_defaults.php
@@ -47,7 +47,7 @@ include("head.inc");
 <?php
       else: ?>
         <form method="post">
-          <p><strong> <?=gettext('If you click "Yes", the firewall will:')?></strong></p>
+          <p><strong> <?=gettext('If you click "Yes", the system will:')?></strong></p>
           <ul>
             <li><?=gettext("Reset to factory defaults");?></li>
             <li><?=gettext("LAN IP address will be reset to 192.168.1.1");?></li>


### PR DESCRIPTION
Probably home users would call their device "router", while professional users with the stronger systems would call their device "firewall". I opted for a more neutral expression here, "device" sounds too technical in my opinion.