### PR TITLE
dhcp6c - Use Reasons

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3196,7 +3196,33 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
     unset($dhcp6cconf);
 
     $dhcp6cscript = "#!/bin/sh\n";
+    $dhcp6cscript .= "case \$REASON in\n";
+    $dhcp6cscript .= "REQUEST)\n";
     $dhcp6cscript .= "/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
+    if (isset($wancfg['adv_dhcp6_debug'])) {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c REQUEST on {$wanif} - running newipv6\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "REBIND)\n";
+    if (!empty($wancfg['adv_dhcp6_debug'])) {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c rebind on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= ";;\n";
+    if (!empty($wancfg['dhcp6norelease'])) {
+        $dhcp6cscript .= "EXIT)\n";
+    } else {
+        $dhcp6cscript .= "RELEASE)\n";
+    }
+    if (!empty($wancfg['adv_dhcp6_debug'])) {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c EXIT or RELEASE on {$wanif} running newipv6\"\n";
+    }
+    $dhcp6cscript .= "/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
+    $dhcp6cscript .= ";;\n";
+    $dhcp6cscript .= "RENEW|INFO)\n";
+    if (!empty($wancfg['adv_dhcp6_debug'])) {
+        $dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c renew, no change - bypassing update on {$wanif}\"\n";
+    }
+    $dhcp6cscript .= "esac\n";
 
     if (!@file_put_contents("/var/etc/dhcp6c_{$interface}_script.sh", $dhcp6cscript)) {
         printf("Error: cannot open dhcp6c_{$interface}_script.sh in interface_dhcpv6_configure() for writing.\n");


### PR DESCRIPTION
Use the REASONS given by dhcp6c when it calls its script. This then only calls newipv6 when 'REQUEST' is the reason.

RENEW, REBIND or INFO do not have changes to the leases, therefore no call to update is needed and this prevents reloading which can affect VPNs, Unbound etc.

On RELEASE or EXIT, once again newipv6 is called as the lease addresses should have been removed by dhcp6c.
