### PR TITLE
Fixed bug which caused the some cache files not being created

### DIFF
--- a/src/etc/rc.newwanipv6
+++ b/src/etc/rc.newwanipv6
@@ -98,7 +98,7 @@ if (is_ipaddrv6($curwanipv6)) {
 
 log_error("rc.newwanipv6: on (IP address: {$curwanipv6}) (interface: {$interface}) (real interface: {$interface_real}).");
 
-$oldipv6 = "";
+$oldipv6 = "::";
 if (file_exists("/var/db/{$interface}_cacheipv6")) {
     $oldipv6 = file_get_contents("/var/db/{$interface}_cacheipv6");
 }


### PR DESCRIPTION
Hello, since opnSense is a fork of pfSense I found a solution for a problem I had with opnSense in the pfSense bugtracker. See: https://redmine.pfsense.org/issues/3669

They state, that there are 2 bugs which cause the cache files /var/db/wan_cacheip and /var/db/wan_cacheipv6 not being created.

One of the bugs is already fixed in pfSense as well as opnSense.
The other bug concerning IPv6 is fixed by my change and working for me.

For me, the bug caused OpenVPN restart every 15 minutes, when WAN has IPv6 enabled. Now it works.

However, I do not know the whole opnSense and can not say if this fix would have other side-effects. 