### PR TITLE
proposal: new dialog to request confirmation

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
@@ -95,7 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     grid_clients.on("loaded.rs.jquery.bootgrid", function(){
                         grid_clients.find(".command-disconnect").on("click", function(e) {
                             var sessionId=$(this).data("row-id");
-                            stdDialogRemoveItem('{{ lang._('Disconnect selected client?') }}',function() {
+                            stdDialogConfirmation('Remove','{{ lang._('Disconnect selected client?') }}',function() {
                                 ajaxCall(url="/api/captiveportal/session/disconnect/" + zoneid + '/',
                                         sendData={'sessionId': sessionId}, callback=function(data,status){
                                             // reload grid after delete

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
@@ -95,7 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     grid_clients.on("loaded.rs.jquery.bootgrid", function(){
                         grid_clients.find(".command-disconnect").on("click", function(e) {
                             var sessionId=$(this).data("row-id");
-                            stdDialogConfirmation('Remove','{{ lang._('Disconnect selected client?') }}',function() {
+                            stdDialogConfirmation('Remove','{{ lang._('Disconnect selected client?') }}','OK','Cancel',function() {
                                 ajaxCall(url="/api/captiveportal/session/disconnect/" + zoneid + '/',
                                         sendData={'sessionId': sessionId}, callback=function(data,status){
                                             // reload grid after delete

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
@@ -79,7 +79,7 @@ POSSIBILITY OF SUCH DAMAGE.
             });
             grid_templates.find(".command-delete").on("click", function(e) {
                 var uuid=$(this).data("row-id");
-                stdDialogRemoveItem('Remove selected item?',function() {
+                stdDialogConfirmation('Remove','Remove selected item?',function() {
                     ajaxCall(url="/api/captiveportal/service/delTemplate/" + uuid,
                             sendData={},callback=function(data,status){
                                 // reload grid after delete

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
@@ -79,7 +79,7 @@ POSSIBILITY OF SUCH DAMAGE.
             });
             grid_templates.find(".command-delete").on("click", function(e) {
                 var uuid=$(this).data("row-id");
-                stdDialogConfirmation('Remove','Remove selected item?',function() {
+                stdDialogConfirmation('Remove','Remove selected item?','OK','Cancel',function() {
                     ajaxCall(url="/api/captiveportal/service/delTemplate/" + uuid,
                             sendData={},callback=function(data,status){
                                 // reload grid after delete

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -209,7 +209,7 @@ $.fn.UIBootgrid = function (params) {
                     {
                         if (gridParams['del'] != undefined) {
                             var uuid=$(this).data("row-id");
-                            stdDialogRemoveItem('Remove selected item?',function() {
+                            stdDialogConfirmation('Remove','Remove selected item?',function() {
                                 ajaxCall(url=gridParams['del'] + uuid,
                                     sendData={},callback=function(data,status){
                                         // reload grid after delete
@@ -269,7 +269,7 @@ $.fn.UIBootgrid = function (params) {
                 // link delete selected items action
                 $(this).find("*[data-action=deleteSelected]").click(function(){
                     if ( gridParams['del'] != undefined) {
-                        stdDialogRemoveItem("Remove selected items?",function(){
+                        stdDialogConfirmation('Remove','Remove selected items?',function(){
                             var rows =$("#"+gridId).bootgrid('getSelectedRows');
                             if (rows != undefined){
                                 var deferreds = [];

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -209,7 +209,7 @@ $.fn.UIBootgrid = function (params) {
                     {
                         if (gridParams['del'] != undefined) {
                             var uuid=$(this).data("row-id");
-                            stdDialogConfirmation('Remove','Remove selected item?',function() {
+                            stdDialogConfirmation('Remove','Remove selected item?','OK','Cancel',function() {
                                 ajaxCall(url=gridParams['del'] + uuid,
                                     sendData={},callback=function(data,status){
                                         // reload grid after delete
@@ -269,7 +269,7 @@ $.fn.UIBootgrid = function (params) {
                 // link delete selected items action
                 $(this).find("*[data-action=deleteSelected]").click(function(){
                     if ( gridParams['del'] != undefined) {
-                        stdDialogConfirmation('Remove','Remove selected items?',function(){
+                        stdDialogConfirmation('Remove','Remove selected items?','OK','Cancel',function(){
                             var rows =$("#"+gridId).bootgrid('getSelectedRows');
                             if (rows != undefined){
                                 var deferreds = [];

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -273,13 +273,13 @@ function initFormAdvancedUI() {
 /**
  * standard dialog when confirmation is required, wrapper around BootstrapDialog
  */
-function stdDialogConfirmation(title, message, callback) {
+function stdDialogConfirmation(title, message, accept, decline, callback) {
     BootstrapDialog.confirm({
         title: title,
         message: message,
         type:BootstrapDialog.TYPE_WARNING,
-        btnCancelLabel: 'Cancel',
-        btnOKLabel: 'Yes',
+        btnCancelLabel: decline,
+        btnOKLabel: accept,
         btnOKClass: 'btn-primary',
         callback: function(result) {
             if(result) {

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -271,13 +271,13 @@ function initFormAdvancedUI() {
 }
 
 /**
- * standard remove items dialog, wrapper around BootstrapDialog
+ * standard dialog when confirmation is required, wrapper around BootstrapDialog
  */
-function stdDialogRemoveItem(message, callback) {
+function stdDialogConfirmation(title, message, callback) {
     BootstrapDialog.confirm({
-        title: 'Remove',
+        title: title,
         message: message,
-        type:BootstrapDialog.TYPE_DANGER,
+        type:BootstrapDialog.TYPE_WARNING,
         btnCancelLabel: 'Cancel',
         btnOKLabel: 'Yes',
         btnOKClass: 'btn-primary',

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -288,3 +288,10 @@ function stdDialogConfirmation(title, message, accept, decline, callback) {
         }
     });
 }
+
+/**
+ * wrapper for backwards compatibility
+ */
+function stdDialogRemoveItem(message, callback) {
+    stdDialogConfirmation('Remove', message, 'Yes', 'Cancel', callback)
+}


### PR DESCRIPTION
I needed a generic dialog (for plugins) to request a users confirmation for various actions. Currently there's only `stdDialogRemoveItem()` available, which really only suits the specific situation where one wants to remove an item, because the title reads "Remove":

![dialog_remove](https://user-images.githubusercontent.com/909706/28926373-e1f9f92a-7867-11e7-8c1f-d82582d0c481.png)

The new dialog is more generic and the title only says "Confirmation Required", that makes it very reusable:

![dialog_confirmation](https://user-images.githubusercontent.com/909706/28926390-efd0a986-7867-11e7-9e10-4ff19a3b0512.png)

Additionally, I am suggesting to replace `stdDialogRemoveItem()` with `stdDialogConfirmation()` everywhere. The old dialog is a little redundant in itself, the header says "Remove" and the text usually repeats this somehow. If you agree I'd do the work and submit an additional PRs for core and plugins.