### PR TITLE
(Base) Default to inf rows not 9999

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -58,7 +58,7 @@ class UIModelGrid
      */
     public function fetchBindRequest($request, $fields, $defaultSort = null)
     {
-        $itemsPerPage = $request->get('rowCount', 'int', 9999);
+        $itemsPerPage = $request->get('rowCount', 'int', -1);
         $currentPage = $request->get('current', 'int', 1);
         $sortBy = array($defaultSort);
         $sortDescending = false;


### PR DESCRIPTION
Looks like updating this default was missed when implementing the return of infinite rows in https://github.com/opnsense/core/commit/5d8b97e2b82b4804d90c4e3b49c69dd39dd516cc