### PR TITLE
Update phpDynDNS.inc

### DIFF
--- a/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -131,7 +131,7 @@ class updatedns {
      *   - $dnsUser, and $dnsPass indicate HTTP Auth for custom DNS, if they are needed in the URL (GET Variables), include them in $dnsUpdateURL.
      *   - $For custom requests, $dnsUpdateURL is parsed for '%IP%', which is replaced with the new IP.
      */
-    function updatedns ($dnsService = '', $dnsHost = '', $dnsUser = '', $dnsPass = '',
+    public function __construct ($dnsService = '', $dnsHost = '', $dnsUser = '', $dnsPass = '',
                 $dnsWildcard = 'OFF', $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
                 $dnsServer = '', $dnsPort = '', $dnsUpdateURL = '', $forceUpdate = false,
                 $dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '',


### PR DESCRIPTION
An API exception occured
Error at /usr/local/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc:92 - Methods with the same name as their class will not be constructors in a future version of PHP; updatedns has a deprecated constructor (errno=8192)