### PR TITLE
Eliminate 300 ms Tap Delay

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -121,6 +121,7 @@ html, body{
 }
 
 body{
+  touch-action: manipulation;
   min-width: 320px;
 }
 

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -5482,6 +5482,7 @@ html, body {
   font-family: 'SourceSansProRegular'; }
 
 body {
+  touch-action: manipulation;
   min-width: 320px; }
 
 .page-head {


### PR DESCRIPTION
Implement touch-action: manipulation CSS property to eliminate 300 ms tap delay.

Does not prevent zoom.  Zoom still available by pinch.  Only prevents double tap zoom in order to eliminate the 300 ms tap delay.

What Exactly Is..... The 300ms Click Delay
https://www.telerik.com/blogs/what-exactly-is.....-the-300ms-click-delay

Mozilla developers page.  Updated Oct 25, 2017.
https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action

W3C Recommendation - The touch-action CSS property
http://www.w3.org/TR/pointerevents/#the-touch-action-css-property