### PR TITLE
License overview generation for GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -52,24 +52,22 @@ Copyright (c) 2011-2014 Warren Baker <warren@decoy.co.za>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2017 Ad Schellevis
+Copyright (c) 2014-2017 Ad Schellevis <ad@opnsense.org>
 Copyright (c) 2004 Bachman Kharazmi
 Copyright (c) 2005-2008 Bill Marquette <bill.marquette@gmail.com>
 Copyright (c) 2003-2005 Bob Zoller <bob@kludgebox.com>
@@ -9,7 +9,6 @@ Copyright (c) 2006 Daniel S. Haischt
 Copyright (c) 2012 Darren Embry <dse@webonastick.com>
 Copyright (c) 2005-2012 David Zeller
 Copyright (c) 2014-2017 Deciso B.V.
-Copyright (c) 2015-2016 Deciso B.V. - Ad Schellevis
 Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
 Copyright (c) 2014 Electric Sheep Fencing, LLC
 Copyright (c) 2010 Erik Fonnesbeck

--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,6 @@ Copyright (c) 2012 Darren Embry <dse@webonastick.com>
 Copyright (c) 2005-2012 David Zeller
 Copyright (c) 2014-2017 Deciso B.V.
 Copyright (c) 2015-2016 Deciso B.V. - Ad Schellevis
-Copyright (c) 2014-2015 Deciso B.V. - J. Schellevis
 Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
 Copyright (c) 2014 Electric Sheep Fencing, LLC
 Copyright (c) 2010 Erik Fonnesbeck
@@ -29,6 +28,7 @@ Copyright (c) 2004 Jim McBeath
 Copyright (c) 2009-2014 Jim Pingle <jimp@pfsense.org>
 Copyright (c) 2012 Jonas von Andrian
 Copyright (c) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
+Copyright (c) 2014-2015 Jos Schellevis <jos@opnsense.org>
 Copyright (c) 2003-2004 Justin Ellison <justin@techadvise.com>
 Copyright (c) 2015 Manuel Faux <mfaux@conf.at>
 Copyright (c) 2003-2009 Manuel Kasper <mk@neon1.net>

--- a/LICENSE
+++ b/LICENSE
@@ -42,8 +42,7 @@ Copyright (c) 2013 Renato Botelho <garga@pfsense.org>
 Copyright (c) 2015 S. Linke <dev@devsash.de>
 Copyright (c) 2007 Sam Wenham
 Copyright (c) 2007 Scott Dale
-Copyright (c) 2004-2012 Scott Ullrich
-Copyright (c) 2003-2010 Scott Ullrich <sullrich@gmail.com>
+Copyright (c) 2003-2012 Scott Ullrich <sullrich@gmail.com>
 Copyright (c) 2007-2012 Seth Mos <seth.mos@dds.nl>
 Copyright (c) 2008-2009 Shrew Soft Inc. <mgrooms@shrew.net>
 Copyright (c) 2004-2005 T. Lechat <dev@lechat.org>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,75 @@
+Copyright (c) 2014-2017 Ad Schellevis
+Copyright (c) 2004 Bachman Kharazmi
+Copyright (c) 2005-2008 Bill Marquette <bill.marquette@gmail.com>
+Copyright (c) 2003-2005 Bob Zoller <bob@kludgebox.com>
+Copyright (c) 2012 Carlos Cesario <carloscesario@gmail.com>
+Copyright (c) 2005-2006 Colin Smith <ethethlay@gmail.com>
+Copyright (c) 2013 Dagorlad
+Copyright (c) 2006 Daniel S. Haischt
+Copyright (c) 2012 Darren Embry <dse@webonastick.com>
+Copyright (c) 2005-2012 David Zeller
+Copyright (c) 2014-2017 Deciso B.V.
+Copyright (c) 2015-2016 Deciso B.V. - Ad Schellevis
+Copyright (c) 2014-2015 Deciso B.V. - J. Schellevis
+Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
+Copyright (c) 2014 Electric Sheep Fencing, LLC
+Copyright (c) 2010 Erik Fonnesbeck
+Copyright (c) 2009 Erik Kristensen <erik@erikkristensen.com>
+Copyright (c) 2008-2014 Ermal Luçi
+Copyright (c) 2005 Espen Johansen
+Copyright (c) 2017 Fabian Franz
+Copyright (c) 2006 Fernando Lemos
+Copyright (c) 2014-2017 Franco Fichtner <franco@opnsense.org>
+Copyright (c) 2004 Fred Mol <fredmol@xs4all.nl>
+Copyright (c) 2010 Gabriel B. <gnoahb@gmail.com>
+Copyright (c) 2016 IT-assistans Sverige AB
+Copyright (c) 2009 Janne Enberg <janne.enberg@lietu.net>
+Copyright (c) 2017 Jeffrey Gentes
+Copyright (c) 2009-2014 Jim Pingle <jimp@pfsense.org>
+Copyright (c) 2012 Jonas von Andrian
+Copyright (c) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
+Copyright (c) 2003-2004 Justin Ellison <justin@techadvise.com>
+Copyright (c) 2015 Manuel Faux <mfaux@conf.at>
+Copyright (c) 2003-2004 Manuel Kasper
+Copyright (c) 2012 Marcello Coutinho
+Copyright (c) 2010-2015 Michael Bostock
+Copyright (c) 2005-2006 Paul Taylor <paultaylor@winn-dixie.com>
+Copyright (c) 2005-2006 Peter Allgeyer <allgeyer@web.de>
+Copyright (c) 2004 Peter Curran <peter@closeconsultants.com>
+Copyright (c) 2012 PiBa-NL <pba_2k3@yahoo.com>
+Copyright (c) 2013 Renato Botelho <garga@pfsense.org>
+Copyright (c) 2015 S. Linke <dev@devsash.de>
+Copyright (c) 2007 Sam Wenham
+Copyright (c) 2007 Scott Dale
+Copyright (c) 2003-2010 Scott Ullrich <sullrich@gmail.com>
+Copyright (c) 2007-2012 Seth Mos <seth.mos@dds.nl>
+Copyright (c) 2008-2009 Shrew Soft Inc. <mgrooms@shrew.net>
+Copyright (c) 2004-2005 T. Lechat <dev@lechat.org>
+Copyright (c) 2008 Tellnet AG
+Copyright (c) 2016 Tobias Boertitz <tbor87@gmail.com>
+Copyright (c) 2010 Vinicius Coque <vinicius.coque@bluepex.com>
+Copyright (c) 2011-2014 Warren Baker <warren@decoy.co.za>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -25,12 +25,13 @@ Copyright (c) 2010 Gabriel B. <gnoahb@gmail.com>
 Copyright (c) 2016 IT-assistans Sverige AB
 Copyright (c) 2009 Janne Enberg <janne.enberg@lietu.net>
 Copyright (c) 2017 Jeffrey Gentes
