### PR TITLE
Fix anchor name quoting

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Plugin.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Plugin.php
@@ -173,8 +173,12 @@ class Plugin
         foreach (explode(',', $types) as $type) {
             foreach ($this->anchors as $anchorKey => $anchor) {
                 if (strpos($anchorKey, "{$type}.{$placement}") === 0) {
+                    $fixed_anchor = "";
+                    foreach (explode(' ', $anchor) as $token) {
+                        $fixed_anchor .= strpos($token, '/') === FALSE ? "$token " : sprintf("\"%s\" ", str_replace('"', '', $token));
+                    }
                     $result .= $type == "fw" ? "" : "{$type}-";
-                    $result .= "anchor \"{$anchor}\"\n";
+                    $result .= "anchor {$fixed_anchor}\n";
                 }
             }
         }


### PR DESCRIPTION
To have possibility in plugins to set anchors:
anchor myanchor quick
or
anchor "myanchor/nested" quick

Quoting of anchor name is auto-fixed if slash exists in anchor name.