### PR TITLE
HTML Compliance - Obsolete table attributes

### DIFF
--- a/src/www/diag_authentication.php
+++ b/src/www/diag_authentication.php
@@ -78,8 +78,8 @@ include("head.inc");
             <table class="table table-striped opnsense_standard_table_form">
               <tbody>
                 <tr>
-                  <td width="22%"><?=gettext("Authentication Server"); ?></td>
-                  <td width="78%">
+                  <td style="width:22%"><?=gettext("Authentication Server"); ?></td>
+                  <td style="width:78%">
                     <select name="authmode" id="authmode" class="form-control" >
 <?php
                     foreach (auth_get_authserver_list() as $auth_server_id => $auth_server):?>
@@ -92,16 +92,16 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <td width="22%"><?=gettext("Username"); ?></td>
-                  <td width="78%"><input type="text" name="username" value="<?=htmlspecialchars($pconfig['username']);?>"></td>
+                  <td style="width:22%"><?=gettext("Username"); ?></td>
+                  <td style="width:78%"><input type="text" name="username" value="<?=htmlspecialchars($pconfig['username']);?>"></td>
                 </tr>
                 <tr>
-                  <td width="22%"><?=gettext("Password"); ?></td>
-                  <td width="78%"><input type="password" name="password" value="<?=htmlspecialchars($pconfig['password']);?>"></td>
+                  <td style="width:22%"><?=gettext("Password"); ?></td>
+                  <td style="width:78%"><input type="password" name="password" value="<?=htmlspecialchars($pconfig['password']);?>"></td>
                 </tr>
                 <tr>
