### PR TITLE
HTML Compliance - Attribute "content" value on Element <meta>

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -356,7 +356,7 @@ function display_error_form($http_code, $desc)
   <head>
 
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <meta name="robots" content="noindex, nofollow, noodp, noydir" />
     <meta name="keywords" content="" />
@@ -424,7 +424,7 @@ function display_login_form($Login_Error)
   <head>
 
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <meta name="robots" content="noindex, nofollow, noodp, noydir" />
     <meta name="keywords" content="" />

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -5,7 +5,7 @@
   <head>
 
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <meta name="robots" content="noindex, nofollow, noodp, noydir" />
     <meta name="keywords" content="" />

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
@@ -3,7 +3,7 @@
     <head>
 
         <meta charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
         <meta name="robots" content="noindex, nofollow, noodp, noydir" />
         <meta name="keywords" content="" />

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -34,7 +34,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
 <!--[if (gt IE 9)|!(IE)]><!--><html lang="<?=system_get_language_code();?>" class="no-js"><!--<![endif]-->
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <meta name="robots" content="noindex, nofollow, noodp, noydir" />
     <meta name="keywords" content="" />


### PR DESCRIPTION
Error: A meta element with an http-equiv attribute whose value is X-UA-Compatible must have a content attribute with the value IE=edge.

The "Chrome=1" value was used to spawn Chrome Frame in IE 6,7,8,9.  However, "Google Chrome Frame was discontinued in January 2014", and think all IE<11 is beyond EOL.
So is this even needed/useful?

If needed/useful it would probably be better to support deployment by HTTP headers method instead.

Google Chrome Frame
https://en.wikipedia.org/wiki/Google_Chrome_Frame