### PR TITLE
Captive portal plugins access

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/CaptivePortal/CaptivePortal.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/CaptivePortal/CaptivePortal.xml
@@ -117,5 +117,12 @@
                 </content>
             </template>
         </templates>
+        <PluginsAccess>
+            <Access type="ArrayField">
+                <Route type="TextField">
+                    <Required>Y</Required>
+                </Route>
+            </Access>
+        </PluginsAccess>
     </items>
 </model>

--- a/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
+++ b/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
@@ -104,6 +104,11 @@ proxy.server = ( "/api/captiveportal/access/" => (
 		( "host" => "127.0.0.1",
 		  "port" => 8999 )
 	)
+{% if helpers.exists('OPNsense.captiveportal.PluginsAccess') %}
+{% 	for access in helpers.toList('OPNsense.captiveportal.PluginsAccess.Access') %}
+	, "{{ access.Route }}" => (( "host" => "127.0.0.1", "port" => 8999 ))
+{%	endfor %}
+{% endif %}
 )
 extforward.headers = ("X-Real-Ip")
 server.upload-dirs = ( "/tmp/" )


### PR DESCRIPTION
Plugins ability to register access paths to custom controllers in captive portal config.
For example, I made captive portal plugin for sms-authentication, and clients must have access to my sms-authentication controller.