### PR TITLE
DHCP6c Uses REASONS to call newipv6

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3195,8 +3195,38 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
     }
     unset($dhcp6cconf);
 
+    /* Use the REASONS given by dhcp6c when it calls its script. This then only calls newipv6 when 'REQUEST' is the reason. */
+    /* RENEW, REBIND or INFO do not have changes to the leases, therefore no call to update is needed and this prevents */
+    /* reloading which can affect VPNs etc */
+
     $dhcp6cscript = "#!/bin/sh\n";
+    $dhcp6cscript .= "case \$REASON in\n";
+    $dhcp6cscript .= "REQUEST)\n";
     $dhcp6cscript .= "/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
+    if (empty($wancfg['adv_dhcp6_debug') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c REQUEST on {$wanif} - running newipv6\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "REBIND)\n";
+    if (empty($wancfg['adv_dhcp6_debug') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c rebind on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    if (isset($wancfg['dhcp6norelease'])) {
+        $dhcp6cscript .= "EXIT)\n";
+    } else {
+        $dhcp6cscript .= "RELEASE)\n";
+    }
+    if (empty($wancfg['adv_dhcp6_debug') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c EXIT or RELEASE on {$wanif} running newipv6\"\n";
+    }
+    $dhcp6cscript .= "/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "RENEW|INFO)\n";
+    if ($debugOption == '-D') {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c renew, no change - bypassing update on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= "esac\n";
 
     if (!@file_put_contents("/var/etc/dhcp6c_{$interface}_script.sh", $dhcp6cscript)) {
         printf("Error: cannot open dhcp6c_{$interface}_script.sh in interface_dhcpv6_configure() for writing.\n");

--- a/src/www/diag_packet_capture.php
+++ b/src/www/diag_packet_capture.php
@@ -422,10 +422,10 @@ include("fbegin.inc");
                     <td><a id="help_for_detail" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Level of Detail");?></td>
                     <td>
                       <select name="detail" class="selectpicker" id="detail">
-                        <option value="normal"><?=gettext("Normal");?></option>
-                        <option value="medium"><?=gettext("Medium");?></option>
-                        <option value="high"><?=gettext("High");?></option>
-                        <option value="full"><?=gettext("Full");?></option>
+                        <option value="normal" <?=$pconfig['detail'] == 'normal' ?  "selected=\"selected\"" : "";?> ><?=gettext("Normal");?></option>
+                        <option value="medium" <?=$pconfig['detail'] == 'medium' ?  "selected=\"selected\"" : "";?> ><?=gettext("Medium");?></option>
+                        <option value="high" <?=$pconfig['detail'] == 'high' ?  "selected=\"selected\"" : "";?> ><?=gettext("High");?></option>
+                        <option value="full" <?=$pconfig['detail'] == 'full' ?  "selected=\"selected\"" : "";?> ><?=gettext("Full");?></option>
                       </select>
                       <div class="hidden" for="help_for_detail">
                         <?=gettext("This is the level of detail that will be displayed after hitting 'Stop' when the packets have been captured.") .  "<br /><b>" .


### PR DESCRIPTION
Use the REASONS given by dhcp6c when it calls its script. This then only calls newipv6 when 'REQUEST' is the reason.

RENEW, REBIND or INFO do not have changes to the leases, therefore no call to update is needed and this prevents reloading which can affect VPNs etc.