### PR TITLE
Fix DynDNS update for IPv6

### DIFF
--- a/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -1282,7 +1282,7 @@ class updatedns {
     }
 
     function _checkIP() {
-        $ip_address = get_dyndns_ip($this->_if, $his->_useIPv6 ? 6 : 4);
+        $ip_address = get_dyndns_ip($this->_if, $this->_useIPv6 ? 6 : 4);
         if (!is_ipaddr($ip_address)) {
             if ($this->_dnsVerboseLog) {
                 log_error("Dynamic DNS ({$this->_dnsHost}): IP address could not be extracted");


### PR DESCRIPTION
I just stared using OPNsense with a downloaded version which was 17.1.4 where a custom v6 DynDNS update worked.
Then I did the upgrade to latest stable 17.1.8 and it just gave me the IPv4 address.
Seems the problem was just a little typo when refactoring...
This fixes it...