### PR TITLE
Allow CNAME overrides for unbound

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -599,6 +599,9 @@ function unbound_add_host_entries()
                 case 'MX':
                     $unbound_entries .= "local-data: \"{$host['host']}{$host['domain']} IN MX {$host['mxprio']} {$host['mx']}\"\n";
                     break;
+                case 'CNAME':
+                    $unbound_entries .= "local-data: \"{$host['host']}{$host['domain']} IN {$host['rr']} {$host['cname']}\"\n";
+                    break;
             }
 
             if (!empty($host['descr']) && isset($config['unbound']['txtsupport'])) {

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -48,7 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $id = $_GET['id'];
     }
     $pconfig = array();
-    foreach (array('rr', 'host', 'domain', 'ip', 'mxprio', 'mx', 'descr') as $fieldname) {
+    foreach (array('rr', 'host', 'domain', 'ip', 'mxprio', 'mx', 'descr', 'cname') as $fieldname) {
         if (isset($id) && !empty($a_hosts[$id][$fieldname])) {
             $pconfig[$fieldname] = $a_hosts[$id][$fieldname];
         } else {
@@ -122,6 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $hostent['ip'] = $pconfig['ip'];
         $hostent['mxprio'] = $pconfig['mxprio'];
         $hostent['mx'] = $pconfig['mx'];
+        $hostent['cname'] = $pconfig['cname'];
         $hostent['descr'] = $pconfig['descr'];
 
         if (isset($id)) {
@@ -269,7 +270,7 @@ include("head.inc");
                   <tr class="cname_rec">
                     <td><a id="help_for_cname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname");?></td>
                     <td>
-                      <input name="cname" type="text" id="cname" value="<?=$pconfig['ip'];?>" />
+                      <input name="cname" type="text" id="cname" value="<?=$pconfig['cname'];?>" />
                       <div class="hidden" for="help_for_cname">
                         <?=gettext("FQDN of the host"); ?><br />
                         <?=gettext("e.g."); ?> <em>myhost.example.com</em>

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -100,6 +100,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 $input_errors[] = gettext("A valid MX host must be specified.");
             }
             break;
+        case 'CNAME':
+            $reqdfields = explode(" ", "cname");
+            $reqdfieldsn = array(gettext("Hostname"));
+            do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
+
+            if (!empty($pconfig['cname']) && !is_hostname($pconfig['cname'])) {
+                $input_errors[] = gettext("A valid hostname must be specified.");
+            }
+            break;
         default:
             $input_errors[] = gettext("A valid resource record type must be specified.");
             break;
@@ -139,18 +148,28 @@ include("head.inc");
     $("#rr").change(function() {
       $(".a_aaa_rec").hide();
       $(".mx_rec").hide();
+      $(".cname_rec").hide();
       switch ($(this).val()) {
         case 'A':
           $('#ip').prop('disabled', false);
           $('#mxprio').prop('disabled', true);
           $('#mx').prop('disabled', true);
+          $('#cname').prop('disabled', true);
           $(".a_aaa_rec").show();
           break;
         case 'MX':
           $('#ip').prop('disabled', true);
           $('#mxprio').prop('disabled', false);
           $('#mx').prop('disabled', false);
+          $('#cname').prop('disabled', true);
           $(".mx_rec").show();
+          break;
+        case 'CNAME':
+          $('#ip').prop('disabled', true);
+          $('#mxprio').prop('disabled', true);
+          $('#mx').prop('disabled', true);
+          $('#cname').prop('disabled', false);
+          $(".cname_rec").show();
           break;
       }
       $( window ).resize(); // call window resize, which will re-apply zebra
@@ -202,7 +221,7 @@ include("head.inc");
                     <td>
                       <select name="rr" id="rr" class="selectpicker">
 <?php
-                       $rrs = array("A" => gettext("A or AAAA (IPv4 or IPv6 address)"), "MX" => gettext("MX (Mail server)"));
+                       $rrs = array("A" => gettext("A or AAAA (IPv4 or IPv6 address)"), "MX" => gettext("MX (Mail server)"), "CNAME" => gettext("CNAME (Alias)"));
                        foreach ($rrs as $rr => $name) :?>
                         <option value="<?=$rr;?>" <?=($rr == $pconfig['rr'] || ($rr == 'A' && $pconfig['rr'] == 'AAAA')) ? "selected=\"selected\"" : "";?> >
                           <?=$name;?>
@@ -244,6 +263,16 @@ include("head.inc");
                       <div class="hidden" for="help_for_mx">
                         <?=gettext("Host name of MX host"); ?><br />
                         <?=gettext("e.g."); ?> <em>mail.example.com</em>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="cname_rec">
+                    <td><a id="help_for_cname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname");?></td>
+                    <td>
+                      <input name="cname" type="text" id="cname" value="<?=$pconfig['ip'];?>" />
+                      <div class="hidden" for="help_for_cname">
+                        <?=gettext("FQDN of the host"); ?><br />
+                        <?=gettext("e.g."); ?> <em>myhost.example.com</em>
                       </div>
                     </td>
                   </tr>

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -186,6 +186,9 @@ include_once("head.inc");
                               case 'MX':
                                   print $hostent['mxprio'] . " " . $hostent['mx'];
                                   break;
+                              case 'CNAME':
+                                  print $hostent['cname'];
+                                  break;
                               default:
                                   print '&nbsp;';
                                   break;


### PR DESCRIPTION
We allow for CNAME to be used in the host override for unbound.

This closes #1614.