### PR TITLE
ModelRelationField: soft-fail on missing classes

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
@@ -85,6 +85,10 @@ class ModelRelationField extends BaseField
                 // only handle valid model sources
                 if (isset($modelData['source']) && isset($modelData['items']) && isset($modelData['display'])) {
                     $className = str_replace(".", "\\", $modelData['source']);
+                    // handle optional/missing classes, i.e. from plugins
+                    if (!class_exists($className)) {
+                        continue;
+                    }
                     $modelObj = new $className;
                     foreach ($modelObj->getNodeByReference($modelData['items'])->__items as $node) {
                         $displayKey = $modelData['display'];


### PR DESCRIPTION
Use case: Plugins (and system components) may depend on optional plugins. For example, our Let's Encrypt plugin provides integration for our HAProxy plugin, but this is completely optional.

Without this fix, a fatal error occurs if the optional plugin is not installed:

```
[08-Feb-2017 10:50:57 Europe/Berlin] PHP Fatal error:  Uncaught Error: Class 'OPNsense\HAProxy\HAProxy' not found in /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php:90
Stack trace:
#0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(182): OPNsense\Base\FieldTypes\ModelRelationField->setModel(Array)
#1 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(228): OPNsense\Base\BaseModel->parseXml(Object(SimpleXMLElement), Object(SimpleXMLElement), Object(OPNsense\Base\FieldTypes\ContainerField))
#2 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(279): OPNsense\Base\BaseModel->parseXml(Object(SimpleXMLElement), Object(SimpleXMLElement), Object(OPNsense\Base\FieldTypes\ContainerField))
#3 /usr/local/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/ValidationsController.php(201): OPNsense\Base\BaseModel->__construct()
#4 [internal function]: OPNsense\AcmeClient\Api\ValidationsController->searchAction()
#5 [internal function]: Phalcon\Dispatcher->callActionMethod(Object(OPNsense\AcmeClient\Api\ in /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php on line 90
```

My proposal is to make a missing class in ModelRelationField a soft-failure. Maybe we should at least log something, but I don't know how to log from within a FieldType :)