### PR TITLE
(BaseModel) Always log the class where validation failed

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
@@ -460,9 +460,10 @@ abstract class BaseModel
         if ($messages->count() > 0) {
             $exception_msg = "";
             foreach ($messages as $msg) {
-                $exception_msg .= "[".$msg-> getField()."] ".$msg->getMessage()."\n";
+                $exception_msg_part = "[".str_replace("\\", ".", get_class($this)).".".$msg-> getField(). "] " .$msg->getMessage();
+                $exception_msg .= "$exception_msg_part\n";
                 // always log validation errors
-                $logger->error(str_replace("\\", ".", get_class($this)).".".$msg-> getField(). " " .$msg->getMessage());
+                $logger->error($exception_msg_part);
             }
             if (!$disable_validation) {
                 throw new \Phalcon\Validation\Exception($exception_msg);


### PR DESCRIPTION
Before:

```
Fatal error: Uncaught exception 'Phalcon\Validation\Exception' with message '[forward.interfaces] please specify a valid interface
' in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:468
Stack trace:
#0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(562): OPNsense\Base\BaseModel->serializeToConfig()
#1 /usr/local/opnsense/mvc/script/run_migrations.php(49): OPNsense\Base\BaseModel->runMigrations()
#2 {main}
  thrown in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php on line 468
```

After:

```
Fatal error: Uncaught exception 'Phalcon\Validation\Exception' with message '[OPNsense.Proxy.Proxy.forward.interfaces] please specify a valid interface
' in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:469
Stack trace:
#0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(563): OPNsense\Base\BaseModel->serializeToConfig()
#1 /usr/local/opnsense/mvc/script/run_migrations.php(49): OPNsense\Base\BaseModel->runMigrations()
#2 {main}
  thrown in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php on line 469
```