### PR TITLE
add local-zone typetransparent to resolving ptr zone

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -508,6 +508,9 @@ function unbound_add_domain_overrides($pvt = false)
         if ($pvt == true) {
             $domain_entries .= "private-domain: \"$domain\"\n";
             $domain_entries .= "domain-insecure: \"$domain\"\n";
+            if ((substr($domain, -14) == ".in-addr.arpa.") || (substr($domain, -13) == ".in-addr.arpa")) {
+                $domain_entries .= "local-zone: \"$domain\" typetransparent\n";
+            }
         } else {
             $domain_entries .= "stub-zone:\n";
             $domain_entries .= "\tname: \"$domain\"\n";


### PR DESCRIPTION
fix ptr resolving. without this patch, unbound doesn't resolv ptr hostname with private ips. Probably there exists a better way.