### PR TITLE
Update system_advanced_misc.php

### DIFF
--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -82,16 +82,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     /* if the old use_mfs_tmpvar is found, set these flags, too */
     $pconfig['use_mfs_var'] = isset($config['system']['use_mfs_tmpvar']) || isset($config['system']['use_mfs_var']);
     $pconfig['use_mfs_tmp'] = isset($config['system']['use_mfs_tmpvar']) || isset($config['system']['use_mfs_tmp']);
-    $pconfig['powerd_ac_mode'] = "hadp";
     $pconfig['rrdbackup'] = !empty($config['system']['rrdbackup']) ? $config['system']['rrdbackup'] : null;
     $pconfig['dhcpbackup'] = !empty($config['system']['dhcpbackup']) ? $config['system']['dhcpbackup'] : null;
     $pconfig['netflowbackup'] = !empty($config['system']['netflowbackup']) ? $config['system']['netflowbackup'] : null;
+    $pconfig['powerd_ac_mode'] = "hadp";
     if (!empty($config['system']['powerd_ac_mode'])) {
         $pconfig['powerd_ac_mode'] = $config['system']['powerd_ac_mode'];
     }
     $pconfig['powerd_battery_mode'] = "hadp";
     if (!empty($config['system']['powerd_battery_mode'])) {
         $pconfig['powerd_battery_mode'] = $config['system']['powerd_battery_mode'];
+    }
+    $pconfig['powerd_normal_mode'] = "hadp";
+    if (!empty($config['system']['powerd_normal_mode'])) {
+        $pconfig['powerd_normal_mode'] = $config['system']['powerd_normal_mode'];
     }
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     //
@@ -115,6 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         $config['system']['powerd_ac_mode'] = $pconfig['powerd_ac_mode'];
         $config['system']['powerd_battery_mode'] = $pconfig['powerd_battery_mode'];
+        $config['system']['powerd_normal_mode'] = $pconfig['powerd_normal_mode'];
 
         if ($pconfig['crypto_hardware']) {
             $config['system']['crypto_hardware'] = $pconfig['crypto_hardware'];
@@ -394,6 +399,28 @@ include("head.inc");
                       <?=gettext("Maximum");?>
                     </option>
                   </select>
+                </td>
+              </tr>
+              <tr>
+                <td><i class="fa fa-info-circle text-muted"></i>  <?=gettext('On Battery Normal Mode') ?></td>
+                <td>
+                  <select name="powerd_normal_mode" class="selectpicker" data-style="btn-default" data-width="auto">
+                    <option value="hadp"<?=$pconfig['powerd_normal_mode']=="hadp" ? "selected=\"selected\"" : "";?>>
+                      <?=gettext("Hiadaptive");?>
+                    </option>
+                    <option value="adp" <?=$pconfig['powerd_normal_mode']=="adp" ? "selected=\"selected\"" : "";?>>
+                      <?=gettext("Adaptive");?>
+                    </option>
+                    <option value="min" <?=$pconfig['powerd_normal_mode']=="min" ? "selected=\"selected\"" :"";?>>
+                      <?=gettext("Minimum");?>
+                    </option>
+                    <option value="max" <?=$pconfig['powerd_normal_mode']=="max" ? "selected=\"selected\"" : "";?>>
+                      <?=gettext("Maximum");?>
+                    </option>
+                  </select>
+                  <div class="hidden" for="help_for_powerd_normal_mode">
+                    <?=gettext("If the powerd utility can not determine the power state it uses \"normal\" for control."); ?>
+                  </div>
                 </td>
               </tr>
               <tr>

--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -402,7 +402,7 @@ include("head.inc");
                 </td>
               </tr>
               <tr>
-                <td><i class="fa fa-info-circle text-muted"></i>  <?=gettext('On Battery Normal Mode') ?></td>
+                <td><a id="help_for_powerd_normal_mode" href="#" class="showhelp"><i class="fa fa-info-circle text-circle"></i></a>  <?=gettext('On Normal Power Mode'); ?></td>
                 <td>
                   <select name="powerd_normal_mode" class="selectpicker" data-style="btn-default" data-width="auto">
                     <option value="hadp"<?=$pconfig['powerd_normal_mode']=="hadp" ? "selected=\"selected\"" : "";?>>


### PR DESCRIPTION
This adds the "normal" power state to the powerd - system_advanced_misc options.
If the powerd utillity can not determine the system power options (ac or battery) it will use the "normal" setting rendering the "ac" and "battery" settings useless for these systems.

_powerd -v_ (from the command-line, on my intel Avoton system)
**Quote**
powerd: unable to determine AC line status <=== Important for "-n" option of powerd !!!
load  10%, current freq 1200 MHz (13), wanted freq 1200 MHz
load   6%, current freq 1200 MHz (13), wanted freq 1200 MHz
load   8%, current freq 1200 MHz (13), wanted freq 1200 MHz
load  10%, current freq 1200 MHz (13), wanted freq 1200 MHz
load   6%, current freq 1200 MHz (13), wanted freq 1200 MHz

_powerd manpage:_
**Quote**
     -n   mode    Selects the mode to use normally when the AC line state is
       unknown.