### PR TITLE
Implement hardware offloading override

### DIFF
--- a/src/etc/inc/interfaces.lib.inc
+++ b/src/etc/inc/interfaces.lib.inc
@@ -297,38 +297,36 @@ function legacy_interface_details($intf)
 function configure_interface_hardware($ifs)
 {
     global $config;
-    $intf_details = legacy_interface_details($ifs);
     /* skip vlans for checksumming  */
-    if (!stristr($ifs, "_vlan") && is_array($intf_details)) {
-        // get current settings
-        $csum_set = in_array('rxcsum', $intf_details['options']) || in_array('txcsum', $intf_details['options']);
-        $csumv6_set = in_array('rxcsum6', $intf_details['options']) || in_array('txcsum6', $intf_details['options']);
-        $tso_set = in_array('tso4', $intf_details['options']) || in_array('tso6', $intf_details['options']);
-        $lro_set = in_array('lro', $intf_details['options']);
+    if (!stristr($ifs, "_vlan")) {
+
+        //Get current override settings
+        if(isset($config['system']['offloadoverride'])) {
+            $overrideifs = isset($config['system']['overridemembers']) ? explode(' ', $config['system']['overridemembers']) : array();
+        } else {
+            $overrideifs = array();
+        }
+
+	$override = in_array($ifs, $overrideifs);
 
         // hardware checksum offloading offloading
-        if (isset($config['system']['disablechecksumoffloading']) && $csum_set) {
-            legacy_interface_flags($ifs, '-txcsum -rxcsum', false);
-        } elseif (!isset($config['system']['disablechecksumoffloading']) && !$csum_set) {
-            legacy_interface_flags($ifs, 'txcsum rxcsum', false);
-        }
-        if (isset($config['system']['disablechecksumoffloading']) && $csumv6_set) {
-            legacy_interface_flags($ifs, '-txcsum6 -rxcsum6', false);
-        } elseif (!isset($config['system']['disablechecksumoffloading']) && !$csumv6_set) {
-            legacy_interface_flags($ifs, 'txcsum6 rxcsum6', false);
+        if (isset($config['system']['disablechecksumoffloading']) && !$override) {
+            legacy_interface_flags($ifs, '-txcsum -rxcsum -txcsum6 -rxcsum6', false);
+        } elseif (!isset($config['system']['disablechecksumoffloading']) || $override) {
+            legacy_interface_flags($ifs, 'txcsum rxcsum txcsum6 rxcsum6', false);
         }
 
         // TCP segmentation offloading
-        if (isset($config['system']['disablesegmentationoffloading']) && $tso_set) {
-            legacy_interface_flags($ifs, '-tso', false);
-        } elseif (!isset($config['system']['disablesegmentationoffloading']) && !$tso_set) {
-            legacy_interface_flags($ifs, 'tso', false);
+        if (isset($config['system']['disablesegmentationoffloading']) && !$override) {
+            legacy_interface_flags($ifs, '-tso -tso4 -tso6', false);
+        } elseif (!isset($config['system']['disablesegmentationoffloading']) || $override) {
+            legacy_interface_flags($ifs, 'tso tso4 tso6', false);
         }
 
         // large receive offload
-        if (isset($config['system']['disablelargereceiveoffloading']) && $lro_set) {
+        if (isset($config['system']['disablelargereceiveoffloading']) && !$override) {
             legacy_interface_flags($ifs, '-lro', false);
-        } elseif (!isset($config['system']['disablelargereceiveoffloading']) && !$lro_set) {
+        } elseif (!isset($config['system']['disablelargereceiveoffloading']) || $override) {
             legacy_interface_flags($ifs, 'lro', false);
         }
     }


### PR DESCRIPTION
Implement hardware offloading override for selected interfaces. Allow to have global flag to turn-off all overrides. Also clean-up how hardware offloading is set/unset, since flags are idempotent.  #1431