### PR TITLE
dhcp6 Client Adanced Options - Enter Prefix Interface Name

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3355,7 +3355,7 @@ function DHCP6_Config_File_Advanced($interface, $wancfg, $wanif)
 
         if (is_numeric($wancfg['adv_dhcp6_prefix_interface_statement_sla_id'])) {
             $id_assoc_statement_prefix .= "\n\tprefix-interface";
-            $id_assoc_statement_prefix .= " {$wanif}";
+            $id_assoc_statement_prefix .= " {$wancfg['adv_dhcp6_prefix_selected_interface']}";
             $id_assoc_statement_prefix .= " {\n";
             $id_assoc_statement_prefix .= "\t\tsla-id {$wancfg['adv_dhcp6_prefix_interface_statement_sla_id']};\n";
             if (($wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] >= 0) &&

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3132,44 +3132,49 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
         $dhcp6cconf .= "};\n";
     } else {
         /* skip address request if this is set */
-        if (!isset($wancfg['dhcp6prefixonly'])) {
-            $dhcp6cconf .= "  send ia-na 0;   # request stateful address\n";
-        }
-        if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
-            $dhcp6cconf .= "  send ia-pd 0;  # request prefix delegation\n";
+        $iflist = link_interface_to_track6($interface);
+        $count = 0;
+        foreach ($iflist as $friendly => $ifcfg) {
+            if (!isset($wancfg['dhcp6prefixonly'])) {
+              $dhcp6cconf .= "  send ia-na {$count};   # request stateful address\n";
+            }
+            if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
+              $dhcp6cconf .= "  send ia-pd {$count};  # request prefix delegation\n";
+            }
+         ++$count;
         }
 
         $dhcp6cconf .= "\trequest domain-name-servers;\n";
         $dhcp6cconf .= "\trequest domain-name;\n";
         $dhcp6cconf .= "\tscript \"/var/etc/dhcp6c_{$interface}_script.sh\"; # we'd like some nameservers please\n";
-
         $dhcp6cconf .= "};\n";
 
