### PR TITLE
Add priority settings to advanced firewall rule options

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2231,7 +2231,7 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
     $int = "";
     $aline = array();
     // initialize array with empty tags
-    foreach (array('schedlabel','divert','icmp-type','icmp6-type','tag','tagged','route','os','reply','prot','log', 'priority', 'priority-match') as $tag) {
+    foreach (array('schedlabel','divert','icmp-type','icmp6-type','tag','tagged','route','os','reply','prot','log', 'set-prio', 'set-prio-alt', 'prio') as $tag) {
         $aline[$tag] = "";
     }
 
@@ -2389,13 +2389,19 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
         $aline['icmp6-type'] = "icmp6-type {$rule['icmptype']} ";
     }
 
-    if (!empty($rule['priority'])) {
-    	// need to use a hack for priority values since rule apparantly cannot store "0"
-		$aline['priority'] = ' set prio '.($rule['priority'] - 1).' ';
+    if (isset($rule['set-prio']) && $rule['set-prio'] !== '') {
+    	if (isset($rule['set-prio-alt']) && $rule['set-prio-alt'] !== '') {
+    		$prio = '('.$rule['set-prio'].','.$rule['set-prio-alt'].')';
+		}
+		else {
+			$prio = $rule['set-prio'];
+		}
+
+		$aline['set-prio'] = ' set prio '.$prio.' ';
 	}
 
-	if (!empty($rule['priority-match'])) {
-		$aline['priority-match'] = ' prio '.($rule['priority-match'] - 1).' ';
+	if (isset($rule['prio']) && $rule['prio'] !== '') {
+		$aline['prio'] = ' prio '.$rule['prio'].' ';
 	}
 
     if (!empty($rule['tag'])) {
@@ -2549,7 +2555,7 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
     $line .= $aline['type'] . $aline['direction'] . $aline['log'] . $aline['quick'] . $aline['interface'] .
       $aline['reply'] . $aline['route'] . $aline['ipprotocol'] . $aline['prot'] . $aline['src'] . $aline['os'] . $aline['dst'] .
       $aline['divert'] . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] .
-      $aline['priority'] . $aline['priority-match'] . $aline['allowopts'] . $aline['flags'] . $aline['schedlabel'];
+      $aline['set-prio'] . $aline['prio'] . $aline['allowopts'] . $aline['flags'] . $aline['schedlabel'];
 
     unset($aline);
 

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2231,7 +2231,7 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
     $int = "";
     $aline = array();
     // initialize array with empty tags
-    foreach (array('schedlabel','divert','icmp-type','icmp6-type','tag','tagged','route','os','reply','prot','log') as $tag) {
+    foreach (array('schedlabel','divert','icmp-type','icmp6-type','tag','tagged','route','os','reply','prot','log', 'priority', 'priority-match') as $tag) {
         $aline[$tag] = "";
     }
 
@@ -2388,6 +2388,16 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
     if (isset($rule['protocol']) && $rule['protocol'] == "icmp" && $rule['icmptype'] && $rule['ipprotocol'] == "inet6") {
         $aline['icmp6-type'] = "icmp6-type {$rule['icmptype']} ";
     }
+
+    if (!empty($rule['priority'])) {
+    	// need to use a hack for priority values since rule apparantly cannot store "0"
+		$aline['priority'] = ' set prio '.($rule['priority'] - 1).' ';
+	}
+
+	if (!empty($rule['priority-match'])) {
+		$aline['priority-match'] = ' prio '.($rule['priority-match'] - 1).' ';
+	}
+
     if (!empty($rule['tag'])) {
         $aline['tag'] = " tag " .$rule['tag']. " ";
     }
@@ -2539,7 +2549,7 @@ function filter_generate_user_rule(&$FilterIflist, $rule)
     $line .= $aline['type'] . $aline['direction'] . $aline['log'] . $aline['quick'] . $aline['interface'] .
       $aline['reply'] . $aline['route'] . $aline['ipprotocol'] . $aline['prot'] . $aline['src'] . $aline['os'] . $aline['dst'] .
       $aline['divert'] . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] .
-      $aline['allowopts'] . $aline['flags'] . $aline['schedlabel'];
+      $aline['priority'] . $aline['priority-match'] . $aline['allowopts'] . $aline['flags'] . $aline['schedlabel'];
 
     unset($aline);
 

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -49,12 +49,19 @@ if ($ostypes == null) {
 function FormSetAdvancedOptions(&$item) {
     foreach (array("max", "max-src-nodes", "max-src-conn", "max-src-states","nopfsync", "statetimeout"
                   ,"max-src-conn-rate","max-src-conn-rates", "tag", "tagged", "allowopts", "disablereplyto","tcpflags1"
-                  ,"tcpflags2", 'set-prio', 'set-prio-alt', 'prio') as $fieldname) {
+                  ,"tcpflags2") as $fieldname) {
 
         if (!empty($item[$fieldname])) {
             return true;
         }
     }
+    // check these fields for anything being set except a blank string
+    foreach (array('set-prio', 'set-prio-alt', 'prio') as $fieldname) {
+        if (isset($item[$fieldname]) && $item[$fieldname] !== '') {
+            return true;
+        }
+    }
+
     if (!empty($item["statetype"]) && $item["statetype"] != 'keep state') {
         return true;
     }


### PR DESCRIPTION
This will add 2 additional advanced options for firewall rules. One to set the priority, and one to match based on the priority. This should be useful for Google Fiber users to unlock full upload speed.