### PR TITLE
DHCPv6 Vlan priority

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -289,11 +289,20 @@ function filter_core_rules_system($fw, $defaults)
                     'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr']),
               $defaults['pass']
             );
-            $fw->registerFilterRule(1,
-              array('protocol' => 'udp', 'from_port' => 546,'to_port' => 547, 'direction' => 'out',
-                    'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr']),
-              $defaults['pass']
-            );
+            /* Allow set-prio for dhcp6 packets */
+            if(isset($intfinfo['dhcp6enablevlanprio'])) {
+                $fw->registerFilterRule(1,
+                  array('protocol' => 'udp', 'from_port' => 546,'to_port' => 547, 'direction' => 'out',
+                        'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr'], 'set-prio' => $intfinfo['dhcp6c_pcp']),
+                  $defaults['pass']
+                );
+            } else {
+                $fw->registerFilterRule(1,
+                  array('protocol' => 'udp', 'from_port' => 546,'to_port' => 547, 'direction' => 'out',
+                        'interface' => $intf, 'label' =>'allow dhcpv6 client in ' . $intfinfo['descr']),
+                  $defaults['pass']
+                );
+            }
         }
         // IPv4
         switch (empty($intfinfo['ipaddr']) ? "" : $intfinfo['ipaddr']) {

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -364,10 +364,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['dhcp6prefixonly'] = isset($a_interfaces[$if]['dhcp6prefixonly']);
     $pconfig['dhcp6usev4iface'] = isset($a_interfaces[$if]['dhcp6usev4iface']);
     $pconfig['dhcp6norelease'] = isset($a_interfaces[$if]['dhcp6norelease']);
+    $pconfig['dhcp6enablevlanprio'] = isset($a_interfaces[$if]['dhcp6enablevlanprio']);
+    $pconfig['dhcp6c_pcp'] = isset($a_vlans[$id]['dhcp6c_pcp']) ? $a_vlans[$id]['dhcp6c_pcp'] : 0;
     // Due to the settings being split per interface type, we need to copy the settings that use the same
     // config directive.
     $pconfig['staticv6usev4iface'] = $pconfig['dhcp6usev4iface'];
     $pconfig['adv_dhcp6_debug'] = isset($a_interfaces[$if]['adv_dhcp6_debug']);
+    $pconfig['dhcp6c_pcp'] = isset($a_interfaces[$if]['dhcp6c_pcp']) ? $a_interfaces[$if]['dhcp6c_pcp'] : 0;
     $pconfig['track6-prefix-id--hex'] = sprintf("%x", empty($pconfig['track6-prefix-id']) ? 0 :$pconfig['track6-prefix-id']);
 
     // ipv4 type (from ipaddr)
@@ -1083,7 +1086,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (!empty($pconfig['dhcp6norelease'])) {
                         $new_config['dhcp6norelease'] = true;
                     }
+                    if (!empty($pconfig['dhcp6enablevlanprio'])) {
+                        $new_config['dhcp6enablevlanprio'] = true;
+                    }
                     $new_config['adv_dhcp6_debug'] = !empty($pconfig['adv_dhcp6_debug']);
+                    $new_config['dhcp6c_pcp'] = $pconfig['dhcp6c_pcp'];
                     $new_config['adv_dhcp6_interface_statement_send_options'] = $pconfig['adv_dhcp6_interface_statement_send_options'];
                     $new_config['adv_dhcp6_interface_statement_request_options'] = $pconfig['adv_dhcp6_interface_statement_request_options'];
                     $new_config['adv_dhcp6_interface_statement_information_only_enable'] = $pconfig['adv_dhcp6_interface_statement_information_only_enable'];
@@ -2538,6 +2545,29 @@ include("head.inc");
                             </div>
                           </td>
                         </tr>
+                        <tr>
+                          <td><a id="help_for_dhcp6cenablevlanprio" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable dhcp6 vlan priority"); ?></td>
+                          <td>
+                            <input name="dhcp6enablevlanprio" type="checkbox" id="dhcp6enablevlanprio" value="yes" <?= !empty($pconfig['dhcp6enablevlanprio']) ? 'checked="checked"' : '' ?> />
+                            <div class="hidden" for="help_for_dhcp6cenablevlanprio">
+                              <?=gettext("Certain ISPs require that dhcp6 requests are sent with a different vlan priority."); ?>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                    <td><a id="help_for_dhcp6c_pcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("dhcp6c VLAN priority");?></td>
+                    <td>
+                      <select name="dhcp6c_pcp">
+<? foreach (interfaces_vlan_priorities() as $dhcp6c_pcp => $priority): ?>
+                        <option value="<?=$dhcp6c_pcp;?>"<?=($pconfig['dhcp6c_pcp'] == $dhcp6c_pcp ? ' selected="selected"' : '');?>><?=htmlspecialchars($priority);?></option>
+<? endforeach ?>
+                      </select>
+                      <div class="hidden" for="help_for_dhcp6c_pcp">
+                        <?=gettext('802.1Q VLAN PCP (priority code point)');?>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
                         <tr>
                             <td><a id="help_for_dhcp6_debug" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable debug"); ?></td>
                             <td>


### PR DESCRIPTION
Certain ISP's, Orange France for example use a VLAN, it is a requirement that the dhcpv6 packets are sent with a different priority, in Orange Frances case it is 6.

This PR allows the user to select whether or not to enable the setting of the VLAN priority for dhcpv6 packets and the value to use.

The is then used in the filter.lib.inc to add the extra set-prio value when the fillter is created.

This PR requires the the sysctl net.link.vlan.mtag_pcp be set to 1.