### PR TITLE
Fix setting locale

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -56,15 +56,19 @@ class ControllerBase extends ControllerRoot
         }
 
         $lang_encoding = $lang . '.UTF-8';
+        $textdomain = 'OPNsense';
 
         $ret = new ViewTranslator(array(
             'directory' => '/usr/local/share/locale',
-            'defaultDomain' => 'OPNsense',
+            'defaultDomain' => $textdomain,
             'locale' => $lang_encoding,
         ));
 
         /* this isn't being done by Phalcon */
         putenv('LANG=' . $lang_encoding);
+        textdomain($textdomain);
+        bindtextdomain($textdomain, '/usr/local/share/locale');
+        bind_textdomain_codeset($textdomain, $lang_encoding);
 
         return $ret;
     }


### PR DESCRIPTION
Setting locale by code 
`$ret = new ViewTranslator(array(
            'directory' => '/usr/local/share/locale',
            'defaultDomain' => 'OPNsense',
            'locale' => $lang_encoding,
        ));`
don't work correctly. After this $ret->_locale = false