### PR TITLE
allow to use CRLs with CertificateField

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/CertificateField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/CertificateField.php
@@ -73,6 +73,8 @@ class CertificateField extends BaseField
     {
         if (trim(strtolower($value)) == "ca") {
             $this->certificateType = "ca";
+        } elseif (trim(strtolower($value)) == "crl") {
+            $this->certificateType = "crl";
         } else {
             $this->certificateType = "cert";
         }


### PR DESCRIPTION
Currently the `CertificateField` is limited to types `ca` and `cert`. This patch allows to use type `crl` too.
Use case: advanced certificate validation in HAProxy plugin.

Is related to #1095 and not useful (for my use case) until the referenced bug is fixed.