### PR TITLE
Incorrect units capitalization in proxy form

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -166,25 +166,25 @@
             </field>
             <field>
                 <id>proxy.general.traffic.maxDownloadSize</id>
-                <label>Maximum download size (Kb)</label>
+                <label>Maximum download size (kB)</label>
                 <type>text</type>
                 <help><![CDATA[Enter the maxium size for downloads in kilobytes (leave empty to disable).]]></help>
             </field>
             <field>
                 <id>proxy.general.traffic.maxUploadSize</id>
-                <label>Maximum upload size (Kb)</label>
+                <label>Maximum upload size (kB)</label>
                 <type>text</type>
                 <help><![CDATA[Enter the maxium size for uploads in kilobytes (leave empty to disable).]]></help>
             </field>
             <field>
                 <id>proxy.general.traffic.OverallBandwidthTrotteling</id>
-                <label>Overall bandwidth throttling (Kbps)</label>
+                <label>Overall bandwidth throttling (kbps)</label>
                 <type>text</type>
                 <help><![CDATA[Enter the allowed overall bandtwith in kilobits per second (leave empty to disable).]]></help>
             </field>
             <field>
                 <id>proxy.general.traffic.perHostTrotteling</id>
-                <label>Per host bandwidth throttling (Kbps)</label>
+                <label>Per host bandwidth throttling (kbps)</label>
                 <type>text</type>
                 <help><![CDATA[Enter the allowed per host bandwidth in kilobits per second (leave empty to disable).]]></help>
             </field>


### PR DESCRIPTION
k = kilo (1000 or 1024)
B = byte
b = bit
K = nothing

So kilobyte is kB (was written as Kb in the form)
And kilobit per second is kbps not Kbps.