### PR TITLE
Firewall Logs Widget - Double Updating

### DIFF
--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -73,7 +73,13 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
 ?>
 
 <script>
+    var firewall_logs_widget_updater;
     $( document ).ready(function() {
+
+        // prevent running again on subsequent document ready events
+        if (firewall_logs_widget_updater) return;
+        firewall_logs_widget_updater = true;
+
         // needed to display the widget settings menu
         $("#log-configure").removeClass("disabled");
         // icons
@@ -157,7 +163,8 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
                 $("#filter-log-entries > tbody > tr").show();
             });
             // schedule next fetch
-            setTimeout(fetch_log, 2000);
+            clearTimeout(firewall_logs_widget_updater);
+            firewall_logs_widget_updater = setTimeout(fetch_log, 2000);
         }
 
         fetch_log();


### PR DESCRIPTION
Each document ready event triggers initiation of another fetch logs set timeout loop.
Use a global var flag to prevent the additional calls to fetch logs.
Clear the set timeout to ensure only a single instance will exist.

https://github.com/opnsense/core/issues/2104