+Copyright (c) 2004 Jim McBeath
 Copyright (c) 2009-2014 Jim Pingle <jimp@pfsense.org>
 Copyright (c) 2012 Jonas von Andrian
 Copyright (c) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
 Copyright (c) 2003-2004 Justin Ellison <justin@techadvise.com>
 Copyright (c) 2015 Manuel Faux <mfaux@conf.at>
-Copyright (c) 2003-2004 Manuel Kasper
+Copyright (c) 2003-2009 Manuel Kasper <mk@neon1.net>
 Copyright (c) 2012 Marcello Coutinho
 Copyright (c) 2010-2015 Michael Bostock
 Copyright (c) 2005-2006 Paul Taylor <paultaylor@winn-dixie.com>
@@ -41,6 +42,7 @@ Copyright (c) 2013 Renato Botelho <garga@pfsense.org>
 Copyright (c) 2015 S. Linke <dev@devsash.de>
 Copyright (c) 2007 Sam Wenham
 Copyright (c) 2007 Scott Dale
+Copyright (c) 2004-2012 Scott Ullrich
 Copyright (c) 2003-2010 Scott Ullrich <sullrich@gmail.com>
 Copyright (c) 2007-2012 Seth Mos <seth.mos@dds.nl>
 Copyright (c) 2008-2009 Shrew Soft Inc. <mgrooms@shrew.net>

--- a/Makefile
+++ b/Makefile
@@ -304,9 +304,14 @@ style: want-pear-PHP_CodeSniffer
 style-fix: want-pear-PHP_CodeSniffer
 	phpcbf --standard=ruleset.xml ${.CURDIR}/src/opnsense || true
 
+license:
+	@${.CURDIR}/Scripts/license > ${.CURDIR}/LICENSE
+
 test: want-phpunit6
 	@cd ${.CURDIR}/src/opnsense/mvc/tests && \
 	    phpunit --configuration PHPunit.xml
 
 clean: want-git
 	${GIT} reset --hard HEAD && ${GIT} clean -xdqf .
+
+.PHONY: license

