### PR TITLE
remove invalid chars from states dump

### DIFF
--- a/src/www/diag_dump_states.php
+++ b/src/www/diag_dump_states.php
@@ -146,11 +146,12 @@ include("head.inc");
                     $iface = convert_real_interface_to_friendly_descr($iface);
 
                     /* break up info and extract $srcip and $dstip */
+                    $charmask = array(' ','\t','\n','\r','\0','\x0B','<','>');
                     $ends = preg_split("/\<?-\>?/", $info);
                     $parts = explode(":", $ends[0]);
-                    $srcip = trim($parts[0]);
+                    $srcip = str_replace($charmask,'',htmlspecialchars_decode($parts[0]));
                     $parts = explode(":", $ends[count($ends) - 1]);
-                    $dstip = trim($parts[0]);
+                    $dstip = str_replace($charmask,'',htmlspecialchars_decode($parts[0]));
                     // states can be deleted by source / dest combination, all matching records use the same class.
                     $rowid = str_replace(array('.', ':'), '_', $srcip.$dstip);
                   ?>


### PR DESCRIPTION
In this example I've got the following state in `Firewall->Diagnostics->States Dump` that I've wanted to remove:

```
Int 	Proto 	Source -> Router -> Destination 	State
all 	carp 	224.0.0.18 <- 10.0.0.1 	NO_TRAFFIC:SINGLE
```

Unfortunately, when clicking the "Remove" button nothing happened and I was seing the following error message in my browser's console:

```
POST: action=remove&srcip=224.0.0.18%3C&dstip=10.0.0.1
Response: invalid input
```

The HTML code looks like this:

```
<tr class="r224_0_0_18 &lt;10_0_0_1">
  <td>all</td>
  <td>carp</td>
  <td>224.0.0.18 &lt;- 10.0.0.1</td>
  <td>NO_TRAFFIC:SINGLE</td>
  <td>
    <a href="#" data-rowid="r224_0_0_18 &lt;10_0_0_1" data-srcip="224.0.0.18 &lt;" data-dstip="10.0.0.1" class="act_del btn btn-default" title="Remove all state entries from 224.0.0.18 &lt; to 10.0.0.1"><span class="glyphicon glyphicon-remove"></span></a>
  </td>
</tr>
```

Apparently the parameter `srcip` is wrong, because it includes an `<`.
This patch removes invalid characters. I'm not sure it is the best way to do it, but it fixes the issue for me. :)