### PR TITLE
Fixed DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3111,6 +3111,13 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
     $wanif = get_real_interface($interface, "inet6");
     $dhcp6cconf = "";
     $dhcp6cconf .= "interface {$wanif} {\n";
+    
+    if (!empty($config['system']['global-v6duid'])) {
+        // Write the DUID file
+        if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
+            log_error(gettext("Failed to write user DUID file!"));
+		}
+    }
 
     /* for SLAAC interfaces we do fire off a dhcp6 client for just our name servers */
     if ($wancfg['ipaddrv6'] == "slaac") {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1370,3 +1370,92 @@ function is_install_media()
 
     return true;
 }
+/* format a string to look (more) like the expected DUID format:
+ * 1) Replace any "-" with ":"
+ * 2) If the user inputs 14 components, then add the expected "0e:00:" to the front.
+ *    This is convenience, because the actual DUID (which is reported in logs) is the last 14 components.
+ * 3) If any components are input with just a single char (hex digit hopefully), put a "0" in front.
+ *
+ * The final result should be closer to:
+ *
+ * "0e:00:00:01:00:01:nn:nn:nn:nn:nn:nn:nn:nn:nn:nn"
+ *
+ * This function does not validate the input. is_duid() will do validation.
+*/
+function format_duid($dhcp6duid) {
+    $values = explode(":", strtolower(str_replace("-", ":", $dhcp6duid)));
+    if (count($values) == 14) {
+        array_unshift($values, "0e", "00");
+    }
+
+    array_walk($values, function(&$value) {
+        $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+    });
+
+    return implode(":", $values);
+}
+
+/* returns true if $dhcp6duid is a valid duid entry */
+function is_duid($dhcp6duid) {
+    $values = explode(":", $dhcp6duid);
+    if (count($values) != 16 || strlen($dhcp6duid) != 47) {
+        return false;
+    }
+    for ($i = 0; $i < 16; $i++) {
+        if (ctype_xdigit($values[$i]) == false)
+            return false;
+        if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+            return false;
+    }
+    return true;
+}
+
+/* Write the DHCP6 DUID file */
+function write_dhcp6_duid($duidstring) {
+    // Create the hex array from the dhcp6duid config entry and write to file
+
+    if(!is_duid($duidstring)) {
+        log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+        return false;
+    }
+    $temp = str_replace(":","",$duidstring);
+    $duid_binstring = pack("H*",$temp);
+    if ($fd = fopen("/var/db//dhcp6c_duid", "wb")) {
+        fwrite($fd, $duid_binstring);
+        fclose($fd);
+        return true;
+    }
+    log_error(gettext("Error: attempting to write DUID file - File write error"));
+    return false;
+}
+
+/* returns duid string from 'vardb_path']}/dhcp6c_duid' */
+function get_duid_from_file() {
+
+    $duid_ASCII = "";
+    $count = 0;
+
+    if (file_exists("/var/db//dhcp6c_duid") &&
+        ($fd = fopen("/var/db/dhcp6c_duid", "r"))) {
+        if(filesize("/var/db//dhcp6c_duid")==16) {
+            $buffer = fread($fd,16);
+            while($count < 16) {
+            $duid_ASCII .= bin2hex($buffer[$count]);
+                $count++;
+                if($count < 16) {
+                    $duid_ASCII .= ":";
+                }
+            }
+        }
+        fclose($fd);
+    }
+    else
+    {
+        log_error(gettext("Error: Could not open /var/db/dhcp6c_duid"));
+    }
+	//if no file or error with read then the string returns blanked DUID string
+    if(!is_duid($duid_ASCII)) {
+        return "--:--:--:--:--:--:--:--:--:--:--:--:--:--:--:--";
+    }
+    return($duid_ASCII);
+}

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -33,12 +33,14 @@ require_once("guiconfig.inc");
 require_once("interfaces.inc");
 require_once("filter.inc");
 require_once("system.inc");
+require_once("util.inc");
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig = array();
     $pconfig['disablechecksumoffloading'] = isset($config['system']['disablechecksumoffloading']);
     $pconfig['disablesegmentationoffloading'] = isset($config['system']['disablesegmentationoffloading']);
     $pconfig['disablelargereceiveoffloading'] = isset($config['system']['disablelargereceiveoffloading']);
+    $pconfig['global-v6duid'] = $config['system']['global-v6duid'];
     if (!isset($config['system']['disablevlanhwfilter'])) {
       $pconfig['disablevlanhwfilter'] = '0';
     } else {
@@ -76,6 +78,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $config['system']['disablevlanhwfilter'] = $pconfig['disablevlanhwfilter'];
     } elseif(isset($config['system']['disablevlanhwfilter'])) {
         unset($config['system']['disablevlanhwfilter']);
+    }
+    
+    if (!empty($_POST['global-v6duid'])) {
+        if (!is_duid($_POST['global-v6duid'])) {
+            $input_errors[] = gettext("A valid DUID must be specified");
+        } else {
+            $config['system']['global-v6duid'] = format_duid($pconfig['global-v6duid']);
+        }      
     }
 
     write_config();
@@ -170,7 +180,35 @@ include("head.inc");
                   </div>
                 </td>
               </tr>
+              <tr>
+                <td width="22%"><strong><?= gettext('DHCP6c DUID') ?></strong></td>
+                <td width="78%" align="right">
+                  <small><?=gettext("full help"); ?> </small>
+                  <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
+                </td>
+              </tr>
+              <tr>
+                  <td><a id="help_for_fixed_DUID" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Fixed DUID"); ?></td>
+                  <td>
+                    <input name="global-v6duid" type="text" id="global-v6duid" value="<?=htmlspecialchars($pconfig['global-v6duid']);?>" />
+                    <div class="hidden" for="help_for_fixed_DUID">
+                      <?= gettext('This field can be used to enter a fixed DUID for use by dhcp6c. The DUID ' .
+                          'may change when the system is rebooted if using RAM disks, it may also change ' .
+                          'when a firmware update takes place. Entering the DUID here will store it in ' .
+                          'in the configuration file.') ?><br />
+<?php
+            
+                      $duid = get_duid_from_file();
+                      if (!empty($duid)):
+?>
+                      <a onclick="document.getElementById('global-v6duid').value='<?= html_safe($duid) ?>';" href="#"><?=gettext("Insert the existing DUID here"); ?></a><br />
+<?php
+                      endif; ?>
+                    </div>
+                  </td>
+                </tr>
             <tr>
+            
               <td>&nbsp;</td>
               <td><input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" /></td>
             </tr>


### PR DESCRIPTION
Allow the user to fix the dhcp6 duid.

The existing DUID may be recalled and stored in the config file or a new DUID may be created.

On the call to function interface_dhcp6_configure the existince of a config variable 'system''global-v6duid' is checked, if it exists then the duid file is written before dhcp6c starts.

The loss of DUID on reboot if using RAM disk or the loss when upgrading or rebuilding is therefore mitigated.

There is just one issue, I cannot get the call 

**$input_errors[] = gettext("A valid DUID must be specified");**

on l**ine 85** of **system_advanced_network.php** to work, missing something, but cannot see what!