### PR TITLE
Fix 	a203c69 to prevent matching interfaces with 'ip' 

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2048,7 +2048,7 @@ function filter_generate_address(&$FilterIflist, &$rule, $target = 'source', $is
         $matches = "";
         if ($network_name == '(self)') {
             $src = "(self)";
-        } elseif (preg_match("/(.*)ip$/", $rule[$target]['network'], $matches)) {
+        } elseif (preg_match("/(^[wan|lan|opt]+[0-9]*)ip$/", $rule[$target]['network'], $matches)) {
             $src = "({$FilterIflist["{$matches[1]}"]['if']})";
         } else {
             $src = "({$FilterIflist[$network_name]['if']}:network)";


### PR DESCRIPTION
Fix for overaggressive regex in a203c69 . If you create interface with "ip" in the end (group interface "testip") it will wrongly match and cause breakage of rules. This should narrow-down the match and fix the issue.