### PR TITLE
Optimized dhcp_clean_leases()

### DIFF
--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -47,45 +47,25 @@ function dhcp_clean_leases()
         return;
     }
 
-    /* Build list of static MACs */
-    $staticmacs = array();
+    /* Build lease patterns for static MACs */
+    $lease_patterns = array();
     foreach (legacy_config_get_interfaces(array("virtual" => false)) as $ifname => $ifarr) {
         if (isset($config['dhcpd'][$ifname]['staticmap'])) {
             foreach($config['dhcpd'][$ifname]['staticmap'] as $static) {
-                $staticmacs[] = $static['mac'];
+                $lease_patterns[] = '(\h*lease\s*[0-9\.]+\s*\{[^\{\}]*hardware\h*ethernet\h*' . $static['mac'] . '[^\{\}]*(.*"[^\{\}]*\}|\})\s?)';
             }
         }
     }
-    /* Read existing leases */
-    $leases_contents = explode("\n", file_get_contents($leasesfile));
-    $newleases_contents = array();
-    $i=0;
-    while ($i < count($leases_contents)) {
-        /* Find a lease definition */
-        if (substr($leases_contents[$i], 0, 6) == "lease ") {
-            $templease = array();
-            $thismac = "";
-            /* Read to the end of the lease declaration */
-            do {
-                if (substr($leases_contents[$i], 0, 20) == "  hardware ethernet ") {
-                    $thismac = substr($leases_contents[$i], 20, 17);
-                }
-                $templease[] = $leases_contents[$i];
-                $i++;
-            } while ($leases_contents[$i-1] != "}");
-            /* Check for a matching MAC address and if not present, keep it. */
-            if (! in_array($thismac, $staticmacs)) {
-                $newleases_contents = array_merge($newleases_contents, $templease);
-            }
-        } else {
-            /* It's a line we want to keep, copy it over. */
-            $newleases_contents[] = $leases_contents[$i];
-            $i++;
-        }
-    }
+
+    /* Read existing leases file */
+    $leases_contents = file_get_contents($leasesfile);
+
+    /* Remove existing leases for static MACs */
+    $leases_contents = preg_replace($lease_patterns, '', $leases_contents);
+
     /* Write out the new leases file */
     $fd = fopen($leasesfile, 'w');
-    fwrite($fd, implode("\n", $newleases_contents));
+    fwrite($fd, $leases_contents);
     fclose($fd);
 }
 

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -52,7 +52,7 @@ function dhcp_clean_leases()
     foreach (legacy_config_get_interfaces(array("virtual" => false)) as $ifname => $ifarr) {
         if (isset($config['dhcpd'][$ifname]['staticmap'])) {
             foreach($config['dhcpd'][$ifname]['staticmap'] as $static) {
-                $lease_patterns[] = '(\h*lease\s*[0-9\.]+\s*\{[^\{\}]*hardware\h*ethernet\h*' . $static['mac'] . '[^\{\}]*(.*"[^\{\}]*\}|\})\s?)';
+                $lease_patterns[] = '(lease\s*[0-9\.]+\s*\{[^\{\}]*hardware ethernet ' . $static['mac'] . '[^\{\}]*(.*"[^\{\}]*\}|\})\s?)';
             }
         }
     }


### PR DESCRIPTION
Current implementation of dhcp_clean_leases() takes too much time to remove static MACs from dhcpd leases database, which can sometimes exceed the max_execution_time, especially when leases database is huge or too many static MACs are configured.
This implementation uses regular expressions to speed up the cleanup process.