### PR TITLE
make configctl call "newip" public to cron

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_interface.conf
+++ b/src/opnsense/service/conf/actions.d/actions_interface.conf
@@ -16,6 +16,7 @@ command:/usr/local/etc/rc.newwanip
 parameters:%s
 type:script
 message:rc.newwanip starting %s
+description:Periodic interface renewal
 
 [newipv6]
 command:/usr/local/etc/rc.newwanipv6


### PR DESCRIPTION
For Multi WAN with DHCP it might be good to have periodic renewal of the interface to fix error with stall routes ( documented in #1821 ).

It could also help in other situations e.g. buggy dhcp servers in the wan world to renew the address in given time ranges.