### PR TITLE
Improved password hashes.

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -204,7 +204,7 @@
       <descr><![CDATA[System Administrator]]></descr>
       <scope>system</scope>
       <groupname>admins</groupname>
-      <password>$6$$Y8Et6wWDdXO2tJZRabvSfQvG2Lc8bAS6D9COIsMXEJ2KjA27wqDuAyd/CdazBQc3H3xQX.JXMKxJeRz2OqTkl.</password>
+      <password>$2b$10$YRVoF4SgskIsrXOvOQjGieB9XqHPRra9R7d80B3BZdbY/j21TwBfS</password>
       <uid>0</uid>
     </user>
     <nextuid>2000</nextuid>

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -488,7 +488,7 @@ function local_user_del($user)
 
 function local_user_set_password(&$user, $password)
 {
-    $user['password'] = crypt($password, '$6$');
+    $user['password'] = generate_password_hash($password, 10);
 
     // Converts ascii to unicode.
     $astr = (string) $password;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1591,3 +1591,11 @@ function is_install_media()
 
     return true;
 }
+
+function generate_password_hash($password, $cost = 10)
+{
+    $hash = password_hash($password, PASSWORD_BCRYPT, ["cost" => $cost]);
+    // at the moment of writing FreeBSD can't recognise $2y$... as bcrypt, $2b$ is needed
+    $hash[2] = 'b';
+    return $hash;
+}

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -40,7 +40,7 @@ if (isset($_POST['save'])) {
     do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
     if ($_POST['passwordfld1'] != $_POST['passwordfld2'] ||
-        $config['system']['user'][$userindex[$username]]['password'] != crypt($_POST['passwordfld0'], '$6$')) {
+        !password_verify($_POST['passwordfld0'], $config['system']['user'][$userindex[$username]]['password'])) {
         $input_errors[] = gettext("The passwords do not match.");
     }
 
@@ -58,7 +58,7 @@ if (isset($_POST['save'])) {
 
     if (count($input_errors) == 0) {
         // all values are okay --> saving changes
-        $config['system']['user'][$userindex[$username]]['password'] = crypt($_POST['passwordfld1'], '$6$');
+        $config['system']['user'][$userindex[$username]]['password'] = generate_password_hash($_POST['passwordfld1'], 10);
         local_user_set($config['system']['user'][$userindex[$username]]);
 
         write_config();


### PR DESCRIPTION
Replaced crypt($password, '$6$') with password_hash and password_verify in order to produce salted hashes from passwords.

crypt($password, '$6$') doesn't create any randomness in password hash, because the second parameter should contain a random salt (and optionally a number of rounds). With only '$6$' neither is provided. Switching from SHA512 to bcrypt seems to be justified be the speed of possible password cracking.