### PR TITLE
harden ciphers and tls versions

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -51,6 +51,9 @@
 sslcrtd_program /usr/local/libexec/squid/ssl_crtd -s /var/squid/ssl_crtd -M {{ OPNsense.proxy.forward.ssl_crtd_storage_max_size|default('4') }}MB
 sslcrtd_children {{ OPNsense.proxy.forward.sslcrtd_children|default('5') }}
 
+sslproxy_cipher HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+sslproxy_options NO_TLSv1
+
 # setup ssl bump acl's
 acl bump_step1 at_step SslBump1
 acl bump_step2 at_step SslBump2


### PR DESCRIPTION
Note: SSL cannot be disabled because it does not exist (at least not in LibreSSL)

Important Note: This directive must be updated when upgrading to Squid 4.