### PR TITLE
DHCP leases: do not link to WOL page if WOL plugin is missing

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2198,3 +2198,46 @@ function service_control_restart($name, $extras)
 
     return sprintf(gettext("%s has been restarted."), htmlspecialchars($name));
 }
+
+function is_plugin_installed($name)
+{
+    // NOTE: Based on infoAction() from Core/Api/FirmwareController.php
+
+    $backend = new \OPNsense\Core\Backend();
+    $keys = array('name', 'version', 'comment', 'flatsize', 'locked', 'license');
+    $plugins = array();
+
+    // Only check local package data for performance reasons
+    $current = $backend->configdRun("firmware local");
+    $current = explode("\n", trim($current));
+
+    foreach ($current as $line) {
+        /* package infos are flat lists with 3 pipes as delimiter */
+        $expanded = explode('|||', $line);
+        $translated = array();
+        $index = 0;
+        if (count($expanded) != count($keys)) {
+            continue;
+        }
+        foreach ($keys as $key) {
+            $translated[$key] = $expanded[$index++];
+        }
+
+        /* mark local packages as "installed" */
+        $translated['installed'] = "1";
+
+        /* figure out local and remote plugins */
+        $plugin = explode('-', $translated['name']);
+        if (count($plugin)) {
+            if ($plugin[0] == 'os' || $plugin[0] == 'ospriv') {
+                $plugins[$translated['name']] = $translated;
+            }
+        }
+    }
+
+    if (isset($plugins[$name]) and $plugins[$name]['installed'] == "1") {
+        return true; // is installed
+    } else {
+        return false; // is not installed
+    }
+}

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -76,6 +76,7 @@ function remove_duplicate($array, $field)
 
 $interfaces = legacy_config_get_interfaces(array('virtual' => false));
 $leasesfile = services_dhcpd_leasesfile();
+$plugin_installed = is_plugin_installed('os-wol');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $awk = "/usr/bin/awk";
@@ -417,9 +418,13 @@ include("head.inc");?>
                   <td><?=$data['int'];?></td>
                   <td><?=$data['ip'];?></td>
                   <td>
+                     <? if ($plugin_installed === true) { ?>
                       <a href="services_wol.php?if=<?=$data['if'];?>&amp;mac=<?=$data['mac'];?>" title="<?=gettext("send Wake on LAN packet to this MAC address");?>">
                         <?=$data['mac'];?>
                       </a>
+                      <? } else { ?>
+                        <?=$data['mac'];?>
+                      <? } ?>
                       <br />
                       <small><i><?=!empty($mac_man[$mac_hi]) ? $mac_man[$mac_hi] : "";?></i></small>
                   </td>


### PR DESCRIPTION
When clicking on the MAC address in DHCP Leases page, you'll get a "404 - Not Found". This is caused by a missing WOL plugin.

My proposal is to check if the WOL plugin is installed. If not, do not link to the WOL page. To make this check possible I've added a new function `is_plugin_installed()`. It may be used for similar glue in the future. Still, there may be better ways to solve this. :)

Reported on IRC by stormy1.