-                  <td width="22%">&nbsp;</td>
-                  <td width="78%"><input id="save" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Test");?>" /></td>
+                  <td style="width:22%">&nbsp;</td>
+                  <td style="width:78%"><input id="save" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Test");?>" /></td>
                 </tr>
               </tbody>
             </table>

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -345,7 +345,7 @@ $( document ).ready(function() {
             <table class="table table-striped ">
               <tbody>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic">
+                  <th colspan="2" style="vertical-align:top" class="listtopic">
                     <?=gettext("Download"); ?>
                   </th>
                 </tr>
@@ -386,7 +386,7 @@ $( document ).ready(function() {
             <table class="table table-striped ">
               <tbody>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic">
+                  <th colspan="2" style="vertical-align:top" class="listtopic">
                     <?=gettext("Restore"); ?>
                   </th>
                 </tr>
@@ -443,7 +443,7 @@ $( document ).ready(function() {
               </thead>
               <tbody>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic">
+                  <th colspan="2" style="vertical-align:top" class="listtopic">
                     <?=gettext("Google Drive"); ?>
                   </th>
                 </tr>

--- a/src/www/diag_confbak.php
+++ b/src/www/diag_confbak.php
@@ -204,7 +204,7 @@ $( document ).ready(function() {
             <div class="content-box tab-content table-responsive __mb">
               <table class="table table-striped">
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Backup Count"); ?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Backup Count"); ?></th>
                 </tr>
                 <tr>
                   <td><input name="backupcount" type="text" class="formfld unknown" size="5" value="<?=htmlspecialchars($pconfig['backupcount']);?>"/></td>
@@ -228,7 +228,7 @@ $( document ).ready(function() {
           <div class="content-box tab-content table-responsive __mb" style="overflow: scroll;">
             <table class="table table-striped">
               <tr>
-                <th colspan="2" valign="top" class="listtopic">
+                <th colspan="2" style="vertical-align:top" class="listtopic">
                   <?= sprintf(
                         gettext('Configuration diff from %s to %s'),
                         date(gettext('n/j/y H:i:s'), $oldtime),

--- a/src/www/diag_logs_settings.php
+++ b/src/www/diag_logs_settings.php
@@ -328,8 +328,8 @@ $(document).ready(function() {
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?=gettext("Local Logging Options");?></strong></td>
-                    <td  width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Local Logging Options");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -431,8 +431,8 @@ $(document).ready(function() {
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><strong><?=gettext("Remote Logging Options");?></strong></td>
-                      <td  width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("Remote Logging Options");?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/src/www/diag_packet_capture.php
+++ b/src/www/diag_packet_capture.php
@@ -299,8 +299,8 @@ include("fbegin.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("Packet capture");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Packet capture");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;

--- a/src/www/diag_sockets.php
+++ b/src/www/diag_sockets.php
@@ -67,7 +67,7 @@ $showAllOption = $showAll ? "" : "?showAll";
           <header class="content-box-head container-fluid">
             <h3><a name="<?=$name;?>"></a><?=$name;?></h3>
           </header>
-         <table class="table table-striped" id="IPv4" summary="ipv4 routes">
+         <table class="table table-striped" id="IPv4">
             <?php
               foreach (explode("\n", $table) as $i => $line) {
                 if (trim($line) == "") {
@@ -107,7 +107,7 @@ $showAllOption = $showAll ? "" : "?showAll";
                                     'The information listed for each socket is:'),'<br />','<br />','<br />') ?></p>
           </div>
 
-          <table class="table table-striped" id="IPv4" summary="ipv4 routes">
+          <table class="table table-striped" id="IPv4">
           <tr><td>USER</td><td><?= gettext('The user who owns the socket.') ?></td></tr>
           <tr><td>COMMAND</td><td><?= gettext('The command which holds the socket.') ?></td></tr>
           <tr><td>PID</td><td><?= gettext('The process ID of the command which holds the socket.') ?></td></tr>

--- a/src/www/diag_testport.php
+++ b/src/www/diag_testport.php
@@ -127,8 +127,8 @@ include("head.inc"); ?>
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%"><strong><?=gettext("Test Port"); ?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("Test Port"); ?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;

--- a/src/www/firewall_aliases_edit.php
+++ b/src/www/firewall_aliases_edit.php
@@ -536,8 +536,8 @@ include("head.inc");
             <form method="post" name="iform" id="iform">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=gettext("Alias Edit");?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext("Alias Edit");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/firewall_aliases_import.php
+++ b/src/www/firewall_aliases_import.php
@@ -170,8 +170,8 @@ include("head.inc");
             <form method="post" name="iform">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=gettext("Alias Import");?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext("Alias Import");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
@@ -202,8 +202,8 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <td width="22%"><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Name') ?></td>
-                  <td width="78%">
+                  <td style="width:22%"><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Name') ?></td>
+                  <td style="width:78%">
                     <input name="name" type="text" class="form-control unknown" size="40" maxlength="31" value="<?=$pconfig['name'];?>" />
                     <div class="hidden" for="help_for_name">
                       <?=gettext("The name of the alias may only consist of the characters \"a-z, A-Z and 0-9\"."); ?>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -247,9 +247,9 @@ $( document ).ready(function() {
                       <td colspan="2"> </td>
                     </tr>
                     <tr>
-                      <th width="2%"><input type="checkbox" id="selectAll"></th>
-                      <th width="2%">&nbsp;</th>
-                      <th width="2%">&nbsp;</th>
+                      <th style="width:2%"><input type="checkbox" id="selectAll"></th>
+                      <th style="width:2%">&nbsp;</th>
+                      <th style="width:2%">&nbsp;</th>
                       <th><?=gettext("If");?></th>
                       <th><?=gettext("Proto");?></th>
                       <th class="hidden-xs hidden-sm"><?=gettext("Address");?></th>
@@ -461,7 +461,7 @@ $( document ).ready(function() {
                       <td colspan="13">&nbsp;</td>
                     </tr>
                     <tr>
-                      <td width="16"><span class="glyphicon glyphicon-play text-success"></span></td>
+                      <td style="width:16px"><span class="glyphicon glyphicon-play text-success"></span></td>
                       <td colspan="12"><?=gettext("Enabled rule"); ?></td>
                     </tr>
                     <tr>

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -209,7 +209,7 @@ $main_buttons = array(
                 $i = 0;
                 foreach ($a_1to1 as $natent):
 ?>
-                  <tr <?=isset($natent['disabled'])?"class=\"text-muted\"":"";?> valign="top" ondblclick="document.location='firewall_nat_1to1_edit.php?id=<?=$i;?>';">
+                  <tr <?=isset($natent['disabled'])?"class=\"text-muted\"":"";?> style="vertical-align:top" ondblclick="document.location='firewall_nat_1to1_edit.php?id=<?=$i;?>';">
                     <td>
                       <input class="rule_select" type="checkbox" name="rule[]" value="<?=$i;?>" />
                     </td>
@@ -316,7 +316,7 @@ $main_buttons = array(
                     <td colspan="9">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td width="16"><span class="glyphicon glyphicon-play text-success"></span></td>
+                    <td style="width:16px"><span class="glyphicon glyphicon-play text-success"></span></td>
                     <td colspan="8"><?=gettext("Enabled rule"); ?></td>
                   </tr>
                   <tr>

--- a/src/www/firewall_nat_1to1_edit.php
+++ b/src/www/firewall_nat_1to1_edit.php
@@ -239,8 +239,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td valign="top"><?=gettext("Edit NAT 1:1 entry"); ?></td>
-                    <td align="right">
+                    <td style="vertical-align:top"><?=gettext("Edit NAT 1:1 entry"); ?></td>
+                    <td style="text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -507,8 +507,8 @@ $( document ).ready(function() {
             <form method="post" name="iform" id="iform">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><?=gettext("Edit Redirect entry"); ?></td>
-                  <td  width="78%" align="right">
+                  <td style="width:22%"><?=gettext("Edit Redirect entry"); ?></td>
+                  <td  style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -193,9 +193,9 @@ $main_buttons = array(
                 <table class="table table-striped">
                   <thead>
                     <tr>
-                      <th width="2%">&nbsp;</th>
-                      <th width="2%"><input type="checkbox" id="selectAll"></th>
-                      <th width="2%">&nbsp;</th>
+                      <th style="width:2%">&nbsp;</th>
+                      <th style="width:2%"><input type="checkbox" id="selectAll"></th>
+                      <th style="width:2%">&nbsp;</th>
                       <th><?=gettext("Interface"); ?></th>
                       <th><?=gettext("External Prefix"); ?></th>
                       <th><?=gettext("Internal prefix"); ?></th>

--- a/src/www/firewall_nat_npt_edit.php
+++ b/src/www/firewall_nat_npt_edit.php
@@ -145,7 +145,7 @@ include("head.inc");
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
                     <td><?=gettext("Edit NAT NPT entry"); ?></td>
-                    <td align="right">
+                    <td style="text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -194,9 +194,9 @@ include("head.inc");
                   <tr>
                     <td><a id="help_for_src" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ". gettext("Address:"); ?></td>
                     <td>
-                      <table border="0" cellspacing="0" cellpadding="0">
+                      <table style="border:0; cellspacing:0; cellpadding:0">
                         <tr>
-                          <td width="348px">
+                          <td style="width:348px">
                             <input name="src" type="text" value="<?=$pconfig['src'];?>" aria-label="<?=gettext("Source address");?>"/>
                           </td>
                           <td >
@@ -232,9 +232,9 @@ include("head.inc");
                   <tr>
                     <td><a id="help_for_dst" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ". gettext("Address:"); ?></td>
                     <td>
-                      <table border="0" cellspacing="0" cellpadding="0">
+                      <table style="border:0; cellspacing:0; cellpadding:0">
                         <tr>
-                          <td width="348px">
+                          <td style="width:348px">
                             <input name="dst" type="text" value="<?=$pconfig['dst'];?>" aria-label="<?=gettext("Source address");?>"/>
                           </td>
                           <td >

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -472,7 +472,7 @@ include("head.inc");
                   <td colspan="12">&nbsp;</td>
                 </tr>
                 <tr>
-                  <td width="16"><span class="glyphicon glyphicon-play text-success"></span></td>
+                  <td style="width:16px"><span class="glyphicon glyphicon-play text-success"></span></td>
                   <td colspan="11"><?=gettext("Enabled rule"); ?></td>
                 </tr>
                 <tr>

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -390,7 +390,7 @@ include("head.inc");
                     <table>
                         <tr>
                             <td><?=gettext("Edit Advanced Outbound NAT entry");?></td>
-                            <td colspan="2" align="right">
+                            <td colspan="2" style="text-align:right">
                                 <small><?=gettext("full help"); ?> </small>
                                 <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                             </td>
@@ -410,7 +410,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><a id="help_for_do_not_nat" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not NAT");?></td>
-                  <td width="78%" class="vtable">
+                  <td style="width:78%" class="vtable">
                     <input type="checkbox" name="nonat" <?=!empty($pconfig['nonat']) ? " checked=\"checked\"" : ""; ?> />
                     <div class="hidden" for="help_for_do_not_nat">
                       <?=gettext("Enabling this option will disable NAT for traffic matching this rule and stop processing Outbound NAT rules.");?><br />

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -302,7 +302,7 @@ $( document ).ready(function() {
                 if (!isset($config['system']['ipv6allow']) &&
                         ($selected_if == 'FloatingRules')):
 ?>
-                  <tr valign="top">
+                  <tr style="vertical-align:top">
                     <td>&nbsp;</td>
                     <td><span class="glyphicon glyphicon-remove text-danger"></span></td>
                     <td>IPv6 *</td>
@@ -324,7 +324,7 @@ $( document ).ready(function() {
                         || ((count($config['interfaces']) == 1) && ($selected_if == 'wan')))):
                         $alports = implode('<br />', filter_core_antilockout_ports());
 ?>
-                  <tr valign="top">
+                  <tr style="vertical-align:top">
                     <td>&nbsp;</td>
                     <td><span class="glyphicon glyphicon-play text-success"></span></td>
                     <td>*</td>
@@ -361,14 +361,14 @@ $( document ).ready(function() {
                     <td class="hidden-xs hidden-sm">*</td>
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
                     <td class="hidden-xs hidden-sm"><?=gettext("Block private networks");?></td>
-                    <td valign="middle" class="list nowrap">
+                    <td style="vertical-align:middle" class="list nowrap">
                         <a href="interfaces.php?if=<?=$selected_if?>#rfc1918" data-toggle="tooltip" title="<?=gettext("change configuration");?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
                     </td>
                   </tr>
 <?php
               endif;
               if (isset($config['interfaces'][$selected_if]['blockbogons'])): ?>
-                  <tr valign="top" id="frrfc1918">
+                  <tr style="vertical-align:top" id="frrfc1918">
                     <td>&nbsp;</td>
                     <td>
                       <span class="glyphicon glyphicon-remove text-danger"></span>
@@ -622,7 +622,7 @@ $( document ).ready(function() {
                   if (!$interface_has_rules):
 ?>
                   <tr>
-                    <td colspan="11" align="center" valign="middle">
+                    <td colspan="11" style="text-align:center; vertical-align:middle">
                     <span class="text-muted">
                 <?php if ($selected_if == 'FloatingRules'): ?>
                       <?= gettext('No floating rules are currently defined. Floating rules are ' .
@@ -673,24 +673,24 @@ $( document ).ready(function() {
                   </tr>
                   <tr class="hidden-xs hidden-sm">
                     <td colspan="11">
-                      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                      <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
                         <tr>
-                          <td width="16"><span class="glyphicon glyphicon-play text-success"></span></td>
-                          <td width="100"><?=gettext("pass");?></td>
-                          <td width="14"></td>
-                          <td width="16"><span class="glyphicon glyphicon-remove text-danger"></span></td>
-                          <td width="100"><?=gettext("block");?></td>
-                          <td width="14"></td>
-                          <td width="16"><span class="glyphicon glyphicon-remove-sign text-danger"></span></td>
-                          <td width="100"><?=gettext("reject");?></td>
-                          <td width="14"></td>
-                          <td width="16"><span class="glyphicon glyphicon-info-sign text-info"></span></td>
-                          <td width="100"><?=gettext("log");?></td>
-                          <td width="16"><span class="fa fa-long-arrow-right text-info"></span></td>
-                          <td width="100"><?=gettext("in");?></td>
+                          <td style="width:16px"><span class="glyphicon glyphicon-play text-success"></span></td>
+                          <td style="width:100px"><?=gettext("pass");?></td>
+                          <td style="width:14px"></td>
+                          <td style="width:16px"><span class="glyphicon glyphicon-remove text-danger"></span></td>
+                          <td style="width:100px"><?=gettext("block");?></td>
+                          <td style="width:14px"></td>
+                          <td style="width:16px"><span class="glyphicon glyphicon-remove-sign text-danger"></span></td>
+                          <td style="width:100px"><?=gettext("reject");?></td>
+                          <td style="width:14px"></td>
+                          <td style="width:16px"><span class="glyphicon glyphicon-info-sign text-info"></span></td>
+                          <td style="width:100px"><?=gettext("log");?></td>
+                          <td style="width:16px"><span class="fa fa-long-arrow-right text-info"></span></td>
+                          <td style="width:100px"><?=gettext("in");?></td>
 <?php                     if ($selected_if == 'FloatingRules'): ?>
-                          <td width="16"><span class="fa fa-flash text-warning"></span></td>
-                          <td width="100"><?=gettext("first match");?></td>
+                          <td style="width:16px"><span class="fa fa-flash text-warning"></span></td>
+                          <td style="width:100px"><?=gettext("first match");?></td>
 <?php                     endif; ?>
                         </tr>
                         <tr>
@@ -703,13 +703,13 @@ $( document ).ready(function() {
                           <td><span class="glyphicon glyphicon-remove-sign text-muted"></span></td>
                           <td class="nowrap"><?=gettext("reject (disabled)");?></td>
                           <td>&nbsp;</td>
-                          <td width="16"><span class="glyphicon glyphicon-info-sign text-muted"></span></td>
+                          <td style="width:16px"><span class="glyphicon glyphicon-info-sign text-muted"></span></td>
                           <td class="nowrap"><?=gettext("log (disabled)");?></td>
-                          <td width="16"><span class="fa fa-long-arrow-left"></span></td>
-                          <td width="100"><?=gettext("out");?></td>
+                          <td style="width:16px"><span class="fa fa-long-arrow-left"></span></td>
+                          <td style="width:100px"><?=gettext("out");?></td>
 <?php                     if ($selected_if == 'FloatingRules'): ?>
-                          <td width="16"><span class="fa fa-flash text-muted"></span></td>
-                          <td width="100"><?=gettext("last match");?></td>
+                          <td style="width:16px"><span class="fa fa-flash text-muted"></span></td>
+                          <td style="width:100px"><?=gettext("last match");?></td>
 <?php                     endif; ?>
                         </tr>
                       </table>

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -676,15 +676,15 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td valign="top"><strong><?=gettext("Edit Firewall rule");?></strong></td>
-                    <td align="right">
+                    <td style="vertical-align:top"><strong><?=gettext("Edit Firewall rule");?></strong></td>
+                    <td style="text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%"><a id="help_for_action" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Action");?></td>
-                    <td width="78%">
+                    <td style="width:22%"><a id="help_for_action" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Action");?></td>
+                    <td style="width:78%">
                       <select name="type" class="selectpicker" data-live-search="true" data-size="5" >
 <?php
                         $type_options = array('Pass' => gettext('Pass'), 'Block' => gettext('Block'), 'Reject' => gettext('Reject'));
@@ -908,10 +908,10 @@ include("head.inc");
                         <tr>
                           <td>
                             <div>
-                              <table border="0" cellpadding="0" cellspacing="0">
+                              <table style="border:0; cellpadding:0; cellspacing:0">
                                 <tbody>
                                   <tr>
-                                      <td width="348px">
+                                      <td style="width:348px">
                                         <!-- updates to "other" option in  src -->
                                         <input <?=!empty($pconfig['associated-rule-id']) ? "disabled" : "";?>  type="text" id="src_address" for="src" value="<?=$pconfig['src'];?>" aria-label="<?=gettext("Source address");?>"/>
                                       </td>
@@ -1037,10 +1037,10 @@ include("head.inc");
                         </tr>
                         <tr>
                           <td>
-                            <table border="0" cellpadding="0" cellspacing="0">
+                            <table style="border:0; cellpadding:0; cellspacing:0">
                               <tbody>
                                 <tr>
-                                    <td width="348px">
+                                    <td style="width:348px">
                                       <!-- updates to "other" option in  src -->
                                       <input <?=!empty($pconfig['associated-rule-id']) ? "disabled" : "";?>  type="text" id="dst_address" for="dst" value="<?=$pconfig['dst'];?>" aria-label="<?=gettext("Destination address");?>"/>
                                     </td>
@@ -1373,7 +1373,7 @@ include("head.inc");
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max-src-conn-rate" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max new connections");?> </td>
                       <td>
-                        <table border="0" cellspacing="0" cellpadding="0">
+                        <table style="border:0; cellspacing:0; cellpadding:0">
                           <tbody>
                             <tr>
                               <td>

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -784,8 +784,8 @@ function removeRow(el) {
                   <table class="table table-striped opnsense_standard_table_form">
                     <tbody>
                       <tr>
-                        <td width="15%"><strong><?=gettext("Schedule information");?></strong></td>
-                        <td width="85%"  align="right">
+                        <td style="width:15%"><strong><?=gettext("Schedule information");?></strong></td>
+                        <td style="width:85%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         </td>
@@ -853,17 +853,17 @@ function removeRow(el) {
                               $positioncounter = 1;//7 for Sun, 1 for Mon, 2 for Tues, etc
 ?>
                             <div id="<?=date("F_y",mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?>" style=" position:relative; display:<?= $firstmonth ? "block" : "none";?>">
-                              <table border="1" cellspacing="1" cellpadding="1" id="calTable<?=$monthcounter . $yearcounter;?>" class="table table-condensed" summary="month">
+                              <table style="border:1; cellspacing:1; cellpadding:1" id="calTable<?=$monthcounter . $yearcounter;?>" class="table table-condensed">
                                 <thead>
-                                  <tr><td colspan="7" align="center"><?= date("F_Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></td></tr>
+                                  <tr><td colspan="7" style="text-align:center"><?= date("F_Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></td></tr>
                                   <tr>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p1');"><u><?=gettext("Mon");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p2');"><u><?=gettext("Tue");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p3');"><u><?=gettext("Wed");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p4');"><u><?=gettext("Thu");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p5');"><u><?=gettext("Fri");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p6');"><u><?=gettext("Sat");?></u></td>
-                                    <td align="center" style="cursor: pointer;" onclick="daytoggle('w1p7');"><u><?=gettext("Sun");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p1');"><u><?=gettext("Mon");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p2');"><u><?=gettext("Tue");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p3');"><u><?=gettext("Wed");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p4');"><u><?=gettext("Thu");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p5');"><u><?=gettext("Fri");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p6');"><u><?=gettext("Sat");?></u></td>
+                                    <td style="text-align:center; cursor: pointer;" onclick="daytoggle('w1p7');"><u><?=gettext("Sun");?></u></td>
                                   </tr>
                                 </thead>
                                 <tbody>
@@ -876,20 +876,20 @@ function removeRow(el) {
                                         echo "<tr>";
                                       }
                                       if ($firstdayofmonth == $positioncounter){?>
-                                        <td align="center" style="cursor: pointer;" class="listr" id="w<?=$weekcounter;?>p<?=$positioncounter;?>" onclick="daytoggle('w<?=$weekcounter;?>p<?=$positioncounter;?>-m<?=$monthcounter;?>d<?=$daycounter;?>');">
+                                        <td style="text-align:center; cursor: pointer;" class="listr" id="w<?=$weekcounter;?>p<?=$positioncounter;?>" onclick="daytoggle('w<?=$weekcounter;?>p<?=$positioncounter;?>-m<?=$monthcounter;?>d<?=$daycounter;?>');">
                                         <?php
                                           echo $daycounter;
                                           $daycounter++;
                                           $firstdayprinted = TRUE;
                                           echo "</td>";
                                       } elseif ($firstdayprinted == TRUE && $daycounter <= $numberofdays){?>
-                                      <td align="center" style="cursor: pointer;" class="listr" id="w<?=$weekcounter;?>p<?=$positioncounter;?>" onclick="daytoggle('w<?=$weekcounter;?>p<?=$positioncounter;?>-m<?=$monthcounter;?>d<?=$daycounter;?>');">
+                                      <td style="text-align:center; cursor: pointer;" class="listr" id="w<?=$weekcounter;?>p<?=$positioncounter;?>" onclick="daytoggle('w<?=$weekcounter;?>p<?=$positioncounter;?>-m<?=$monthcounter;?>d<?=$daycounter;?>');">
                                         <?php
                                           echo $daycounter;
                                           $daycounter++;
                                           echo "</td>";
                                       } else {
-                                        echo "<td align=\"center\" class=\"listr\"></td>";
+                                        echo "<td style=\"text-align:center\" class=\"listr\"></td>";
                                       }
 
                                       if ($positioncounter == 7 || $daycounter > $numberofdays) {
@@ -920,7 +920,7 @@ function removeRow(el) {
                       <tr>
                         <td><a id="help_for_time" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Time");?></td>
                         <td>
-                          <table cellspacing="2" class="tabcont" summary="time">
+                          <table style="cellspacing:2" class="tabcont">
                             <tr>
                               <td><?=gettext("Start Time");?></td>
                               <td><?=gettext("Stop Time");?></td>
@@ -987,18 +987,18 @@ function removeRow(el) {
                         </td>
                       </tr>
                       <tr>
-                        <th colspan="2" valign="top" class="listtopic"><?=gettext("Schedule repeat");?></td>
+                        <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Schedule repeat");?></td>
                       </tr>
                       <tr>
                         <td><?=gettext("Configured Ranges");?></td>
                         <td>
-                          <table id="scheduletable" summary="range">
+                          <table id="scheduletable">
                             <tbody>
                               <tr>
-                                <td width="35%"><?=gettext("Day(s)");?></td>
-                                <td width="12%"><?=gettext("Start Time");?></td>
-                                <td width="11%"><?=gettext("Stop Time");?></td>
-                                <td width="42%"><?=gettext("Description");?></td>
+                                <td style="width:35%"><?=gettext("Day(s)");?></td>
+                                <td style="width:12%"><?=gettext("Start Time");?></td>
+                                <td style="width:11%"><?=gettext("Stop Time");?></td>
+                                <td style="width:42%"><?=gettext("Description");?></td>
                               </tr>
                               <?php
                               if (isset($pconfig['timerange'])){

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -223,8 +223,8 @@ $( document ).ready(function() {
                 <table class="table table-striped table-hover opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%"><strong><?=gettext("General settings");?></strong></td>
-                      <td  width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("General settings");?></strong></td>
+                      <td style="width:78%; text-align:right">
                            <small><?=gettext("full help"); ?> </small>
                            <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button">&nbsp;</i>
                       </td>

--- a/src/www/firewall_scrub_edit.php
+++ b/src/www/firewall_scrub_edit.php
@@ -289,15 +289,15 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td valign="top"><strong><?=gettext("Edit Firewall scrub rule");?></strong></td>
-                    <td align="right">
+                    <td style="vertical-align:top"><strong><?=gettext("Edit Firewall scrub rule");?></strong></td>
+                    <td style="text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
-                    <td width="78%">
+                    <td style="width:22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
+                    <td style="width:78%">
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
                       <div class="hidden" for="help_for_disabled">
                         <strong><?=gettext("Disable this rule"); ?></strong><br />
@@ -396,10 +396,10 @@ include("head.inc");
                         <tr>
                           <td>
                             <div>
-                              <table border="0" cellpadding="0" cellspacing="0">
+                              <table style="border:0; cellpadding:0; cellspacing:0">
                                 <tbody>
                                   <tr>
-                                      <td width="348px">
+                                      <td style="width:348px">
                                         <!-- updates to "other" option in  src -->
                                         <input type="text" id="src_address" for="src" value="<?=$pconfig['src'];?>" aria-label="<?=gettext("Source address");?>"/>
                                       </td>
@@ -495,10 +495,10 @@ include("head.inc");
                         </tr>
                         <tr>
                           <td>
-                            <table border="0" cellpadding="0" cellspacing="0">
+                            <table style="border:0; cellpadding:0; cellspacing:0">
                               <tbody>
                                 <tr>
-                                    <td width="348px">
+                                    <td style="width:348px">
                                       <!-- updates to "other" option in  src -->
                                       <input  type="text" id="dst_address" for="dst" value="<?=$pconfig['dst'];?>" aria-label="<?=gettext("Destination address");?>"/>
                                     </td>
@@ -575,8 +575,8 @@ include("head.inc");
                     <td colspan="2"><strong><?=gettext("Normalizations");?></strong></td>
                   </tr>
                   <tr>
-                      <td width="22%"><a id="help_for_maxmss" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max mss"); ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_maxmss" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max mss"); ?></td>
+                      <td style="width:78%">
                           <input name="max-mss" type="text" value="<?=$pconfig['max-mss'];?>" />
                           <div class="hidden" for="help_for_maxmss">
                             <?=gettext("Enforces a maximum MSS for matching TCP packets."); ?>
@@ -584,8 +584,8 @@ include("head.inc");
                       </td>
                   </tr>
                   <tr>
-                      <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext('TOS / DSCP'); ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext('TOS / DSCP'); ?></td>
+                      <td style="width:78%">
                           <select name="set-tos" class="selectpicker" data-size="5" data-width="auto"  data-live-search="true">
 <?php
                             foreach (filter_tos_values() as $tos_value => $tos_label): ?>
@@ -598,8 +598,8 @@ include("head.inc");
                       </td>
                   </tr>
                   <tr>
-                      <td width="22%"><a id="help_for_minttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Minimum TTL') ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_minttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Minimum TTL') ?></td>
+                      <td style="width:78%">
                           <input name="min-ttl" type="text" value="<?=$pconfig['min-ttl'];?>" />
                           <div class="hidden" for="help_for_minttl">
                             <?=gettext("Enforces a minimum TTL for matching IP packets."); ?>
@@ -607,8 +607,8 @@ include("head.inc");
                       </td>
                   </tr>
                   <tr>
-                      <td width="22%"><a id="help_for_nodf" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not fragment"); ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_nodf" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not fragment"); ?></td>
+                      <td style="width:78%">
                           <input name="no-df" type="checkbox" value="1" <?= !empty($pconfig['no-df']) ? "checked=\"checked\"" : ""; ?> />
                           <div class="hidden" for="help_for_nodf">
                             <?=gettext("Clears the dont-fragment bit from a matching IP packet."); ?>
@@ -616,8 +616,8 @@ include("head.inc");
                       </td>
                   </tr>
                   <tr>
-                      <td width="22%"><a id="help_for_randomid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Random ID') ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_randomid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Random ID') ?></td>
+                      <td style="width:78%">
                           <input name="random-id" type="checkbox" value="1" <?= !empty($pconfig['random-id']) ? "checked=\"checked\"" : ""; ?> />
                           <div class="hidden" for="help_for_randomid">
                             <?=gettext("Replaces the IP identification field with random values to compensate for ".
@@ -646,8 +646,8 @@ include("head.inc");
 <?php
                     if ($has_created_time): ?>
                     <tr>
-                      <td width="22%"><?=gettext("Created");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><?=gettext("Created");?></td>
+                      <td style="width:78%">
                         <?= date(gettext("n/j/y H:i:s"), $a_scrub[$id]['created']['time']) ?> <?= gettext("by") ?> <strong><?= $a_scrub[$id]['created']['username'] ?></strong>
                       </td>
                     </tr>

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -313,8 +313,8 @@ $( document ).ready(function() {
                 <thead></thead>
                 <tbody>
                   <tr>
-                    <td width="22%"><strong><?=gettext("Edit Virtual IP");?></strong></td>
-                    <td  width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Edit Virtual IP");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -368,9 +368,9 @@ $( document ).ready(function() {
                   <tr>
                       <td><a id="help_for_address" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Address");?></td>
                       <td>
-                        <table border="0" cellspacing="0" cellpadding="0">
+                        <table style="border:0; cellspacing:0; cellpadding:0">
                           <tr>
-                            <td width="348px">
+                            <td style="width:348px">
                               <input name="subnet" type="text" class="form-control" id="subnet" size="28" value="<?=$pconfig['subnet'];?>" />
                             </td>
                             <td >

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -1653,8 +1653,8 @@ include("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <thead>
                       <tr>
-                        <td width="22%"><strong><?=gettext("General configuration"); ?></strong></td>
-                        <td width="78%" align="right">
+                        <td style="width:22%"><strong><?=gettext("General configuration"); ?></strong></td>
+                        <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                           &nbsp;
@@ -1692,8 +1692,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
+                          <td style="width:78%">
                             <input name="descr" type="text" id="descr" value="<?=$pconfig['descr'];?>" />
                             <div class="hidden" for="help_for_descr">
                               <?= gettext("Enter a description (name) for the interface here."); ?>
@@ -1701,8 +1701,8 @@ include("head.inc");
                           </td>
                         </tr>
                         <tr>
-                          <td width="22%"><a id="help_for_blockpriv" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Block private networks"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_blockpriv" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Block private networks"); ?></td>
+                          <td style="width:78%">
                             <input name="blockpriv" type="checkbox" id="blockpriv" value="yes" <?=!empty($pconfig['blockpriv']) ? "checked=\"checked\"" : ""; ?> />
                             <div class="hidden" for="help_for_blockpriv">
                               <?=gettext("When set, this option blocks traffic from IP addresses that are reserved " .
@@ -1833,11 +1833,11 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("IPv4 address"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("IPv4 address"); ?></td>
+                          <td style="width:78%">
                             <table>
                               <tr>
-                                <td width="348px">
+                                <td style="width:348px">
                                   <input name="ipaddr" type="text" id="ipaddr" value="<?=$pconfig['ipaddr'];?>" />
                                 </td>
                                 <td>
@@ -1930,8 +1930,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_dhcp_mode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration Mode"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_dhcp_mode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration Mode"); ?></td>
+                          <td style="width:78%">
                             <div id="dhcp_mode" class="btn-group" data-toggle="buttons">
                               <label class="btn btn-default <?=empty($pconfig['adv_dhcp_config_advanced']) && empty($pconfig['adv_dhcp_config_file_override']) ? "active" : "";?>">
                                 <input type="radio" value="basic" <?=empty($pconfig['adv_dhcp_config_advanced']) && empty($pconfig['adv_dhcp_config_file_override']) ? "checked=\"\"" : "";?>/>
@@ -1958,7 +1958,7 @@ include("head.inc");
                           <td>
                             <table>
                               <tr>
-                                <td width="348px;">
+                                <td style="width:348px;">
                                   <input name="alias-address" type="text" id="alias-address" value="<?=$pconfig['alias-address'];?>" />
                                 </td>
                                 <td>
@@ -2093,8 +2093,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_country" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Service Provider"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_country" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Service Provider"); ?></td>
+                          <td style="width:78%">
                             <table class="table table-condensed">
                               <tr id="trcountry" class="hidden">
                                 <td><?=gettext("Country:"); ?></td>
@@ -2195,8 +2195,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Username"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Username"); ?></td>
+                          <td style="width:78%">
                               <input name="pppoe_username" type="text" id="pppoe_username" value="<?=$pconfig['pppoe_username'];?>" />
                           </td>
                         </tr>
@@ -2270,8 +2270,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Username"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Username"); ?></td>
+                          <td style="width:78%">
                             <input name="pptp_username" type="text" id="pptp_username" value="<?=$pconfig['pptp_username'];?>" />
                           </td>
                         </tr>
@@ -2286,7 +2286,7 @@ include("head.inc");
                           <td>
                             <table>
                               <tr>
-                                <td width="348px">
+                                <td style="width:348px">
                                   <input name="localip" type="text" id="localip"  value="<?=$pconfig['localip'];?>" />
                                 </td>
                                 <td>
@@ -2349,11 +2349,11 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("IPv6 address"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("IPv6 address"); ?></td>
+                          <td style="width:78%">
                             <table>
                               <tr>
-                                <td width="257px">
+                                <td style="width:257px">
                                   <input name="ipaddrv6" type="text" id="ipaddrv6" size="28" value="<?=htmlspecialchars($pconfig['ipaddrv6']);?>" />
                                 </td>
                                 <td>
@@ -2456,8 +2456,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_dhcpv6_mode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration Mode"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_dhcpv6_mode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration Mode"); ?></td>
+                          <td style="width:78%">
                             <div id="dhcpv6_mode" class="btn-group" data-toggle="buttons">
                               <label class="btn btn-default <?=empty($pconfig['adv_dhcp6_config_advanced']) && empty($pconfig['adv_dhcp6_config_file_override']) ? "active" : "";?>">
                                 <input type="radio" value="basic" <?=empty($pconfig['adv_dhcp6_config_advanced']) && empty($pconfig['adv_dhcp6_config_file_override']) ? "checked=\"\"" : "";?>/>
@@ -2703,8 +2703,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_prefix-6rd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("6RD prefix"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_prefix-6rd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("6RD prefix"); ?></td>
+                          <td style="width:78%">
                             <input name="prefix-6rd" type="text" id="prefix-6rd" value="<?=$pconfig['prefix-6rd'];?>" />
                             <div class="hidden" for="help_for_prefix-6rd">
                               <?=gettext("The value in this field is the 6RD IPv6 prefix assigned by your ISP. e.g. '2001:db8::/32'") ?>
@@ -2750,8 +2750,8 @@ include("head.inc");
                           <th colspan="2"><?=gettext("Track IPv6 Interface"); ?></th>
                         </tr>
                         <tr>
-                          <td width="22%"><a id="help_for_track6-interface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Interface"); ?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_track6-interface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Interface"); ?></td>
+                          <td style="width:78%">
                             <select name='track6-interface' class='selectpicker' data-style='btn-default' >
 <?php
                             foreach (get_configured_interface_with_descr(false, true) as $iface => $ifacename):
@@ -2808,8 +2808,8 @@ include("head.inc");
                       </thead>
                       <tbody>
                         <tr>
-                          <td width="22%"><a id="help_for_persistcommonwireless" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Persist common settings");?></td>
-                          <td width="78%">
+                          <td style="width:22%"><a id="help_for_persistcommonwireless" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Persist common settings");?></td>
+                          <td style="width:78%">
                             <input name="persistcommonwireless" type="checkbox" value="yes"  id="persistcommonwireless" <?=!empty($pconfig['persistcommonwireless']) ? "checked=\"checked\"" : "";?> />
                             <div class="hidden" for="help_for_persistcommonwireless">
                               <?=gettext("Enabling this preserves the common wireless configuration through interface deletions and reassignments.");?>
@@ -3303,8 +3303,8 @@ include("head.inc");
                 <div class="table-responsive">
                     <table class="table table-striped opnsense_standard_table_form">
                       <tr>
-                        <td width="22%"></td>
-                        <td width="78%">
+                        <td style="width:22%"></td>
+                        <td style="width:78%">
                           <input id="save" name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                           <input id="cancel" type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces.php'" />
                           <input name="if" type="hidden" id="if" value="<?=$if;?>" />

--- a/src/www/interfaces_bridge_edit.php
+++ b/src/www/interfaces_bridge_edit.php
@@ -229,8 +229,8 @@ $(document).ready(function() {
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%"><strong><?=gettext("Bridge configuration");?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("Bridge configuration");?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;
@@ -285,8 +285,8 @@ $(document).ready(function() {
                   </thead>
                   <tbody>
                     <tr>
-                      <td width="22%"><a id="help_for_enablestp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_enablestp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable");?></td>
+                      <td style="width:78%">
                         <input type="checkbox" name="enablestp" <?= !empty($pconfig['enablestp']) ? 'checked="checked"' : "";?> />
                         <div class="hidden" for="help_for_enablestp">
                           <?=gettext("Enable spanning tree options for this bridge."); ?>
@@ -439,8 +439,8 @@ $(document).ready(function() {
                   </thead>
                   <tbody>
                     <tr>
-                      <td width="22%"><a id="help_for_maxaddr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Cache size"); ?> (<?=gettext("entries"); ?>)</td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_maxaddr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Cache size"); ?> (<?=gettext("entries"); ?>)</td>
+                      <td style="width:78%">
                         <input name="maxaddr" type="text" value="<?=$pconfig['maxaddr'];?>" />
                       <div class="hidden" for="help_for_maxaddr">
                         <?=gettext("Set the size of the bridge address cache to size. The default is .100 entries."); ?>
@@ -609,8 +609,8 @@ $(document).ready(function() {
                 <table class="table table-striped">
                   <tbody>
                     <tr>
-                      <td width="22%" valign="top">&nbsp;</td>
-                      <td width="78%">
+                      <td style="width:22%; vertical-align:top">&nbsp;</td>
+                      <td style="width:78%">
                         <input type="hidden" name="bridgeif" value="<?=$pconfig['bridgeif']; ?>" />
                         <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                         <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces_bridge.php'" />

--- a/src/www/interfaces_gif_edit.php
+++ b/src/www/interfaces_gif_edit.php
@@ -157,8 +157,8 @@ include("head.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("GIF configuration");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("GIF configuration");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;
@@ -167,8 +167,8 @@ include("head.inc");
                 </thead>
                 <tbody>
                   <tr>
-                    <td width="22%"><a id="help_for_if" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Parent interface"); ?></td>
-                    <td width="78%">
+                    <td style="width:22%"><a id="help_for_if" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Parent interface"); ?></td>
+                    <td style="width:78%">
                       <select name="if" class="selectpicker" data-live-search="true">
 <?php
                       $portlist = get_configured_interface_with_descr();
@@ -215,7 +215,7 @@ include("head.inc");
                     <td>
                       <table class="table table-condensed">
                         <tr>
-                          <td width="285px">
+                          <td style="width:285px">
                             <input name="tunnel-remote-addr" type="text" id="tunnel-remote-addr" value="<?=$pconfig['tunnel-remote-addr'];?>" />
                           </td>
                           <td>

--- a/src/www/interfaces_gre_edit.php
+++ b/src/www/interfaces_gre_edit.php
@@ -132,8 +132,8 @@ include("head.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("GRE configuration");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("GRE configuration");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;
@@ -192,7 +192,7 @@ include("head.inc");
                     <td>
                       <table class="table table-condensed">
                         <tr>
-                          <td width="285px">
+                          <td style="width:285px">
                             <input name="tunnel-remote-addr" type="text" id="tunnel-remote-addr" value="<?=$pconfig['tunnel-remote-addr'];?>" />
                           </td>
                           <td>
@@ -253,8 +253,8 @@ include("head.inc");
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="greif" value="<?=$pconfig['greif']; ?>" />
                       <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                       <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces_gre.php'" />

--- a/src/www/interfaces_groups_edit.php
+++ b/src/www/interfaces_groups_edit.php
@@ -143,8 +143,8 @@ legacy_html_escape_form_data($pconfig);
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("Interface Groups Edit");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Interface Groups Edit");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;

--- a/src/www/interfaces_lagg_edit.php
+++ b/src/www/interfaces_lagg_edit.php
@@ -185,8 +185,8 @@ legacy_html_escape_form_data($pconfig);
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("LAGG configuration");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("LAGG configuration");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;
@@ -294,8 +294,8 @@ legacy_html_escape_form_data($pconfig);
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="laggif" value="<?=$pconfig['laggif']; ?>" />
                       <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                       <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces_lagg.php'" />

--- a/src/www/interfaces_ppps_edit.php
+++ b/src/www/interfaces_ppps_edit.php
@@ -410,8 +410,8 @@ include("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <thead>
                       <tr>
-                        <td width="22%"><strong><?=gettext("PPPs configuration");?></strong></td>
-                        <td width="78%" align="right">
+                        <td style="width:22%"><strong><?=gettext("PPPs configuration");?></strong></td>
+                        <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                           &nbsp;
@@ -475,8 +475,8 @@ include("head.inc");
                         </td>
                       </tr>
                       <tr id="ppp_provider">
-                        <td width="22%"><a id="help_for_country" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Service Provider"); ?></td>
-                        <td width="78%">
+                        <td style="width:22%"><a id="help_for_country" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Service Provider"); ?></td>
+                        <td style="width:78%">
                           <table class="table table-condensed">
                             <tr id="trcountry" class="hidden">
                               <td><?=gettext("Country:"); ?></td>
@@ -561,8 +561,8 @@ include("head.inc");
 <?php
                       for ($intf_idx=0; $intf_idx <= max(count($serialports), count($portlist)) ; ++$intf_idx):?>
                       <tr style="display:none" class="intf_select_<?=$intf_idx;?>">
-                        <td width="22%"><a id="help_for_localip_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local IP");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
-                        <td width="78%">
+                        <td style="width:22%"><a id="help_for_localip_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local IP");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
+                        <td style="width:78%">
                           <input name="localip[]" type="text" class="intf_select_<?=$intf_idx;?>" value="<?=isset($pconfig['localip'][$intf_idx]) ? $pconfig['localip'][$intf_idx] : "";?>" />
                           /
                           <select name="subnet[]" class="intf_select_<?=$intf_idx;?>">
@@ -578,8 +578,8 @@ include("head.inc");
                         </td>
                       </tr>
                       <tr style="display:none" class="intf_select_<?=$intf_idx;?>">
-                        <td width="22%"><a id="help_for_gateway_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
-                        <td width="78%">
+                        <td style="width:22%"><a id="help_for_gateway_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
+                        <td style="width:78%">
                           <input name="gateway[]" type="text" class="intf_select_<?=$intf_idx;?>" value="<?=isset($pconfig['gateway'][$intf_idx]) ? $pconfig['gateway'][$intf_idx] : "";?>" />
                           <div class="hidden" for="help_for_gateway_<?=$intf_idx;?>">
                             <?= gettext("IP Address OR Hostname"); ?>
@@ -599,8 +599,8 @@ include("head.inc");
                   <table class="table table-striped" >
                     <tbody>
                       <tr>
-                        <td width="22%">&nbsp;</td>
-                        <td width="78%">
+                        <td style="width:22%">&nbsp;</td>
+                        <td style="width:78%">
                           <input type="button" id="show_advanced" value="<?=gettext("Show advanced options"); ?>" class="btn btn-default btn-xs"/>
                         </td>
                       </tr>
@@ -619,8 +619,8 @@ include("head.inc");
                     </thead>
                     <tbody>
                       <tr style="display:none" class="act_show_advanced">
-                        <td width="22%"><a id="help_for_apnum" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("APN number (optional)"); ?></td>
-                        <td width="78%">
+                        <td style="width:22%"><a id="help_for_apnum" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("APN number (optional)"); ?></td>
+                        <td style="width:78%">
                           <input name="apnum" type="text" id="apnum" value="<?=$pconfig['apnum'];?>" />
                           <div class="hidden" for="help_for_apnum">
                             <?= gettext("Note: Defaults to 1 if you set APN above. Ignored if you set no APN above."); ?>
@@ -677,8 +677,8 @@ include("head.inc");
                   <table class="table table-striped" >
                     <tbody>
                       <tr style="display:none" class="act_show_advanced">
-                        <td width="22%"><a id="help_for_ondemand" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Dial On Demand"); ?></td>
-                        <td width="78%">
+                        <td style="width:22%"><a id="help_for_ondemand" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Dial On Demand"); ?></td>
+                        <td style="width:78%">
                           <input type="checkbox" value="on" id="ondemand" name="ondemand" <?=!empty($pconfig['ondemand']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Enable Dial-on-Demand mode"); ?>
                           <div class="hidden" for="help_for_ondemand">
@@ -762,8 +762,8 @@ include("head.inc");
 <?php
                       for ($intf_idx=0; $intf_idx <= max(count($serialports), count($portlist)) ; ++$intf_idx):?>
                       <tr style="display:none" class="intf_select_<?=$intf_idx;?>">
-                        <td width="22%"> <a id="help_for_link_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Link Parameters");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
-                        <td width="78%">
+                        <td style="width:22%"> <a id="help_for_link_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Link Parameters");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
+                        <td style="width:78%">
                           <table class="table table-striped table-condensed">
                             <tr>
                               <td><?=gettext("Bandwidth");?></td>
@@ -807,8 +807,8 @@ include("head.inc");
                   <table class="table table-striped">
                     <tbody>
                       <tr>
-                        <td width="22%" valign="top">&nbsp;</td>
-                        <td width="78%">
+                        <td style="width:22%; vertical-align:top">&nbsp;</td>
+                        <td style="width:78%">
                           <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                           <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces_ppps.php'" />
                           <input name="ptpid" type="hidden" value="<?=$pconfig['ptpid'];?>" />

--- a/src/www/interfaces_qinq_edit.php
+++ b/src/www/interfaces_qinq_edit.php
@@ -134,8 +134,8 @@ include("head.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("Interface QinQ Edit");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Interface QinQ Edit");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;

--- a/src/www/interfaces_vlan_edit.php
+++ b/src/www/interfaces_vlan_edit.php
@@ -153,8 +153,8 @@ include("head.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%"><strong><?=gettext("Interface VLAN Edit");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Interface VLAN Edit");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;
@@ -230,8 +230,8 @@ include("head.inc");
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="vlanif" value="<?=$pconfig['vlanif']; ?>" />
                       <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                       <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/interfaces_vlan.php'" />

--- a/src/www/interfaces_wireless_edit.php
+++ b/src/www/interfaces_wireless_edit.php
@@ -139,8 +139,8 @@ include("head.inc");
             <table class="table table-striped opnsense_standard_table_form">
               <thead>
                 <tr>
-                  <td width="22%"><strong><?=gettext("Wireless clone configuration");?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext("Wireless clone configuration");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     &nbsp;

--- a/src/www/reporting_settings.php
+++ b/src/www/reporting_settings.php
@@ -161,7 +161,7 @@ $(document).ready(function() {
                     <td colspan="2"><strong><?=gettext('Reporting Database Options');?></strong></td>
                   </tr>
                   <tr>
-                    <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Round-Robin-Database");?></td>
+                    <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Round-Robin-Database");?></td>
                     <td>
                       <input name="rrdenable" type="checkbox" id="rrdenable" value="yes" <?=!empty($pconfig['rrdenable']) ? "checked=\"checked\"" : ""?> />
                       &nbsp;<strong><?=gettext("Enables the RRD graphing backend.");?></strong>
@@ -193,7 +193,7 @@ $(document).ready(function() {
                     <td colspan="2"><strong><?=gettext('Collected reports');?></strong></td>
                   </tr>
                   <tr>
-                    <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Reports");?> </td>
+                    <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Reports");?> </td>
                     <td>
                       <table class="table table-condensed">
 <?php

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -629,8 +629,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%" valign="top"></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%; vertical-align:top"></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
@@ -1089,7 +1089,7 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped">
                   <tr>
-                    <td colspan="5" valign="top"><?=gettext("DHCP Static Mappings for this interface.");?></td>
+                    <td colspan="5" style="vertical-align:top"><?=gettext("DHCP Static Mappings for this interface.");?></td>
                     <td>&nbsp;</td>
                   </tr>
                   <tr>

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -325,8 +325,8 @@ include("head.inc");
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%" valign="top"><strong><?=gettext("Static DHCP Mapping");?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%; vertical-align:top"><strong><?=gettext("Static DHCP Mapping");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/services_dhcp_relay.php
+++ b/src/www/services_dhcp_relay.php
@@ -117,8 +117,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%" valign="top"><strong><?=gettext("DHCP Relay configuration"); ?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%; vertical-align:top"><strong><?=gettext("DHCP Relay configuration"); ?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -421,8 +421,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%" valign="top"></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%; vertical-align:top"></td>
+                      <td style="width:78; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
@@ -733,7 +733,7 @@ include("head.inc");
           <section class="col-xs-12">
             <div class="tab-content content-box col-xs-12">
                 <div class="table-responsive">
-                  <table class="tabcont table table-striped" width="100%" border="0" cellpadding="0" cellspacing="0" summary="static mappings">
+                  <table class="tabcont table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0">
                     <tr>
                       <td colspan="4" class="listtopic"><?=gettext("DHCPv6 Static Mappings for this interface.");?></td>
                       <td>&nbsp;</td>

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -159,8 +159,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%" valign="top"><strong><?=gettext("Static DHCPv6 Mapping");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%; vertical-align:top"><strong><?=gettext("Static DHCPv6 Mapping");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/services_dhcpv6_relay.php
+++ b/src/www/services_dhcpv6_relay.php
@@ -117,8 +117,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%" valign="top"><strong><?=gettext("DHCPv6 Relay configuration"); ?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%; vertical-align:top"><strong><?=gettext("DHCPv6 Relay configuration"); ?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -230,15 +230,15 @@ $( document ).ready(function() {
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td valign="top"><strong><?=gettext("General DNS Forwarder Options");?></strong></td>
-                  <td align="right">
+                  <td style="vertical-align:top"><strong><?=gettext("General DNS Forwarder Options");?></strong></td>
+                  <td style="text-align:right">
                       <small><?=gettext("full help");?> </small>
                       <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
                 </tr>
                 <tr>
-                  <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
-                  <td width="78%">
+                  <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
+                  <td style="width:78%">
                     <input name="enable" type="checkbox" id="enable" value="yes" <?=!empty($pconfig['enable']) ? "checked=\"checked\"" : "";?> />
                      <strong><?=gettext("Enable DNS Forwarder");?></strong>
                   </td>

--- a/src/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/www/services_dnsmasq_domainoverride_edit.php
@@ -137,15 +137,15 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><strong><?=gettext("Edit Domain Override entry");?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("Edit Domain Override entry");?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%"><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
+                      <td style="width:78%">
                         <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
                         <div class="hidden" for="help_for_domain">
                           <?=gettext("Domain to override (NOTE: this does not have to be a valid TLD!)"); ?><br />

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -180,8 +180,8 @@ include("head.inc");
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=gettext("Edit DNS Forwarder entry");?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext("Edit DNS Forwarder entry");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -208,10 +208,10 @@ include("head.inc");
               <table class="table table-striped opnsense_standard_table_form">
                 <thead>
                   <tr>
-                    <td width="22%">
+                    <td style="width:22%">
                       <strong><?=gettext("NTP Server Configuration"); ?></strong>
                     </td>
-                    <td width="78%" align="right">
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       &nbsp;&nbsp;
@@ -416,8 +416,8 @@ include("head.inc");
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                     <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                     </td>
                   </tr>

--- a/src/www/services_ntpd_gps.php
+++ b/src/www/services_ntpd_gps.php
@@ -300,10 +300,10 @@ SureGPS =    #Sure Electronics SKG16B
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("NTP Serial GPS Configuration"); ?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;&nbsp;

--- a/src/www/services_ntpd_pps.php
+++ b/src/www/services_ntpd_pps.php
@@ -85,10 +85,10 @@ include("head.inc");
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("NTP PPS Configuration"); ?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;&nbsp;

--- a/src/www/services_opendns.php
+++ b/src/www/services_opendns.php
@@ -132,8 +132,8 @@ include 'head.inc';
             <table class="table table-striped opnsense_standard_table_form">
               <thead>
                 <tr>
-                  <td width="22%"><strong><?=gettext('OpenDNS Setup'); ?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext('OpenDNS Setup'); ?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     &nbsp;

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -210,8 +210,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped">
                   <tr>
-                    <td width="22%"><a id="help_for_ramode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Router Advertisements");?></td>
-                    <td width="78%">
+                    <td style="width:22%"><a id="help_for_ramode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Router Advertisements");?></td>
+                    <td style="width:78%">
                       <select name="ramode">
                         <option value="disabled" <?=$pconfig['ramode'] == "disabled" ? "selected=\"selected\"" : ""; ?> >
                           <?=gettext("Disabled");?>

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -153,8 +153,8 @@ include_once("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <tbody>
                       <tr>
-                        <td width="22%"><strong><?=gettext("General DNS Resolver Options");?></strong></td>
-                        <td width="78%" align="right">
+                        <td style="width:22%"><strong><?=gettext("General DNS Resolver Options");?></strong></td>
+                        <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         </td>

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -200,8 +200,8 @@ include("head.inc");
               <input name="act" type="hidden" value="<?=$act;?>" />
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=ucwords(sprintf(gettext("%s Access List"),$act));?></strong></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><strong><?=ucwords(sprintf(gettext("%s Access List"),$act));?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -124,8 +124,8 @@ include_once("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <tbody>
                       <tr>
-                        <td width="22%"><strong><?=gettext("Advanced Resolver Options");?></strong></td>
-                        <td width="78%" align="right">
+                        <td style="width:22%"><strong><?=gettext("Advanced Resolver Options");?></strong></td>
+                        <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         </td>

--- a/src/www/services_unbound_domainoverride_edit.php
+++ b/src/www/services_unbound_domainoverride_edit.php
@@ -110,8 +110,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?=gettext("Edit Domain Override entry");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Edit Domain Override entry");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -169,8 +169,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?=gettext("Edit DNS Resolver entry");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("Edit DNS Resolver entry");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -99,8 +99,8 @@ include("head.inc");
                   <table class="table table-striped">
                   <tbody>
                     <tr>
-                      <td width="22%"><?= gettext("Status") ?></td>
-                      <td width="78%"><?= $ifinfo['status'] ?></td>
+                      <td style="width:22%"><?= gettext("Status") ?></td>
+                      <td style="width:78%"><?= $ifinfo['status'] ?></td>
                     </tr>
 <?php
                     if (!empty($ifinfo['dhcplink'])): ?>

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -341,8 +341,8 @@ include("head.inc");
           <form method="post" name="iform" id="iform">
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"><strong><?=gettext('Web GUI');?></strong></td>
-                <td  width="78%" align="right">
+                <td style="width:22%"><strong><?=gettext('Web GUI');?></strong></td>
+                <td style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>
@@ -420,7 +420,7 @@ include("head.inc");
                 </tr>
                 <tr class="ssl_opts">
                   <td><a id="help_for_disablehttpredirect" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('HTTP Redirect'); ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <input name="disablehttpredirect" type="checkbox" value="yes" <?= empty($pconfig['disablehttpredirect']) ? '' : 'checked="checked"';?> />
                     <strong><?= gettext('Disable web GUI redirect rule') ?></strong>
                     <div class="hidden" for="help_for_disablehttpredirect">
@@ -466,7 +466,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><a id="help_for_compression" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("HTTP Compression")?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <select name="compression" class="formselect selectpicker">
                         <option value="" <?=empty($pconfig['compression'])? 'selected="selected"' : '';?>>
                           <?=gettext("Off");?>
@@ -552,7 +552,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><a id="help_for_sshport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("SSH port"); ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <input name="sshport" type="text" value="<?=$pconfig['sshport'];?>" placeholder="22" />
                     <div class="hidden" for="help_for_sshport">
                       <?=gettext("Leave this blank for the default of 22."); ?>
@@ -579,14 +579,14 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i></a> <?= gettext('Console driver') ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <input name="usevirtualterminal" type="checkbox" value="yes" <?= empty($pconfig['usevirtualterminal']) ? '' : 'checked="checked"' ?>  />
                     <strong><?= gettext('Use the virtual terminal driver (vt)') ?></strong>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_primaryconsole" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Primary Console")?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <select name="primaryconsole" id="primaryconsole" class="formselect selectpicker">
 <?php               foreach (system_console_types() as $console_key => $console_type): ?>
                       <option value="<?= html_safe($console_key) ?>" <?= $pconfig['primaryconsole'] == $console_key ? 'selected="selected"' : '' ?>><?= $console_type['name'] ?></option>
@@ -600,7 +600,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><a id="help_for_secondaryconsole" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Secondary Console")?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <select name="secondaryconsole" id="secondaryconsole" class="formselect selectpicker">
                       <option value="" <?= empty($pconfig['secondaryconsole']) ? 'selected="selected"' : '' ?>><?= gettext('None') ?></option>
 <?php               foreach (system_console_types() as $console_key => $console_type): ?>
@@ -631,14 +631,14 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i></a> <?= gettext("Console menu") ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <input name="disableconsolemenu" type="checkbox" value="yes" <?= empty($pconfig['disableconsolemenu']) ? '' : 'checked="checked"' ?>  />
                     <strong><?=gettext("Password protect the console menu"); ?></strong>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_disableintegratedauth" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Integrated authentication") ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <input name="disableintegratedauth" type="checkbox" value="yes" <?= empty($pconfig['disableintegratedauth']) ? '' : 'checked="checked"' ?>  />
                     <strong><?=gettext("Disable integrated authentication"); ?></strong>
                     <div class="hidden" for="help_for_disableintegratedauth">
@@ -648,7 +648,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i> <?= gettext("Sudo usage") ?></td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <select name="sudo_allow_wheel" id="sudo_allow_wheel" class="formselect selectpicker">
                       <option value="" <?= empty($pconfig['sudo_allow_wheel']) ? 'selected="selected"' : '' ?>><?= gettext('Disallow') ?></option>
                       <option value="1" <?= $pconfig['sudo_allow_wheel'] == 1 ? 'selected="selected"' : '' ?>><?= gettext('Ask password') ?></option>
@@ -657,8 +657,8 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <td width="22%" valign="top">&nbsp;</td>
-                  <td width="78%"><input name="Submit" type="submit" class="btn btn-primary" value="<?= gettext("Save") ?>" /></td>
+                  <td style="width:22%; vertical-align:top">&nbsp;</td>
+                  <td style="width:78%"><input name="Submit" type="submit" class="btn btn-primary" value="<?= gettext("Save") ?>" /></td>
                 </tr>
             </table>
           </form>

--- a/src/www/system_advanced_firewall.php
+++ b/src/www/system_advanced_firewall.php
@@ -255,8 +255,8 @@ include("head.inc");
             <form method="post" name="iform" id="iform">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=gettext("IPv6 Options");?></strong></td>
-                  <td  width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext("IPv6 Options");?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
@@ -274,7 +274,7 @@ include("head.inc");
                 </tr>
 <?php           if (count($config['interfaces']) > 1): ?>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Network Address Translation");?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Network Address Translation");?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_natreflection" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reflection for port forwards");?></td>
@@ -316,7 +316,7 @@ include("head.inc");
                 </tr>
 <?php           endif; ?>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Bogon Networks");?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Bogon Networks");?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_bogonsinterval" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Update Frequency");?></td>
@@ -338,7 +338,7 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Gateway Monitoring"); ?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Gateway Monitoring"); ?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_kill_states" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Kill states");?> </td>
@@ -373,7 +373,7 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?= gettext('Multi-WAN') ?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?= gettext('Multi-WAN') ?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_lb_use_sticky" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Sticky connections");?> </td>
@@ -423,7 +423,7 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Schedules"); ?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Schedules"); ?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_schedule_states" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Schedule States"); ?></td>
@@ -436,7 +436,7 @@ include("head.inc");
                   </td>
                 </tr>
                 <tr>
-                  <th colspan="2" valign="top" class="listtopic"><?=gettext("Miscellaneous");?></th>
+                  <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Miscellaneous");?></th>
                 </tr>
                 <tr>
                   <td><a id="help_for_optimization" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Firewall Optimization");?></td>

--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -225,8 +225,8 @@ include("head.inc");
           <form method="post" name="iform" id="iform">
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"><strong><?= gettext('Cryptographic Hardware Acceleration') ?></strong></td>
-                <td width="78%" align="right">
+                <td style="width:22%"><strong><?= gettext('Cryptographic Hardware Acceleration') ?></strong></td>
+                <td style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>
@@ -272,7 +272,7 @@ include("head.inc");
                 </td>
               </tr>
               <tr>
-                <th colspan="2" valign="top" class="listtopic"><?=gettext("Thermal Sensors"); ?></th>
+                <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Thermal Sensors"); ?></th>
               </tr>
               <tr>
                 <td><a id="help_for_thermal_hardware" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hardware");?> </td>
@@ -298,7 +298,7 @@ include("head.inc");
                 </td>
               </tr>
               <tr>
-                <th colspan="2" valign="top" class="listtopic"><?=gettext("Periodic Backups"); ?></th>
+                <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Periodic Backups"); ?></th>
               </tr>
               <tr>
                 <td><a id="help_for_rrdbackup" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Periodic RRD Backup");?></td>
@@ -374,7 +374,7 @@ include("head.inc");
                 </td>
               </tr>
               <tr>
-                <th colspan="2" valign="top" class="listtopic"><?=gettext("Power Savings"); ?></th>
+                <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Power Savings"); ?></th>
               </tr>
               <tr>
                 <td><a id="help_for_powerd_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use PowerD"); ?></td>
@@ -457,7 +457,7 @@ include("head.inc");
                 </td>
               </tr>
               <tr>
-                <th colspan="2" valign="top" class="listtopic"><?=gettext("Disk / Memory Settings (reboot to apply changes)"); ?></th>
+                <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Disk / Memory Settings (reboot to apply changes)"); ?></th>
               </tr>
               <tr>
                 <td><i class="fa fa-info-circle text-muted"></i> <?=gettext('Swap file'); ?></td>

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -203,8 +203,8 @@ include("head.inc");
         <form method="post" name="iform" id="iform">
           <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"><strong><?= gettext('Network Interfaces') ?></strong></td>
-                <td width="78%" align="right">
+                <td style="width:22%"><strong><?= gettext('Network Interfaces') ?></strong></td>
+                <td style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>

--- a/src/www/system_advanced_notifications.php
+++ b/src/www/system_advanced_notifications.php
@@ -155,8 +155,8 @@ include("head.inc");
             <form method="post" name="iform">
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"><strong><?=gettext("Growl");?></strong></td>
-                <td  width="78%" align="right">
+                <td style="width:22%"><strong><?=gettext("Growl");?></strong></td>
+                <td style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -194,7 +194,7 @@ $( document ).ready(function() {
               <table class="table table-striped">
                 <thead>
                   <tr>
-                    <th colspan="2" valign="top" class="listtopic"><?=gettext("Edit system tunable"); ?></th>
+                    <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Edit system tunable"); ?></th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -424,8 +424,8 @@ $( document ).ready(function() {
             <form id="iform" name="iform" method="post">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"></td>
-                  <td  width="78%" align="right">
+                  <td style="width:22%"></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
@@ -731,9 +731,9 @@ else :
               <thead>
                 <tr>
                   <th><?=gettext("Server Name");?></th>
-                  <th width="25%"><?=gettext("Type");?></th>
-                  <th width="35%"><?=gettext("Host Name");?></th>
-                  <th width="10%" class="list"></th>
+                  <th style="width:25%"><?=gettext("Type");?></th>
+                  <th style="width:35%"><?=gettext("Host Name");?></th>
+                  <th style="width:10%" class="list"></th>
                 </tr>
               </thead>
               <tbody>

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -478,8 +478,8 @@ $main_buttons = array(
           <input type="hidden" name="act" id="action" value="<?=$act;?>"/>
           <table class="table table-striped opnsense_standard_table_form">
             <tr>
-              <td width="22%"></td>
-              <td  width="78%" align="right">
+              <td style="width:22%"></td>
+              <td style="width:78%; text-align:right">
                 <small><?=gettext("full help"); ?> </small>
                 <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
               </td>
@@ -516,8 +516,8 @@ $main_buttons = array(
             </thead>
             <tbody>
               <tr>
-                <td width="22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
-                <td width="78%">
+                <td style="width:22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
+                <td style="width:78%">
                   <textarea name="cert" cols="65" rows="7" id="cert"><?=isset($pconfig['cert']) ? $pconfig['cert'] : "";?></textarea>
                   <div class="hidden" for="help_for_cert">
                     <?=gettext("Paste a certificate in X.509 PEM format here.");?>
@@ -529,7 +529,7 @@ $main_buttons = array(
                   <a id="help_for_key" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate Private Key");?><br />
                   <?=gettext("(optional)");?>
                 </td>
-                <td width="78%">
+                <td style="width:78%">
                   <textarea name="key" id="key" cols="65" rows="7"><?= isset($pconfig['key']) ? $pconfig['key'] : "";?></textarea>
                   <div class="hidden" for="help_for_key">
                     <?=gettext("Paste the private key for the above certificate here. This is optional in most cases, but required if you need to generate a Certificate Revocation List (CRL).");?>
@@ -556,8 +556,8 @@ $main_buttons = array(
               </thead>
               <tbody>
                 <tr id='intermediate'>
-                  <td width="22%"> <i class="fa fa-info-circle text-muted"></i>  <?=gettext("Signing Certificate Authority");?></td>
-                  <td width="78%">
+                  <td style="width:22%"> <i class="fa fa-info-circle text-muted"></i>  <?=gettext("Signing Certificate Authority");?></td>
+                  <td style="width:78%">
                     <select name='caref' id='caref' class="selectpicker" onchange='internalca_change()'>
 <?php
                     foreach ($a_ca as $ca) :
@@ -572,7 +572,7 @@ $main_buttons = array(
                 </tr>
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Key length");?> (<?=gettext("bits");?>)</td>
-                  <td width="78%">
+                  <td style="width:78%">
                     <select name='keylen' id='keylen' class="selectpicker">
 <?php
                     foreach ($ca_keylens as $len) :?>
@@ -680,8 +680,8 @@ $main_buttons = array(
 
             <table class="table opnsense_standard_table_form">
             <tr>
-              <td width="22%">&nbsp;</td>
-              <td width="78%">
+              <td style="width:22%">&nbsp;</td>
+              <td style="width:78%">
                 <input id="submit" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
               </td>
             </tr>
@@ -694,7 +694,7 @@ $main_buttons = array(
           <input type="hidden" name="id" id="id" value="<?=isset($id) ? $id :"";?>"/>
           <input type="hidden" name="act" id="action" value="<?=$act;?>"/>
         </form>
-        <table width="100%" border="0" cellpadding="0" cellspacing="0" summary="" class="table table-striped">
+        <table style="width:100%; border:0; cellpadding:0; cellspacing:0" class="table table-striped">
           <thead>
             <tr>
               <th><?=gettext("Name");?></th>
@@ -747,11 +747,11 @@ $main_buttons = array(
               <td><?=$issuer_name;?>&nbsp;</td>
               <td><?=$certcount;?>&nbsp;</td>
               <td><?=$subj;?><br />
-                  <table width="100%" style="font-size: 9px">
+                  <table style="width:100%; font-size: 9px">
                     <tr>
                       <td>&nbsp;</td>
-                      <td width="20%"><?=gettext("Valid From")?>:</td>
-                      <td width="70%"><?= $startdate ?></td>
+                      <td style="width:20%"><?=gettext("Valid From")?>:</td>
+                      <td style="width:70%"><?= $startdate ?></td>
                     </tr>
                     <tr>
                       <td>&nbsp;</td>

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -707,8 +707,8 @@ $( document ).ready(function() {
             endif;?>
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"></td>
-                <td  width="78%" align="right">
+                <td style="width:22%"></td>
+                <td  style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>
@@ -743,8 +743,8 @@ $( document ).ready(function() {
               </thead>
               <tbody>
                 <tr>
-                  <td width="22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
-                  <td width="78%">
+                  <td style="width:22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
+                  <td style="width:78%">
                     <textarea name="cert" id="cert" cols="65" rows="7"><?=$pconfig['cert'];?></textarea>
                     <div class="hidden" for="help_for_cert">
                       <?=gettext("Paste a certificate in X.509 PEM format here.");?>
@@ -771,8 +771,8 @@ $( document ).ready(function() {
               </thead>
               <tbody>
               <tr>
-                <td width="22%"><?=gettext("Certificate authority");?></td>
-                <td width="78%">
+                <td style="width:22%"><?=gettext("Certificate authority");?></td>
+                <td style="width:78%">
                   <select name='caref' id='caref'>
 <?php
                   foreach ($a_ca as $ca) :
@@ -985,8 +985,8 @@ $( document ).ready(function() {
               </thead>
               <tbody>
                 <tr>
-                  <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Key length");?> (<?=gettext("bits");?>)</td>
-                  <td width="78%">
+                  <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Key length");?> (<?=gettext("bits");?>)</td>
+                  <td style="width:78%">
                     <select name='csr_keylen' class="selectpicker">
 <?php
                     foreach ($cert_keylens as $len) :?>
@@ -1108,8 +1108,8 @@ $( document ).ready(function() {
             </thead>
               <tbody>
               <tr>
-                <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Existing Certificates");?></td>
-                <td width="78%">
+                <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Existing Certificates");?></td>
+                <td style="width:78%">
                   <select name='certref'>
 <?php
                   foreach ($config['cert'] as $cert) :
@@ -1139,8 +1139,8 @@ $( document ).ready(function() {
             <!-- submit -->
             <table class="table">
               <tr>
-                <td width="22%">&nbsp;</td>
-                <td width="78%">
+                <td style="width:22%">&nbsp;</td>
+                <td style="width:78%">
                   <input id="submit" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                 </td>
               </tr>
@@ -1159,8 +1159,8 @@ $( document ).ready(function() {
             endif;?>
             <table class="table table-striped">
               <tr>
-                <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Descriptive name");?></td>
-                <td width="78%">
+                <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Descriptive name");?></td>
+                <td style="width:78%">
                   <input name="descr" type="text" id="descr" readonly="readonly" value="<?=$pconfig['descr'];?>"/>
                 </td>
               </tr>
@@ -1200,7 +1200,7 @@ $( document ).ready(function() {
             <input type="hidden" name="id" id="id" value="<?=isset($id) ? $id :"";?>"/>
             <input type="hidden" name="act" id="action" value="<?=$act;?>"/>
           </form>
-          <table summary="details"  class="table table-striped">
+          <table class="table table-striped">
             <thead>
               <tr>
                 <th><?=gettext("Name");?></th>
@@ -1252,11 +1252,11 @@ $( document ).ready(function() {
                 </td>
                 <td><?=$caname;?>&nbsp;</td>
                 <td><?=$subj;?>&nbsp;<br />
-                  <table summary="valid">
+                  <table>
                       <tr>
-                          <td width="10%">&nbsp;</td>
-                          <td width="20%"><?=gettext("Valid From")?>:</td>
-                          <td width="70%"><?= $startdate ?></td>
+                          <td style="width:10%">&nbsp;</td>
+                          <td style="width:20%"><?=gettext("Valid From")?>:</td>
+                          <td style="width:70%"><?= $startdate ?></td>
                       </tr>
                       <tr>
                           <td>&nbsp;</td>

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -333,8 +333,8 @@ include("head.inc");
 <?php
               if (!isset($id)) :?>
               <tr>
-                <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Method");?></td>
-                <td width="78%">
+                <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Method");?></td>
+                <td style="width:78%">
                   <select name="crlmethod" id='crlmethod' class="formselect">
                     <option value="internal" <?=$pconfig['crlmethod'] == "internal" ? "selected=\"selected\"" : "";?>><?=gettext("Create an internal Certificate Revocation List");?></option>
                     <option value="existing" <?=$pconfig['crlmethod'] == "existing" ? "selected=\"selected\"" : "";?>><?=gettext("Import an existing Certificate Revocation List");?></option>
@@ -373,8 +373,8 @@ include("head.inc");
               </thead>
               <tbody>
                 <tr>
-                  <td width="22%"><a id="help_for_crltext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("CRL data");?></td>
-                  <td width="78%">
+                  <td style="width:22%"><a id="help_for_crltext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("CRL data");?></td>
+                  <td style="width:78%">
                     <textarea name="crltext" id="crltext" cols="65" rows="7" class="formfld_crl"><?=$pconfig['crltext'];?></textarea>
                     <div class="hidden" for="help_for_crltext">
                       <?=gettext("Paste a Certificate Revocation List in X.509 CRL format here.");?>
@@ -392,8 +392,8 @@ include("head.inc");
               </thead>
               <tbody>
                 <tr>
-                  <td width="22%"><a id="help_for_lifetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Lifetime");?> (<?=gettext("days");?>)</td>
-                  <td width="78%">
+                  <td style="width:22%"><a id="help_for_lifetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Lifetime");?> (<?=gettext("days");?>)</td>
+                  <td style="width:78%">
                     <input name="lifetime" type="text" id="lifetime" size="5" value="<?=$pconfig['lifetime'];?>"/>
                     <div class="hidden" for="help_for_lifetime">
                       <?=gettext("Default: 9999");?>
@@ -414,8 +414,8 @@ include("head.inc");
 
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%">&nbsp;</td>
-                <td width="78%">
+                <td style="width:22%">&nbsp;</td>
+                <td style="width:78%">
                   <input id="submit" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
 <?php
                   if (isset($id)) :?>
@@ -434,8 +434,8 @@ include("head.inc");
                 <th colspan="2"><?=gettext("Edit Imported Certificate Revocation List");?></th>
               </tr>
               <tr>
-                <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Descriptive name");?></td>
-                <td width="78%">
+                <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Descriptive name");?></td>
+                <td style="width:78%">
                   <input name="descr" type="text" id="descr" size="20" value="<?=$thiscrl['descr'];?>"/>
                 </td>
               </tr>
@@ -532,7 +532,7 @@ include("head.inc");
                   <td>
                     <b><?=gettext("Choose a Certificate to Revoke"); ?></b>:
                   </td>
-                  <td colspan="3" align="left">
+                  <td colspan="3" style="text-align:left">
                     <select name='certref' id='certref' class="selectpicker" data-style="btn-default" data-live-search="true">
 <?php
                   foreach ($ca_certs as $cert) :?>
@@ -546,7 +546,7 @@ include("head.inc");
                   <td>
                     <b><?=gettext("Reason");?></b>:
                   </td>
-                  <td colspan="3" align="left">
+                  <td colspan="3" style="text-align:left">
                     <select name='crlreason' id='crlreason' class="selectpicker" data-style="btn-default">
 <?php
                   foreach ($openssl_crl_status as $code => $reason) :?>
@@ -558,7 +558,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td></td>
-                  <td colspan="3" align="left">
+                  <td colspan="3" style="text-align:left">
                     <input name="act" type="hidden" value="addcert" />
                     <input name="id" type="hidden" value="<?=$thiscrl['refid'];?>" />
                     <input id="submit" name="add" type="submit" class="formbtn btn btn-primary" value="<?=gettext("Add"); ?>" />

--- a/src/www/system_gateway_groups_edit.php
+++ b/src/www/system_gateway_groups_edit.php
@@ -172,10 +172,10 @@ $( document ).ready(function() {
           <div class="tab-content content-box col-xs-12">
             <div class="table-responsive">
               <form method="post" name="iform" id="iform">
-                <table class="table table-striped opnsense_standard_table_form" summary="system groups edit">
+                <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/system_gateways_edit.php
+++ b/src/www/system_gateways_edit.php
@@ -560,8 +560,8 @@ $( document ).ready(function() {
               <input type='hidden' name='friendlyiface' id='friendlyiface' value="<?=$pconfig['friendlyiface'];?>"/>
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><?=gettext("Edit gateway");?></td>
-                  <td  width="78%" align="right">
+                  <td style="width:22%"><?=gettext("Edit gateway");?></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -242,8 +242,8 @@ include("head.inc");
         <form method="post">
           <table class="table table-striped opnsense_standard_table_form">
             <tr>
-              <td width="22%"><strong><?=gettext("System");?></strong></td>
-              <td width="78%" align="right">
+              <td style="width:22%"><strong><?=gettext("System");?></strong></td>
+              <td style="width:78%; text-align:right">
                 <small><?=gettext("full help"); ?> </small>
                 <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
               </td>
@@ -327,7 +327,7 @@ include("head.inc");
               </td>
             </tr>
             <tr>
-              <th colspan="2" valign="top" class="listtopic"><?=gettext("Networking"); ?></th>
+              <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext("Networking"); ?></th>
             </tr>
             <tr>
               <td><a id="help_for_prefer_ipv4" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Prefer IPv4 over IPv6"); ?></td>

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -249,7 +249,7 @@ $( document ).ready(function() {
               <tr>
                 <td><a id="help_for_groups" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Group Memberships");?></td>
                 <td>
-                  <table class="table" width="100%" border="0" cellpadding="0" cellspacing="0">
+                  <table class="table" style="width:100%; border:0; cellpadding:0; cellspacing:0">
                     <thead>
                       <tr>
                         <th><?=gettext("Not Member Of"); ?></th>

--- a/src/www/system_hasync.php
+++ b/src/www/system_hasync.php
@@ -105,8 +105,8 @@ include("head.inc");
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><strong><?=gettext('State Synchronization') ?></strong></td>
-                  <td  width="78%" align="right">
+                  <td style="width:22%"><strong><?=gettext('State Synchronization') ?></strong></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
@@ -179,7 +179,7 @@ include("head.inc");
                   <th colspan="2" class="listtopic"><?=gettext('Configuration Synchronization Settings (XMLRPC Sync)') ?></th>
                 </tr>
                 <tr>
-                  <td width="22%"><a id="help_for_synchronizetoip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Synchronize Config to IP') ?></td>
+                  <td style="width:22%"><a id="help_for_synchronizetoip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Synchronize Config to IP') ?></td>
                   <td>
                     <input name="synchronizetoip" type="text" value="<?=$pconfig['synchronizetoip']; ?>" />
                     <div class="hidden" for="help_for_synchronizetoip">

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -556,8 +556,8 @@ $( document ).ready(function() {
                 <input type="hidden" id="certid" name="certid" value="" /> <!-- remove cert association action -->
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -647,7 +647,7 @@ $( document ).ready(function() {
                   <tr>
                     <td><a id="help_for_groups" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Group Memberships");?></td>
                     <td>
-                      <table class="table" width="100%" border="0" cellpadding="0" cellspacing="0">
+                      <table class="table" style="width:100%; border:0; cellpadding:0; cellspacing:0">
                         <thead>
                           <tr>
                             <th><?=gettext("Not Member Of"); ?></th>
@@ -989,13 +989,13 @@ $( document ).ready(function() {
                         <table>
                           <tr>
                             <td></td>
-                            <td width="20px"></td>
-                            <td width="20px"><span class="glyphicon glyphicon-user text-danger"></span></td>
-                            <td width="200px"><?= gettext('System Administrator') ?></td>
-                            <td width="20px"><span class="glyphicon glyphicon-user text-muted"></span></td>
-                            <td width="200px"><?= gettext('Disabled User') ?></td>
-                            <td width="20px"><span class="glyphicon glyphicon-user text-info"></span></td>
-                            <td width="200px"><?= gettext('Normal User') ?></td>
+                            <td style="width:20px"></td>
+                            <td style="width:20px"><span class="glyphicon glyphicon-user text-danger"></span></td>
+                            <td style="width:200px"><?= gettext('System Administrator') ?></td>
+                            <td style="width:20px"><span class="glyphicon glyphicon-user text-muted"></span></td>
+                            <td style="width:200px"><?= gettext('Disabled User') ?></td>
+                            <td style="width:20px"><span class="glyphicon glyphicon-user text-info"></span></td>
+                            <td style="width:200px"><?= gettext('Normal User') ?></td>
                             <td></td>
                           </tr>
                         </table>

--- a/src/www/system_usermanager_addprivs.php
+++ b/src/www/system_usermanager_addprivs.php
@@ -169,8 +169,8 @@ include("head.inc");
             <input name="input_type" type="hidden" value="<?=$input_type;?>" />
             <table class="table table-striped opnsense_standard_table_form">
               <tr>
-                <td width="22%"><?=gettext("System Privileges");?></td>
-                <td width="78%">
+                <td style="width:22%"><?=gettext("System Privileges");?></td>
+                <td style="width:78%">
                     <table class="table table-condensed table-hoover">
                         <thead>
                             <tr>

--- a/src/www/system_usermanager_import_ldap.php
+++ b/src/www/system_usermanager_import_ldap.php
@@ -155,7 +155,7 @@ else :
       <?php endforeach;
 ?>
       <tr>
-        <td align="left" colspan="3">
+        <td style="text-align:left" colspan="3">
           <input type='submit' class="btn btn-primary" value='<?=gettext("Save");?>'>
         </td>
       </tr>

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -110,8 +110,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped">
                   <tr>
-                    <td width="22%"><strong><?= gettext('User Settings') ?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?= gettext('User Settings') ?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/src/www/system_usermanager_settings.php
+++ b/src/www/system_usermanager_settings.php
@@ -107,8 +107,8 @@ endif;?>
             <form method="post">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><a id="help_for_session_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Session Timeout"); ?></td>
-                  <td width="78%">
+                  <td style="width:22%"><a id="help_for_session_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Session Timeout"); ?></td>
+                  <td style="width:78%">
                     <input class="form-control" name="session_timeout" id="session_timeout" type="text" size="8" value="<?=$pconfig['session_timeout'];?>" />
                     <div class="hidden" for="help_for_session_timeout">
                       <?=gettext("Time in minutes to expire idle management sessions. The default is 4 hours (240 minutes).");?><br />

--- a/src/www/system_usermanager_settings_ldapacpicker.php
+++ b/src/www/system_usermanager_settings_ldapacpicker.php
@@ -99,7 +99,7 @@ if (isset($_GET['basedn']) && isset($_GET['host'])) {
 <?php
               endforeach;?>
               <tr>
-                <td align="right">
+                <td style="text-align:right">
                   <input type='button' class="btn btn-primary" value='<?=gettext("Save");?>' onClick="post_choices();">
                 </td>
               </tr>

--- a/src/www/system_usermanager_settings_test.php
+++ b/src/www/system_usermanager_settings_test.php
@@ -96,7 +96,7 @@ if (isset($config['system']['authserver'][0]['host'])) {
         endif;
       endif;?>
       <tr>
-        <td colspan="2" align="right">
+        <td colspan="2" style="text-align:right">
           <input type="Button" value="<?=gettext("Close"); ?>" class="btn btn-default" onClick='Javascript:window.close();'>
         </td>
       </tr>

--- a/src/www/vpn_ipsec_mobile.php
+++ b/src/www/vpn_ipsec_mobile.php
@@ -350,8 +350,8 @@ if (isset($input_errors) && count($input_errors) > 0) {
                <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><b><?=gettext("IKE Extensions"); ?> </b></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><b><?=gettext("IKE Extensions"); ?> </b></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -552,8 +552,8 @@ include("head.inc");
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><b><?=gettext("General information"); ?></b></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><b><?=gettext("General information"); ?></b></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -572,7 +572,7 @@ include("head.inc");
 <?php
                   endif;?>
                   <tr>
-                    <td width="22%" valign="top"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
+                    <td style="width:22%; vertical-align:top"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td>
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?=!empty($pconfig['disabled'])?"checked=\"checked\"":"";?> />
                       <div class="hidden" for="help_for_disabled">

--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -476,15 +476,15 @@ if (isset($input_errors) && count($input_errors) > 0) {
             <div class="table-responsive">
               <table class="table table-striped opnsense_standard_table_form">
                 <tr>
-                  <td width="22%"><b><?=gettext("General information"); ?></b></td>
-                  <td width="78%" align="right">
+                  <td style="width:22%"><b><?=gettext("General information"); ?></b></td>
+                  <td style="width:78%; text-align:right">
                     <small><?=gettext("full help"); ?> </small>
                     <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                   </td>
                 </tr>
                 <tr>
-                  <td width="22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
-                  <td width="78%" class="vtable">
+                  <td style="width:22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
+                  <td style="width:78%" class="vtable">
                     <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : "" ;?> />
                     <div class="hidden" for="help_for_disabled">
                         <?=gettext("Disable this phase2 entry"); ?><br/>
@@ -603,7 +603,7 @@ endif; ?>
                 </tr>
                 <tr>
                   <td><a id="help_for_proto" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Protocol"); ?></td>
-                  <td width="78%" class="vtable">
+                  <td style="width:78%" class="vtable">
                     <select name="protocol" id="proto">
 <?php
                     foreach (array('esp' => 'ESP','ah' => 'AH') as $proto => $protoname) :?>
@@ -656,7 +656,7 @@ endif; ?>
                 </tr>
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Hash algorithms"); ?></td>
-                  <td width="78%" class="vtable">
+                  <td style="width:78%" class="vtable">
 <?php
                   foreach ($p2_halgos as $algo => $algoname) :?>
                     <input type="checkbox" name="hash-algorithm-option[]" value="<?=$algo;?>" <?= isset($pconfig['hash-algorithm-option']) && in_array($algo, $pconfig['hash-algorithm-option']) ?  'checked="checked"' : '';?>/>
@@ -732,7 +732,7 @@ endif; ?>
                 endif; ?>
                 <tr>
                   <td>&nbsp;</td>
-                  <td width="78%">
+                  <td style="width:78%">
 <?php
                  if (isset($pconfig['mobile'])) :?>
                     <input name="mobile" type="hidden" value="true" />

--- a/src/www/vpn_ipsec_settings.php
+++ b/src/www/vpn_ipsec_settings.php
@@ -143,7 +143,7 @@ if (isset($input_errors) && count($input_errors) > 0) {
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
                       <td ><strong><?=gettext("IPsec Advanced Settings"); ?></strong></td>
-                      <td align="right">
+                      <td style="text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
@@ -157,7 +157,7 @@ if (isset($input_errors) && count($input_errors) > 0) {
                     </tr>
                     <tr>
                       <td><a id="help_for_preferoldsa_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Security Associations"); ?></td>
-                      <td width="78%" class="vtable">
+                      <td style="width:78%" class="vtable">
                         <input name="preferoldsa_enable" type="checkbox" id="preferoldsa_enable" value="yes" <?= !empty($pconfig['preferoldsa_enable']) ? "checked=\"checked\"" : "";?> />
                         <strong><?=gettext("Prefer older IPsec SAs"); ?></strong>
                         <div class="hidden" for="help_for_preferoldsa_enable">

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -545,8 +545,8 @@ $( document ).ready(function() {
           <div class="table-responsive">
           <table class="table table-striped opnsense_standard_table_form">
             <tr>
-              <td width="22%"><strong><?=gettext("General information"); ?></strong></td>
-              <td width="78%" align="right">
+              <td style="width:22%"><strong><?=gettext("General information"); ?></strong></td>
+              <td style="width:78%; text-align:right">
                 <small><?=gettext("full help"); ?> </small>
                 <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
               </td>
@@ -771,8 +771,8 @@ $( document ).ready(function() {
             <td colspan="2"><strong><?=gettext("User Authentication Settings"); ?></strong></td>
           </tr>
           <tr>
-            <td width="22%"><a id="help_for_auth_user_pass" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("User name/pass"); ?></td>
-            <td width="78%">
+            <td style="width:22%"><a id="help_for_auth_user_pass" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("User name/pass"); ?></td>
+            <td style="width:78%">
               <div><?=gettext("Username"); ?></div>
               <div><input name="auth_user" id="auth_user" class="form-control unknown" type="text" size="20" value="<?=$pconfig['auth_user'];?>" /></div>
               <div><?=gettext("Password"); ?></div>
@@ -801,8 +801,8 @@ $( document ).ready(function() {
          <div class="table-responsive">
           <table class="table table-striped opnsense_standard_table_form">
           <tr>
-            <td width="22%"><strong><?=gettext("Cryptographic Settings"); ?></strong></td>
-            <td width="78%"></td>
+            <td style="width:22%"><strong><?=gettext("Cryptographic Settings"); ?></strong></td>
+            <td style="width:78%"></td>
           </tr>
           <tr class="tls_option">
             <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("TLS Authentication"); ?></td>
@@ -968,8 +968,8 @@ $( document ).ready(function() {
             <td colspan="2"><strong><?=gettext("Tunnel Settings"); ?></strong></td>
           </tr>
           <tr>
-            <td width="22%"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
-            <td width="78%">
+            <td style="width:22%"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
+            <td style="width:78%">
               <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
               <div class="hidden" for="help_for_tunnel_network">
                 <?=gettext("This is the IPv4 virtual network used for private " .
@@ -1107,8 +1107,8 @@ $( document ).ready(function() {
             <td colspan="2"><strong><?=gettext("Advanced configuration"); ?></strong></td>
           </tr>
           <tr>
-            <td width="22%"><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
-            <td width="78%">
+            <td style="width:22%"><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
+            <td style="width:78%">
               <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea><br />
               <div class="hidden" for="help_for_custom_options">
                 <?=gettext("Enter any additional options you would like to add to the configuration file here."); ?>
@@ -1148,7 +1148,7 @@ $( document ).ready(function() {
         <table class="table table-striped opnsense_standard_table_form">
           <tr>
             <td>&nbsp;</td>
-            <td width="78%">
+            <td style="width:78%">
               <input name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
               <input name="act" type="hidden" value="<?=$act;?>" />
 <?php

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -381,14 +381,14 @@ if ($act!="new" && $act!="edit") {
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
                     <td><?=gettext("General information"); ?></td>
-                    <td align="right">
+                    <td style="text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%"><a id="help_for_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
-                    <td width="78%">
+                    <td style="width:22%"><a id="help_for_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
+                    <td style="width:78%">
                       <input name="disable" type="checkbox" value="yes" <?= !empty($pconfig['disable']) ? "checked=\"checked\"" : "";?> />
                       <div class="hidden" for="help_for_disable">
                         <?=gettext("Set this option to disable this client-specific override without removing it from the list"); ?>
@@ -670,7 +670,7 @@ if ($act!="new" && $act!="edit") {
                     </td>
                   </tr>
                   <tr>
-                    <td valign="top">&nbsp;</td>
+                    <td style="vertical-align:top">&nbsp;</td>
                     <td>
                       <input name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                       <input name="act" type="hidden" value="<?=$act;?>" />

--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -1271,14 +1271,14 @@ if (isset($savemsg)) {
           <div class="table-responsive">
             <table class="table table-striped opnsense_standard_table_form" >
               <tr>
-                <td width="22%"></td>
-                <td width="78%" align="right">
+                <td style="width:22%"></td>
+                <td style="width:78%; text-align:right">
                   <small><?=gettext("full help"); ?> </small>
                   <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                 </td>
               </tr>
               <tr>
-                <td valign="top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Remote Access Server");?></td>
+                <td style="vertical-align:top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Remote Access Server");?></td>
                 <td>
                   <select name="server" id="server" class="formselect">
 <?php
@@ -1290,7 +1290,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr>
-                <td valign="top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Host Name Resolution");?></td>
+                <td style="vertical-align:top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Host Name Resolution");?></td>
                 <td>
                       <select name="useaddr" id="useaddr">
                         <option value="serveraddr" ><?=gettext("Interface IP Address");?></option>
@@ -1326,7 +1326,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr class="mode_server">
-                <td valign="top"><a id="help_for_verify_server_cn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Verify Server CN");?></td>
+                <td style="vertical-align:top"><a id="help_for_verify_server_cn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Verify Server CN");?></td>
                 <td >
                       <select name="verifyservercn" id="verifyservercn" class="formselect">
                         <option value="auto"><?=gettext("Automatic - Use verify-x509-name (OpenVPN 2.3+) where possible");?></option>
@@ -1342,7 +1342,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr class="mode_server">
-                <td valign="top"><a id="help_for_random_local_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Random Local Port");?></td>
+                <td style="vertical-align:top"><a id="help_for_random_local_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Random Local Port");?></td>
                 <td >
                       <input name="randomlocalport" id="randomlocalport" type="checkbox" value="yes" checked="CHECKED" />
                       <div class="hidden" for="help_for_random_local_port">
@@ -1352,7 +1352,7 @@ if (isset($savemsg)) {
                       </div>
               </tr>
               <tr class="mode_server">
-                <td valign="top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Certificate Export Options");?></td>
+                <td style="vertical-align:top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Certificate Export Options");?></td>
                 <td >
                       <div>
                         <input name="usetoken" id="usetoken" type="checkbox" value="yes" />
@@ -1371,7 +1371,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr>
-                <td valign="top"><a id="help_for_http_proxy" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Proxy");?></td>
+                <td style="vertical-align:top"><a id="help_for_http_proxy" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Proxy");?></td>
                 <td >
                       <input name="useproxy" id="useproxy" type="checkbox" value="yes" />
                       <div class="hidden" for="help_for_http_proxy">
@@ -1407,7 +1407,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr class="mode_server">
-                <td valign="top"><a id="help_for_openvpnmanager" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Management Interface OpenVPN Manager");?></td>
+                <td style="vertical-align:top"><a id="help_for_openvpnmanager" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Management Interface OpenVPN Manager");?></td>
                 <td >
                       <input name="openvpnmanager" id="openvpnmanager" type="checkbox" value="yes" />
                       <div class="hidden" for="help_for_openvpnmanager">
@@ -1418,7 +1418,7 @@ if (isset($savemsg)) {
                 </td>
               </tr>
               <tr class="mode_server">
-                <td valign="top"><a id="help_for_advancedoptions" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Additional configuration options");?></td>
+                <td style="vertical-align:top"><a id="help_for_advancedoptions" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Additional configuration options");?></td>
                 <td >
                       <textarea rows="6" cols="68" name="advancedoptions" id="advancedoptions"></textarea><br/>
                       <div class="hidden" for="help_for_advancedoptions">
@@ -1433,9 +1433,9 @@ if (isset($savemsg)) {
                   <table id="export_users" class="table table-striped table-condensed">
                     <thead>
                       <tr>
-                        <td width="25%" ><b><?=gettext("User");?></b></td>
-                        <td width="35%" ><b><?=gettext("Certificate Name");?></b></td>
-                        <td width="40%" ><b><?=gettext("Export");?></b></td>
+                        <td style="width:25%" ><b><?=gettext("User");?></b></td>
+                        <td style="width:35%" ><b><?=gettext("Certificate Name");?></b></td>
+                        <td style="width:40%" ><b><?=gettext("Export");?></b></td>
                       </tr>
                     </thead>
                     <tbody>
@@ -1561,7 +1561,7 @@ if (isset($savemsg)) {
                   </td>
                 </tr>
                 <tr>
-                  <td valign="top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Links to OpenVPN clients");?></td>
+                  <td style="vertical-align:top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Links to OpenVPN clients");?></td>
                   <td>
                     <a href="http://www.sparklabs.com/viscosity/"><?= gettext("Viscosity") ?></a> - <?= gettext("Recommended client for Mac OSX and Windows") ?><br/>
                     <a href="http://openvpn.net/index.php/open-source/downloads.html"><?= gettext("OpenVPN Community Client") ?></a> - <?=gettext("Binaries for Windows, Source for other platforms.")?><br/>

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -596,8 +596,8 @@ $( document ).ready(function() {
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><strong><?=gettext("General information"); ?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("General information"); ?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
@@ -616,7 +616,7 @@ $( document ).ready(function() {
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
+                      <td style="width:22%"><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                       <td>
                         <input name="description" type="text" class="form-control unknown" size="30" value="<?=htmlspecialchars($pconfig['description']);?>" />
                         <div class="hidden" for="help_for_description">
@@ -782,8 +782,8 @@ $( document ).ready(function() {
                       <td colspan="2"><strong><?=gettext("Cryptographic Settings"); ?></strong></td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("TLS Authentication"); ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("TLS Authentication"); ?></td>
+                      <td style="width:78%">
                         <div>
                           <input name="tlsauth_enable" id="tlsauth_enable" type="checkbox" value="yes" <?=!empty($pconfig['tlsauth_enable']) ? "checked=\"checked\"" : "" ;?>/>
                           <?=gettext("Enable authentication of TLS packets"); ?>.
@@ -920,7 +920,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_shared_key">
-                      <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Shared Key"); ?></td>
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Shared Key"); ?></td>
                       <td>
 <?php
                         if (empty($pconfig['shared_key'])) :?>
@@ -1000,7 +1000,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_cert_depth" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate Depth"); ?></td>
+                      <td style="width:22%"><a id="help_for_cert_depth" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate Depth"); ?></td>
                       <td>
                         <table>
                         <tr><td>
@@ -1038,7 +1038,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_strictusercn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Strict User/CN Matching"); ?></td>
+                      <td style="width:22%"><a id="help_for_strictusercn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Strict User/CN Matching"); ?></td>
                       <td>
                         <input name="strictusercn" type="checkbox" value="yes" <?=!empty($pconfig['strictusercn']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_strictusercn">
@@ -1060,7 +1060,7 @@ endif; ?>
                       <td colspan="2"><strong><?=gettext("Tunnel Settings"); ?></strong></td>
                     </tr>
                     <tr>
-                      <td width="22%" id="ipv4_tunnel_network"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
+                      <td style="width:22%" id="ipv4_tunnel_network"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
                       <td witdh="78%">
                         <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
                         <div class="hidden" for="help_for_tunnel_network">
@@ -1075,7 +1075,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_tunnel_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Tunnel Network"); ?></td>
+                      <td style="width:22%"><a id="help_for_tunnel_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Tunnel Network"); ?></td>
                       <td>
                         <input name="tunnel_networkv6" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_networkv6'];?>" />
                         <div class="hidden" for="help_for_tunnel_networkv6">
@@ -1090,7 +1090,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
-                      <td width="22%" ><a id="help_for_serverbridge_dhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Bridge DHCP"); ?></td>
+                      <td style="width:22%"><a id="help_for_serverbridge_dhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Bridge DHCP"); ?></td>
                       <td>
                               <input id="serverbridge_dhcp" name="serverbridge_dhcp" type="checkbox" value="yes" <?=!empty($pconfig['serverbridge_dhcp']) ? "checked=\"checked\"" : "" ;?>/>
                               <div class="hidden" for="help_for_serverbridge_dhcp">
@@ -1101,7 +1101,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
-                      <td width="22%" ><a id="help_for_serverbridge_interface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Bridge Interface"); ?></td>
+                      <td style="width:22%"><a id="help_for_serverbridge_interface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Bridge Interface"); ?></td>
                       <td>
                         <select id="serverbridge_interface" name="serverbridge_interface" class="form-control">
 <?php
@@ -1138,7 +1138,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
-                      <td width="22%" ><a id="help_for_serverbridge_dhcp_start" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Server Bridge DHCP Start"); ?></td>
+                      <td style="width:22%"><a id="help_for_serverbridge_dhcp_start" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Server Bridge DHCP Start"); ?></td>
                       <td>
                         <input  id="serverbridge_dhcp_start" name="serverbridge_dhcp_start" type="text" class="form-control unknown" size="20" value="<?=$pconfig['serverbridge_dhcp_start'];?>" />
                         <div class="hidden" for="help_for_serverbridge_dhcp_start">
@@ -1152,13 +1152,13 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
-                      <td width="22%" ><i class="fa fa-info-circle text-muted"></i> <?=gettext("Server Bridge DHCP End"); ?></td>
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Server Bridge DHCP End"); ?></td>
                       <td>
                         <input id="serverbridge_dhcp_end" name="serverbridge_dhcp_end" type="text" class="form-control unknown" size="20" value="<?=$pconfig['serverbridge_dhcp_end'];?>" />
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_gwredir" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Redirect Gateway"); ?></td>
+                      <td style="width:22%"><a id="help_for_gwredir" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Redirect Gateway"); ?></td>
                       <td>
                         <input name="gwredir" id="gwredir" type="checkbox" value="yes" <?=!empty($pconfig['gwredir']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_gwredir">
@@ -1169,7 +1169,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user opt_gwredir">
-                      <td width="22%" ><a id="help_local_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Local Network"); ?></td>
+                      <td style="width:22%"><a id="help_local_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Local Network"); ?></td>
                       <td>
                         <input name="local_network" type="text" class="form-control unknown" size="40" value="<?=$pconfig['local_network'];?>" />
                         <div class="hidden" for="help_local_network">
@@ -1183,7 +1183,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user opt_gwredir">
-                      <td width="22%" ><a id="help_for_local_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Local Network"); ?></td>
+                      <td style="width:22%"><a id="help_for_local_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Local Network"); ?></td>
                       <td>
                         <input name="local_networkv6" type="text" class="form-control unknown" size="40" value="<?=$pconfig['local_networkv6'];?>" />
                         <div class="hidden" for="help_for_local_networkv6">
@@ -1197,7 +1197,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_remote_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Remote Network"); ?></td>
+                      <td style="width:22%"><a id="help_for_remote_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Remote Network"); ?></td>
                       <td>
                         <input name="remote_network" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_network'];?>" />
                         <div class="hidden" for="help_for_remote_network">
@@ -1212,7 +1212,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_remote_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Remote Network"); ?></td>
+                      <td style="width:22%"><a id="help_for_remote_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Remote Network"); ?></td>
                       <td>
                         <input name="remote_networkv6" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_networkv6'];?>" />
                         <div class="hidden" for="help_for_remote_networkv6">
@@ -1227,7 +1227,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_maxclients" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Concurrent connections");?></td>
+                      <td style="width:22%"><a id="help_for_maxclients" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Concurrent connections");?></td>
                       <td>
                         <input name="maxclients" type="text" class="form-control unknown" size="5" value="<?=$pconfig['maxclients'];?>" />
                         <div class="hidden" for="help_for_maxclients">
@@ -1236,7 +1236,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_compression" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Compression"); ?></td>
+                      <td style="width:22%"><a id="help_for_compression" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Compression"); ?></td>
                       <td>
                         <select name="compression" class="form-control">
 <?php
@@ -1256,7 +1256,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_passtos" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Type-of-Service"); ?></td>
+                      <td style="width:22%"><a id="help_for_passtos" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Type-of-Service"); ?></td>
                       <td>
                         <input name="passtos" type="checkbox" value="yes" <?=!empty($pconfig['passtos']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_passtos">
@@ -1267,7 +1267,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_client2client" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Inter-client communication"); ?></td>
+                      <td style="width:22%"><a id="help_for_client2client" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Inter-client communication"); ?></td>
                       <td>
                           <input name="client2client" type="checkbox" value="yes"  <?=!empty($pconfig['client2client']) ? "checked=\"checked\"" : "" ;?> />
                           <div class="hidden" for="help_for_client2client">
@@ -1278,7 +1278,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr id="duplicate_cn">
-                      <td width="22%" ><a id="help_for_duplicate_cn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Duplicate Connections"); ?></td>
+                      <td style="width:22%"><a id="help_for_duplicate_cn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Duplicate Connections"); ?></td>
                       <td>
                             <input name="duplicate_cn" type="checkbox" value="yes" <?=!empty($pconfig['duplicate_cn']) ? "checked=\"checked\"" : "" ;?> />
                             <div class="hidden" for="help_for_duplicate_cn">
@@ -1289,7 +1289,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tun">
-                      <td width="22%" ><a id="help_for_no_tun_ipv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable IPv6"); ?></td>
+                      <td style="width:22%"><a id="help_for_no_tun_ipv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable IPv6"); ?></td>
                       <td>
                         <input name="no_tun_ipv6" type="checkbox" value="yes" <?=!empty($pconfig['no_tun_ipv6']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_no_tun_ipv6">
@@ -1311,8 +1311,8 @@ endif; ?>
                       <td colspan="2"><strong><?=gettext("Client Settings"); ?></strong></td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_dynamic_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Dynamic IP"); ?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_dynamic_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Dynamic IP"); ?></td>
+                      <td style="width:78%">
                         <input name="dynamic_ip" type="checkbox" id="dynamic_ip" value="yes" <?=!empty($pconfig['dynamic_ip']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_dynamic_ip">
                           <span>
@@ -1322,7 +1322,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_pool_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Address Pool"); ?></td>
+                      <td style="width:22%"><a id="help_for_pool_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Address Pool"); ?></td>
                       <td>
                         <input name="pool_enable" type="checkbox" id="pool_enable" value="yes" <?=!empty($pconfig['pool_enable']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_pool_enable">
@@ -1333,7 +1333,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tun" id="topology_subnet_opt">
-                      <td width="22%" ><a id="help_for_topology_subnet" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Topology"); ?></td>
+                      <td style="width:22%"><a id="help_for_topology_subnet" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Topology"); ?></td>
                       <td>
                         <input name="topology_subnet" type="checkbox" id="topology_subnet" value="yes"  <?=!empty($pconfig['topology_subnet']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_topology_subnet">
@@ -1346,7 +1346,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_dns_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Default Domain"); ?></td>
+                      <td style="width:22%"><a id="help_for_dns_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Default Domain"); ?></td>
                       <td>
                         <input name="dns_domain_enable" type="checkbox" id="dns_domain_enable" value="yes" <?=!empty($pconfig['dns_domain']) ? "checked=\"checked\"" : "" ;?> />
                         <div id="dns_domain_data">
@@ -1360,7 +1360,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_dns_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Servers"); ?></td>
+                      <td style="width:22%"><a id="help_for_dns_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Servers"); ?></td>
                       <td>
                         <input name="dns_server_enable" type="checkbox" id="dns_server_enable" value="yes" <?=!empty($pconfig['dns_server1']) || !empty($pconfig['dns_server2']) || !empty($pconfig['dns_server3']) || !empty($pconfig['dns_server4']) ? "checked=\"checked\"" : "" ;?> />
                         <div id="dns_server_data">
@@ -1389,7 +1389,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr id="chkboxPushRegisterDNS">
-                      <td width="22%" ><a id="help_for_push_register_dns" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Force DNS cache update"); ?></td>
+                      <td style="width:22%"><a id="help_for_push_register_dns" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Force DNS cache update"); ?></td>
                       <td>
                         <input name="push_register_dns" type="checkbox" value="yes" <?=!empty($pconfig['push_register_dns']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_push_register_dns">
@@ -1400,7 +1400,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_ntp_server_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NTP Servers"); ?></td>
+                      <td style="width:22%"><a id="help_for_ntp_server_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NTP Servers"); ?></td>
                       <td>
                         <input name="ntp_server_enable" type="checkbox" id="ntp_server_enable" value="yes" <?=!empty($pconfig['ntp_server1']) || !empty($pconfig['ntp_server2']) ? "checked=\"checked\"" : "" ;?>  />
                         <div id="ntp_server_data">
@@ -1421,7 +1421,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_netbios_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NetBIOS Options"); ?></td>
+                      <td style="width:22%"><a id="help_for_netbios_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NetBIOS Options"); ?></td>
                       <td>
                         <input name="netbios_enable" type="checkbox" id="netbios_enable" value="yes" <?=!empty($pconfig['netbios_enable']) ? "checked=\"checked\"" : "" ;?>  />
                         <div class="hidden" for="help_for_netbios_enable">
@@ -1467,7 +1467,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr id="wins_opts">
-                      <td width="22%" ><a id="help_for_wins_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("WINS Servers"); ?></td>
+                      <td style="width:22%"><a id="help_for_wins_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("WINS Servers"); ?></td>
                       <td>
                         <input name="wins_server_enable" type="checkbox" id="wins_server_enable" value="yes" <?=!empty($pconfig['wins_server1']) || !empty($pconfig['wins_server2']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_wins_server">
@@ -1488,7 +1488,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_client_mgmt_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Client Management Port"); ?></td>
+                      <td style="width:22%"><a id="help_for_client_mgmt_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Client Management Port"); ?></td>
                       <td>
                         <input name="client_mgmt_port_enable" type="checkbox" id="client_mgmt_port_enable" value="yes" <?=!empty($pconfig['client_mgmt_port']) ? "checked=\"checked\"" : "" ;?> />
                         <div id="client_mgmt_port_data">
@@ -1502,7 +1502,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls_user">
-                      <td width="22%" ><a id="help_for_use-common-name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use common name"); ?></td>
+                      <td style="width:22%"><a id="help_for_use-common-name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use common name"); ?></td>
                       <td>
                         <input name="use-common-name" type="checkbox" value="1" <?=!empty($pconfig['use-common-name']) ? "checked=\"checked\"" : "" ;?> />
                         <div class="hidden" for="help_for_use-common-name">
@@ -1524,7 +1524,7 @@ endif; ?>
                       <td colspan="2"><strong><?=gettext("Advanced configuration"); ?></strong></td>
                     </tr>
                     <tr>
-                      <td width="22%" ><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
+                      <td style="width:22%"><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
                       <td>
                         <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea><br />
                         <div class="hidden" for="help_for_custom_options">
@@ -1533,7 +1533,7 @@ endif; ?>
                       </td>
                     </tr>
                     <tr id="comboboxVerbosityLevel">
-                      <td width="22%" ><a id="help_for_verbosity_level" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Verbosity level");?></td>
+                      <td style="width:22%"><a id="help_for_verbosity_level" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Verbosity level");?></td>
                       <td>
                         <select name="verbosity_level" class="form-control">
 <?php
@@ -1571,8 +1571,8 @@ endif; ?>
                       </td>
                     </tr>
                     <tr>
-                      <td width="22%">&nbsp;</td>
-                      <td width="78%">
+                      <td style="width:22%">&nbsp;</td>
+                      <td style="width:78%">
                         <input name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                         <input name="act" type="hidden" value="<?=$act;?>" />
 <?php

--- a/src/www/widgets/widgets/system_information.widget.php
+++ b/src/www/widgets/widgets/system_information.widget.php
@@ -158,7 +158,7 @@ require_once("system.inc");
 <table class="table table-striped table-condensed" data-plugin="system" data-callback="system_information_widget_update">
   <tbody>
     <tr>
-      <td width="30%"><?=gettext("Name");?></td>
+      <td style="width:30%"><?=gettext("Name");?></td>
       <td><?=$config['system']['hostname'] . "." . $config['system']['domain']; ?></td>
     </tr>
     <tr>

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -454,11 +454,11 @@ function showchange() {
 			switch ($field['type']) {
 			case "input":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>\n";
 				}
@@ -477,18 +477,18 @@ function showchange() {
 				}
 				break;
 			case "text":
-				echo "<td colspan=\"2\" align=\"center\" class=\"vncell\">\n";
+				echo "<td colspan=\"2\" style=\"text-align:center\" class=\"vncell\">\n";
 				if($field['description'] <> "") {
 					echo "<center><br /> " . gettext($field['description']) . "</center>";
 				}
 				break;
 			case "inputalias":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>\n";
 				}
@@ -512,7 +512,7 @@ function showchange() {
 				$size = "";
 				$multiple = "";
 				$name = strtolower($name);
-				echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+				echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 				echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
 				echo "</td>";
 				echo "<td class=\"vtable\">\n";
@@ -559,11 +559,11 @@ function showchange() {
 				break;
 			case "password":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>\n";
 				}
@@ -583,7 +583,7 @@ function showchange() {
 				$size = "";
 				$multiple = "";
 				$name = strtolower($name);
-				echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+				echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 				echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
 				echo "</td>";
 				echo "<td class=\"vtable\">\n";
@@ -624,7 +624,7 @@ function showchange() {
 				$size = "";
 				$multiple = "";
 				$name = strtolower($name);
-				echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+				echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 				echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
 				echo "</td>";
 				echo "<td class=\"vtable\">\n";
@@ -662,11 +662,11 @@ function showchange() {
 				break;
 			case "select":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>\n";
 				}
@@ -702,11 +702,11 @@ function showchange() {
 				break;
 			case "textarea":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>";
 				}
@@ -726,7 +726,7 @@ function showchange() {
 
 				break;
 			case "submit":
-				echo "<td colspan=\"2\" align=\"center\">";
+				echo "<td colspan=\"2\" style=\"text-align:center\">";
 				echo "<input type='submit' class=\"btn btn-primary\" name='" . $name . "' value=\"" . htmlspecialchars(gettext($field['name'])) . "\" />\n";
 
 				if($field['description'] <> "") {
@@ -740,11 +740,11 @@ function showchange() {
 				break;
 			case "subnet_select":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>";
 				}
@@ -776,11 +776,11 @@ function showchange() {
 				$languagelist = get_locale_list();
 
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>";
 				}
@@ -805,11 +805,11 @@ function showchange() {
 				$timezonelist = get_zoneinfo();
 
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>";
 				}
@@ -834,11 +834,11 @@ function showchange() {
 				break;
 			case "checkbox":
 				if ($field['displayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['displayname']);
 					echo ":</td>\n";
 				} else if(!$field['dontdisplayname']) {
-					echo "<td width=\"22%\" align=\"right\" class=\"vncellreq\">\n";
+					echo "<td style=\"width:22%; text-align:right\" class=\"vncellreq\">\n";
 					echo gettext($field['name']);
 					echo ":</td>";
 				}


### PR DESCRIPTION
width, align, valign, cellpadding, cellspacing, border, summary

Error: The width attribute on the table element is obsolete. Use CSS instead.
Error: The align attribute on the table element is obsolete. Use CSS instead.
Error: The valign attribute on the table element is obsolete. Use CSS instead.
Error: The cellpadding attribute on the table element is obsolete. Use CSS instead.
Error: The cellspacing attribute on the table element is obsolete. Use CSS instead.
Error: The border attribute on the table element is obsolete. Use CSS instead.
Error: The summary attribute on the table element is obsolete. Consider describing the structure of the table in a caption element or in a figure element containing the table; or, simplify the structure of the table so that no description is needed.
  