### PR TITLE
ApiMutableTableModelControllerBase

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -123,7 +123,7 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
         foreach ($valMsgs as $field => $msg) {
             // replace absolute path to attribute for relative one at uuid.
             if ($node != null) {
-                $fieldnm = str_replace($node->__reference, static:$internalModelName, $msg->getField());
+                $fieldnm = str_replace($node->__reference, static::$internalModelName, $msg->getField());
                 $result["validations"][$fieldnm] = $msg->getMessage();
             } else {
                 $result["validations"][$msg->getField()] = $msg->getMessage();

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -45,7 +45,8 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         return $this->getModel()->getNodeByReference($ref);
     }
     private function getNodeByUUID($uuid) {
-        return $this->getNodes()->$uuid;
+        $nodes = $this->getNodes();
+        return !empty($nodes) ? $nodes->$uuid : null;
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *    Copyright (C) 2016 IT-assistans Sverige AB
+ *    Copyright (C) 2016 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base;
+
+
+/**
+ * Class ApiMutableTableModelControllerBase, inherit this class to implement
+ * an API that exposes a model for tables.
+ * @package OPNsense\Base
+ */
+abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
+{
+    static protected $modelPathPrefix = '';
+    private function getNodes() {
+        $ref = static::$modelPathPrefix
+             + static::$internalModelName;
+        return $this->getModel()->getNodeByReference($ref);
+    }
+    private function getNodeByUUID($uuid) {
+        return $this->getNodes()->$uuid;
+    }
+    public function getItemAction($uuid = null) {
+        $mdl = $this->getModel();
+        if ($uuid != null) {
+            $node = getNodeByUUID($uuid);
+            if ($node != null) {
+                // return node
+                return array(static::$internalModelName => $node->getNodes());
+            }
+        } else {
+            // generate new node, but don't save to disc
+            $node = getNodes()->add();
+            return array(static::$internalModelName => $node->getNodes());
+        }
+        return array();
+    }
+    public function setItemAction($uuid) {
+        // FIXME To be implemented
+    }
+    public function addItemAction() {
+        // FIXME To be implemented
+    }
+    public function delItemAction($uuid) {
+        // FIXME To be implemented
+    }
+    public function toggleItemAction($uuid, $enabled = null) {
+        // FIXME To be implemented
+    }
+    public function searchItemsAction() {
+        // FIXME To be implemented
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -66,7 +66,7 @@ abstract class ApiMutableTableModelControllerBase extends ApiMutableModelControl
             }
         } else {
             // generate new node, but don't save to disc
-            $node = getNodes()->add();
+            $node = $this->getNodes()->add();
             return array(static::$internalModelName => $node->getNodes());
         }
         return array();

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -34,14 +34,15 @@ namespace OPNsense\Base;
  * an API that exposes a model for tables.
  * @package OPNsense\Base
  */
-abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
+abstract class ApiMutableTableModelControllerBase extends ApiMutableModelControllerBase
 {
     // FIXME What about validation?
 
     static protected $modelPathPrefix = '';
+    static protected $gridFields = array();
+    static protected $gridDefaultSort = null;
     private function getNodes() {
-        $ref = static::$modelPathPrefix
-             + static::$internalModelName;
+        $ref = static::$modelPathPrefix . static::$internalModelName;
         return $this->getModel()->getNodeByReference($ref);
     }
     private function getNodeByUUID($uuid) {
@@ -98,12 +99,12 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
     public function addItemAction()
     {
         $result = array("result"=>"failed");
-        if ($this->request->isPost() && $this->request->hasPost(static::$internalModelName))) {
+        if ($this->request->isPost() && $this->request->hasPost(static::$internalModelName)) {
             $mdl = $this->getModel();
             // FIXME Is this correct?
             $node = $this->getNodes()->add();
-            $node->setNodes($this->request->getPost(static::$internalModelName)));
-            return $this->save($mdl, $node, static::$internalModelName));
+            $node->setNodes($this->request->getPost(static::$internalModelName));
+            return $this->save($mdl, $node, static::$internalModelName);
         }
         return $result;
     }
@@ -172,11 +173,6 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         $this->sessionClose();
         $mdl = $this->getModel();
         $grid = new UIModelGrid($this->getNodes());
-        return $grid->fetchBindRequest(
-            $this->request,
-            // FIXME Where do we get this list from? Is this something to be supplied by class implementor?
-            array("enabled","number", "bandwidth","bandwidthMetric","burst","description","mask","origin"),
-            "number"
-        );
+        return $grid->fetchBindRequest($this->request, static::$gridFields, static::$gridDefaultSort);
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -85,7 +85,7 @@ abstract class ApiMutableTableModelControllerBase extends ApiMutableModelControl
                 $node = $this->getNodeByUUID($uuid);
                 if ($node != null) {
                     $node->setNodes($this->request->getPost(static::$internalModelName));
-                    return $this->save($mdl, $node, static::$internalModelName);
+                    return $this->save($node);
                 }
             }
         }
@@ -101,10 +101,9 @@ abstract class ApiMutableTableModelControllerBase extends ApiMutableModelControl
         $result = array("result"=>"failed");
         if ($this->request->isPost() && $this->request->hasPost(static::$internalModelName)) {
             $mdl = $this->getModel();
-            // FIXME Is this correct?
             $node = $this->getNodes()->add();
             $node->setNodes($this->request->getPost(static::$internalModelName));
-            return $this->save($mdl, $node, static::$internalModelName);
+            return $this->save($node);
         }
         return $result;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -119,7 +119,7 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
             if ($uuid != null) {
                 if (getNodes()->del($uuid)) {
                     // if item is removed, serialize to config and save
-                    $mdlShaper->serializeToConfig();
+                    $mdl->serializeToConfig();
                     Config::getInstance()->save();
                     $result['result'] = 'deleted';
                 } else {
@@ -152,7 +152,7 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
                     }
                     $result['result'] = $node->enabled;
                     // if item has toggled, serialize to config and save
-                    $mdlShaper->serializeToConfig();
+                    $mdl->serializeToConfig();
                     Config::getInstance()->save();
                 }
             }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -29,7 +29,6 @@
  */
 namespace OPNsense\Base;
 
