### PR TITLE
 improve sorting of DHCP leases

### DIFF
--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -33,11 +33,6 @@ require_once("config.inc");
 require_once("services.inc");
 require_once("interfaces.inc");
 
-function leasecmp($a, $b)
-{
-    return strcmp($a[$_GET['order']], $b[$_GET['order']]);
-}
-
 function adjust_gmt($dt)
 {
     global $config;
@@ -242,9 +237,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
     }
 
-    if ($_GET['order']) {
-        usort($leases, "leasecmp");
+    $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
+    usort($leases, function ($a, $b) use ($order) {
+        return strnatcasecmp($a[$order].$a[ip],$b[$order].$b[ip]);
     }
+  );
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         // delete dhcp lease
@@ -353,14 +350,14 @@ include("head.inc");?>
             <table class="table table-striped">
               <thead>
                 <tr>
-                    <td class="act_sort" data-field="if"><?=gettext("Interface"); ?></td>
+                    <td><?=gettext("Interface"); ?></td>
                     <td class="act_sort" data-field="ip"><?=gettext("IP address"); ?></td>
                     <td class="act_sort" data-field="mac"><?=gettext("MAC address"); ?></td>
                     <td class="act_sort" data-field="hostname"><?=gettext("Hostname"); ?></td>
                     <td class="act_sort" data-field="desc"><?=gettext("Description"); ?></td>
                     <td class="act_sort" data-field="start"><?=gettext("Start"); ?></td>
                     <td class="act_sort" data-field="end"><?=gettext("End"); ?></td>
-                    <td class="act_sort" data-field="status"><?=gettext("Status"); ?></td>
+                    <td class="act_sort" data-field="online"><?=gettext("Status"); ?></td>
                     <td class="act_sort" data-field="type"><?=gettext("Lease type"); ?></td>
                     <td>&nbsp;</td>
                 </tr>

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -238,10 +238,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     }
 
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
-    usort($leases, function ($a, $b) use ($order) {
-        return strnatcasecmp($a[$order].$a[ip],$b[$order].$b[ip]);
-    }
-  );
+    usort($leases, 
+        function ($a, $b) use ($order) {
+            return strnatcasecmp($a[$order].$a[ip],$b[$order].$b[ip]);
+        }
+    );
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         // delete dhcp lease

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -240,10 +240,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
     usort($leases, 
         function ($a, $b) use ($order) {
-			$cmp = strnatcasecmp($a[$order], $b[$order]);
-			if ($cmp === 0) {
-				$cmp = strnatcasecmp($a['ip'], $b['ip']);
-			}
+            $cmp = strnatcasecmp($a[$order], $b[$order]);
+            if ($cmp === 0) {
+                $cmp = strnatcasecmp($a['ip'], $b['ip']);
+            }
             return $cmp;
         }
     );

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -360,7 +360,7 @@ include("head.inc");?>
                     <td class="act_sort" data-field="start"><?=gettext("Start"); ?></td>
                     <td class="act_sort" data-field="end"><?=gettext("End"); ?></td>
                     <td class="act_sort" data-field="online"><?=gettext("Status"); ?></td>
-                    <td class="act_sort" data-field="type"><?=gettext("Lease type"); ?></td>
+                    <td class="act_sort" data-field="act"><?=gettext("Lease type"); ?></td>
                     <td>&nbsp;</td>
                 </tr>
               </thead>

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -240,7 +240,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
     usort($leases, 
         function ($a, $b) use ($order) {
-            return strnatcasecmp($a[$order].$a[ip], $b[$order].$b[ip]);
+            return strnatcasecmp($a[$order].$a['ip'], $b[$order].$b['ip']);
         }
     );
      

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -240,7 +240,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
     usort($leases, 
         function ($a, $b) use ($order) {
-            return strnatcasecmp($a[$order].$a['ip'], $b[$order].$b['ip']);
+			$cmp = strnatcasecmp($a[$order], $b[$order]);
+			if ($cmp === 0) {
+				$cmp = strnatcasecmp($a['ip'], $b['ip']);
+			}
+            return $cmp;
         }
     );
      

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -240,9 +240,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
     usort($leases, 
         function ($a, $b) use ($order) {
-            return strnatcasecmp($a[$order].$a[ip],$b[$order].$b[ip]);
+            return strnatcasecmp($a[$order].$a[ip], $b[$order].$b[ip]);
         }
     );
+     
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         // delete dhcp lease
@@ -355,7 +356,7 @@ include("head.inc");?>
                     <td class="act_sort" data-field="ip"><?=gettext("IP address"); ?></td>
                     <td class="act_sort" data-field="mac"><?=gettext("MAC address"); ?></td>
                     <td class="act_sort" data-field="hostname"><?=gettext("Hostname"); ?></td>
-                    <td class="act_sort" data-field="desc"><?=gettext("Description"); ?></td>
+                    <td class="act_sort" data-field="descr"><?=gettext("Description"); ?></td>
                     <td class="act_sort" data-field="start"><?=gettext("Start"); ?></td>
                     <td class="act_sort" data-field="end"><?=gettext("End"); ?></td>
                     <td class="act_sort" data-field="online"><?=gettext("Status"); ?></td>


### PR DESCRIPTION
* replaces strcmp with strnatcasecmp, which is much better at sorting ip addresses
* sorts the list by IP address by default
* does a secondary sort by IP address, which gives better results when sorting by status or lease type
* fixes sorting on the "status" column (the underlying data structure is keyed on "online" instead of "status")
* removes the option to sort by interface, since that doesn't work (the data doesn't exist at the time the array is sorted)