### PR TITLE
Traffic Graph improvements

### DIFF
--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -257,8 +257,9 @@ path {
                		html.push('<td>'+formatSizeUnits(record.totalin)+'</td>');
                		html.push('<td>'+formatSizeUnits(record.totalout)+'</td>');
                		html.push('</tr>');
-            });
-            $("#bandwidth_details").html(html.join(''));
+			   });
+			   tablearray = null;
+			   $("#bandwidth_details").html(html.join(''));
           }
         });
         setTimeout(update_bandwidth_stats, 2000);
@@ -363,6 +364,12 @@ path {
                         </option>
                         <option value="30">
                           <?= gettext('30') ?>
+                        </option>
+                        <option value="40">
+                          <?= gettext('40') ?>
+                        </option>
+                        <option value="50">
+                          <?= gettext('50') ?>
                         </option>
                       </select>
                     </td>

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -145,6 +145,7 @@ path {
 	var h = 30 - m[0] - m[2]; // height of minigraphs
 	var datasize = 45; //size of minigraph history - 45 @ 2sec poll = 1min 30sec history
 	var maxvalue = 0; //top value of minigraph - changes based on incoming spikes
+    var hostmax = 20; //arbitrary max of top 20 hosts
 
   	$( document ).ready(function() {
       function update_bandwidth_stats() {
@@ -219,9 +220,8 @@ path {
 			   tablearray.sort(function(a, b) {
 					return parseFloat(b[sortval]) - parseFloat(a[sortval]);
 			   });
-			   if (tablearray.length > 20) {
-					//Arbitrary limit of top 20
-					tablearray.length = 20;
+			   if (tablearray.length > hostmax) {
+					tablearray.length = hostmax;
 			   }
 			   graphtable = {};
                $.each(tablearray, function(idx, record){
@@ -291,6 +291,7 @@ path {
                     <th><?= gettext('Sort by') ?></th>
                     <th><?= gettext('Filter') ?></th>
                     <th><?= gettext('Display') ?></th>
+                    <th><?= gettext('Top') ?></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -349,6 +350,22 @@ path {
                         </option>
                       </select>
                     </td>
+                    <td>
+                      <select id="hostmax" name="hostmax">
+                        <option value="5">
+                          <?= gettext('5') ?>
+                        </option>
+                        <option value="10">
+                          <?= gettext('10') ?>
+                        </option>
+                        <option value="20" selected>
+                          <?= gettext('20') ?>
+                        </option>
+                        <option value="30">
+                          <?= gettext('30') ?>
+                        </option>
+                      </select>
+                    </td>
                   </tr>
                 </tbody>
               </table>
@@ -388,6 +405,9 @@ path {
   });
   $('#hostipformat').on('change', function () {
         graphtable = {};
+  });
+  $('#hostmax').on('change', function () {
+        hostmax = parseInt($( "#hostmax option:selected" ).val());
   });
 </script>
 <?php include("foot.inc"); ?>

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -125,8 +125,7 @@ path {
         if      (bytes>=1000000000) {bytes=(bytes/1000000000).toFixed(2)+'G';}
         else if (bytes>=1000000)    {bytes=(bytes/1000000).toFixed(2)+'M';}
         else if (bytes>=1000)       {bytes=(bytes/1000).toFixed(2)+'k';}
-        else if (bytes>1)           {bytes=bytes.toFixed(2) +'b';}
-        else if (bytes==1)          {bytes=bytes.toFixed(2) +'b';}
+        else if (bytes>=1)          {bytes=bytes.toFixed(2) +'b';}
         else                        {bytes='0.00b';}
         return bytes;
     }
@@ -139,21 +138,6 @@ path {
         }
         return false;
     }
-    function sortProperties(obj, item)
-	{
-	  // convert object into array
-		var sortable=[];
-		for(var key in obj)
-			if(obj.hasOwnProperty(key))
-				sortable.push([key, obj[key]][item]); // each item is an array in format [key, value]
-
-		// sort items by value
-		sortable.sort(function(a, b)
-		{
-		  return a[1]-b[1]; // compare numbers
-		});
-		return sortable; // array in format [ [ key1, val1 ], [ key2, val2 ], ... ]
-	}
     // define dimensions of graph
 	var m = [3, 3, 1, 3]; // margins
 	var w = 150 - m[1] - m[3]; // width

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -1,7 +1,8 @@
 <?php
 
 /*
-    Copyright (C) 2014-2016 Deciso B.V.
+    Copyright (C) 2014-2017 Deciso B.V.
+    Copyright (C) 2017 Jeffrey Gentes
     Copyright (C) 2004 Scott Ullrich
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
@@ -139,11 +140,11 @@ path {
         return false;
     }
     // define dimensions of graph
-	var m = [3, 3, 1, 3]; // margins
-	var w = 150 - m[1] - m[3]; // width
-	var h = 30 - m[0] - m[2]; // height
-	var datasize = 45;
-	var maxvalue = 0;
+	var m = [3, 3, 1, 3]; // margins of minigraphs
+	var w = 150 - m[1] - m[3]; // width of minigraphs
+	var h = 30 - m[0] - m[2]; // height of minigraphs
+	var datasize = 45; //size of minigraph history - 45 @ 2sec poll = 1min 30sec history
+	var maxvalue = 0; //top value of minigraph - changes based on incoming spikes
 
   	$( document ).ready(function() {
       function update_bandwidth_stats() {
@@ -236,23 +237,23 @@ path {
 							return y(d); 
 						})
 					var svg = document.createElementNS(d3.ns.prefix.svg, 'g');
-					var graph = d3.select(svg).append("svg:svg")
+					var graphIn = d3.select(svg).append("svg:svg")
 						  .attr("width", w + m[1] + m[3])
 						  .attr("height", h + m[0] + m[2])
 						.append("svg:g")
 						  .attr("transform", "translate(" + m[3] + "," + m[0] + ")");
 					var svg2 = document.createElementNS(d3.ns.prefix.svg, 'g');
-					var graph2 = d3.select(svg).append("svg:svg")
+					var graphOut = d3.select(svg).append("svg:svg")
 						  .attr("width", w + m[1] + m[3])
 						  .attr("height", h + m[0] + m[2])
 						.append("svg:g")
 						  .attr("transform", "translate(" + m[3] + "," + m[0] + ")");
                		html.push('<tr>');
                		html.push('<td>'+record.host+'</td>');
-                    graph.append("svg:path").attr("d", line(record.historyin));
-                    graph2.append("svg:path").attr("d", line(record.historyout));
-                    html.push('<td style="width: 55px;">' +formatSizeUnits(record.in)+'</td><td style="padding: 0; width: ' + w + '; height: ' + h + ';"><svg class="minigraph" style="width: ' + w  + '; height: ' + h + ';">' + graph.html() + '</svg></td>');
-                    html.push('<td style="width: 55px;">' +formatSizeUnits(record.out)+'</td><td style="padding: 0; width: ' + w + '; height: ' + h + ';"><svg class="minigraph" style="width: ' + w  + '; height: ' + h + ';">' + graph2.html() + '</svg></td>');
+                    graphIn.append("svg:path").attr("d", line(record.historyin));
+                    graphOut.append("svg:path").attr("d", line(record.historyout));
+                    html.push('<td style="width: 55px;">' +formatSizeUnits(record.in)+'</td><td style="padding: 0; width: ' + w + '; height: ' + h + ';"><svg class="minigraph" style="width: ' + w  + '; height: ' + h + ';">' + graphIn.html() + '</svg></td>');
+                    html.push('<td style="width: 55px;">' +formatSizeUnits(record.out)+'</td><td style="padding: 0; width: ' + w + '; height: ' + h + ';"><svg class="minigraph" style="width: ' + w  + '; height: ' + h + ';">' + graphOut.html() + '</svg></td>');
                		html.push('<td>'+formatSizeUnits(record.totalin)+'</td>');
                		html.push('<td>'+formatSizeUnits(record.totalout)+'</td>');
                		html.push('</tr>');

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -52,19 +52,14 @@ foreach (array('server', 'client') as $mode) {
 
 //Create array of hostnames from DHCP
 foreach ($interfaces as $ifname => $ifarr) {
-	if (isset($config['dhcpd'][$ifname]['staticmap'])) {
-		foreach($config['dhcpd'][$ifname]['staticmap'] as $entry) {
-			if (htmlentities($entry['hostname']) !== "") {
-				$hostlist[$entry['ipaddr']] = htmlentities($entry['hostname']);
+	foreach (array('dhcpd', 'dhcpdv6') as $dhcp) {
+		if (isset($config[$dhcp][$ifname]['staticmap'])) {
+			foreach($config[$dhcp][$ifname]['staticmap'] as $entry) {
+				if (!empty($entry['hostname'])) {
+					$hostlist[$entry['ipaddr']] = htmlentities($entry['hostname']);
+				}
 			}
 		}
-	}
-	if (isset($config['dhcpdv6'][$ifname]['staticmap'])) {
-        foreach($config['dhcpdv6'][$ifname]['staticmap'] as $entry) {
-        	if (htmlentities($entry['hostname']) !== "") {
-            	$hostlist[$entry['ipaddrv6']] = htmlentities($entry['hostname']);
-            }
-        }
     }
 }
 

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -107,7 +107,7 @@ include("head.inc");
 <?php include("fbegin.inc"); ?>
 <style>
 path {
-    stroke: steelblue; 
+    stroke: steelblue;
     stroke-width: 1;
     fill: none;
 }
@@ -190,7 +190,7 @@ path {
                		historyout.push(parseInt(record.out));
                		historyin.shift();
                		historyout.shift();
-               		graphtable[record.host] = record;				
+               		graphtable[record.host] = record;
                		graphtable[record.host].totalin = totalin;
                		graphtable[record.host].totalout = totalout;
                		graphtable[record.host].historyin = historyin;
@@ -230,11 +230,11 @@ path {
 					//using non-linear y so that large spikes don't zero out the other graphs
 					var y = d3.scale.pow().exponent(0.3).domain([0, maxvalue]).range([h, 0]);
 					var line = d3.svg.line()
-						.x(function(d,i) { 
-							return x(i); 
+						.x(function(d,i) {
+							return x(i);
 						})
 						.y(function(d) {
-							return y(d); 
+							return y(d);
 						})
 					var svg = document.createElementNS(d3.ns.prefix.svg, 'g');
 					var graphIn = d3.select(svg).append("svg:svg")
@@ -258,7 +258,6 @@ path {
                		html.push('<td>'+formatSizeUnits(record.totalout)+'</td>');
                		html.push('</tr>');
 			   });
-			   tablearray = null;
 			   $("#bandwidth_details").html(html.join(''));
           }
         });
@@ -267,7 +266,7 @@ path {
       update_bandwidth_stats();
 
   });
-  
+
 </script>
 
 <section class="page-content-main">

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -109,6 +109,11 @@
               d3.select(this).on("click").apply(this, [d, i]);
           }
       });
+      chart_data_in = null;
+      chart_data_out = null;
+      chart_data_keys = null;
+      deselected_series_in = null;
+      deselected_series_out = null;
   }
   /**
    * page setup

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -97,7 +97,7 @@
       if (traffic_graph_widget_chart_data_out !== null) {
       	traffic_graph_widget_chart_data_out.datum(chart_data_out).transition().duration(500).call(traffic_graph_widget_chart_out);
       }
-      
+
       // set selection
       d3.selectAll("#traffic_graph_widget_chart_in").selectAll(".nv-series").each(function(d, i) {
           if (deselected_series_in.indexOf(d.key) > -1) {
@@ -109,11 +109,6 @@
               d3.select(this).on("click").apply(this, [d, i]);
           }
       });
-      chart_data_in = null;
-      chart_data_out = null;
-      chart_data_keys = null;
-      deselected_series_in = null;
-      deselected_series_out = null;
   }
   /**
    * page setup

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -94,8 +94,10 @@
 
       // load data
       traffic_graph_widget_chart_data_in.datum(chart_data_in).transition().duration(500).call(traffic_graph_widget_chart_in);
-      traffic_graph_widget_chart_data_out.datum(chart_data_out).transition().duration(500).call(traffic_graph_widget_chart_out);
-
+      if (traffic_graph_widget_chart_data_out !== null) {
+      	traffic_graph_widget_chart_data_out.datum(chart_data_out).transition().duration(500).call(traffic_graph_widget_chart_out);
+      }
+      
       // set selection
       d3.selectAll("#traffic_graph_widget_chart_in").selectAll(".nv-series").each(function(d, i) {
           if (deselected_series_in.indexOf(d.key) > -1) {


### PR DESCRIPTION
This update includes many of the items discussed in feature request https://github.com/opnsense/core/issues/1462.  

This allows the hosts entries to persist for the duration of the overall traffic graph (showing the top 20), dynamically updating the traffic for each. It includes a small micrograph for each item displaying "bw in" and "bw out".  It also includes new columns for Total In, Total Out, as well as new sorting for Total In, Total Out, Bw In Avg, Bw Out Avg.  The Avg sorting helps reduce fluctuation in the table.

This pull request is based on code from the last commit of Mar 13, 2017. https://github.com/opnsense/core/issues/1449