### PR TITLE
HTML Compliance - Element <button> Descendant of <a> Element

### DIFF
--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -739,8 +739,8 @@ include("head.inc");
                               <td><?=htmlspecialchars($poolent['range']['to']);?></td>
                               <td><?=htmlspecialchars($poolent['descr']);?></td>
                               <td>
-                                <a href="services_dhcp.php?if=<?=$if;?>&amp;pool=<?=$i;?>"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-pencil"></span></button></a>
-                                <a href="#" data-if="<?=$if;?>" data-id="<?=$i;?>" class="act_delete_pool"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                                <a href="services_dhcp.php?if=<?=$if;?>&amp;pool=<?=$i;?>" class="btn btn-xs btn-default"><i class="fa fa-pencil"></i></a>
+                                <a href="#" data-if="<?=$if;?>" data-id="<?=$i;?>" class="act_delete_pool btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                               </td>
                             </tr>
 <?php
@@ -1130,7 +1130,7 @@ include("head.inc");
                       </td>
                       <td>
                         <a href="services_dhcp_edit.php?if=<?=htmlspecialchars($if);?>&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a href="#" data-if="<?=$if;?>" data-id="<?=$i;?>" class="act_delete_static"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                        <a href="#" data-if="<?=$if;?>" data-id="<?=$i;?>" class="act_delete_static btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                       </td>
                     </tr>
 <?php

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -442,7 +442,7 @@ $( document ).ready(function() {
                   <td><?=htmlspecialchars($hostent['descr']);?></td>
                   <td>
                     <a href="services_dnsmasq_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                    <a href="#" data-id="<?=$i;?>" class="act_delete_host"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                    <a href="#" data-id="<?=$i;?>" class="act_delete_host btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                   </td>
                 </tr>
 <?php
@@ -508,7 +508,7 @@ $( document ).ready(function() {
                     <a href="services_dnsmasq_domainoverride_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs">
                       <span class="glyphicon glyphicon-pencil"></span>
                     </a>
-                    <a href="#" data-id="<?=$i;?>" class="act_delete_override"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                    <a href="#" data-id="<?=$i;?>" class="act_delete_override btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                   </td>
                 </tr>
 <?php

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -397,7 +397,7 @@ include("head.inc");
                     </td>
                     <td>
                       <a href="services_unbound_acls.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                      <a href="#" data-id="<?=$i;?>" class="act_delete_acl"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                      <a href="#" data-id="<?=$i;?>" class="act_delete_acl btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                     </td>
                   </tr>
 <?php

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -185,7 +185,7 @@ include_once("head.inc");
                         <td><?=$hostent['descr'];?></td>
                         <td>
                           <a href="services_unbound_host_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                          <a href="#" data-id="<?=$i;?>" class="act_delete_host"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                          <a href="#" data-id="<?=$i;?>" class="act_delete_host btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                         </td>
                       </tr>
 <?php
@@ -236,7 +236,7 @@ include_once("head.inc");
                         <td><?=htmlspecialchars($doment['descr']);?></td>
                         <td>
                           <a href="services_unbound_domainoverride_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                          <a href="#" data-id="<?=$i;?>" class="act_delete_override"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                          <a href="#" data-id="<?=$i;?>" class="act_delete_override btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                         </td>
                       </tr>
 <?php


### PR DESCRIPTION
Error: The element button must not appear as a descendant of the a element.

Specification:
http://w3c.github.io/html/textlevel-semantics.html#the-a-element
"Allowed ARIA role attribute values: link (default - do not set), button, checkbox, radio, switch, tab or treeitem"
"The <a> element may be wrapped around entire paragraphs, lists, tables, and so forth, even entire sections, so long as there is no interactive content within (e.g., buttons or other links)."