### PR TITLE
(get_interface_list) Properly handle an interface not appearing in dmesg

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -948,12 +948,13 @@ function get_interface_list($only_active = false)
         }
 
         $dmesg_arr = array();
+        $toput['dmesg'] = null;
         exec("/sbin/dmesg |grep $ifname", $dmesg_arr);
-        preg_match_all("/<(.*?)>/i", $dmesg_arr[0], $dmesg);
-        if (isset($dmesg[1][0])) {
-            $toput['dmesg'] = $dmesg[1][0];
-        } else {
-            $toput['dmesg'] = null;
+        if (count($dmesg_arr) > 0) {
+            preg_match_all("/<(.*?)>/i", $dmesg_arr[0], $dmesg);
+            if (isset($dmesg[1][0])) {
+                $toput['dmesg'] = $dmesg[1][0];
+            }
         }
 
         $iflist[$ifname] = $toput;


### PR DESCRIPTION
get_interface_list() tries to extract interface information by grepping through dmesg. This fails if there are interfaces present that for some reason do not appear in dmesg. The code attempts to handle it, but only handles the case where the first line returned from the grep is unparsable, it does not handle the case where no lines are returned at all. This leaks an undesired PHP info or warning out on stdout if not checked.

This may be the case for example, if a user has manually cloned VLAN interfaces on the FreeBSD end. (I'm sure other things break at least, but at least we don't have to leak this particular warning any more.)