### PR TITLE
Fix bootup script

### DIFF
--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -21,7 +21,7 @@ ls /usr/local/etc/rc.d/* /etc/rc.d/* | while read rc_filename; do
 	# start/stop service
 	if [ "$is_enabled" == "YES" ]; then
 		if [ "$1" == "start" ]; then
-			pre_run_var="`basename $rc_filename`_opnsense_bootup_run"
+			pre_run_var="`basename $rc_filename`_opnsense_bootup_run | /usr/bin/sed 's/-/_/g'"
 			eval "pre_run=\$"$pre_run_var""
 			if [ ! -z "$pre_run" ]; then
 				eval "$pre_run"


### PR DESCRIPTION
If bootup-script contains "-" in name, then in logs:
Oct 12 13:37:45	kernel: <118>eval: -ng_opnsense_bootup_run: not found
Oct 12 13:37:32	kernel: <118>eval: -freshclam_opnsense_bootup_run: not found