### PR TITLE
UIModelGrid: use empty string instead of "##Unlinked"

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -116,7 +116,7 @@ class UIModelGrid
                                 }
                             }
                             if (empty($row[$fieldname])) {
-                                $row[$fieldname] = "##Unlinked";
+                                $row[$fieldname] = "";
                             }
                         }
                     }


### PR DESCRIPTION
Hmm, does it serve any purpose to set `##Unlinked` instead of just using an empty string?
It looks ugly if empty fields get filled with `##Unlinked` :)

![unlinked](https://cloud.githubusercontent.com/assets/909706/22346715/6611faa2-e405-11e6-885c-3a0d43f5c45c.png)
