### PR TITLE
dhcp6c No Release Option

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3195,10 +3195,13 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
     unset($dhcp6cscript);
     chmod("/var/etc/dhcp6c_{$interface}_script.sh", 0755);
 
+    $noreleaseoption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
+    
     $dhcp6ccommand = exec_safe(
-        "/usr/local/sbin/dhcp6c %s -c %s -p %s %s",
+        "/usr/local/sbin/dhcp6c %s %s -c %s -p %s %s",
         array(
             empty($wancfg['adv_dhcp6_debug']) ? '-d' : '-D',
+            "{$noreleaseoption},
             "/var/etc/dhcp6c_{$interface}.conf",
             "/var/run/dhcp6c_{$wanif}.pid",
             "{$wanif}"

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -363,6 +363,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['dhcp6sendsolicit'] = isset($a_interfaces[$if]['dhcp6sendsolicit']);
     $pconfig['dhcp6prefixonly'] = isset($a_interfaces[$if]['dhcp6prefixonly']);
     $pconfig['dhcp6usev4iface'] = isset($a_interfaces[$if]['dhcp6usev4iface']);
+    $pconfig['dhcp6norelease'] = isset($a_interfaces[$if]['dhcp6norelease']);
     // Due to the settings being split per interface type, we need to copy the settings that use the same
     // config directive.
     $pconfig['staticv6usev4iface'] = $pconfig['dhcp6usev4iface'];
@@ -1078,6 +1079,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     }
                     if (!empty($pconfig['dhcp6usev4iface'])) {
                         $new_config['dhcp6usev4iface'] = true;
+                    }
+                    if (!empty($pconfig['dhcp6norelease'])) {
+                        $new_config['dhcp6norelease'] = true;
                     }
                     $new_config['adv_dhcp6_debug'] = !empty($pconfig['adv_dhcp6_debug']);
                     $new_config['adv_dhcp6_interface_statement_send_options'] = $pconfig['adv_dhcp6_interface_statement_send_options'];
@@ -2524,6 +2528,15 @@ include("head.inc");
                             <input name="dhcp6usev4iface" type="checkbox" id="dhcp6usev4iface" value="yes" <?=!empty($pconfig['dhcp6usev4iface']) ? "checked=\"checked\"" : ""; ?> />
                             <div class="hidden" for="help_for_dhcp6usev4iface">
                               <?=gettext("Request a IPv6 prefix/information through the IPv4 connectivity link"); ?>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td><a id="help_for_dhcp6norelease" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("dhcp6c no release"); ?></td>
+                          <td>
+                            <input name="dhcp6norelease" type="checkbox" id="dhcp6norelease" value="yes" <?=!empty($pconfig['dhcp6norelease']) ? "checked=\"checked\"" : ""; ?> />
+                            <div class="hidden" for="help_for_dhcp6norelease">
+                              <?=gettext("By default, dhcp6c will send a release to the ISP on exit, some ISPs then release the allocated address or prefix. This option prevents that signal from being sent"); ?>
                             </div>
                           </td>
                         </tr>


### PR DESCRIPTION
dhcp6c sends a release signal on exit by default. This can cause the loss of the allocated prefix or address and a new one on the next connection. This is the case with many ISPs especially Sky UK.

This option allows the user to disable the release send.

I added the  -n option to the FreeBSD dhcp6c quite a while back.