### PR TITLE
Extract ApiModelControllerBase and ApiMutableModelControllerBase classes

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiModelControllerBase.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *    Copyright (C) 2016 IT-assistans Sverige AB
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base;
+
+use OPNsense\Base\ApiControllerBase;
+
+/**
+ * Class ApiModelControllerBase, inherit this class to implement
+ * an API that exposes a model with a get action.
+ * You need to implement a method to create new blank model
+ * objecs (newModelObject) as well as a method to return
+ * the name of the model.
+ * @package OPNsense\Base
+ */
+abstract class ApiModelControllerBase extends ApiControllerBase
+{
+    public function getAction()
+    {
+        // define list of configurable settings
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdl = $this->getModel();
+            $result[$this->getModelName()] = $this->getModelNodes($mdl);
+        }
+        return $result;
+    }
+    abstract protected function getModel();
+    abstract protected function getModelName();
+    /**
+     * override this to customize what part of the model gets exposed
+     */
+    protected function getModelNodes($mdl) {
+        return $mdl->getNodes();
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *    Copyright (C) 2016 IT-assistans Sverige AB
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base;
+
+use OPNsense\Base\ApiModelControllerBase;
+
+/**
+ * Class ApiMutableModelControllerBase, inherit this class to implement
+ * an API that exposes a model with get and set actions.
+ * You need to implement a method to create new blank model
+ * objecs (newModelObject) as well as a method to return
+ * the name of the model.
+ * @package OPNsense\Base
+ */
+abstract class ApiMutableModelControllerBase extends ApiModelControllerBase
+{
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            // load model and update with provided data
+            $mdl = $this->getModel();
+            $mdl->setNodes($this->request->getPost(getModelName()));
+
+            // perform validation
+            $valMsgs = $mdl->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validations", $result)) {
+                    $result["validations"] = array();
+                }
+                $result["validations"][$this->getModelName().".".$msg->getField()] = $msg->getMessage();
+            }
+
+            // serialize model to config and save
+            if ($valMsgs->count() == 0) {
+                $mdl->serializeToConfig();
+                Config::getInstance()->save();
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
@@ -29,7 +29,7 @@
 namespace OPNsense\IDS\Api;
 
 use \Phalcon\Filter;
-use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Base\ApiMutableModelControllerBase;
 use \OPNsense\Base\Filters\QueryFilter;
 use \OPNsense\Core\Backend;
 use \OPNsense\IDS\IDS;
@@ -40,7 +40,7 @@ use \OPNsense\Base\UIModelGrid;
  * Class SettingsController Handles settings related API actions for the IDS module
  * @package OPNsense\IDS
  */
-class SettingsController extends ApiControllerBase
+class SettingsController extends ApiMutableModelControllerBase
 {
     /**
      * @var null|IDS IDS model to share across some methods (see getModel)
@@ -464,47 +464,14 @@ class SettingsController extends ApiControllerBase
         return $result;
     }
 
-    /**
-     * retrieve IDS settings
-     * @return array IDS settings
-     */
-    public function getAction()
-    {
-        // define list of configurable settings
-        $settingsNodes = array('general');
+    protected function getModelNodes($mdlIDS) {
         $result = array();
-        if ($this->request->isGet()) {
-            $mdlIDS = $this->getModel();
-            $result['ids'] = array();
-            foreach ($settingsNodes as $key) {
-                $result['ids'][$key] = $mdlIDS->$key->getNodes();
-            }
-        }
+        $result['general'] = $mdlIDS->general->getNodes();
         return $result;
     }
 
-    /**
-     * update IDS settings
-     * @return array status
-     */
-    public function setAction()
-    {
-        $result = array("result"=>"failed");
-        if ($this->request->isPost()) {
-            // load model and update with provided data
-            $mdlIDS = $this->getModel();
-            $mdlIDS->setNodes($this->request->getPost("ids"));
-
-            $validations = $mdlIDS->validate(null, "ids.");
-            if (count($validations)) {
-                $result['validations'] = $validations;
-            } else {
-                $mdlIDS->serializeToConfig();
-                Config::getInstance()->save();
-                $result["result"] = "saved";
-            }
-        }
-        return $result;
+    protected function getModelName() {
+        return "ids";
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
@@ -28,7 +28,7 @@
  */
 namespace OPNsense\Proxy\Api;
 
-use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Base\ApiMutableModelControllerBase;
 use \OPNsense\Proxy\Proxy;
 use \OPNsense\Cron\Cron;
 use \OPNsense\Core\Config;
@@ -38,56 +38,14 @@ use \OPNsense\Base\UIModelGrid;
  * Class SettingsController
  * @package OPNsense\Proxy
  */
-class SettingsController extends ApiControllerBase
+class SettingsController extends ApiMutableModelControllerBase
 {
-    /**
-     * retrieve proxy settings
-     * @return array
-     */
-    public function getAction()
-    {
-        $result = array();
-        if ($this->request->isGet()) {
-            $mdlProxy = new Proxy();
-            $result['proxy'] = $mdlProxy->getNodes();
-        }
-
-        return $result;
+    protected function getModel() {
+        return new Proxy();
     }
 
-
-    /**
-     * update proxy configuration fields
-     * @return array
-     * @throws \Phalcon\Validation\Exception
-     */
-    public function setAction()
-    {
-        $result = array("result"=>"failed");
-        if ($this->request->hasPost("proxy")) {
-            // load model and update with provided data
-            $mdlProxy = new Proxy();
-            $mdlProxy->setNodes($this->request->getPost("proxy"));
-
-            // perform validation
-            $valMsgs = $mdlProxy->performValidation();
-            foreach ($valMsgs as $field => $msg) {
-                if (!array_key_exists("validations", $result)) {
-                    $result["validations"] = array();
-                }
-                $result["validations"]["proxy.".$msg->getField()] = $msg->getMessage();
-            }
-
-            // serialize model to config and save
-            if ($valMsgs->count() == 0) {
-                $mdlProxy->serializeToConfig();
-                $cnf = Config::getInstance();
-                $cnf->save();
-                $result["result"] = "saved";
-            }
-        }
-
-        return $result;
+    protected function getModelName() {
+        return 'proxy';
     }
 
     /**


### PR DESCRIPTION
As per issue https://github.com/opnsense/core/issues/1123 I hereby submit a proposed refactoring.

In order to support the very common case of a controller that that implements getters and setters on a model, I've extracted out two classes, ApiModelControllerBase that can be inherited by read-only API controllers, and ApiMutableModelControllerBase that can be inherited by read-write API controllers.

I have also refactored the IDS and traffic shaper using these two classes. The set code path probably needs review, especially the validation may be a little bit iffy. I also think there's some room for further simplification, specifically in whether OPNsense\Base\ApiModelControllerBase\getModelNodes is correct in the general case. That, or if there needs to be an extention to the model to mark in the metadata if a field should be exposed in the API or not.

I have done basic validation of the get methods, ensuring that I get the same result before and after refactoring, but I have not done testing of the set methods or validation.