### PR TITLE
HTML Compliance - Lobby: Dashboard Widgets

### DIFF
--- a/src/www/widgets/widgets/interface_list.widget.php
+++ b/src/www/widgets/widgets/interface_list.widget.php
@@ -77,24 +77,24 @@ require_once("interfaces.inc");
         <td>
 <?php
           if (isset($ifinfo['ppplink'])):?>
-            <span alt="3g" class="glyphicon glyphicon-phone text-success"></span>
+            <span title="3g" class="glyphicon glyphicon-phone text-success"></span>
 <?php
           elseif ($iswireless):
             if ($ifinfo['status'] == 'associated' || $ifinfo['status'] == 'up'):?>
-            <span alt="wlan" class="glyphicon glyphicon-signal text-success"></span>
+            <span title="wlan" class="glyphicon glyphicon-signal text-success"></span>
 <?php
             else:?>
-            <span alt="wlan_d" class="glyphicon glyphicon-signal text-danger"></span>
+            <span title="wlan_d" class="glyphicon glyphicon-signal text-danger"></span>
 <?php
             endif;?>
 <?php
           else:?>
 <?php
             if ($ifinfo['status'] == "up"):?>
-              <span alt="cablenic" class="glyphicon glyphicon-transfer text-success"></span>
+              <span title="cablenic" class="glyphicon glyphicon-transfer text-success"></span>
 <?php
             else:?>
-              <span alt="cablenic" class="glyphicon glyphicon-transfer text-danger"></span>
+              <span title="cablenic" class="glyphicon glyphicon-transfer text-danger"></span>
 <?php
             endif;?>
 <?php

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -209,7 +209,7 @@ else {
 <div style="display:block">
    <table class="table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0;">
     <tr>
-      <td colspan="4">
+      <td>
           <span class="vexpl">
             <span class="red">
               <strong>

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -231,6 +231,8 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
     </tr>
   </thead>
   <tbody>
-    <tr/>
+    <tr>
+      <td colspan=5></td>
+    </tr>
   </tbody>
 </table>

--- a/src/www/widgets/widgets/picture.widget.php
+++ b/src/www/widgets/widgets/picture.widget.php
@@ -76,7 +76,7 @@ if ($_POST) {
       </tr>
       <tr>
         <td>
-          <input id="submita" name="submita" type="submit" class="btn btn-primary formbtn" value="<?= gettext('Upload') ?>" />
+          <input id="submit_pictfile_widget" name="submit_pictfile_widget" type="submit" class="btn btn-primary formbtn" value="<?= gettext('Upload') ?>" />
         </td>
       </tr>
     </table>
@@ -88,7 +88,7 @@ if ($_POST) {
 if ($config['widgets']['picturewidget_filename'] != "") :?>
   <div id="picture-widgets" style="padding: 5px">
     <a href='/widgets/widgets/picture.widget.php?getpic=true' target='_blank'>
-      <img border="0" width="100%" height="100%" src="/widgets/widgets/picture.widget.php?getpic=true" alt="picture" />
+      <img style="border:0px solid; width:100%; height:100%" src="/widgets/widgets/picture.widget.php?getpic=true" alt="picture" />
     </a>
   </div>
 <?php

--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -61,7 +61,7 @@ require_once('diag_logs_common.inc');
           </select>
         </td>
         <td>
-          <input id="submit" name="submit" type="submit" class="btn btn-primary formbtn" value="<?= gettext('Save') ?>" autocomplete="off">
+          <input id="submit_system_log_widget" name="submit_system_log_widget" type="submit" class="btn btn-primary formbtn" value="<?= gettext('Save') ?>">
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Error: Attribute alt not allowed on element span at this point.

Error: Table columns in range 2…4 established by element td have no cells beginning in them.

Error: Self-closing syntax (/>) used on a non-void HTML element. Ignoring the slash and treating as a start tag.
Error: Row 1 of a row group established by a tbody element has no cells beginning on it.
Warning: A table row was 0 columns wide, which is less than the column count established by the first row (5).

Error: Duplicate ID submita.
Error: Bad value 100% for attribute width on element img: Expected a digit but saw % instead.
Error: Bad value 100% for attribute height on element img: Expected a digit but saw % instead.
Warning: The border attribute is obsolete. Consider specifying img { border: 0; } in CSS instead.

Avoid potential future Error: Duplicate ID submit.
Error: Attribute autocomplete is only allowed when the input type is color, date, datetime-local, email, hidden, month, number, password, range, search, tel, text, time, url, or week.