### PR TITLE
Clean-up how interface address/network rules are generated.

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2083,124 +2083,39 @@ function filter_generate_address(&$FilterIflist, &$rule, $target = 'source', $is
         if (strstr($rule[$target]['network'], "opt")) {
             $optmatch = "";
             $matches = "";
-            if ($rule['ipprotocol'] == "inet6") {
-                if (preg_match("/opt([0-9]*)$/", $rule[$target]['network'], $optmatch)) {
-                    $opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ipv6'];
-                    if (!is_ipaddrv6($opt_ip)) {
-                        return "";
-                    }
-                    $src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['snv6'];
-                    /* check for opt$NUMip here */
-                } elseif (preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
-                    $src = $FilterIflist["opt{$matches[1]}"]['ipv6'];
-                    if (!is_ipaddrv6($src)) {
-                        return "";
-                    }
-                    if (isset($rule[$target]['not'])) {
-                        $src = " !{$src}";
-                    }
-                }
-            } else {
-                if (preg_match("/opt([0-9]*)$/", $rule[$target]['network'], $optmatch)) {
-                    $opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ip'];
-                    if (!is_ipaddrv4($opt_ip)) {
-                        return "";
-                    }
-                    $src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['sn'];
-                    /* check for opt$NUMip here */
-                } elseif (preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
-                    $src = $FilterIflist["opt{$matches[1]}"]['ip'];
-                    if (!is_ipaddrv4($src)) {
-                        return "";
-                    }
-                    if (isset($rule[$target]['not'])) {
-                        $src = " !{$src}";
-                    }
-                }
+            if (preg_match("/opt([0-9]*)$/", $rule[$target]['network'], $optmatch)) {
+                $src = "({$FilterIflist["opt{$optmatch[1]}"]['if']}:network)";
+                /* check for opt$NUMip here */
+            } elseif (preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
+                $src = "({$FilterIflist["opt{$matches[1]}"]['if']})";
             }
         } else {
-            if ($rule['ipprotocol'] == "inet6") {
-                switch ($rule[$target]['network']) {
-                    case 'wan':
-                        $wansa = $FilterIflist['wan']['sav6'];
-                        if (!is_ipaddrv6($wansa)) {
-                            return "";
-                        }
-                        $wansn = $FilterIflist['wan']['snv6'];
-                        $src = "{$wansa}/{$wansn}";
-                        break;
-                    case 'wanip':
-                        $src = $FilterIflist["wan"]['ipv6'];
-                        if (!is_ipaddrv6($src)) {
-                            return "";
-                        }
-                        break;
-                    case 'lanip':
-                        $src = $FilterIflist["lan"]['ipv6'];
-                        if (!is_ipaddrv6($src)) {
-                            return "";
-                        }
-                        break;
-                    case 'lan':
-                        $lansa = $FilterIflist['lan']['sav6'];
-                        if (!is_ipaddrv6($lansa)) {
-                            return "";
-                        }
-                        $lansn = $FilterIflist['lan']['snv6'];
-                        $src = "{$lansa}/{$lansn}";
-                        break;
-                    case '(self)':
-                        $src = "(self)";
-                        break;
-                    default:
-                        if (!empty($FilterIflist[$rule[$target]['network']]['sav6'])) {
-                            $src = $FilterIflist[$rule[$target]['network']]['sav6'] . "/" . $FilterIflist[$rule[$target]['network']]['snv6'];
-                        } else {
-                            return "";
-                        }
-                }
-                if (isset($rule[$target]['not']) && !is_subnet($src)) {
-                    $src = " !{$src}";
-                }
-            } else {
-                switch ($rule[$target]['network']) {
-                    case 'wan':
-                        $wansa = $FilterIflist['wan']['sa'];
-                        if (!is_ipaddrv4($wansa)) {
-                            return "";
-                        }
-                        $wansn = $FilterIflist['wan']['sn'];
-                        $src = "{$wansa}/{$wansn}";
-                        break;
-                    case 'wanip':
-                        $src = $FilterIflist["wan"]['ip'];
-                        break;
-                    case 'lanip':
-                        $src = $FilterIflist["lan"]['ip'];
-                        break;
-                    case 'lan':
-                        $lansa = $FilterIflist['lan']['sa'];
-                        if (!is_ipaddrv4($lansa)) {
-                            return "";
-                        }
-                        $lansn = $FilterIflist['lan']['sn'];
-                        $src = "{$lansa}/{$lansn}";
-                        break;
-                    case '(self)':
-                        $src = "(self)";
-                        break;
-                    default:
-                        if (!empty($FilterIflist[$rule[$target]['network']]['sa'])) {
-                            $src = $FilterIflist[$rule[$target]['network']]['sa'] . "/" . $FilterIflist[$rule[$target]['network']]['sn'];
-                        } else {
-                            return "";
-                        }
-                }
-                if (isset($rule[$target]['not']) && !is_subnet($src) &&
-                  (strpos($src, '{') === false)) {
-                    $src = " !{$src}";
-                }
+            switch ($rule[$target]['network']) {
+                case 'wan':
+                    $src = "({$FilterIflist['wan']['if']}:network)";
+                    break;
+                case 'wanip':
+                    $src = "({$FilterIflist['wan']['if']})";
+                    break;
+                case 'lan':
+                    $src = "({$FilterIflist['lan']['if']}:network)";
+                    break;
+                case 'lanip':
+                    $src = "({$FilterIflist['lan']['if']})";
+                    break;
+                case '(self)':
+                    $src = "(self)";
+                    break;
+                default:
+                    if (!empty($FilterIflist[$rule[$target]['network']]['if'])) {
+                        $src = "({$FilterIflist[$rule[$target]['network']]['if']}:network)";
+                    } else {
+                        return "";
+                    }
             }
+        }
+        if (isset($rule[$target]['not'])) {
+            $src = " !{$src}";
         }
         if (is_subnet($src)) {
             filter_address_add_vips_subnets($FilterIflist, $src, $rule[$target]['network'], isset($rule[$target]['not']));

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2035,42 +2035,6 @@ function filter_generate_port(& $rule, $target = "source", $isnat = false) {
     return $src;
 }
 
-function filter_address_add_vips_subnets(&$FilterIflist, &$subnets, $if, $not)
-{
-    $if_subnets = array($subnets);
-
-    if ($not == true) {
-        $subnets = "!{$subnets}";
-    }
-
-    if (!empty($FilterIflist[$if]['vips']) || !empty($FilterIflist[$if]['vips6'])) {
-        $all_vips = array();
-        $all_vips = array_merge($all_vips, !empty($FilterIflist[$if]['vips']) ?  $FilterIflist[$if]['vips'] : array());
-        $all_vips = array_merge($all_vips, !empty($FilterIflist[$if]['vips6']) ?  $FilterIflist[$if]['vips6'] : array());
-        foreach ($all_vips as $vip) {
-            foreach ($if_subnets as $subnet) {
-                if (ip_in_subnet($vip['ip'], $subnet)) {
-                    continue 2;
-                }
-            }
-            $network = null;
-            if (is_ipaddrv4($vip['ip']) && is_subnetv4($if_subnets[0])) {
-                $network = gen_subnet($vip['ip'], $vip['sn']);
-            } elseif (is_ipaddrv6($vip['ip']) && is_subnetv6($if_subnets[0])) {
-                $network = gen_subnetv6($vip['ip'], $vip['sn']);
-            }
-            if (!empty($network)) {
-                $subnets .= ' ' . ($not == true ? '!' : '') . $network . '/' . $vip['sn'];
-                $if_subnets[] = $network . '/' . $vip['sn'];
-            }
-        }
-
-        if (strpos($subnets, ' ') !== false) {
-            $subnets = "{ {$subnets} }";
-        }
-    }
-}
-
 function filter_generate_address(&$FilterIflist, &$rule, $target = 'source', $isnat = false)
 {
     global $config;
@@ -2116,9 +2080,6 @@ function filter_generate_address(&$FilterIflist, &$rule, $target = 'source', $is
         }
         if (isset($rule[$target]['not'])) {
             $src = " !{$src}";
-        }
-        if (is_subnet($src)) {
-            filter_address_add_vips_subnets($FilterIflist, $src, $rule[$target]['network'], isset($rule[$target]['not']));
         }
     } elseif ($rule[$target]['address']) {
         $expsrc = alias_expand($rule[$target]['address']);


### PR DESCRIPTION
This change cleans-up the rule generation for interface addresses and networks. It also addresses the issue with network addresses for interface groups (https://forum.opnsense.org/index.php?topic=4556.0). I have done some testing but not anywhere close to cover all of the scenarios. In theory, this should work as expected, and will also work with multiple interface alias IPs that I would like to add in the near future. Please consider this change as WiP and suggest any other areas and things that should be considered. Thanks.