### PR TITLE
Add ability to have IPv6-only OpenVPN vpns

### DIFF
--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -298,8 +298,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
 
         if ($pconfig['dev_mode'] != "tap") {
-            $reqdfields[] = 'tunnel_network';
-            $reqdfieldsn[] = gettext('Tunnel network');
+            if (!$pconfig['tunnel_networkv6']) {
+                $reqdfields[] = 'tunnel_network';
+                $reqdfieldsn[] = gettext('Tunnel network');
+            }
         } else {
             if ($pconfig['serverbridge_dhcp'] && $pconfig['tunnel_network']) {
                 $input_errors[] = gettext("Using a tunnel network and server bridge settings together is not allowed.");


### PR DESCRIPTION
As discussed with Franco Fichtner on IRC, I wanted to have an IPv6 only VPN but the check in the WebUI was a little bit to restrictive as the network tunnel IPv4 seems to be mandatory.

I think this is a simple fix. Therefore, I decided to bring this PR on the table. This has not been tested (I don't have a CI for OPNsense - and I don't like to push untested code - sorry), but I assume (read hope) this will be enough to have this feature :)