-        if (!isset($wancfg['dhcp6prefixonly'])) {
-            $dhcp6cconf .= "id-assoc na 0 { };\n";
-        }
-
-        if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
-            /* Setup the prefix delegation */
-            $dhcp6cconf .= "id-assoc pd 0 {\n";
-            $preflen = 64 - $wancfg['dhcp6-ia-pd-len'];
-            if (isset($wancfg['dhcp6-ia-pd-send-hint'])) {
-                $dhcp6cconf .= "  prefix ::/{$preflen} infinity;\n";
+        $count = 0;
+        foreach ($iflist as $friendly => $ifcfg) {
+            if (!isset($wancfg['dhcp6prefixonly'])) {
+                $dhcp6cconf .= "id-assoc na {$count} { };\n";
             }
-            $iflist = link_interface_to_track6($interface);
-            foreach ($iflist as $friendly => $ifcfg) {
-                if (is_numeric($ifcfg['track6-prefix-id'])) {
-                    $realif = get_real_interface($friendly);
-                    $dhcp6cconf .= "  prefix-interface {$realif} {\n";
-                    $dhcp6cconf .= "    sla-id {$ifcfg['track6-prefix-id']};\n";
-                    $dhcp6cconf .= "    sla-len {$wancfg['dhcp6-ia-pd-len']};\n";
-                    $dhcp6cconf .= "  };\n";
+            if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
+                /* Setup the prefix delegation */
+                $dhcp6cconf .= "id-assoc pd {$count} {\n";
+                $preflen = 64 - $wancfg['dhcp6-ia-pd-len'];
+                if (isset($wancfg['dhcp6-ia-pd-send-hint'])) {
+                    $dhcp6cconf .= "  prefix ::/{$preflen} infinity;\n";
                 }
             }
-            unset($preflen, $iflist, $ifcfg);
+            if (is_numeric($ifcfg['track6-prefix-id'])) {
+                $realif = get_real_interface($friendly);
+                $dhcp6cconf .= "  prefix-interface {$realif} {\n";
+                $dhcp6cconf .= "    sla-id 0;\n";
+                $dhcp6cconf .= "    sla-len {$wancfg['dhcp6-ia-pd-len']};\n";
+                $dhcp6cconf .= "  };\n";
+            }
             $dhcp6cconf .= "};\n";
+            ++$count;
         }
+        unset($preflen, $iflist, $ifcfg);
     }
+
 
     // DHCP6 Config File Advanced
     if ($wancfg['adv_dhcp6_config_advanced']) {
@@ -3354,8 +3359,9 @@ function DHCP6_Config_File_Advanced($interface, $wancfg, $wanif)
         }
 
         if (is_numeric($wancfg['adv_dhcp6_prefix_interface_statement_sla_id'])) {
+            $ad_if = get_real_interface($wancfg['adv_dhcp6_prefix_selected_interface']);
             $id_assoc_statement_prefix .= "\n\tprefix-interface";
-            $id_assoc_statement_prefix .= " {$wancfg['adv_dhcp6_prefix_selected_interface']}";
+            $id_assoc_statement_prefix .= " {$ad_if}";
             $id_assoc_statement_prefix .= " {\n";
             $id_assoc_statement_prefix .= "\t\tsla-id {$wancfg['adv_dhcp6_prefix_interface_statement_sla_id']};\n";
             if (($wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] >= 0) &&

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -2625,8 +2625,25 @@ include("head.inc");
                         <tr class="dhcpv6_advanced">
                           <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Prefix Interface");?></td>
                           <td>
-                            <i><?=gettext("Prefix Interface name ( real \"igb1\" - \"em1\" etc )"); ?></i>
-                            <input name="adv_dhcp6_prefix_selected_interface" type="text" id="adv_dhcp6_prefix_selected_interface" value="<?=$pconfig['adv_dhcp6_prefix_selected_interface'];?>" />
+                            <select name='adv_dhcp6_prefix_selected_interface' class='selectpicker' data-style='btn-default' >
+<?php
+                            foreach (get_configured_interface_with_descr(false, true) as $iface => $ifacename):
+                              switch($config['interfaces'][$iface]['ipaddrv6']) {
+                                case "track6":
+                                    break;
+                                default:
+                                    continue 2;
+                              }?>
+                                <option value="<?=$iface;?>" <?=$iface == $pconfig['adv_dhcp6_prefix_selected_interface'] ? " selected=\"selected\"" : "";?>>
+                                    <?= htmlspecialchars($ifacename);?>
+                                </option>
+<?php
+                            endforeach;?>
+                            </select>
+                          </td>
+                        <tr class="dhcpv6_advanced">
+                          <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Prefix Interface");?></td>
+                          <td>
                             <i><?=gettext("Site-Level Aggregation Identifier"); ?></i>
                             <input name="adv_dhcp6_prefix_interface_statement_sla_id" type="text" id="adv_dhcp6_prefix_interface_statement_sla_id" value="<?=$pconfig['adv_dhcp6_prefix_interface_statement_sla_id'];?>" />
                             <i><?=gettext("Site-Level Aggregation Length"); ?></i>

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -344,7 +344,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       "adv_dhcp6_id_assoc_statement_prefix_enable", "adv_dhcp6_id_assoc_statement_prefix", "adv_dhcp6_id_assoc_statement_prefix_id",
       "adv_dhcp6_id_assoc_statement_prefix_pltime", "adv_dhcp6_id_assoc_statement_prefix_vltime",
       "adv_dhcp6_prefix_interface_statement_sla_id", "adv_dhcp6_prefix_interface_statement_sla_len",
-      "adv_dhcp6_authentication_statement_authname", "adv_dhcp6_authentication_statement_protocol", "adv_dhcp6_authentication_statement_algorithm",
+      "adv_dhcp6_authentication_statement_authname", "adv_dhcp6_authentication_statement_protocol", "adv_dhcp6_authentication_statement_algorithm", "adv_dhcp6_prefix_selected_interface",
       "adv_dhcp6_authentication_statement_rdm", "adv_dhcp6_key_info_statement_keyname", "adv_dhcp6_key_info_statement_realm",
       "adv_dhcp6_key_info_statement_keyid", "adv_dhcp6_key_info_statement_secret", "adv_dhcp6_key_info_statement_expire",
       "adv_dhcp6_config_advanced", "adv_dhcp6_config_file_override", "adv_dhcp6_config_file_override_path",
@@ -1100,6 +1100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $new_config['adv_dhcp6_id_assoc_statement_prefix_vltime'] = $pconfig['adv_dhcp6_id_assoc_statement_prefix_vltime'];
                     $new_config['adv_dhcp6_prefix_interface_statement_sla_id'] = $pconfig['adv_dhcp6_prefix_interface_statement_sla_id'];
                     $new_config['adv_dhcp6_prefix_interface_statement_sla_len'] = $pconfig['adv_dhcp6_prefix_interface_statement_sla_len'];
+                    $new_config['adv_dhcp6_prefix_selected_interface'] = $pconfig['adv_dhcp6_prefix_selected_interface'];
                     $new_config['adv_dhcp6_authentication_statement_authname'] = $pconfig['adv_dhcp6_authentication_statement_authname'];
                     $new_config['adv_dhcp6_authentication_statement_protocol'] = $pconfig['adv_dhcp6_authentication_statement_protocol'];
                     $new_config['adv_dhcp6_authentication_statement_algorithm'] = $pconfig['adv_dhcp6_authentication_statement_algorithm'];
@@ -2624,7 +2625,8 @@ include("head.inc");
                         <tr class="dhcpv6_advanced">
                           <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Prefix Interface");?></td>
                           <td>
-                            <?=gettext("Prefix Interface "); ?>
+                            <i><?=gettext("Prefix Interface name ( real \"igb1\" - \"em1\" etc )"); ?></i>
+                            <input name="adv_dhcp6_prefix_selected_interface" type="text" id="adv_dhcp6_prefix_selected_interface" value="<?=$pconfig['adv_dhcp6_prefix_selected_interface'];?>" />
                             <i><?=gettext("Site-Level Aggregation Identifier"); ?></i>
                             <input name="adv_dhcp6_prefix_interface_statement_sla_id" type="text" id="adv_dhcp6_prefix_interface_statement_sla_id" value="<?=$pconfig['adv_dhcp6_prefix_interface_statement_sla_id'];?>" />
                             <i><?=gettext("Site-Level Aggregation Length"); ?></i>


### PR DESCRIPTION
Currently, when using Advanced for dhcp6 client, the config file has the real WAN name as the interface on which the prefix will be applied, this needs to be a LAN ( real ) interface. Simply enter the interface name.

No error checking is carried out as this is already in an advanced selection.