### PR TITLE
Widgets Controls on Touch Screen

### DIFF
--- a/src/www/index.php
+++ b/src/www/index.php
@@ -276,6 +276,8 @@ include("fbegin.inc");?>
       // sortable widgets
       $(".dashboard_grid_column").sortable({
         handle: '.content-box-head',
+        delay: 50,
+        distance: 2,
         group: 'dashboard_grid_column',
         itemSelector: '.widgetdiv',
         containerSelector: '.dashboard_grid_column',
@@ -369,7 +371,7 @@ include("fbegin.inc");?>
           }?>
           <section class="widgetdiv" data-sortkey="<?=$widgetItem['sortKey'] ?>" id="<?=$widgetItem['name'];?>"  style="display:<?=$divdisplay;?>;">
             <div class="content-box">
-              <header class="content-box-head container-fluid">
+              <header class="content-box-head container-fluid" style="touch-action: none">
                 <ul class="list-inline __nomb">
                   <li><h3>
 <?php


### PR DESCRIPTION
Touch events not working with the widget controls (link, buttons, drag/drop sort).
Add distance, delay and touch-action css for the widget controls to work with touch screen input.

Widget controls not working correctly with touch screen input
https://github.com/opnsense/core/issues/2092