### PR TITLE
mv PR from plugins: add known hosts support to OPNsense for SSH hardening

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -414,6 +414,18 @@ function local_user_set(&$user, $force_password = false)
 {
     global $config;
 
+    /* load SSH Key DB*/
+    $available_ssh_keys_raw = config_read_array('OPNsense', 'ssh-keys', 'key_pair');
+    if (!is_array($available_ssh_keys_raw)) {
+        $available_ssh_keys_raw = array();
+    }
+    // like in a template: we need to add it to an array if we only got a single element
+    if (array_key_exists('key_name', $available_ssh_keys_raw)) {
+        $available_ssh_keys = array($available_ssh_keys_raw);
+    } else {
+        $available_ssh_keys = $available_ssh_keys_raw;
+    }
+
     if (empty($user['password'])) {
         log_error(sprintf(
           gettext('There is something wrong in your config because user %s password is missing!'),
@@ -490,7 +502,26 @@ function local_user_set(&$user, $force_password = false)
     if (isset($user['authorizedkeys'])) {
         @mkdir("{$user_home}/.ssh", 0700);
         @chown("{$user_home}/.ssh", $user_name);
-        $keys = base64_decode($user['authorizedkeys']);
+        // TODO
+        $ssh_keys_assigned = explode(',',$user['authorizedkeys']);
+        $tmp_key_array = array();
+        // BEGIN READ KEYS from Key DB
+        foreach ($ssh_keys_assigned as $selected_key) {
+            $found = false;
+            foreach ($available_ssh_keys as $sshkey) {
+                if ($sshkey['@attributes']['uuid'] == $selected_key) {
+                    $found = true;
+                    $tmp_key_array[] = $sshkey['public_key'];
+                    break;
+                }
+            }
+            if (!$found) {
+                log_error( "SSH key for user not found.");
+            }
+        }
+        $keys = implode("\n", $tmp_key_array);
+        // END READ KEYS from Key DB
+        //$keys = base64_decode($user['authorizedkeys']);
         $keys = preg_split('/[\n\r]+/', $keys);
         $keys[] = '';
         $keys = implode($keys, "\n");

--- a/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/Api/SshController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/Api/SshController.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ *    Copyright (C) 2015-2017 Deciso B.V.
+ *    Copyright (C) 2015 Jos Schellevis
+ *    Copyright (C) 2018 Fabian Franz
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Sshkeys\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Base\UIModelGrid;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Sshkeys\SSH;
+
+class SshController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelName = 'ssh';
+    static protected $internalModelClass = '\OPNsense\Sshkeys\SSH';
+    public function search_known_hostsAction()
+    {
+        $this->sessionClose();
+        $mdl = $this->getModel();
+        $grid = new UIModelGrid($mdl->known_host);
+        return $grid->fetchBindRequest(
+            $this->request,
+            array('key_type', 'host')
+        );
+    }
+    public function get_known_hostAction($uuid = null)
+    {
+        $mdl = $this->getModel();
+        if ($uuid != null) {
+            $node = $mdl->getNodeByReference('known_host.' . $uuid);
+            if ($node != null) {
+                // return node
+                return array('known_host' => $node->getNodes());
+            }
+        } else {
+            $node = $mdl->known_host->add();
+            return array('known_host' => $node->getNodes());
+        }
+        return array();
+    }
+    public function add_known_hostAction()
+    {
+        $result = array('result' => 'failed');
+        if ($this->request->isPost() && $this->request->hasPost('known_host')) {
+            $result = array('result' => 'failed', 'validations' => array());
+            $mdl = $this->getModel();
+            $node = $mdl->known_host->Add();
+            $node->setNodes($this->request->getPost('known_host'));
+            $valMsgs = $mdl->performValidation();
+
+            foreach ($valMsgs as $field => $msg) {
+                $fieldnm = str_replace($node->__reference, 'known_host', $msg->getField());
+                $result['validations'][$fieldnm] = $msg->getMessage();
+            }
+
+            if (count($result['validations']) == 0) {
+                // save config if validated correctly
+                $mdl->serializeToConfig();
+                Config::getInstance()->save();
+                unset($result['validations']);
+                $result['result'] = 'saved';
+                $this->refresh_template();
+            }
+        }
+        return $result;
+    }
+    public function del_known_hostAction($uuid)
+    {
+
+        $result = array('result' => 'failed');
+
+        if ($this->request->isPost()) {
+            $mdl = $this->getModel();
+            if ($uuid != null) {
+                if ($mdl->known_host->del($uuid)) {
+                    $mdl->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result['result'] = 'deleted';
+                    $this->refresh_template();
+                } else {
+                    $result['result'] = 'not found';
+                }
+            }
+        }
+        return $result;
+    }
+    public function set_known_hostAction($uuid)
+    {
+        if ($this->request->isPost() && $this->request->hasPost('known_host')) {
+            $mdl = $this->getModel();
+            if ($uuid != null) {
+                $node = $mdl->getNodeByReference('known_host.' . $uuid);
+                if ($node != null) {
+                    $result = array('result' => 'failed', 'validations' => array());
+                    $info = $this->request->getPost('known_host');
+
+                    $node->setNodes($info);
+                    $valMsgs = $mdl->performValidation();
+                    foreach ($valMsgs as $field => $msg) {
+                        $fieldnm = str_replace($node->__reference, 'known_host', $msg->getField());
+                        $result['validations'][$fieldnm] = $msg->getMessage();
+                    }
+
+                    if (count($result['validations']) == 0) {
+                        // save config if validated correctly
+                        $mdl->serializeToConfig();
+                        unset($result['validations']);
+                        Config::getInstance()->save();
+                        $result = array('result' => 'saved');
+                        $this->refresh_template();
+                    }
+                    return $result;
+                }
+            }
+        }
+        return array('result' => 'failed');
+    }
+    private function refresh_template()
+    {
+        $backend = new Backend();
+        $backend->configdRun('template reload OPNsense/Sshkeys');
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
@@ -1,0 +1,45 @@
+<?php
+/*
+
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+
+namespace OPNsense\Sshkeys;
+
+/**
+* Class IndexController
+* @package OPNsense/Sshkeys
+*/
+class IndexController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->known_host_form = $this->getForm("known_host");
+        $this->view->pick('OPNsense/Sshkeys/index');
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
@@ -40,6 +40,7 @@ class IndexController extends \OPNsense\Base\IndexController
     public function indexAction()
     {
         $this->view->known_host_form = $this->getForm("known_host");
+        $this->view->key_pair_form = $this->getForm("key_pair");
         $this->view->pick('OPNsense/Sshkeys/index');
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/key_pair.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/key_pair.xml
@@ -1,0 +1,20 @@
+<form>
+  <field>
+    <id>key_pair.key_name</id>
+    <label>Name</label>
+    <type>text</type>
+    <help>Choose a name for your key (will be displayed in dropdown menus).</help>
+  </field>
+  <field>
+    <id>key_pair.private_key</id>
+    <label>Private Key</label>
+    <type>textbox</type>
+    <help>Private Key in OpenSSH format</help>
+  </field>
+  <field>
+    <id>key_pair.public_key</id>
+    <label>Public Key</label>
+    <type>text</type>
+    <help>Public Key in OpenSSH format (type - space - base64 key - space - comment </help>
+  </field>
+</form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/known_host.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/known_host.xml
@@ -1,0 +1,20 @@
+<form>
+  <field>
+    <id>known_host.host</id>
+    <label>Host</label>
+    <type>text</type>
+    <help>Enter an IPv4- or IPv6 address or a hostname.</help>
+  </field>
+  <field>
+    <id>known_host.key_type</id>
+    <label>Key Type</label>
+    <type>dropdown</type>
+    <help>Select a key type - you need to add one entry per key type the server supports.</help>
+  </field>
+  <field>
+    <id>known_host.public_key</id>
+    <label>Public Key</label>
+    <type>text</type>
+    <help>Enter a Base64 encoded public key.</help>
+  </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/Base64Field.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/Base64Field.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *    Copyright (C) 2018 Fabian Franz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base\FieldTypes;
+
+use Phalcon\Validation\Validator\Regex;
+use \OPNsense\Base\Validators\Base64Validator;
+use Phalcon\Validation\Validator\PresenceOf;
+
+/**
+ * Class Base64Field
+ * @package OPNsense\Base\FieldTypes
+ */
+class Base64Field extends BaseField
+{
+    /**
+     * @var bool marks if this is a data node or a container
+     */
+    protected $internalIsContainer = false;
+
+    /**
+     * @var string default validation message string
+     */
+    protected $internalValidationMessage = "Base64 validation error";
+
+    /**
+     * retrieve field validators for this field type
+     * @return array returns Base64 validator
+     */
+    public function getValidators()
+    {
+        $validators = parent::getValidators();
+        if ($this->internalValue != null) {
+            if ($this->internalValue != null) {
+                $validators[] = new Base64Validator(array('message' => $this->internalValidationMessage));
+            }
+        }
+        return $validators;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/SSHKeyField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/SSHKeyField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *    Copyright (C) 2018 Fabian Franz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base\FieldTypes;
+
+use OPNsense\Base\Validators\SSHKeyValidator;
+use Phalcon\Validation\Validator\PresenceOf;
+
+/**
+ * Class SSHKeyField
+ * @package OPNsense\Base\FieldTypes
+ */
+class SSHKeyField extends BaseField
+{
+    /**
+     * @var bool marks if this is a data node or a container
+     */
+    protected $internalIsContainer = false;
+
+    /**
+     * @var string default validation message string
+     */
+    protected $internalValidationMessage = "SSH Key validation error";
+
+    /**
+     * retrieve field validators for this field type
+     * @return array returns SSH Key validator
+     */
+    public function getValidators()
+    {
+        $validators = parent::getValidators();
+        if ($this->internalValue != null) {
+            if ($this->internalValue != null) {
+                $validators[] = new SSHKeyValidator(array('message' => $this->internalValidationMessage));
+            }
+        }
+        return $validators;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Validators/Base64Validator.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Validators/Base64Validator.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 Fabian Franz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base\Validators;
+
+use \Phalcon\Validation\Validator;
+use \Phalcon\Validation\ValidatorInterface;
+use \Phalcon\Validation\Message;
+
+/**
+ * Class Base64Validator
+ * @package OPNsense\Base\Validators
+ */
+class Base64Validator extends Validator implements ValidatorInterface
+{
+
+    /**
+    * Executes Base64 validation
+    *
+    * @param \Phalcon\Validation $validator
+    * @param string $attribute
+    * @return boolean
+    */
+    public function validate(\Phalcon\Validation $validator, $attribute)
+    {
+        $value = $validator->getValue($attribute);
+        $msg = $this->getOption('message');
+        if (!preg_match('/^(?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?$/', $value)) {
+            $validator->appendMessage(new Message($msg, $attribute, 'Base64Validator'));
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Validators/SSHKeyValidator.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Validators/SSHKeyValidator.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 Fabian Franz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\Base\Validators;
+
+use \Phalcon\Validation\Validator;
+use \Phalcon\Validation\ValidatorInterface;
+use \Phalcon\Validation\Message;
+
+/**
+ * Class SSHKeyValidator
+ * @package OPNsense\Base\Validators
+ */
+class SSHKeyValidator extends Validator implements ValidatorInterface
+{
+
+    /**
+    * Executes SSH Key validation
+    *
+    * @param \Phalcon\Validation $validator
+    * @param string $attribute
+    * @return boolean
+    */
+    public function validate(\Phalcon\Validation $validator, $attribute)
+    {
+        $value = trim($validator->getValue($attribute)); // content
+        $msg = $this->getOption('message');
+        // check if a SSH Key header exist
+        if (!preg_match('/\-{5}BEGIN.*PRIVATE KEY\-{5}/', $value)) {
+            $validator->appendMessage(new Message($msg, $attribute, 'SSHKeyValidator'));
+            return false;
+        }
+        // check if a ssh trailor exists
+        if (!preg_match('/\-{5}END.*PRIVATE KEY\-{5}/', $value)) {
+            $validator->appendMessage(new Message($msg, $attribute, 'SSHKeyValidator'));
+            return false;
+        }
+        $lines = explode("\n", $value);
+        array_shift($lines); // remove BEGIN ... Message
+        array_pop($lines);   // remove END ... Message
+        // remove empty lines if ssh generator adds headers
+        // like in HTTP, remove them too
+        while (isset($lines[0]) && ($lines[0] == '' || strstr($lines[0], ':') !== FALSE))
+        {
+            array_shift($lines);
+        }
+        $base64key = implode($lines);
+        if (!preg_match('/^(?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?$/', $base64key)) {
+            $validator->appendMessage(new Message($msg, $attribute, 'SSHKeyValidator'));
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+  <page-sshkeys>
+    <name>SSH Keys</name>
+    <patterns>
+      <pattern>ui/sshkeys/*</pattern>
+      <pattern>api/sshkeys/*</pattern>
+    </patterns>
+  </page-sshkeys>
+</acl>

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/Menu/Menu.xml
@@ -1,0 +1,7 @@
+<menu>
+  <System>
+    <Access>
+      <ssh-keys VisibleName="SSH Keys" url="/ui/sshkeys/" />
+    </Access>
+  </System>
+</menu>

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.php
@@ -1,0 +1,34 @@
+<?php
+/*
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Sshkeys;
+
+use OPNsense\Base\BaseModel;
+
+class SSH extends BaseModel
+{
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
@@ -1,0 +1,26 @@
+<model>
+  <mount>//OPNsense/ssh-keys</mount>
+  <description>Management of SSH Keys</description>
+  <items>
+    <known_host type="ArrayField">
+      <key_type type="OptionField">
+        <Required>Y</Required>
+        <default>ssh-ed25519</default>
+        <OptionValues>
+          <ecdsa-sha2-nistp256>ECDSA-SHA2-NISTP256</ecdsa-sha2-nistp256>
+          <ssh-ed25519>ED25519</ssh-ed25519>
+          <ssh-rsa>RSA</ssh-rsa>
+        </OptionValues>
+      </key_type>
+      <public_key type="TextField">
+        <Required>Y</Required>
+        <mask>/^(?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?$/</mask>
+        <ValidationMessage>This must be a valid base64 encoded public key.</ValidationMessage>
+      </public_key>
+      <host type="TextField">
+        <Required>Y</Required>
+        <mask>/^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}|[a-fA-F0-9:]{2,40}$|[a-zA-Z][a-zA-Z0-9\-_\.]{3,}$)/</mask>
+      </host>
+    </known_host>
+  </items>
+</model>

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
@@ -30,7 +30,7 @@
         <mask>/^[a-zA-Z0-9_\-]+ (?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?.*$/</mask>
       </public_key>
       <private_key type="SSHKeyField">
-        <Required>Y</Required>
+        <Required>N</Required>
       </private_key>
     </key_pair>
   </items>

--- a/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
@@ -12,9 +12,8 @@
           <ssh-rsa>RSA</ssh-rsa>
         </OptionValues>
       </key_type>
-      <public_key type="TextField">
+      <public_key type="Base64Field">
         <Required>Y</Required>
-        <mask>/^(?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?$/</mask>
         <ValidationMessage>This must be a valid base64 encoded public key.</ValidationMessage>
       </public_key>
       <host type="TextField">
@@ -22,5 +21,17 @@
         <mask>/^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}|[a-fA-F0-9:]{2,40}$|[a-zA-Z][a-zA-Z0-9\-_\.]{3,}$)/</mask>
       </host>
     </known_host>
+    <key_pair type="ArrayField">
+      <key_name type="TextField">
+        <Required>Y</Required>
+      </key_name>
+      <public_key type="TextField">
+        <Required>Y</Required>
+        <mask>/^[a-zA-Z0-9_\-]+ (?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?.*$/</mask>
+      </public_key>
+      <private_key type="SSHKeyField">
+        <Required>Y</Required>
+      </private_key>
+    </key_pair>
   </items>
 </model>

--- a/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
@@ -38,11 +38,21 @@ $( document ).ready(function() {
           'options':{selection:false, multiSelect:false}
         }
     );
+    $("#grid-ssh-keys").UIBootgrid(
+        { 'search':'/api/sshkeys/ssh/search_key_pair',
+          'get':'/api/sshkeys/ssh/get_key_pair/',
+          'set':'/api/sshkeys/ssh/set_key_pair/',
+          'add':'/api/sshkeys/ssh/add_key_pair/',
+          'del':'/api/sshkeys/ssh/del_key_pair/',
+          'options':{selection:false, multiSelect:false}
+        }
+    );
 });
 
 </script>
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#known-hosts">{{ lang._('Known Hosts') }}</a></li>
+    <li><a data-toggle="tab" href="#key-pairs">{{ lang._('Key Pairs') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content" style="padding-bottom: 1.5em;">
@@ -62,6 +72,26 @@ $( document ).ready(function() {
           </tbody>
           <tfoot>
               <tr>
+                  <td colspan="2"></td>
+                  <td>
+                      <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                  </td>
+              </tr>
+          </tfoot>
+      </table>
+    </div>
+    <div id="key-pairs" class="tab-pane fade in">
+        <table id="grid-ssh-keys" class="table table-responsive" data-editDialog="keypairdlg">
+          <thead>
+              <tr>
+                  <th data-column-id="key_name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
+                  <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+              </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+              <tr>
                   <td colspan="1"></td>
                   <td>
                       <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
@@ -73,3 +103,4 @@ $( document ).ready(function() {
 </div>
 
 {{ partial("layout_partials/base_dialog",['fields': known_host_form,'id':'knownhostdlg', 'label':lang._('Edit Known Host')]) }}
+{{ partial("layout_partials/base_dialog",['fields': key_pair_form,'id':'keypairdlg', 'label':lang._('Edit Key Pair')]) }}

--- a/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
@@ -1,0 +1,75 @@
+{#
+
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+#}
+
+<script type="text/javascript">
+$( document ).ready(function() {
+    $("#grid-known-hosts").UIBootgrid(
+        { 'search':'/api/sshkeys/ssh/search_known_hosts',
+          'get':'/api/sshkeys/ssh/get_known_host/',
+          'set':'/api/sshkeys/ssh/set_known_host/',
+          'add':'/api/sshkeys/ssh/add_known_host/',
+          'del':'/api/sshkeys/ssh/del_known_host/',
+          'options':{selection:false, multiSelect:false}
+        }
+    );
+});
+
+</script>
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#known-hosts">{{ lang._('Known Hosts') }}</a></li>
+</ul>
+
+<div class="tab-content content-box tab-content" style="padding-bottom: 1.5em;">
+    <div id="known-hosts" class="tab-pane fade in active">
+        <div class="alert alert-info" role="alert">
+          {{ lang._('Known hosts can be used to harden SSH connections by whitelisting the public keys of servers (also known as public key pinning).') }}
+        </div>
+        <table id="grid-known-hosts" class="table table-responsive" data-editDialog="knownhostdlg">
+          <thead>
+              <tr>
+                  <th data-column-id="host" data-type="string" data-visible="true">{{ lang._('Host') }}</th>
+                  <th data-column-id="key_type" data-type="string" data-visible="true">{{ lang._('Key Type') }}</th>
+                  <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+              </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+              <tr>
+                  <td colspan="1"></td>
+                  <td>
+                      <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                  </td>
+              </tr>
+          </tfoot>
+      </table>
+    </div>
+</div>
+
+{{ partial("layout_partials/base_dialog",['fields': known_host_form,'id':'knownhostdlg', 'label':lang._('Edit Known Host')]) }}

--- a/src/opnsense/service/templates/OPNsense/Sshkeys/+TARGETS
+++ b/src/opnsense/service/templates/OPNsense/Sshkeys/+TARGETS
@@ -1,0 +1,1 @@
+os_known_hosts:/tmp/os_known_hosts

--- a/src/opnsense/service/templates/OPNsense/Sshkeys/os_known_hosts
+++ b/src/opnsense/service/templates/OPNsense/Sshkeys/os_known_hosts
@@ -1,0 +1,7 @@
+{% if helpers.exists('OPNsense.ssh-keys') %}
+{%   if helpers.exists('OPNsense.ssh-keys.known_host') %}
+{%     for key in helpers.toList('OPNsense.ssh-keys.known_host') %}
+{{ key.host }} {{ key.key_type }} {{ key.public_key }}
+{%     endfor %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
This should be extended to do SSH Key management like in Trust and provide settings to plugins. This is for the file `known_hosts` which can be used for public key pinning.

Changes done while moving:
* Correct (C) year -> we have 2018 now.
* Remove second (C) block in volt template

Original PR:
opnsense/plugins#472 