### PR TITLE
Dhcp6c use reasons to call rc.newwanipv6

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -291,7 +291,7 @@ function filter_core_rules_system($fw, $defaults)
             );
             $fw->registerFilterRule(1,
               array('protocol' => 'udp', 'from_port' => 546,'to_port' => 547, 'direction' => 'out',
-                    'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr']),
+                    'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr'],'set-prio' => '2'),
               $defaults['pass']
             );
         }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3195,8 +3195,39 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
     }
     unset($dhcp6cconf);
 
+    /* Use the REASONS given by dhcp6c when it calls its script. This then only calls newipv6 when 'REQUEST' is the reason. */
+    /* RENEW, REBIND or INFO do not have changes to the leases, therefore no call to update is needed and this prevents */
+    /* reloading which can affect VPNs etc */
+    $debugOption = isset($wancfg['adv_dhcp6_debug']) ? "-D" : "-d";
+    $noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
     $dhcp6cscript = "#!/bin/sh\n";
+    $dhcp6cscript .= "case \$REASON in\n";
+    $dhcp6cscript .= "REQUEST)\n";
     $dhcp6cscript .= "/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
+    if ($debugOption == '-D') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c REQUEST on {$wanif} - running rc.newwanipv6\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "REBIND)\n";
+    if ($debugOption == '-D') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c rebind on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    if (isset($wancfg['dhcp6norelease'])) {
+        $dhcp6cscript .= "EXIT)\n";
+    } else {
+        $dhcp6cscript .= "RELEASE)\n";
+    }
+    if ($debugOption == '-D') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c EXIT or RELEASE on {$wanif} running rc.newwanipv6\"\n";
+    }
+    $dhcp6cscript .= "/usr/local/sbin/fcgicli -f /etc/rc.newwanipv6 -d \"interface={$wanif}&dmnames=\${dmnames}&dmips=\${dmips}\"\n";
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "RENEW|INFO)\n";
+    if ($debugOption == '-D') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c renew, no change - bypassing update on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= "esac\n";
 
     if (!@file_put_contents("/var/etc/dhcp6c_{$interface}_script.sh", $dhcp6cscript)) {
         printf("Error: cannot open dhcp6c_{$interface}_script.sh in interface_dhcpv6_configure() for writing.\n");

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -115,6 +115,7 @@ function get_default_sysctl_value($id)
         "net.route.netisr_maxqlen" => 1024,
         "net.inet.icmp.reply_from_interface" => 1,
         "vfs.read_max" => "32",
+        "net.link.vlan.mtag_pcp" => "1",
     );
 
     if (isset($sysctls[$id])) {


### PR DESCRIPTION
RENEW, REBIND or INFO do not make changes to the leases, therefore no call to newwanipv6 is needed and this prevents reloading which can affect VPNs etc.

RELEASE or EXIT should call newwanipv6 as the lease has been removed from the interface.

The REASONS env was added to freebsd/dhcp6c several months ago.