### PR TITLE
squid.conf: reorder pre-auth plugins and local auth settings

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -270,13 +270,13 @@ icap_service request_mod reqmod_precache {{OPNsense.proxy.forward.icap.RequestUR
 icap_enable off
 {% endif %}
 
+# Pre-auth plugins
+include /usr/local/etc/squid/pre-auth/*.conf
+
 # Authentication Settings
 {% if helpers.exists('OPNsense.proxy.forward.authentication.method') and  OPNsense.proxy.forward.authentication.method != '' %}
 {% include ['OPNsense/Proxy/squid.user.alt_auth.conf', 'OPNsense/Proxy/squid.user.local_auth.conf'] %}
 {% endif %}
-
-# Pre-auth plugins
-include /usr/local/etc/squid/pre-auth/*.conf
 
 {% include "OPNsense/Proxy/squid.acl.conf" ignore missing with context %}
 


### PR DESCRIPTION
Reason: to allow squid plugins define auth methods.
In my case I made plugin proxy-sso, which defines negotiate method for proxy authentication. This method included before basic to allow domain user to authenticate without appearing user credentials dialog.
squid.conf part:
`icap_enable off`

`include /usr/local/etc/squid/pre-auth/*.conf`

`auth_param basic program /usr/local/etc/inc/squid.auth-user.php`
`auth_param basic realm OPNsense proxy authentication`
`auth_param basic credentialsttl 2 hours`
`auth_param basic children 5`

`acl local_auth proxy_auth REQUIRED`

pre-auth plugin:
`auth_param negotiate program /usr/local/libexec/squid/negotiate_kerberos_auth -d -i -s HTTP/ting4.tingnet.local@TINGNET.LOCAL`
`auth_param negotiate keep_alive on`
`auth_param negotiate children 5`

In this case if user is domain member and logged in to domain, it authenticates without entering user credentials. If user is domain member, but not logged to domain, it enters credentials and authenticates using LDAP connector. If user is not domain member, it has ability to enter user credentials and authenticate on Local Database.