### PR TITLE
filter: fix floating rules default for quick parameter

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -337,7 +337,7 @@ class FilterRule
                 }
                 if (!isset($tmp['quick'])) {
                     // all rules are quick by default except floating
-                    $tmp['quick'] = !isset($rule['floating']) ? true : false;
+                    $tmp['quick'] = !isset($tmp['floating']) ? true : false;
                 }
                 // restructure flags
                 if (isset($tmp['protocol']) && $tmp['protocol'] == "tcp") {


### PR DESCRIPTION
Fix for #1745. Turns out this was a simple typo, but an important one, because it made it impossible to have floating rules without the `quick` keyword.