-
 /**
  * Class ApiMutableTableModelControllerBase, inherit this class to implement
  * an API that exposes a model for tables.
@@ -37,8 +36,8 @@ namespace OPNsense\Base;
  */
 abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
 {
-	// FIXME What about validation?
-	
+    // FIXME What about validation?
+
     static protected $modelPathPrefix = '';
     private function getNodes() {
         $ref = static::$modelPathPrefix
@@ -49,12 +48,13 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         return $this->getNodes()->$uuid;
     }
 
-	/**
+    /**
      * retrieve item or return defaults
      * @param $uuid item unique id
      * @return array
      */
-    public function getItemAction($uuid = null) {
+    public function getItemAction($uuid = null)
+    {
         $mdl = $this->getModel();
         if ($uuid != null) {
             $node = $this->getNodeByUUID($uuid);
@@ -69,13 +69,14 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         }
         return array();
     }
-	
+
     /**
      * update item with given properties
      * @param $uuid item unique id
      * @return array
      */
-    public function setItemAction($uuid) {
+    public function setItemAction($uuid)
+    {
         if ($this->request->isPost() && $this->request->hasPost(static::$internalModelName)) {
             $mdl = $this->getModel();
             if ($uuid != null) {
@@ -93,26 +94,28 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
      * add new item and set with attributes from post
      * @return array
      */
-    public function addItemAction() {
+    public function addItemAction()
+    {
         $result = array("result"=>"failed");
         if ($this->request->isPost() && $this->request->hasPost(static::$internalModelName))) {
             $mdl = $this->getModel();
-			// FIXME Is this correct?
-			$node = $this->getNodes()->add();
+            // FIXME Is this correct?
+            $node = $this->getNodes()->add();
             $node->setNodes($this->request->getPost(static::$internalModelName)));
-			// FIXME What do we do with this? Is this traffic-shaper specific? Do we need a hook here?
+            // FIXME What do we do with this? Is this traffic-shaper specific? Do we need a hook here?
             $node->origin = "TrafficShaper"; // set origin to this component.
             return $this->save($mdl, $node, static::$internalModelName));
         }
         return $result;
     }
-	
+
     /**
      * delete item by uuid
      * @param $uuid item unique id
      * @return array status
      */
-    public function delItemAction($uuid) {
+    public function delItemAction($uuid)
+    {
         $result = array("result"=>"failed");
         if ($this->request->isPost()) {
             $mdl = $this->getModel();
@@ -129,14 +132,15 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         }
         return $result;
     }
-	
+
     /**
      * toggle item by uuid (enable/disable)
      * @param $uuid item unique id
      * @param $enabled desired state enabled(1)/disabled(1), leave empty for toggle
      * @return array status
      */
-    public function toggleItemAction($uuid, $enabled = null) {
+    public function toggleItemAction($uuid, $enabled = null)
+    {
         $result = array("result" => "failed");
         if ($this->request->isPost()) {
             $mdl = $this->getModel();
@@ -159,18 +163,19 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
         }
         return $result;
     }
-	
+
     /**
      * search items
      * @return array
      */
-    public function searchItemsAction() {
+    public function searchItemsAction()
+    {
         $this->sessionClose();
         $mdl = $this->getModel();
         $grid = new UIModelGrid($this->getNodes());
         return $grid->fetchBindRequest(
             $this->request,
-			// FIXME Where do we get this list from? Is this something to be supplied by class implementor?
+            // FIXME Where do we get this list from? Is this something to be supplied by class implementor?
             array("enabled","number", "bandwidth","bandwidthMetric","burst","description","mask","origin"),
             "number"
         );

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableTableModelControllerBase.php
@@ -103,8 +103,6 @@ abstract class ApiMutableTableModelControllerBase extends ApiControllerBase
             // FIXME Is this correct?
             $node = $this->getNodes()->add();
             $node->setNodes($this->request->getPost(static::$internalModelName)));
-            // FIXME What do we do with this? Is this traffic-shaper specific? Do we need a hook here?
-            $node->origin = "TrafficShaper"; // set origin to this component.
             return $this->save($mdl, $node, static::$internalModelName));
         }
         return $result;


### PR DESCRIPTION
As per discussions with @AdSchellevis here's my first stab at an ApiMutableTableModelControllerBase class. The use case for this abstract base class is to have a base class that can be derived from to act as an API controller for a gridview.

I've based this code on the pipe methods in OPNsense\TrafficShaper\SettingsController. A [diff](https://github.com/opnsense/core/files/407603/diff.txt) between these methods and my methods has been attached. This might be useful for understanding what I've done.

A few questions remain before this can be merged:

- What about validation? It seems that the code I looked at does not do validation. I'm not sure if that's correct in the general case.
- I'm not sure if I've implemented addItemAction() correctly.
- In addItemAction(), the traffic shaper code sets an origin node in the model. I'm not sure if this is something that needs to happen in the general case. And if not, do we need to add a hook for it?
- In searchItemsAction(), the fetchBindRequest method is passed a list of column headers. Who should supply this list? Can this be gleaned from metadata rather than hardcoded? And what about the "number" parameter?