### PR TITLE
rc: fix an infinite loop on tty close

### DIFF
--- a/src/etc/rc.initial
+++ b/src/etc/rc.initial
@@ -18,6 +18,13 @@ fi
 # endless loop
 while : ; do
 
+# We `set -e' to force exit if we encounter an error.
+# This is mainly useful in case we lose our tty (happens when
+# an ssh connection breaks, for example), in which case our stdout
+# is closed and the `echo' commands in the while loop will silently fail.
+# Failure to exit at that moment would lead to an infinite loop.
+set -e
+
 echo
 
 echo " 0) Logout                             7) Ping host"
@@ -31,6 +38,9 @@ echo " 6) Reboot system                     13) Restore a configuration"
 echo
 read -p "Enter an option: " OPCODE
 echo
+
+# The scripts we'll call below may return non-zero, don't exit if they do
+set +e
 
 # see what the user has chosen
 case ${OPCODE} in


### PR DESCRIPTION
if the tty is closed while the script is running,
it would previously go in an infinite loop trying
to read from and write to the now-defunct tty.

I finally opted for the set -e/set +e mechanism,
which introduces a minimal diff.

fixes: https://github.com/opnsense/core/issues/1240