### PR TITLE
RFC2136 RecordType Option

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1748,7 +1748,7 @@ EOD;
                 $need_update = false;
 
                 /* Update IPv4 if we have it. */
-                if (is_ipaddrv4($wanip)) {
+                if (is_ipaddrv4($wanip) && $dnsupdate['recordtype'] != "AAAA") {
                     if (($wanip != $cachedipv4) || (($currentTime - $cacheTimev4) > $maxCacheAgeSecs) || $forced) {
                         $upinst .= "update delete {$dnsupdate['host']}. A\n";
                         $upinst .= "update add {$dnsupdate['host']}. {$dnsupdate['ttl']} A {$wanip}\n";
@@ -1764,7 +1764,7 @@ EOD;
                 }
 
                 /* Update IPv6 if we have it. */
-                if (is_ipaddrv6($wanipv6)) {
+                if (is_ipaddrv6($wanipv6) && $dnsupdate['recordtype'] != "A") {
                     if (($wanipv6 != $cachedipv6) || (($currentTime - $cacheTimev6) > $maxCacheAgeSecs) || $forced) {
                         $upinst .= "update delete {$dnsupdate['host']}. AAAA\n";
                         $upinst .= "update add {$dnsupdate['host']}. {$dnsupdate['ttl']} AAAA {$wanipv6}\n";

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1748,7 +1748,7 @@ EOD;
                 $need_update = false;
 
                 /* Update IPv4 if we have it. */
-                if (is_ipaddrv4($wanip) && $dnsupdate['recordtype'] != "AAAA") {
+                if (is_ipaddrv4($wanip) && (empty($dnsupdate['recordtype']) || $dnsupdate['recordtype'] == 'A')) {
                     if (($wanip != $cachedipv4) || (($currentTime - $cacheTimev4) > $maxCacheAgeSecs) || $forced) {
                         $upinst .= "update delete {$dnsupdate['host']}. A\n";
                         $upinst .= "update add {$dnsupdate['host']}. {$dnsupdate['ttl']} A {$wanip}\n";
@@ -1764,7 +1764,7 @@ EOD;
                 }
 
                 /* Update IPv6 if we have it. */
-                if (is_ipaddrv6($wanipv6) && $dnsupdate['recordtype'] != "A") {
+                if (is_ipaddrv6($wanipv6) && (empty($dnsupdate['recordtype']) || $dnsupdate['recordtype'] == 'AAAA')) {
                     if (($wanipv6 != $cachedipv6) || (($currentTime - $cacheTimev6) > $maxCacheAgeSecs) || $forced) {
                         $upinst .= "update delete {$dnsupdate['host']}. AAAA\n";
                         $upinst .= "update add {$dnsupdate['host']}. {$dnsupdate['ttl']} AAAA {$wanipv6}\n";

--- a/src/www/services_rfc2136.php
+++ b/src/www/services_rfc2136.php
@@ -140,7 +140,7 @@ $main_buttons = array(
                       <td>
 <?php
                         $filename = "/conf/dyndns_{$rfc2136['interface']}_rfc2136_" . escapeshellarg($rfc2136['host']) . "_{$rfc2136['server']}.cache";
-                        if (file_exists($filename) && !empty($rfc2136['enable']) && $rfc2136['recordtype'] != "AAAA") {
+                        if (file_exists($filename) && !empty($rfc2136['enable']) && (empty($dnsupdate['recordtype']) || $dnsupdate['recordtype'] == 'A')) {
                             echo "IPv4: ";
                             if (isset($rfc2136['usepublicip'])) {
                                 $ipaddr = dyndnsCheckIP($rfc2136['interface']);
@@ -160,7 +160,7 @@ $main_buttons = array(
                             echo "IPv4: N/A";
                         }
                         echo "<br />";
-                        if (file_exists("{$filename}.ipv6") && !empty($rfc2136['enable']) && $rfc2136['recordtype'] != "A") {
+                        if (file_exists("{$filename}.ipv6") && !empty($rfc2136['enable']) && (empty($dnsupdate['recordtype']) || $dnsupdate['recordtype'] == 'AAAA')) {
                             echo "IPv6: ";
                             $ipaddr = get_interface_ipv6($rfc2136['interface']);
                             $cached_ip_s = explode("|", file_get_contents("{$filename}.ipv6"));

--- a/src/www/services_rfc2136.php
+++ b/src/www/services_rfc2136.php
@@ -140,7 +140,7 @@ $main_buttons = array(
                       <td>
 <?php
                         $filename = "/conf/dyndns_{$rfc2136['interface']}_rfc2136_" . escapeshellarg($rfc2136['host']) . "_{$rfc2136['server']}.cache";
-                        if (file_exists($filename) && !empty($rfc2136['enable'])) {
+                        if (file_exists($filename) && !empty($rfc2136['enable']) && $rfc2136['recordtype'] != "AAAA") {
                             echo "IPv4: ";
                             if (isset($rfc2136['usepublicip'])) {
                                 $ipaddr = dyndnsCheckIP($rfc2136['interface']);
@@ -160,7 +160,7 @@ $main_buttons = array(
                             echo "IPv4: N/A";
                         }
                         echo "<br />";
-                        if (file_exists("{$filename}.ipv6")) {
+                        if (file_exists("{$filename}.ipv6") && !empty($rfc2136['enable']) && $rfc2136['recordtype'] != "A") {
                             echo "IPv6: ";
                             $ipaddr = get_interface_ipv6($rfc2136['interface']);
                             $cached_ip_s = explode("|", file_get_contents("{$filename}.ipv6"));

--- a/src/www/services_rfc2136_edit.php
+++ b/src/www/services_rfc2136_edit.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['usetcp'] = isset($a_rfc2136[$id]['usetcp']);
     $pconfig['usepublicip'] = isset($a_rfc2136[$id]['usepublicip']);
 
-    $pconfig['recordtype'] = $a_rfc2136[$id]['recordtype'];
+    $pconfig['recordtype'] = isset($id) && !empty($a_rfc2136[$id]['recordtype']) ? $a_rfc2136[$id]['recordtype'] : null;
 
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['id']) && !empty($a_rfc2136[$_POST['id']])) {

--- a/src/www/services_rfc2136_edit.php
+++ b/src/www/services_rfc2136_edit.php
@@ -59,7 +59,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['usepublicip'] = isset($a_rfc2136[$id]['usepublicip']);
 
     $pconfig['recordtype'] = $a_rfc2136[$id]['recordtype'];
-    if (!$pconfig['recordtype']) $pconfig['recordtype'] = "both";
 
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['id']) && !empty($a_rfc2136[$_POST['id']])) {
@@ -228,9 +227,9 @@ include("head.inc");
                   <tr>
                     <td valign="top" class="vncellreq"><?=gettext("Record Type");?> </td>
                     <td class="vtable">
+                      <input name="recordtype" type="radio" value="" <?php if (empty($pconfig['recordtype'])) echo "checked=\"checked\""; ?> /> <?=gettext("All");?> &nbsp;
                       <input name="recordtype" type="radio" value="A" <?php if ($pconfig['recordtype'] == "A") echo "checked=\"checked\""; ?> /> <?=gettext("A (IPv4)");?> &nbsp;
-                      <input name="recordtype" type="radio" value="AAAA" <?php if ($pconfig['recordtype'] == "AAAA") echo "checked=\"checked\""; ?> /> <?=gettext("AAAA (IPv6)");?> &nbsp;
-                      <input name="recordtype" type="radio" value="both" <?php if ($pconfig['recordtype'] == "both") echo "checked=\"checked\""; ?> /> <?=gettext("Both");?>
+                      <input name="recordtype" type="radio" value="AAAA" <?php if ($pconfig['recordtype'] == "AAAA") echo "checked=\"checked\""; ?> /> <?=gettext("AAAA (IPv6)");?>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_rfc2136_edit.php
+++ b/src/www/services_rfc2136_edit.php
@@ -58,6 +58,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['usetcp'] = isset($a_rfc2136[$id]['usetcp']);
     $pconfig['usepublicip'] = isset($a_rfc2136[$id]['usepublicip']);
 
+    $pconfig['recordtype'] = $a_rfc2136[$id]['recordtype'];
+    if (!$pconfig['recordtype']) $pconfig['recordtype'] = "both";
+
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['id']) && !empty($a_rfc2136[$_POST['id']])) {
         $id = $_POST['id'];
@@ -93,6 +96,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $rfc2136['server'] = $pconfig['server'];
         $rfc2136['usetcp'] = !empty($pconfig['usetcp']);
         $rfc2136['usepublicip'] = !empty($pconfig['usepublicip']);
+        $rfc2136['recordtype'] = $_POST['recordtype'];
         $rfc2136['interface'] = $pconfig['interface'];
         $rfc2136['descr'] = $pconfig['descr'];
 
@@ -219,6 +223,14 @@ include("head.inc");
                     <td>
                       <input name="usepublicip" type="checkbox" id="usepublicip" value="<?=gettext("yes");?>" <?=!empty($pconfig['usepublicip']) ? "checked=\"checked\"" : ""; ?> />
                       <strong><?=gettext("If the interface IP is private, attempt to fetch and use the public IP instead.");?></strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td valign="top" class="vncellreq"><?=gettext("Record Type");?> </td>
+                    <td class="vtable">
+                      <input name="recordtype" type="radio" value="A" <?php if ($pconfig['recordtype'] == "A") echo "checked=\"checked\""; ?> /> <?=gettext("A (IPv4)");?> &nbsp;
+                      <input name="recordtype" type="radio" value="AAAA" <?php if ($pconfig['recordtype'] == "AAAA") echo "checked=\"checked\""; ?> /> <?=gettext("AAAA (IPv6)");?> &nbsp;
+                      <input name="recordtype" type="radio" value="both" <?php if ($pconfig['recordtype'] == "both") echo "checked=\"checked\""; ?> /> <?=gettext("Both");?>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_rfc2136_edit.php
+++ b/src/www/services_rfc2136_edit.php
@@ -225,11 +225,14 @@ include("head.inc");
                     </td>
                   </tr>
                   <tr>
-                    <td valign="top" class="vncellreq"><?=gettext("Record Type");?> </td>
+                    <td><a id="help_for_recordtype" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Record Type");?></td>
                     <td class="vtable">
                       <input name="recordtype" type="radio" value="" <?php if (empty($pconfig['recordtype'])) echo "checked=\"checked\""; ?> /> <?=gettext("All");?> &nbsp;
                       <input name="recordtype" type="radio" value="A" <?php if ($pconfig['recordtype'] == "A") echo "checked=\"checked\""; ?> /> <?=gettext("A (IPv4)");?> &nbsp;
                       <input name="recordtype" type="radio" value="AAAA" <?php if ($pconfig['recordtype'] == "AAAA") echo "checked=\"checked\""; ?> /> <?=gettext("AAAA (IPv6)");?>
+                      <div class="hidden" for="help_for_recordtype">
+                        <?=gettext("'All' will update all available record types.");?>
+                      </div>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
As explained in #1456 this PR makes it possible to control whether A, AAAA or both record types are changed when updating using RFC2136.

### Tasks

- [x] Modify edit page
- [x] Modify service function
- [x] Modify table overview

### Open Questions

_pfSense do not changed their table overview template, so you cannot see which record types are updated. Should we add this in OPNsense as it might be useful because you do not have to open the edit page for each update task?_ (see discussion)