### PR TITLE
Part 2 of 2 - EAP-RADIUS ipsec/strongswan support, 2. try

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -626,7 +626,7 @@ EOD;
         if (isset($a_client['enable'])) {
             $strongswan .= "\t\tattr {\n";
             if ($a_client['pool_address'] && $a_client['pool_netbits']) {
-                $strongswan .= "\t\tsubnet = {$a_client['pool_address']}/{$a_client['pool_netbits']}\n";
+                $strongswan .= "\t\t\tsubnet = {$a_client['pool_address']}/{$a_client['pool_netbits']}\n";
             }
             $cfgservers = array();
             foreach (array('dns_server1', 'dns_server2', 'dns_server3', 'dns_server4') as $dns_server) {
@@ -635,7 +635,7 @@ EOD;
                 }
             }
             if (!empty($cfgservers)) {
-                $strongswan .= "\t\tdns = " . implode(",", $cfgservers) . "\n";
+                $strongswan .= "\t\t\tdns = " . implode(",", $cfgservers) . "\n";
             }
             unset($cfgservers);
             $cfgservers = array();
@@ -646,7 +646,7 @@ EOD;
                 $cfgservers[] = $a_client['wins_server2'];
             }
             if (!empty($cfgservers)) {
-                $strongswan .= "\t\tnbns = " . implode(",", $cfgservers) . "\n";
+                $strongswan .= "\t\t\tnbns = " . implode(",", $cfgservers) . "\n";
             }
             unset($cfgservers);
 
@@ -667,41 +667,41 @@ EOD;
                 }
 
                 if (!empty($net_list)) {
-                    $strongswan .= "\t\tsplit-include = {$net_list}\n";
+                    $strongswan .= "\t\t\tsplit-include = {$net_list}\n";
                     unset($net_list);
                 }
             }
 
             if (!empty($a_client['dns_domain'])) {
-                $strongswan .= "\t\t# Search domain and default domain\n";
-                $strongswan .= "\t\t28674 = {$a_client['dns_domain']}\n";
+                $strongswan .= "\t\t\t# Search domain and default domain\n";
+                $strongswan .= "\t\t\t28674 = {$a_client['dns_domain']}\n";
                 if (empty($a_client['dns_split'])) {
-                    $strongswan .= "\t\t28675 = {$a_client['dns_domain']}";
+                    $strongswan .= "\t\t\t28675 = {$a_client['dns_domain']}";
                 }
                 $strongswan .= "\n";
             }
 
             if (!empty($a_client['dns_split'])) {
-                $strongswan .= "\t\t28675 = {$a_client['dns_split']}\n";
+                $strongswan .= "\t\t\t28675 = {$a_client['dns_split']}\n";
             }
 
             if (!empty($a_client['login_banner'])) {
-                $strongswan .= "\t\t28672 = {$a_client['login_banner']}\n";
+                $strongswan .= "\t\t\t28672 = {$a_client['login_banner']}\n";
             }
 
             if (isset($a_client['save_passwd'])) {
-                $strongswan .= "\t\t28673 = 1\n";
+                $strongswan .= "\t\t\t28673 = 1\n";
             }
 
             if (!empty($a_client['pfs_group'])) {
-                $strongswan .= "\t\t28679 = {$a_client['pfs_group']}\n";
+                $strongswan .= "\t\t\t28679 = {$a_client['pfs_group']}\n";
             }
             $strongswan .= "\t\t}\n";
 
             if ($a_client['user_source'] != "none") {
-                $strongswan .= "\txauth-generic {\n";
-                $strongswan .= "\t\tscript = /usr/local/etc/inc/ipsec.auth-user.php\n";
-                $strongswan .= "\t\tauthcfg = ";
+                $strongswan .= "\t\txauth-generic {\n";
+                $strongswan .= "\t\t\tscript = /usr/local/etc/inc/ipsec.auth-user.php\n";
+                $strongswan .= "\t\t\tauthcfg = ";
                 $firstsed = 0;
                 $authcfgs = explode(",", $a_client['user_source']);
                 foreach ($authcfgs as $authcfg) {
@@ -715,7 +715,7 @@ EOD;
                     $firstsed = 1;
                 }
                 $strongswan .= "\n";
-                $strongswan .= "\t}\n";
+                $strongswan .= "\t\t}\n";
             }
         }
 
