### PR TITLE
Allow input fields to be rendered as readonly

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -90,6 +90,7 @@ label           :   dialog label
                             {% set maxheight=false %}
                             {% set width=false %}
                             {% set allownew=false %}
+                            {% set readonly=false %}
                             {% if field['type'] == 'header' %}
                               {# close table and start new one with header #}
 

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -77,6 +77,7 @@ data_title      :   data-title to set on form
             {% set maxheight=false %}
             {% set width=false %}
             {% set allownew=false %}
+            {% set readonly=false %}
             {% if field['type'] == 'header' %}
               {# close table and start new one with header #}
 

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -38,6 +38,7 @@ style       :   css class to add
 maxheight   :   maximum height in rows if applicable
 width       :   width in pixels if applicable
 allownew    :   allow new items (for list) if applicable
+readonly    :   if true, then textareas (textboxes) will be readonly
 
 #}
 
@@ -65,7 +66,7 @@ allownew    :   allow new items (for list) if applicable
         {% elseif type == "password" %}
             <input type="password" class="form-control" size="{{size|default("50")}}" id="{{ id }}" >
         {% elseif type == "textbox" %}
-            <textarea rows="{{height|default("5")}}" id="{{ id }}"></textarea>
+            <textarea rows="{{height|default("5")}}" id="{{ id }}" {{ readonly ? 'readonly' : '' }}></textarea>
         {% elseif type == "info" %}
             <span id="{{ id }}" ></span>
         {% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -38,7 +38,7 @@ style       :   css class to add
 maxheight   :   maximum height in rows if applicable
 width       :   width in pixels if applicable
 allownew    :   allow new items (for list) if applicable
-readonly    :   if true, then textareas (textboxes) will be readonly
+readonly    :   if true, input fields will be readonly
 
 #}
 
@@ -55,7 +55,7 @@ readonly    :   if true, then textareas (textboxes) will be readonly
     </td>
     <td >
         {% if type == "text" %}
-            <input type="text" class="form-control" size="{{size|default("50")}}" id="{{ id }}" >
+            <input type="text" class="form-control" size="{{size|default("50")}}" id="{{ id }}" {{ readonly ?  'readonly' : '' }} >
         {% elseif type == "checkbox"  %}
             <input type="checkbox" id="{{ id }}" >
         {% elseif type == "select_multiple" %}
@@ -64,7 +64,7 @@ readonly    :   if true, then textareas (textboxes) will be readonly
         {% elseif type == "dropdown" %}
             <select {% if size|default(false) %}size="{{size}}"{% endif %}  id="{{ id }}" class="{{style|default('selectpicker')}}"  data-width="{{width|default("348px")}}"></select>
         {% elseif type == "password" %}
-            <input type="password" class="form-control" size="{{size|default("50")}}" id="{{ id }}" >
+            <input type="password" class="form-control" size="{{size|default("50")}}" id="{{ id }}"  {{ readonly ?  'readonly' : '' }} >
         {% elseif type == "textbox" %}
             <textarea rows="{{height|default("5")}}" id="{{ id }}" {{ readonly ? 'readonly' : '' }}></textarea>
         {% elseif type == "info" %}


### PR DESCRIPTION
Hi,

Allow input fields to be rendered as readonly. This helps when displaying data in a form (to adhere to the form layout of the other input elements), but clearly mark it as readonly so modifications are not allowed.

-=david=-