### PR TITLE
make csrf error page translateable, fix HTML errors in csrf.inc

### DIFF
--- a/src/www/csrf.inc
+++ b/src/www/csrf.inc
@@ -90,7 +90,7 @@ class LegacyCSRF
         }
         if ($this->is_html_output) {
             $csrf = $this->newToken();
-            $inputtag = "<input type=\"hidden\" id=\"__opnsense_csrf\" name=\"{$csrf['key']}\" value=\"{$csrf['token']}\"\/>";
+            $inputtag = "<input type=\"hidden\" id=\"__opnsense_csrf\" name=\"{$csrf['key']}\" value=\"{$csrf['token']}\" />";
             $buffer = preg_replace('#(<form[^>]*method\s*=\s*["\']post["\'][^>]*>)#i', '$1' . $inputtag, $buffer);
             // csrf token for Ajax type requests
             $script = "
@@ -104,7 +104,7 @@ class LegacyCSRF
               });
             </script>
             ";
-            $buffer = str_ireplace('</head>', '</head>'.$script, $buffer);
+            $buffer = str_ireplace('</head>', $script.'</head>', $buffer);
         }
         return $buffer;
     }
@@ -114,11 +114,12 @@ $LegacyCSRFObject = new LegacyCSRF();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'GET' && !$LegacyCSRFObject->checkToken()) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
-    echo "<html><head><title>CSRF check failed</title></head>
-        <body>
-        <p>CSRF check failed. Your form session may have expired, or you may not have
-        cookies enabled.</p>
-        </body></html>
-    ";
+    echo sprintf("<html><head><title>%s</title></head>
+                  <body>
+                  <p>%s</p>
+                  </body></html>",
+                  gettext('CSRF check failed'),
+                  gettext('CSRF check failed. Your form session may have expired, or you may not have cookies enabled.')
+                );
     die;
 }


### PR DESCRIPTION
* the script tag cannot be between head and body -> move into head
* the input was invalid (looks like a wrongly copied escape sequence
* add gettext