@@ -918,7 +918,7 @@ EOD;
                         break;
                     case 'eap-mschapv2':
                         $authentication = "leftauth = pubkey\n\trightauth = eap-mschapv2";
-                        $authentication .= "\n\teap_identity=%any";
+                        $authentication .= "\n\teap_identity = %any";
                         break;
                     case 'xauth_rsa_server':
                         $authentication = "leftauth = pubkey\n\trightauth = pubkey";
@@ -940,7 +940,7 @@ EOD;
                         break;
                 }
                 if (!empty($ph1ent['certref'])) {
-                    $authentication .= "\n\tleftcert={$certpath}/cert-{$ph1ent['ikeid']}.crt";
+                    $authentication .= "\n\tleftcert = {$certpath}/cert-{$ph1ent['ikeid']}.crt";
                 }
                 if (!empty($ph1ent['caref'])) {
                     $ca = lookup_ca($ph1ent['caref']);
@@ -949,7 +949,7 @@ EOD;
                          foreach (cert_get_subject_array($ca['crt']) as $ca_field) {
                             $rightca .= "{$ca_field['a']}={$ca_field['v']}/";
                          }
-                         $authentication .= "\n\trightca=\"/$rightca\"";
+                         $authentication .= "\n\trightca = \"/$rightca\"";
                     }
                 }
                 $left_spec = $ep;

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -64,6 +64,7 @@ $p1_authentication_methods = array(
     'xauth_psk_server' => array( 'name' => 'Mutual PSK + Xauth', 'mobile' => true ),
     'eap-tls' => array( 'name' => 'EAP-TLS', 'mobile' => true),
     'eap-mschapv2' => array( 'name' => 'EAP-MSCHAPV2', 'mobile' => true),
+    'eap-radius' => array( 'name' => 'EAP-RADIUS', 'mobile' => true),
     'rsasig' => array( 'name' => 'Mutual RSA', 'mobile' => false ),
     'pre_shared_key' => array( 'name' => 'Mutual PSK', 'mobile' => false ),
 );
@@ -498,6 +499,10 @@ function ipsec_configure($verbose = false)
         $rgmap = array();
         $filterdns_list = array();
         $ipsecpinghosts = "";
+
+        $radius_enabled = false;
+        $radius_accounting_enabled = false;
+
         /* step through each phase1 entry */
         foreach ($a_phase1 as $ph1ent) {
             if (isset($ph1ent['disabled'])) {
@@ -508,6 +513,21 @@ function ipsec_configure($verbose = false)
                 $aggressive_psk = true;
             }
             $ep = ipsec_get_phase1_src($ph1ent);
+
+            /* only run once */
+            if ($ph1ent['authentication_method'] == "eap-radius" && $radius_enabled == false) {
+                $radius_enabled = true;
+
+                foreach (auth_get_authserver_list() as $auth_server) {
+                    if ($auth_server['type'] == "radius") {
+                        $radius_servers[] = $auth_server;
+
+                        if (!empty($auth_server['radius_acct_port'])) {
+                            $radius_accounting_enabled = true;
+                        }
+                    }
+                }
+            }
 
             /* see if this tunnel has a hostname for the remote-gateway. If so,
                try to resolve it now and add it to the list for filterdns */
@@ -717,6 +737,35 @@ EOD;
                 $strongswan .= "\n";
                 $strongswan .= "\t\t}\n";
             }
