### PR TITLE
Fix ipv4 subnet matching

### DIFF
--- a/src/etc/inc/interfaces.lib.inc
+++ b/src/etc/inc/interfaces.lib.inc
@@ -246,8 +246,15 @@ function legacy_interfaces_details($intf = null)
             $result[$current_interface]["macaddr"] = $line_parts[1];
         } elseif (strpos($line, "\tinet ") !== false) {
             // IPv4 information
-            $mask = substr_count(base_convert(hexdec($line_parts[3]), 10, 2), '1');
-            $result[$current_interface]["ipv4"][] = array("ipaddr" => $line_parts[1], "subnetbits" => $mask);
+			unset($mask);
+            for ($i = 0; $i < count($line_parts) - 1; ++$i) {
+                if ($line_parts[$i] == 'netmask') {
+                    $mask = substr_count(base_convert(hexdec($line_parts[($i + 1)]), 10, 2), '1');
+                }
+            }
+            if (isset($mask)) {
+                $result[$current_interface]["ipv4"][] = array("ipaddr" => $line_parts[1], "subnetbits" => $mask);
+            }
         } elseif (strpos($line, "\tinet6 ") !== false) {
             // IPv6 information
             $addr = strtok($line_parts[1], '%');


### PR DESCRIPTION
This will fix the issue with tun interfaces (ie openvpn) having their subnet detected incorrectly. It also brings the code more in line with the IPv6 code.