### PR TITLE
Support non-whitespace field separators for URLtable lists

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -175,7 +175,7 @@ function process_alias_urltable($name, $alias_type, $url, $freq, $forceupdate = 
                     continue;
                 }
                 // cleanse line item
-                $line = preg_split('/\s+/', $line)[0];
+                $line = preg_split('/[\s,;|]+/', $line)[0];
                 if ($alias_type == "urltable_ports") {
                     // todo: add proper validation for ports here
                     fwrite($output_file_handle, "{$line}\n");

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -175,7 +175,7 @@ function process_alias_urltable($name, $alias_type, $url, $freq, $forceupdate = 
                     continue;
                 }
                 // cleanse line item
-                $line = preg_split('/[\s,;|]+/', $line)[0];
+                $line = preg_split('/[\s,;|#]+/', $line)[0];
                 if ($alias_type == "urltable_ports") {
                     // todo: add proper validation for ports here
                     fwrite($output_file_handle, "{$line}\n");


### PR DESCRIPTION
Adds support for non-whitespace field separators to URLtable IP lists.

Some IP lists use alternate characters as field separators - commas, semicolons, vertical bars.  For example, feeds from http://osint.bambenekconsulting.com/feeds/ use commas to separate list values.