### PR TITLE
Fix autocomplete, autocapitalize and autocorrect in Captive Portal login form

### DIFF
--- a/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
@@ -173,7 +173,7 @@
               <form class="form-signin">
                   <h2 class="form-signin-heading">Please sign in</h2>
                   <label for="inputUsername" class="sr-only">Username</label>
-                  <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus>
+                  <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus autocomplete="none" autocapitalize="none" autocorrect="off">
                   <label for="inputPassword" class="sr-only">Password</label>
                   <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
                   <button class="btn btn-primary btn-block" id="signin" type="button">Sign in</button>


### PR DESCRIPTION
New iOS versions do autocapitalization, autocrrection and/or autocompletion in Web Forms. All three can be annoying when entering always changing usernames with sometimes lower-case first characters, as in the Captive Portal Vouchers' usernames. 

This should fix the behaviour and make the portal more graceful towards iOS devices.

Source for the attributes and their values: https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html 