### PR TITLE
HTML Compliance - Obsolete table attributes - II  (few stragglers)

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
@@ -207,7 +207,7 @@
             </colgroup>
             <tbody>
             <tr>
-                <td colspan="2" align="right">
+                <td colspan="2" style="text-align:right">
                     <small>{{ lang._('full help') }} </small><a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_show_all_help_frm_proxy-forward-acl-remoteACLS" type="button"></i></a>
                 </td>
             </tr>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -62,8 +62,8 @@ data_title      :   data-title to set on form
         <tbody>
 {% if advanced|default(false) or help|default(false) %}
         <tr>
-            <td align="left">{% if advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}" type="button"></i> </a><small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
-            <td colspan="2" align="right">
+            <td style="text-align:left">{% if advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}" type="button"></i> </a><small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
+            <td colspan="2" style="text-align:right">
                 {% if help|default(false) %}<small>{{ lang._('full help') }} </small><a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_{{base_form_id}}" type="button"></i></a>{% endif %}
             </td>
         </tr>

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -207,7 +207,7 @@ if (isset($config['ipsec']['phase2'])) {
 else {
 ?>
 <div style="display:block">
-   <table class="table table-striped" width="100%" border="0" cellpadding="0" cellspacing="0" summary="note">
+   <table class="table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0;">
     <tr>
       <td colspan="4">
           <span class="vexpl">

--- a/src/www/widgets/widgets/ntp_status.widget.php
+++ b/src/www/widgets/widgets/ntp_status.widget.php
@@ -126,8 +126,8 @@ if ($_REQUEST['updateme']) {
 <table >
   <tbody>
     <tr>
-      <td width="40%" class="vncellt">Sync Source</td>
-      <td width="60%" class="listr">
+      <td style="width:40%" class="vncellt">Sync Source</td>
+      <td style="width:60%" class="listr">
       <?php if ($ntpq_counter == 0) :
 ?>
         <?= gettext('No active peers available') ?>
@@ -142,8 +142,8 @@ endif; ?>
     <?php if (($gps_ok) && ($gps_lat) && ($gps_lon)) :
 ?>
       <tr>
-        <td width="40%" class="vncellt"><?= gettext('Clock location') ?></td>
-        <td width="60%" class="listr">
+        <td style="width:40%" class="vncellt"><?= gettext('Clock location') ?></td>
+        <td style="width:60%" class="listr">
           <a target="_gmaps" href="http://maps.google.com/?q=<?= html_safe($gps_lat) ?>,<?= html_safe($gps_lon) ?>">
           <?php
                     echo sprintf("%.5f", $gps_lat) . " " . $gps_la . ", " . sprintf("%.5f", $gps_lon) . " " . $gps_lo; ?>
@@ -156,8 +156,8 @@ endif; ?>
       <?php if (isset($gps_sat) || isset($gps_satview)) :
 ?>
         <tr>
-        <td width="40%" class="vncellt"><?= gettext('Satellites') ?></td>
-          <td width="60%" class="listr">
+        <td style="width:40%" class="vncellt"><?= gettext('Satellites') ?></td>
+          <td style="width:60%" class="listr">
           <?php
                     if (isset($gps_satview)) {
                         echo gettext('in view ') . intval($gps_satview);
@@ -461,8 +461,8 @@ function clockUpdate()
 <table class="table table-striped table-condensed">
   <tbody>
     <tr>
-      <td width="40%" class="vncellt">Server Time</td>
-      <td width="60%" class="listr">
+      <td style="width:40%" class="vncellt">Server Time</td>
+      <td style="width:60%" class="listr">
         <div id="ClockTime">
           <b><?= clockTimeString($gDate, $gClockShowsSeconds) ?></b>
         </div>

--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -69,7 +69,7 @@ require_once('diag_logs_common.inc');
 </div>
 
 <div id="system_log-widgets" class="content-box" style="overflow:scroll;">
-  <table class="table table-striped" cellspacing="0" cellpadding="0">
+  <table class="table table-striped" style="cellspacing:0; cellpadding:0">
     <?php dump_clog($system_logfile, $syslogEntriesToFetch); ?>
   </table>
 </div>


### PR DESCRIPTION
width, align, valign, cellpadding, cellspacing, border, summary

Error: The width attribute on the table element is obsolete. Use CSS instead.
Error: The align attribute on the table element is obsolete. Use CSS instead.
Error: The valign attribute on the table element is obsolete. Use CSS instead.
Error: The cellpadding attribute on the table element is obsolete. Use CSS instead.
Error: The cellspacing attribute on the table element is obsolete. Use CSS instead.
Error: The border attribute on the table element is obsolete. Use CSS instead.
Error: The summary attribute on the table element is obsolete. Consider describing the structure of the table in a caption element or in a figure element containing the table; or, simplify the structure of the table so that no description is needed.