### PR TITLE
fix broken squid configuration

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -57,9 +57,13 @@ http_access deny blockuseragents
 # ACL list (Deny) blockmimetypes
 {% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
 adaptation_access response_mod deny blockmimetypes {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted {% endif %}
+
 adaptation_access request_mod deny blockmimetypes {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted {% endif %}
+
 adaptation_access response_mod deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted {% endif %}
+
 adaptation_access request_mod deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted {% endif %}
+
 {% endif %}
 http_reply_access deny blockmimetypes {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted {% endif %}
 


### PR DESCRIPTION
this fixes an issue that some newlines are missing and because of this, the configuration becomes invalid and squid will not start.