### PR TITLE
Host-Uniq field in PPPoE connection

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1582,6 +1582,8 @@ EOD;
             $provider = isset($ppp['provider']) ? $ppp['provider'] : "";
             $mpdconf_arr[] = "set pppoe service \"{$provider}\"";
             $mpdconf_arr[] = "set pppoe iface {$port}";
+            if (!empty($ppp['hostuniq'])) {
+              $mpdconf_arr[] = "set host-uniq {$ppp["hostuniq"]}";
         } elseif ($ppp['type'] == "pptp" || $ppp['type'] == "l2tp") {
             $mpdconf_arr[] = "set {$ppp['type']} self {$localips[$pid]}";
             $mpdconf_arr[] = "set {$ppp['type']} peer {$gateways[$pid]}";

--- a/src/www/interfaces_ppps_edit.php
+++ b/src/www/interfaces_ppps_edit.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     }
     // plain 1-on-1 copy
     $copy_fields = array('ptpid', 'type', 'username', 'idletimeout', 'uptime', 'descr', 'simpin', 'pin-wait',
-                        'apn', 'apnum', 'phone', 'connect-timeout', 'provider');
+                        'apn', 'apnum', 'phone', 'connect-timeout', 'provider', 'hostuniq');
     foreach ($copy_fields as $fieldname) {
         if (isset($a_ppps[$id][$fieldname])) {
             $pconfig[$fieldname] = $a_ppps[$id][$fieldname];
@@ -175,7 +175,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
 
         // Loop through fields associated with a individual link/port and make an array of the data
-        $port_fields = array("localip", "gateway", "subnet", "bandwidth", "mtu", "mru", "mrru");
+        $port_fields = array("localip", "gateway", "subnet", "bandwidth", "mtu", "mru", "mrru", "hostuniq");
         $port_data = array();
         foreach($pconfig['ports'] as $iface_idx => $iface){
             foreach($port_fields as $field_label){
@@ -233,6 +233,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $ppp['mtu'] = implode(',', $port_data['mtu']);
         $ppp['mru'] = implode(',', $port_data['mru']);
         $ppp['mrru'] = implode(',', $port_data['mrru']);
+        $ppp['hostuniq'] = $pconfig['hostuniq'];
 
         // XXX this was already in here, but is probably not the correct place to create this
         if (!is_dir('/var/spool/lock')) {
@@ -782,6 +783,12 @@ include("head.inc");
                                 <input name="mrru[]" class="intf_select_<?=$intf_idx;?>" type="text" value="<?=isset($pconfig['mrru'][$intf_idx]) ? $pconfig['mrru'][$intf_idx] : "";?>" />
                               </td>
                             </tr>
+                            <tr>
+                              <td><?=gettext("Host-Uniq"); ?></td>
+                              <td>
+                                <input name="hostuniq" class="intf_select_<?=$intf_idx;?>" type="text" value="<?=$pconfig['hostuniq'];?>" />
+                              </td>
+                            </tr>
                           </table>
                           <div class="hidden" for="help_for_link_<?=$intf_idx;?>">
                             <ul>
@@ -789,6 +796,7 @@ include("head.inc");
                               <li><?=gettext("MTU: MTU will default to 1492.");?></li>
                               <li><?=gettext("MRU: MRU will be auto-negotiated by default.");?></li>
                               <li><?=gettext("MRRU: Set ONLY for MLPPP connections. MRRU will be auto-negotiated by default.");?></li>
+			      <li><?=gettext("Host-Uniq: Set ONLY if requested.");?></li>
                             </ul>
                           </div>
                         </td>


### PR DESCRIPTION
Add a custom field in the "advanced configuration" tab in pppoe connection page.
The custom field "host-uniq" is needed in order to connect with some ISP (for example Vodafone fiber in Italy).

Thread on forum: https://forum.opnsense.org/index.php?topic=5307.0

![host-uniq1](https://user-images.githubusercontent.com/6001344/28371867-6b1eb2d4-6c9e-11e7-942c-78245545ab8e.png)