### PR TITLE
Default form: ability to hide header under 'advanced' tag

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -90,7 +90,7 @@ data_title      :   data-title to set on form
             <col class="col-md-5"/>
         </colgroup>
         <thead>
-          <tr>
+          <tr {% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>
             <th colspan="3"><h2>{{field['label']}}</h2></th>
           </tr>
         </thead>


### PR DESCRIPTION
For the case where I want to make the settings block "advanced" with the block header.