--- a/Scripts/development/crawl_legacy_deps.py
+++ b/Scripts/development/crawl_legacy_deps.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/Scripts/development/inspect_function_usage.py
+++ b/Scripts/development/inspect_function_usage.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/Scripts/development/lib/legacy_deps.py
+++ b/Scripts/development/lib/legacy_deps.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/Scripts/license
+++ b/Scripts/license
@@ -67,9 +67,12 @@ my %copyrights = ();
 sub process_file
 {
     my $filename = $File::Find::name;
+
     return if not -f "$cwd/$filename";
+
     my @lines = read_file( "$cwd/$filename" );
     my $possibly_bsd;
+
     for my $line ( @lines ) {
         $possibly_bsd = 1 if $line =~ /Redistribution and use in source and binary forms/i;
         if ( $line =~ /Apache License/i ) {
@@ -77,15 +80,19 @@ sub process_file
             last;
         }
     }
+
     return if not $possibly_bsd;
+
     for my $line ( @lines ) {
         my $copy = $line;
-        chomp $copy;
         next if $line !~ s/copyright\s+\(c\)\s+//i;
-        my ( $start, $end ) = ( 0, 9999 );
-        $line =~ s/(^[\*\\#\s]+|[\.\s]+$)//g;
+        $line =~ s/^[\*\\#\s]+//g;
+        $line =~ s/[\.\s]+$//g;
         $line =~ s/Inc$/Inc./;
         $line =~ s/B\.V$/B.V./;
+        chomp $copy;
+        $copy =~ s/^[\*\\#\s]+//g;
+        my ( $start, $end ) = ( 0, 9999 );
         if ( $line =~ s/(\d\d\d\d\s*,?-?\s*)// ) {
             $start = $1;
             $start =~ s/[,\s\-]+//g;
@@ -95,6 +102,7 @@ sub process_file
             $end =~ s/[,\s]+//g;
         }
         $end = $start if $end == 9999;
+        say STDERR "Error in $filename: $copy" if $end == 0;
         if ( exists $copyrights{$line} ) {
             if ( $start > $copyrights{$line}[0] ) {
                 $start = $copyrights{$line}[0];

--- a/Scripts/license
+++ b/Scripts/license
@@ -1,0 +1,119 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2017 Franco Fichtner <franco@opnsense.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+use strict;
+use warnings;
+use autodie;
+
+use Cwd;
+use File::Find;
+use File::Slurp;
+
+my $src = shift || 'src';
+my $cwd = getcwd;
+my $lic = << 'END_LIC';
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+END_LIC
+
+my %copyrights = ();
+
+sub process_file
+{
+    my $filename = $File::Find::name;
+    return if not -f "$cwd/$filename";
+    my @lines = read_file( "$cwd/$filename" );
+    my $possibly_bsd;
+    for my $line ( @lines ) {
+        $possibly_bsd = 1 if $line =~ /Redistribution and use in source and binary forms/i;
+        if ( $line =~ /Apache License/i ) {
+            $possibly_bsd = 0;
+            last;
+        }
+    }
+    return if not $possibly_bsd;
+    for my $line ( @lines ) {
+        my $copy = $line;
+        chomp $copy;
+        next if $line !~ s/copyright\s+\(c\)\s+//i;
+        my ( $start, $end ) = ( 0, 9999 );
+        $line =~ s/(^[\*\\#\s]+|[\.\s]+$)//g;
+        $line =~ s/Inc$/Inc./;
+        $line =~ s/B\.V$/B.V./;
+        if ( $line =~ s/(\d\d\d\d\s*,?-?\s*)// ) {
+            $start = $1;
+            $start =~ s/[,\s\-]+//g;
+        }
+        if ( $line =~ s/(\d\d\d\d\s*,?\s+)// ) {
+            $end = $1;
+            $end =~ s/[,\s]+//g;
+        }
+        $end = $start if $end == 9999;
+        if ( exists $copyrights{$line} ) {
+            if ( $start > $copyrights{$line}[0] ) {
+                $start = $copyrights{$line}[0];
+            }
+            if ( $copyrights{$line}[1] == 9999 or $end < $copyrights{$line}[1] ) {
+                $end = $copyrights{$line}[1];
+            }
+        }
+        $copyrights{$line} = [ $start, $end ];
+    }
+}
+
+find( \&process_file, $src );
+
+for ( sort keys %copyrights ) {
+    my $date = $copyrights{$_}[0];
+    next if $date == 0;
+    $date = join '-', @{ $copyrights{$_} } if $copyrights{$_}[1] != $date;
+    print "Copyright (c) $date $_\n";
+}
+
+print $lic;

--- a/Scripts/license
+++ b/Scripts/license
@@ -39,27 +39,25 @@ my $lic = << 'END_LIC';
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 END_LIC
 
 my %copyrights = ();

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2010 Ermal Luçi
-    Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
+    Copyright (C) 2007-2008 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
     Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
     Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.

--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2007-2008 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
     Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 

--- a/src/etc/inc/crypt.inc
+++ b/src/etc/inc/crypt.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2017 Deciso B.V.
-    Copyright (C) 2004-2007 Scott Ullrich
+    Copyright (C) 2004-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>
     Copyright (C) 2006 Peter Allgeyer <allgeyer@web.de>
     Copyright (C) 2008-2010 Ermal Luçi

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3,9 +3,9 @@
 /*
     Copyright (C) 2017 Deciso B.V.
     Copyright (C) 2004-2007 Scott Ullrich
-    Copyright (C) 2005 Bill Marquette
-    Copyright (C) 2006 Peter Allgeyer
-    Copyright (C) 2008-2010  Ermal Luci
+    Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>
+    Copyright (C) 2006 Peter Allgeyer <allgeyer@web.de>
+    Copyright (C) 2008-2010 Ermal Luçi
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/etc/inc/filter_log.inc
+++ b/src/etc/inc/filter_log.inc
@@ -2,7 +2,6 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) Scott Ullrich
     Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 

--- a/src/etc/inc/filter_log.inc
+++ b/src/etc/inc/filter_log.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) Scott Ullrich
-    Copyright (C) 2009 Jim Pingle
+    Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1,7 +1,8 @@
 <?php
 
 /*
-    Copyright (C) 2008 Bill Marquette, Seth Mos
+    Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>
+    Copyright (C) 2008 Seth Mos <seth.mos@dds.nl>
     Copyright (C) 2010 Ermal Luçi
     All rights reserved.
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2004-2008 Scott Ullrich
+ * Copyright (C) 2004-2008 Scott Ullrich <sullrich@gmail.com>
  * Copyright (C) 2008-2009 Ermal Luçi
  * Copyright (C) 2005 Espen Johansen
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>

--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2017 Franco Fichtner <franco@opnsense.org>
-    Copyright (C) 2010 Ermal Luci
+    Copyright (C) 2010 Ermal Luçi
     Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2016 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2008 Ermal Luçi
     Copyright (C) 2004-2007 Scott Ullrich
     Copyright (C) 2003-2004 Manuel Kasper

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -4,7 +4,7 @@
     Copyright (C) 2016 Deciso B.V.
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2008 Ermal Luçi
-    Copyright (C) 2004-2007 Scott Ullrich
+    Copyright (C) 2004-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -5,7 +5,7 @@
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2008 Ermal Luçi
     Copyright (C) 2004-2007 Scott Ullrich
-    Copyright (C) 2003-2004 Manuel Kasper
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/inc/plugins.inc.d/ipsec/auth-user.php
+++ b/src/etc/inc/plugins.inc.d/ipsec/auth-user.php
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2010 Ermal Luçi
     All rights reserved.
 

--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2004 Scott K Ullrich
+ * Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
  * Copyright (C) 2004 Fred Mol <fredmol@xs4all.nl>.
  * Copyright (C) 2015-2017 Franco Fichtner <franco@opnsense.org>
  * All rights reserved.

--- a/src/etc/inc/plugins.inc.d/openvpn/auth-user.php
+++ b/src/etc/inc/plugins.inc.d/openvpn/auth-user.php
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2010 Ermal Luçi
     All rights reserved.
 

--- a/src/etc/inc/plugins.inc.d/openvpn/tls-verify.php
+++ b/src/etc/inc/plugins.inc.d/openvpn/tls-verify.php
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2011 Jim Pingle
+    Copyright (C) 2011 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2017 Franco Fichtner <franco@opnsense.org>
-    Copyright (C) 2010 Ermal Luci
+    Copyright (C) 2010 Ermal Luçi
     Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/etc/inc/xmlrpc/legacy.inc
+++ b/src/etc/inc/xmlrpc/legacy.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2015-2016 Deciso B.V.
     Copyright (C) 2004-2010 Scott Ullrich
-    Copyright (C) 2005 Colin Smith
+    Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/inc/xmlrpc/legacy.inc
+++ b/src/etc/inc/xmlrpc/legacy.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2015-2016 Deciso B.V.
-    Copyright (C) 2004-2010 Scott Ullrich
+    Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -3,9 +3,9 @@
 
 /*
     Copyright (C) 2014-2017 Franco Fichtner <franco@opnsense.org>
-    Copyright (C) 2004-2009 Scott Ullrich <sullrich@pfsense.org>.
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-    Copyright (C) 2009 Erik Kristensen
+    Copyright (C) 2009 Erik Kristensen <erik@erikkristensen.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.carpbackup
+++ b/src/etc/rc.carpbackup
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.carpmaster
+++ b/src/etc/rc.carpmaster
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.expireaccounts
+++ b/src/etc/rc.expireaccounts
@@ -2,7 +2,7 @@
 <?php
 
 /*
-	Copyright (C) 2009 Shrew Soft Inc.
+	Copyright (C) 2009 Shrew Soft Inc. <mgrooms@shrew.net>
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.filter_configure
+++ b/src/etc/rc.filter_configure
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -4,9 +4,9 @@
 /*
     Copyright (C) 2016 Deciso B.V.
     Copyright (C) 2004-2006 Scott Ullrich
-    Copyright (C) 2005 Bill Marquette
-    Copyright (C) 2006 Peter Allgeyer
-    Copyright (C) 2008 Ermal Luci
+    Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>
+    Copyright (C) 2006 Peter Allgeyer <allgeyer@web.de>
+    Copyright (C) 2008 Ermal Luçi
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -3,7 +3,7 @@
 
 /*
     Copyright (C) 2016 Deciso B.V.
-    Copyright (C) 2004-2006 Scott Ullrich
+    Copyright (C) 2004-2006 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>
     Copyright (C) 2006 Peter Allgeyer <allgeyer@web.de>
     Copyright (C) 2008 Ermal Luçi

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2015-2017 Ad Schellevis
+# Copyright (c) 2015-2017 Ad Schellevis <ad@opnsense.org>
 # Copyright (c) 2015-2017 Franco Fichtner <franco@opnsense.org>
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2015-2017 Ad Schellevis <ad@opnsense.org>
+# Copyright (c) 2015-2017 Ad Schellevis
 # Copyright (c) 2015-2017 Franco Fichtner <franco@opnsense.org>
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.initial.banner
+++ b/src/etc/rc.initial.banner
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2005 Scott Ullrich
+ * Copyright (C) 2005 Scott Ullrich <sullrich@gmail.com>
  * Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
  * Copyright (C) 2009 Ermal Luçi
  * All rights reserved

--- a/src/etc/rc.initial.banner
+++ b/src/etc/rc.initial.banner
@@ -2,8 +2,9 @@
 <?php
 
 /*
- * Copyright (C) 2005 Scott Ullrich and Colin Smith
- * Copyright (C) 2009 Ermal LuÁi
+ * Copyright (C) 2005 Scott Ullrich
+ * Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
+ * Copyright (C) 2009 Ermal Lu√ßi
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.initial.password
+++ b/src/etc/rc.initial.password
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2017 Franco Fichter <franco@opnsense.org>
+ * Copyright (C) 2017 Franco Fichtner <franco@opnsense.org>
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * All rights reserved.
  *

--- a/src/etc/rc.interfaces_wan_configure
+++ b/src/etc/rc.interfaces_wan_configure
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.reload_all
+++ b/src/etc/rc.reload_all
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.reload_interfaces
+++ b/src/etc/rc.reload_interfaces
@@ -2,7 +2,7 @@
 <?php
 
 /*
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.resolv_conf_generate
+++ b/src/etc/rc.resolv_conf_generate
@@ -2,30 +2,30 @@
 <?php
 
 /*
-        Copyright (C) 2010 Ermal Luçi
-        All rights reserved.
-
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
-
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
-
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
-
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (C) 2010 Ermal LuÃ§i
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 require_once("util.inc");
 require_once("config.inc");

--- a/src/etc/rc.sshd
+++ b/src/etc/rc.sshd
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2004 Scott K Ullrich
+ * Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
  * Copyright (C) 2004 Fred Mol <fredmol@xs4all.nl>.
  * Copyright (C) 2015-2017 Franco Fichtner <franco@opnsense.org>
  * All rights reserved.

--- a/src/etc/rc.syshook.d/90-carp.start
+++ b/src/etc/rc.syshook.d/90-carp.start
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2017 Ad Schellevis
+ * Copyright (C) 2017 Ad Schellevis <ad@opnsense.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/etc/rc.syshook.d/90-carp.start
+++ b/src/etc/rc.syshook.d/90-carp.start
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2017 Ad Schellevis <ad@opnsense.org>
+ * Copyright (C) 2017 Ad Schellevis
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *    Copyright (C) 2015 Deciso B.V. - J. Schellevis
+ *    Copyright (C) 2015 Jos Schellevis <jos@opnsense.org>
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/SystemhealthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/SystemhealthController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- *    Copyright (C) 2015 Deciso B.V. - J. Schellevis
+ *    Copyright (C) 2015 Jos Schellevis <jos@opnsense.org>
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/SystemhealthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/SystemhealthController.php
@@ -1,8 +1,7 @@
 <?php
 
-/**
- *    Copyright (C) 2015 Deciso B.V. - J.Schellevis
- *
+/*
+ *    Copyright (C) 2015 Deciso B.V. - J. Schellevis
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -25,7 +24,6 @@
  *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *    POSSIBILITY OF SUCH DAMAGE.
- *
  */
 
 namespace OPNsense\Diagnostics;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
@@ -1,7 +1,7 @@
 <?php
+
 /**
- *    Copyright (C) 2015 J. Schellevis - Deciso B.V.
- *
+ *    Copyright (C) 2015 Deciso B.V. - J. Schellevis
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,8 @@
  *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *    POSSIBILITY OF SUCH DAMAGE.
- *
  */
+
 namespace OPNsense\Proxy\Api;
 
 use \OPNsense\Base\ApiMutableModelControllerBase;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/SettingsController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *    Copyright (C) 2015 Deciso B.V. - J. Schellevis
+ *    Copyright (C) 2015 Jos Schellevis <jos@opnsense.org>
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
@@ -1,7 +1,6 @@
 <!--
-/**
-*    Copyright (C) 2015 Deciso B.V. - J.Schellevis
-*
+/*
+*    Copyright (C) 2015 Deciso B.V. - J. Schellevis
 *    All rights reserved.
 *
 *    Redistribution and use in source and binary forms, with or without
@@ -24,7 +23,6 @@
 *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *    POSSIBILITY OF SUCH DAMAGE.
-*
 */
 -->
 

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
@@ -1,6 +1,6 @@
 <!--
 /*
-*    Copyright (C) 2015 Deciso B.V. - J. Schellevis
+*    Copyright (C) 2015 Jos Schellevis <jos@opnsense.org>
 *    All rights reserved.
 *
 *    Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/allow.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/allow.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/disconnect.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/disconnect.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/fetch_template.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/fetch_template.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/generate_certs.php
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/generate_certs.php
@@ -1,9 +1,8 @@
 #!/usr/local/bin/php
 <?php
 
-/**
+/*
  *    Copyright (C) 2015 Deciso B.V.
- *
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -26,7 +25,6 @@
  *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *    POSSIBILITY OF SUCH DAMAGE.
- *
  */
 
 // use legacy code to generate certs and ca's

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/lib/__init__.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/lib/__init__.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/lib/arp.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/lib/arp.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/lib/db.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/lib/db.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/lib/ipfw.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/lib/ipfw.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/listARPtable.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/listARPtable.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/listClients.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/listClients.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/overlay_template.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/overlay_template.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
@@ -1,8 +1,8 @@
 #!/usr/local/bin/php
 <?php
-/**
+
+/*
  *    Copyright (C) 2015 Deciso B.V.
- *
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,6 @@
  *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *    POSSIBILITY OF SUCH DAMAGE.
- *
  */
 
 require_once('script/load_phalcon.php');

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/set_session_restrictions.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/set_session_restrictions.py
@@ -1,6 +1,6 @@
 #!/usr/local/bin/python2.7
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/strip_template.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/strip_template.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/dhcp/get_leases.py
+++ b/src/opnsense/scripts/dhcp/get_leases.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2017 Ad Schellevis
+    Copyright (c) 2017 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/dns/unbound_dhcpd.py
+++ b/src/opnsense/scripts/dns/unbound_dhcpd.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/delete_table.py
+++ b/src/opnsense/scripts/filter/delete_table.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/download_geoip.py
+++ b/src/opnsense/scripts/filter/download_geoip.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/kill_table.py
+++ b/src/opnsense/scripts/filter/kill_table.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_counters.py
+++ b/src/opnsense/scripts/filter/list_counters.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2017 Ad Schellevis
+    Copyright (c) 2017 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_osfp.py
+++ b/src/opnsense/scripts/filter/list_osfp.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_pfsync.py
+++ b/src/opnsense/scripts/filter/list_pfsync.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_states.py
+++ b/src/opnsense/scripts/filter/list_states.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_table.py
+++ b/src/opnsense/scripts/filter/list_table.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/list_tables.py
+++ b/src/opnsense/scripts/filter/list_tables.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/filter/pfinfo.py
+++ b/src/opnsense/scripts/filter/pfinfo.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/interfaces/list_arp.py
+++ b/src/opnsense/scripts/interfaces/list_arp.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/interfaces/list_macdb.py
+++ b/src/opnsense/scripts/interfaces/list_macdb.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/interfaces/list_ndp.py
+++ b/src/opnsense/scripts/interfaces/list_ndp.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/ipsec/connect.py
+++ b/src/opnsense/scripts/ipsec/connect.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/ipsec/disconnect.py
+++ b/src/opnsense/scripts/ipsec/disconnect.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/ipsec/list_leases.py
+++ b/src/opnsense/scripts/ipsec/list_leases.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/ipsec/list_status.py
+++ b/src/opnsense/scripts/ipsec/list_status.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015-2017 Ad Schellevis
+    Copyright (c) 2015-2017 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/export_details.py
+++ b/src/opnsense/scripts/netflow/export_details.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/flowctl_stats.py
+++ b/src/opnsense/scripts/netflow/flowctl_stats.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/flowd_aggregate.py
+++ b/src/opnsense/scripts/netflow/flowd_aggregate.py
@@ -1,6 +1,6 @@
 #!/usr/local/bin/python2.7
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/flowd_aggregate_metadata.py
+++ b/src/opnsense/scripts/netflow/flowd_aggregate_metadata.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/get_timeseries.py
+++ b/src/opnsense/scripts/netflow/get_timeseries.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/get_top_usage.py
+++ b/src/opnsense/scripts/netflow/get_top_usage.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/aggregate.py
+++ b/src/opnsense/scripts/netflow/lib/aggregate.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/aggregates/__init__.py
+++ b/src/opnsense/scripts/netflow/lib/aggregates/__init__.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/aggregates/interface.py
+++ b/src/opnsense/scripts/netflow/lib/aggregates/interface.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/aggregates/ports.py
+++ b/src/opnsense/scripts/netflow/lib/aggregates/ports.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/aggregates/source.py
+++ b/src/opnsense/scripts/netflow/lib/aggregates/source.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/netflow/lib/parse.py
+++ b/src/opnsense/scripts/netflow/lib/parse.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/proxy/fetchACLs.py
+++ b/src/opnsense/scripts/proxy/fetchACLs.py
@@ -2,7 +2,7 @@
 
 """
     Copyright (c) 2016 Deciso B.V. - Ad Schellevis
-    Copyright (c) 2015 Deciso B.V. - J. Schellevis
+    Copyright (c) 2015 Jos Schellevis <jos@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/proxy/fetchACLs.py
+++ b/src/opnsense/scripts/proxy/fetchACLs.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     Copyright (c) 2015 Jos Schellevis <jos@opnsense.org>
     All rights reserved.
 

--- a/src/opnsense/scripts/proxy/fetchACLs.py
+++ b/src/opnsense/scripts/proxy/fetchACLs.py
@@ -1,8 +1,8 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis - Deciso B.V.
-    Copyright (c) 2015 Jos Schellevis - Deciso B.V.
+    Copyright (c) 2016 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Deciso B.V. - J. Schellevis
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/routes/show_routes.py
+++ b/src/opnsense/scripts/routes/show_routes.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/dropAlertLog.py
+++ b/src/opnsense/scripts/suricata/dropAlertLog.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/installRules.py
+++ b/src/opnsense/scripts/suricata/installRules.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/__init__.py
+++ b/src/opnsense/scripts/suricata/lib/__init__.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/downloader.py
+++ b/src/opnsense/scripts/suricata/lib/downloader.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/log.py
+++ b/src/opnsense/scripts/suricata/lib/log.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/metadata.py
+++ b/src/opnsense/scripts/suricata/lib/metadata.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/params.py
+++ b/src/opnsense/scripts/suricata/lib/params.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/lib/rulecache.py
+++ b/src/opnsense/scripts/suricata/lib/rulecache.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/listAlertLogs.py
+++ b/src/opnsense/scripts/suricata/listAlertLogs.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/listClasstypes.py
+++ b/src/opnsense/scripts/suricata/listClasstypes.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/listInstallableRulesets.py
+++ b/src/opnsense/scripts/suricata/listInstallableRulesets.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/queryAlertLog.py
+++ b/src/opnsense/scripts/suricata/queryAlertLog.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/queryInstalledRules.py
+++ b/src/opnsense/scripts/suricata/queryInstalledRules.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/suricata/rule-updater.py
+++ b/src/opnsense/scripts/suricata/rule-updater.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/system/list_interrupts.py
+++ b/src/opnsense/scripts/system/list_interrupts.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2017 Ad Schellevis
+    Copyright (c) 2017 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/system/ssl_ciphers.py
+++ b/src/opnsense/scripts/system/ssl_ciphers.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/systemhealth/activity.py
+++ b/src/opnsense/scripts/systemhealth/activity.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/systemhealth/fetchData.py
+++ b/src/opnsense/scripts/systemhealth/fetchData.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/systemhealth/flush_rrd.py
+++ b/src/opnsense/scripts/systemhealth/flush_rrd.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2016 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/systemhealth/listReports.py
+++ b/src/opnsense/scripts/systemhealth/listReports.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Deciso B.V. - Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/scripts/unbound/unboundctlwrapper
+++ b/src/opnsense/scripts/unbound/unboundctlwrapper
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2017 Ad Schellevis
+    Copyright (c) 2017 Ad Schellevis <ad@opnsense.org>
     Copyright (C) 2017 Fabian Franz
     All rights reserved.
 

--- a/src/opnsense/service/configd.py
+++ b/src/opnsense/service/configd.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-    Copyright (c) 2014-2016 Ad Schellevis
+    Copyright (c) 2014-2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/configd_ctl.py
+++ b/src/opnsense/service/configd_ctl.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python2.7
 
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/__init__.py
+++ b/src/opnsense/service/modules/__init__.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2014 Ad Schellevis
+    Copyright (c) 2014 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/addons/template_helpers.py
+++ b/src/opnsense/service/modules/addons/template_helpers.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/config.py
+++ b/src/opnsense/service/modules/config.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/csconfigparser.py
+++ b/src/opnsense/service/modules/csconfigparser.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/ph_inline_actions.py
+++ b/src/opnsense/service/modules/ph_inline_actions.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2014 Ad Schellevis
+    Copyright (c) 2014 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/processhandler.py
+++ b/src/opnsense/service/modules/processhandler.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2014 Ad Schellevis
+    Copyright (c) 2014 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/modules/template.py
+++ b/src/opnsense/service/modules/template.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015 Ad Schellevis
+    Copyright (c) 2015 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/run_unittests.py
+++ b/src/opnsense/service/run_unittests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/tests/__init__.py
+++ b/src/opnsense/service/tests/__init__.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/tests/core.py
+++ b/src/opnsense/service/tests/core.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/service/tests/template.py
+++ b/src/opnsense/service/tests/template.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/site-python/params.py
+++ b/src/opnsense/site-python/params.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2015-2016 Ad Schellevis
+    Copyright (c) 2015-2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/site-python/sqlite3_helper.py
+++ b/src/opnsense/site-python/sqlite3_helper.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/site-python/watchers/dhcpd.py
+++ b/src/opnsense/site-python/watchers/dhcpd.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Ad Schellevis
+    Copyright (c) 2016 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/sbin/mpd.script
+++ b/src/sbin/mpd.script
@@ -1,6 +1,7 @@
 #################################################################
 #
-# Copyright (c) 1995-1999 Whistle Communications, Inc. All rights reserved.
+# Copyright (c) 1995-1999 Whistle Communications, Inc.
+# All rights reserved.
 #
 # Subject to the following obligations and disclaimer of warranty,
 # use and redistribution of this software, in source or object code

--- a/src/sbin/ping_hosts.sh
+++ b/src/sbin/ping_hosts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2006 Scott Ullrich
+# Copyright (c) 2006 Scott Ullrich <sullrich@gmail.com>
 # All rights reserved.
 
 # Format of file should be deliminted by |

--- a/src/wizard/openvpn.xml
+++ b/src/wizard/openvpn.xml
@@ -3,7 +3,7 @@
 <copyright>
 /*
 	Copyright (C) 2014 Deciso B.V.
-	Copyright (C) 2010 Ermal Luci
+	Copyright (C) 2010 Ermal Luçi
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/src/wizard/system.xml
+++ b/src/wizard/system.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wizard>
-<copyright>
+<copyright><![CDATA[
 /*
 	Copyright (C) 2014 Deciso B.V.
-	Copyright (C) 2004-2005 Scott Ullrich
+	Copyright (C) 2004-2005 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-</copyright>
+]]></copyright>
 <totalsteps>9</totalsteps>
 <step>
 	<id>1</id>

--- a/src/wizard/system.xml
+++ b/src/wizard/system.xml
@@ -3,7 +3,7 @@
 <copyright>
 /*
 	Copyright (C) 2014 Deciso B.V.
-	Copyright (C) 2004, 2005 Scott Ullrich
+	Copyright (C) 2004-2005 Scott Ullrich
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/src/www/carp_status.php
+++ b/src/www/carp_status.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/crash_reporter.php
+++ b/src/www/crash_reporter.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2015-2017 Franco Fichtner <franco@opnsense.org>
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2011 Scott Ullrich
+    Copyright (C) 2011 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_confbak.php
+++ b/src/www/diag_confbak.php
@@ -2,8 +2,8 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2005 Colin Smith
-    Copyright (C) 2010 Jim Pingle
+    Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
+    Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_defaults.php
+++ b/src/www/diag_defaults.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_dns.php
+++ b/src/www/diag_dns.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2016 Deciso B.V.
-    Copyright (C) 2009 Jim Pingle (jpingle@gmail.com)
+    Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_dump_states.php
+++ b/src/www/diag_dump_states.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2005-2009 Scott Ullrich
-    Copyright (C) 2005 Colin Smith
+    Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_dump_states.php
+++ b/src/www/diag_dump_states.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2005-2009 Scott Ullrich
+    Copyright (C) 2005-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 

--- a/src/www/diag_halt.php
+++ b/src/www/diag_halt.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_ipsec.php
+++ b/src/www/diag_ipsec.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2004-2009 Scott Ullrich
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
-    Copyright (C) 2003-2004 Manuel Kasper
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_ipsec.php
+++ b/src/www/diag_ipsec.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2004-2009 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc <mgrooms@shrew.net>
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper
     All rights reserved.
 

--- a/src/www/diag_ipsec.php
+++ b/src/www/diag_ipsec.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/diag_ipsec_leases.php
+++ b/src/www/diag_ipsec_leases.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2014 Ermal LUÇi
+    Copyright (C) 2014 Ermal Luçi
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_ipsec_sad.php
+++ b/src/www/diag_ipsec_sad.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/diag_ipsec_spd.php
+++ b/src/www/diag_ipsec_spd.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/diag_limiter_info.php
+++ b/src/www/diag_limiter_info.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2010 Scott Ullrich
+    Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_logs_common.inc
+++ b/src/www/diag_logs_common.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2015-2016 Franco Fichtner <franco@opnsense.org>
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_logs_filter.php
+++ b/src/www/diag_logs_filter.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2009-2010 Jim Pingle <jimp@pfsense.org>
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2009 Manuel Kasper <mk@neon1.net>
     Originally Sponsored By Anathematic @ pfSense Forums
     All rights reserved.

--- a/src/www/diag_logs_filter.php
+++ b/src/www/diag_logs_filter.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2009-2010 Jim Pingle <jim@pingle.org>
+    Copyright (C) 2009-2010 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2004-2009 Scott Ullrich
     Copyright (C) 2003-2009 Manuel Kasper <mk@neon1.net>
     Originally Sponsored By Anathematic @ pfSense Forums

--- a/src/www/diag_logs_filter_dynamic.php
+++ b/src/www/diag_logs_filter_dynamic.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/diag_logs_filter_summary.php
+++ b/src/www/diag_logs_filter_summary.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-    Copyright (C) 2014-2015 Deciso B.V. - J. Schellevis
+    Copyright (C) 2014-2015 Jos Schellevis <jos@opnsense.org>
     Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 

--- a/src/www/diag_logs_filter_summary.php
+++ b/src/www/diag_logs_filter_summary.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V. - J. Schellevis
-    Copyright (C) 2009 Jim Pingle <jpingle@gmail.com>
+    Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_logs_settings.php
+++ b/src/www/diag_logs_settings.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_logs_template.inc
+++ b/src/www/diag_logs_template.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2012 Seth Mos <seth.mos@dds.nl>
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/diag_logs_template.inc
+++ b/src/www/diag_logs_template.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2012 Seth Mos
+    Copyright (C) 2012 Seth Mos <seth.mos@dds.nl>
     Copyright (C) 2004-2009 Scott Ullrich
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/diag_pf_info.php
+++ b/src/www/diag_pf_info.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2010 Scott Ullrich
+    Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_ping.php
+++ b/src/www/diag_ping.php
@@ -2,7 +2,8 @@
 
 /*
     Copyright (C) 2016 Deciso B.V.
-    Copyright (C) 2003-2005 Bob Zoller (bob@kludgebox.com) and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_resetstate.php
+++ b/src/www/diag_resetstate.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/diag_sockets.php
+++ b/src/www/diag_sockets.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2012
+    Copyright (C) 2012 PiBa-NL <pba_2k3@yahoo.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_states_summary.php
+++ b/src/www/diag_states_summary.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2010-2014 Jim Pingle <jimp@pfsense.org>
-    Copyright (C) 2005-2009 Scott Ullrich
+    Copyright (C) 2005-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 

--- a/src/www/diag_states_summary.php
+++ b/src/www/diag_states_summary.php
@@ -2,9 +2,9 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2010-2014 Jim Pingle
+    Copyright (C) 2010-2014 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2005-2009 Scott Ullrich
-    Copyright (C) 2005 Colin Smith
+    Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_system_pftop.php
+++ b/src/www/diag_system_pftop.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2008-2009 Scott Ullrich
+    Copyright (C) 2008-2009 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_tables.php
+++ b/src/www/diag_tables.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
-    Copyright (C) 2010 Scott Ullrich
+    Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_tables.php
+++ b/src/www/diag_tables.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2010 Jim Pingle
+    Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2010 Scott Ullrich
     All rights reserved.
 

--- a/src/www/diag_testport.php
+++ b/src/www/diag_testport.php
@@ -3,7 +3,8 @@
 /*
     Copyright (C) 2016 Deciso B.V.
     Copyright (C) 2013 Jim Pingle <jimp@pfsense.org>
-    Copyright (C) 2003-2005 Bob Zoller (bob@kludgebox.com) and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_traceroute.php
+++ b/src/www/diag_traceroute.php
@@ -2,7 +2,8 @@
 
 /*
     Copyright (C) 2016 Deciso B.V.
-    Copyright (C) 2005 Paul Taylor (paultaylor@winndixie.com) and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2005 Paul Taylor <paultaylor@winn-dixie.com>
+    Copyright (C) Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/diag_traceroute.php
+++ b/src/www/diag_traceroute.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2016 Deciso B.V.
     Copyright (C) 2005 Paul Taylor <paultaylor@winn-dixie.com>
-    Copyright (C) Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2012 Jim Pingle
+    Copyright (C) 2012 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2007-2008 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
     All rights reserved.

--- a/src/www/firewall_aliases.php
+++ b/src/www/firewall_aliases.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_aliases_edit.php
+++ b/src/www/firewall_aliases_edit.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2009 Ermal Luçi
     Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/src/www/firewall_aliases_edit.php
+++ b/src/www/firewall_aliases_edit.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2004 Scott Ullrich
     Copyright (C) 2009 Ermal Luçi
-    Copyright (C) 2010 Jim Pingle
+    Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_aliases_import.php
+++ b/src/www/firewall_aliases_import.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2005 Scott Ullrich
+    Copyright (C) 2005 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2009 Janne Enberg <janne.enberg@lietu.net>
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-    Copyright (C) 2004-2005 Scott Ullrich <geekgod@pfsense.com>.
+    Copyright (C) 2004-2005 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-    Copyright (C) 2004-2005 Scott Ullrich <geekgod@pfsense.com>.
+    Copyright (C) 2004-2005 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2015-2016 Franco Fichtner <franco@opnsense.org>
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/index.php
+++ b/src/www/index.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2004-2012 Scott Ullrich
+    Copyright (C) 2004-2012 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2010 Erik Fonnesbeck
     Copyright (C) 2008-2010 Ermal Luçi
-    Copyright (C) 2004-2008 Scott Ullrich
+    Copyright (C) 2004-2008 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2006 Daniel S. Haischt
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) Jim McBeath
+    Copyright (C) 2004 Jim McBeath
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/interfaces_groups.php
+++ b/src/www/interfaces_groups.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2009 Ermal Luçi
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/interfaces_groups_edit.php
+++ b/src/www/interfaces_groups_edit.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2009 Ermal Luçi
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/reporting_settings.php
+++ b/src/www/reporting_settings.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/services_dhcpv6_relay.php
+++ b/src/www/services_dhcpv6_relay.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2003-2004 Justin Ellison <justin@techadvise.com>.
     Copyright (C) 2010  Ermal Luçi
-    Copyright (C) 2010  Seth Mos
+    Copyright (C) 2010  Seth Mos <seth.mos@dds.nl>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -2,7 +2,8 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/www/services_dnsmasq_domainoverride_edit.php
@@ -2,7 +2,8 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -2,7 +2,8 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -2,8 +2,8 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2013  Dagorlad
-    Copyright (C) 2012  Jim Pingle
+    Copyright (C) 2013 Dagorlad
+    Copyright (C) 2012 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_ntpd_gps.php
+++ b/src/www/services_ntpd_gps.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2013 Dagorlad
-    Copyright (C) 2012 Jim Pingle
+    Copyright (C) 2012 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2014 Warren Baker <warren@pfsense.org>
+    Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2011 Warren Baker <warren@pfsense.org>
+    Copyright (C) 2011 Warren Baker <warren@decoy.co.za>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_unbound_domainoverride_edit.php
+++ b/src/www/services_unbound_domainoverride_edit.php
@@ -2,8 +2,9 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2014 Warren Baker (warren@decoy.co.za)
-    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
+    Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -4,7 +4,8 @@
     Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
-    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2014 Warren Baker <warren@pfsense.org>
+    Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2004-2009 Scott Ullrich
+    Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2011 Seth Mos <seth.mos@dds.nl>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2004-2009 Scott Ullrich
-    Copyright (C) 2011 Seth Mos
+    Copyright (C) 2011 Seth Mos <seth.mos@dds.nl>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/status_filter_reload.php
+++ b/src/www/status_filter_reload.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-    Copyright (C) 2006 Scott Ullrich
+    Copyright (C) 2006 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2017 Deciso B.V.
     Copyright (C) 2017 Jeffrey Gentes
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
     All rights reserved.
 

--- a/src/www/status_ntpd.php
+++ b/src/www/status_ntpd.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2013 Dagorlad
-    Copyright (C) 2012 Jim Pingle
+    Copyright (C) 2012 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/status_openvpn.php
+++ b/src/www/status_openvpn.php
@@ -2,9 +2,10 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2010 Jim Pingle
-    Copyright (C) 2008 Shrew Soft Inc.
-    Copyright (C) 2005 Scott Ullrich, Colin Smith
+    Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
+    Copyright (C) 2005 Scott Ullrich
+    Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/status_openvpn.php
+++ b/src/www/status_openvpn.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
-    Copyright (C) 2005 Scott Ullrich
+    Copyright (C) 2005 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2005 Colin Smith <ethethlay@gmail.com>
     All rights reserved.
 

--- a/src/www/status_services.php
+++ b/src/www/status_services.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
-    Copyright (C) 2004-2005 Scott Ullrich
+    Copyright (C) 2004-2005 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/status_wireless.php
+++ b/src/www/status_wireless.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2004 Scott Ullrich
+    Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2005-2010 Scott Ullrich
+    Copyright (C) 2005-2010 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2010 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/system_advanced_firewall.php
+++ b/src/www/system_advanced_firewall.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2005-2007 Scott Ullrich
+    Copyright (C) 2005-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/system_advanced_firewall.php
+++ b/src/www/system_advanced_firewall.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2007 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2005-2007 Scott Ullrich
+    Copyright (C) 2005-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2007 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2005-2007 Scott Ullrich
+    Copyright (C) 2005-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2007 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2005-2007 Scott Ullrich
+    Copyright (C) 2005-2007 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2005-2007 Scott Ullrich
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2010 Ermal Luçi
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2010 Jim Pingle
+    Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2005 Paul Taylor <paultaylor@winn-dixie.com>.
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
     All rights reserved.

--- a/src/www/system_routes_edit.php
+++ b/src/www/system_routes_edit.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2015 Deciso B.V.
     Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-    Copyright (C) 2010 Scott Ullrich
+    Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2005 Paul Taylor <paultaylor@winn-dixie.com>
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/vpn_ipsec_mobile.php
+++ b/src/www/vpn_ipsec_mobile.php
@@ -2,7 +2,7 @@
 
 /*
   Copyright (C) 2014-2015 Deciso B.V.
-  Copyright (C) 2008 Shrew Soft Inc
+  Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     Copyright (C) 2014 Ermal Luçi
     All rights reserved.

--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -4,7 +4,7 @@
     Copyright (C) 2010 Ermal Luçi
     Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
-    Copyright (C) 2003-2004 Manuel Kasper
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
-    Copyright (C) 2010 Ermal Luci
+    Copyright (C) 2010 Ermal Luçi
     Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
-    Copyright (C) 2008 Shrew Soft Inc
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     Copyright (C) 2003-2004 Manuel Kasper
     All rights reserved.
 

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2015 Deciso B.V.
-    Copyright (C) 2008 Shrew Soft Inc.
+    Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/gateways.widget.php
+++ b/src/www/widgets/widgets/gateways.widget.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2008 Seth Mos
+    Copyright (C) 2008 Seth Mos <seth.mos@dds.nl>
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/src/www/widgets/widgets/interface_list.widget.php
+++ b/src/www/widgets/widgets/interface_list.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -3,9 +3,10 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2009 Jim Pingle (jpingle@gmail.com)
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/ntp_status.widget.php
+++ b/src/www/widgets/widgets/ntp_status.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014 Deciso B.V.
     Copyright (c) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/picture.widget.php
+++ b/src/www/widgets/widgets/picture.widget.php
@@ -2,7 +2,7 @@
 
 /*
         Copyright (C) 2014 Deciso B.V.
-        Copyright (C) 2009 Scott Ullrich
+        Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
 
         Redistribution and use in source and binary forms, with or without
         modification, are permitted provided that the following conditions are met:

--- a/src/www/widgets/widgets/rss.widget.php
+++ b/src/www/widgets/widgets/rss.widget.php
@@ -2,7 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
-    Copyright (C) 2009 Scott Ullrich
+    Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/src/www/widgets/widgets/services_status.widget.php
+++ b/src/www/widgets/widgets/services_status.widget.php
@@ -4,7 +4,7 @@
     Copyright (C) 2014 Deciso B.V.
     Copyright (C) 2007 Sam Wenham
     Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
-    Copyright (C) 2004-2005 Scott Ullrich
+    Copyright (C) 2004-2005 Scott Ullrich <sullrich@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/system_information.widget.php
+++ b/src/www/widgets/widgets/system_information.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/www/widgets/widgets/thermal_sensors.widget.php
@@ -2,6 +2,7 @@
 
 /*
     Copyright (C) 2014-2016 Deciso B.V.
+    All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -3,8 +3,9 @@
 /*
     Copyright (C) 2014-2016 Deciso B.V.
     Copyright (C) 2007 Scott Dale
-    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-    and Jonathan Watt <jwatt@jwatt.org>.
+    Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>
+    Copyright (C) 2004-2005 Manuel Kasper <mk@neon1.net>
+    Copyright (C) 2004-2005 Jonathan Watt <jwatt@jwatt.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -2,7 +2,7 @@
 
 /*
 	Copyright (C) 2014-2015 Deciso B.V.
-	Copyright (C) 2004 Scott Ullrich
+	Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
 	Copyright (C) 2010 Ermal Luçi
 	All rights reserved.
 


### PR DESCRIPTION
The purpose is simple... generate an overview LICENSE file with all individual contributor copyrights from the sources using:

    # make license

To that end, split copyright lines with multiple holders, unify spelling and e-mail usage, fix a few attributions (e.g. missing copyright year or holder or misattribution) and adapt the Deciso B.V. attribution in some cases where individual authors were named.