### PR TITLE
(base) Do not encourage overriding getModel()

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -95,7 +95,6 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
     }
 
     /**
-     * override this to customize the model binding behavior
      * @return null|BaseModel
      */
     protected function getModel()


### PR DESCRIPTION
Overriding getModel() is not to be done lightly. The code relies on the same object being there through multiple calls to getModel(). Any overriding methods should preserve this same behavior. For this reason, we should not encourage tinkering with this in a comment, better be silent on the matter.