### PR TITLE
Put custom scrub rules first

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -570,26 +570,7 @@ function filter_generate_scrubing(&$FilterIflist)
 
     $scrubrules = '';
 
-    /* scrub per interface options */
-    if (empty($config['system']['scrub_interface_disable'])) {
-        foreach ($FilterIflist as $scrubif => $scrubcfg) {
-            if (isset($scrubcfg['virtual']) || empty($scrubcfg['descr'])) {
-                continue;
-            } else {
-                /* set up MSS clamping */
-                if (!empty($scrubcfg['mss']) && is_numeric($scrubcfg['mss']) &&
-                    !in_array($scrubcfg['if'], array('pppoe', 'pptp', 'l2tp'))) {
-                    $mssclamp = "max-mss " . (intval($scrubcfg['mss'] - 40));
-                } else {
-                    $mssclamp = '';
-                }
-                $scrubnodf = !empty($config['system']['scrubnodf']) ? "no-df" : "";
-                $scrubrnid = !empty($config['system']['scrubrnid']) ? "random-id" : "";
-                $scrubrules .= "scrub on \${$scrubcfg['descr']} all {$scrubnodf} {$scrubrnid} {$mssclamp}\n";
-            }
-        }
-    }
-
+    /* custom rules must be first */
     if (!empty($config['filter']['scrub']['rule'])) {
         foreach ($config['filter']['scrub']['rule'] as $scrub_rule) {
             if (!isset($scrub_rule['disabled'])) {
@@ -630,6 +611,26 @@ function filter_generate_scrubing(&$FilterIflist)
                 $scrub_rule_out .= !empty($scrub_rule['set-tos']) ? " set-tos " . $scrub_rule['set-tos'] .  " " : "";
                 $scrub_rule_out .= "\n";
                 $scrubrules .= $scrub_rule_out;
+            }
+        }
+    }
+
+    /* scrub per interface options */
+    if (empty($config['system']['scrub_interface_disable'])) {
+        foreach ($FilterIflist as $scrubif => $scrubcfg) {
+            if (isset($scrubcfg['virtual']) || empty($scrubcfg['descr'])) {
+                continue;
+            } else {
+                /* set up MSS clamping */
+                if (!empty($scrubcfg['mss']) && is_numeric($scrubcfg['mss']) &&
+                    !in_array($scrubcfg['if'], array('pppoe', 'pptp', 'l2tp'))) {
+                    $mssclamp = "max-mss " . (intval($scrubcfg['mss'] - 40));
+                } else {
+                    $mssclamp = '';
+                }
+                $scrubnodf = !empty($config['system']['scrubnodf']) ? "no-df" : "";
+                $scrubrnid = !empty($config['system']['scrubrnid']) ? "random-id" : "";
+                $scrubrules .= "scrub on \${$scrubcfg['descr']} all {$scrubnodf} {$scrubrnid} {$mssclamp}\n";
             }
         }
     }


### PR DESCRIPTION
It appears that the custom normalization rules do not function unless "disable interface scrub" is enabled.

This is simply because the "interface scrub" rules appear before the custom rules, and since they match all traffic on each interface, the custom scrub rules are never reached.

This patch puts the custom rules first.