### PR TITLE
configdctl: default timeout too low

### DIFF
--- a/src/opnsense/service/configd_ctl.py
+++ b/src/opnsense/service/configd_ctl.py
@@ -82,7 +82,7 @@ def exec_config_cmd(exec_command):
 
 
 # set a timeout to the socket
-socket.setdefaulttimeout(120)
+socket.setdefaulttimeout(3600)
 
 # validate parameters
 if len(sys.argv) <= 1:


### PR DESCRIPTION
The timeout for configctl is way too low for long running task (such as acme.sh certificate validation):

```
Jan 26 23:50:18 opnsense configd[51720]: Timeout (120) executing : acmeclient sign-all-certs
```

(In this specific example _each_ certificates took roughly 2 minutes to complete, which isn't unsual for DNS validation.)

It would be better to make this a configurable limit (and make the config variable accessible from plugins!), but for now it would be sufficient to just use a much higher value.