+
+            if ($radius_enabled == true) {
+                $strongswan .= "\t\teap-radius {\n";
+
+                if ($radius_accounting_enabled == true) {
+                    $strongswan .= "\t\t\taccounting = yes\n";
+                }
+
+                $strongswan .= "\t\t\tservers {\n";
+                $i = 1;
+
+                foreach ($radius_servers as $radius_server) {
+                    $strongswan .= "\t\t\t\tserver" . $i . " {\n";
+
+                    $strongswan .= "\t\t\t\t\taddress = " . $radius_server['host'] . "\n";
+                    $strongswan .= "\t\t\t\t\tsecret = " . $radius_server['radius_secret'] . "\n";
+                    $strongswan .= "\t\t\t\t\tauth_port = " . $radius_server['radius_auth_port'] . "\n";
+
+                    if (!empty($radius_server['radius_acct_port'])) {
+                        $strongswan .= "\t\t\t\t\tacct_port = " . $radius_server['radius_acct_port'] . "\n";
+                    }
+
+                    $strongswan .= "\t\t\t\t}\n";
+                    $i = $i + 1;
+                }
+
+                $strongswan .= "\t\t\t}\n";
+                $strongswan .= "\t\t}\n";
+            }
         }
 
         $strongswan .= "\t}\n}\n";
@@ -918,6 +967,11 @@ EOD;
                         break;
                     case 'eap-mschapv2':
                         $authentication = "leftauth = pubkey\n\trightauth = eap-mschapv2";
+                        $authentication .= "\n\teap_identity = %any";
+                        break;
+                    case 'eap-radius':
+                        $authentication = "leftauth = pubkey\n\trightauth = eap-radius";
+                        $authentication .= "\n\trightsendcert = never";
                         $authentication .= "\n\teap_identity = %any";
                         break;
                     case 'xauth_rsa_server':

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -170,6 +170,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $pconfig['peerid_data'] = "";
     }
 
+    /* RADIUS server means no CA being sent */
+    if ($pconfig['authentication_method'] == "eap-radius") {
+        $pconfig['caref'] = "";
+    }
+
     /* input validation */
     $method = $pconfig['authentication_method'];
 
@@ -178,6 +183,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     switch ($method) {
         case "eap-tls":
         case "eap-mschapv2":
+        case "eap-radius":
           if ($pconfig['iketype'] != 'ikev2') {
               $input_errors[] = sprintf(gettext("%s can only be used with IKEv2 type VPNs."), strtoupper($method));
           }
@@ -461,6 +467,12 @@ include("head.inc");
                     $(".auth_eap_tls_caref").show();
                     $(".auth_eap_tls_caref :input").prop( "disabled", false );
                     break;
+                case 'eap-radius':
+                    $(".auth_eap_tls").show();
+                    $(".auth_eap_tls :input").prop( "disabled", false );
+                    $(".auth_eap_tls_caref").hide();
+                    $(".auth_eap_tls_caref :input").prop( "disabled", true );
+                    break;
                 case 'pre_shared_key':
                     if ($("#mobile").val() == undefined) {
                         $(".auth_psk").show();
@@ -697,7 +709,8 @@ include("head.inc");
 ?>
                       </select>
                       <div class="hidden" for="help_for_authmethod">
-                        <?=gettext("Must match the setting chosen on the remote side."); ?>
+                        <?=gettext("Must match the setting chosen on the remote side."); ?><br />
+                        <?=sprintf(gettext("If you select EAP-RADIUS, you must define your RADIUS servers on the %sServers%s page."), '<a href="/system_authservers.php">', '</a>'); ?>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
This pull request is split across the tools and core repositories, this is the core part.
It has been changed, so it uses the radius servers defined in the auth framework.

1: commit improves readability of the generated strongswan.conf by fixing indentions, and ipsec.conf by adding some missing spaces.
2: commit implements the config file generation parts that is missing.
3: commit implements the ui part, adding some helper text, and hiding fields not to be used for EAP-RADIUS.