### PR TITLE
HTML Compliance - Attribute "type" on Element <script>

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -437,12 +437,12 @@ function display_login_form($Login_Error)
     <link href="/ui/themes/<?= $themename ?>/build/css/main.css" rel="stylesheet">
     <link href="/ui/themes/<?= $themename ?>/build/images/favicon.png" rel="shortcut icon">
 
-    <script type="text/javascript" src="/ui/js/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
+    <script src="/ui/js/jquery-3.2.1.min.js"></script>
+    <script src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
 
 <?php
     if (file_exists("/usr/local/opnsense/www/themes/".$themename."/build/js/theme.js")):?>
-    <script type="text/javascript" src="/ui/themes/<?=$themename?>/build/js/theme.js"></script>
+    <script src="/ui/themes/<?=$themename?>/build/js/theme.js"></script>
 <?php
     endif;?>
 

--- a/src/opnsense/mvc/app/config/services.php
+++ b/src/opnsense/mvc/app/config/services.php
@@ -45,7 +45,7 @@ $di->set('view', function () use ($config) {
             // register additional volt template functions
             $volt->getCompiler()->addFunction('javascript_include_when_exists', function ($local_url) {
                 $chk_path = "str_replace('/ui/','/usr/local/opnsense/www/',".$local_url.")";
-                $js_tag = "'<script type=\"text/javascript\" src=\"'.$local_url.'\"></script>'";
+                $js_tag = "'<script src=\"'.$local_url.'\"></script>'";
                 return "file_exists(".$chk_path.") ? ".$js_tag." :''";
             });
 

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt
@@ -25,9 +25,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script src="/ui/js/moment-with-locales.min.js" type="text/javascript"></script>
+<script src="/ui/js/moment-with-locales.min.js"></script>
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /**

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/vouchers.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/CaptivePortal/vouchers.volt
@@ -25,9 +25,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script src="/ui/js/moment-with-locales.min.js" type="text/javascript"></script>
+<script src="/ui/js/moment-with-locales.min.js"></script>
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /**

--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
 
     /**
      * prepare for checking update status

--- a/src/opnsense/mvc/app/views/OPNsense/Cron/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Cron/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /**

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/arp.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/arp.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         /**
          * fetch system arp table

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var field_type_icons = {'pass': 'fa-play', 'block': 'fa-ban'}
         var interface_descriptions = {};

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/ndp.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/ndp.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         /**
          * fetch system NDP table

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/netflow.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/netflow.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_CaptureSettings':"/api/diagnostics/netflow/getconfig"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/networkinsight.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/networkinsight.volt
@@ -37,12 +37,12 @@ POSSIBILITY OF SUCH DAMAGE.
 <link rel="stylesheet" href="/ui/css/nv.d3.css">
 
 <!-- d3 -->
-<script type="text/javascript" src="/ui/js/d3.min.js"></script>
+<script src="/ui/js/d3.min.js"></script>
 
 <!-- nvd3 -->
-<script type="text/javascript" src="/ui/js/nv.d3.min.js"></script>
+<script src="/ui/js/nv.d3.min.js"></script>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
       var resizeEnd ;
       $(window).on('resize', function() {

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/routes.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/routes.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var gridopt = {
             ajax: false,

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemactivity.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemactivity.volt
@@ -25,9 +25,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script src="/ui/js/moment-with-locales.min.js" type="text/javascript"></script>
+<script src="/ui/js/moment-with-locales.min.js"></script>
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /**

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/systemhealth.volt
@@ -37,10 +37,10 @@
 <link rel="stylesheet" href="/ui/css/nv.d3.css">
 
 <!-- d3 -->
-<script type="text/javascript" src="/ui/js/d3.min.js"></script>
+<script src="/ui/js/d3.min.js"></script>
 
 <!-- nvd3 -->
-<script type="text/javascript" src="/ui/js/nv.d3.min.js"></script>
+<script src="/ui/js/nv.d3.min.js"></script>
 
 <!-- System Health -->
 <style>
@@ -52,7 +52,7 @@
 </style>
 
 
-<script type="application/javascript">
+<script>
     var chart;
     var data = [];
     var fetching_data = true;

--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -45,7 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
     }
 </style>
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         var interface_descriptions = {};

--- a/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
@@ -24,7 +24,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/src/opnsense/mvc/app/views/OPNsense/Routes/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Routes/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/src/opnsense/mvc/app/views/OPNsense/TrafficShaper/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/TrafficShaper/index.volt
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
     }
 </style>
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -43,9 +43,9 @@
     <link rel="stylesheet" href="/ui/css/font-awesome.min.css">
 
     <!-- JQuery -->
-    <script type="text/javascript" src="/ui/js/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
-    <script type="text/javascript">
+    <script src="/ui/js/jquery-3.2.1.min.js"></script>
+    <script src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
+    <script>
             // setup default scripting after page loading.
             $( document ).ready(function() {
                 // hook into jquery ajax requests to ensure csrf handling.
@@ -208,12 +208,12 @@
 
 
         <!-- JQuery Tokenize (http://zellerda.com/projects/tokenize) -->
-        <script type="text/javascript" src="/ui/js/jquery.tokenize.js"></script>
+        <script src="/ui/js/jquery.tokenize.js"></script>
         <link rel="stylesheet" type="text/css" href="/ui/css/jquery.tokenize.css" />
 
         <!-- Bootgrind (grid system from http://www.jquery-bootgrid.com/ )  -->
         <link rel="stylesheet" type="text/css" href="/ui/css/jquery.bootgrid.css"/>
-        <script type="text/javascript" src="/ui/js/jquery.bootgrid.js"></script>
+        <script src="/ui/js/jquery.bootgrid.js"></script>
         <script>
         /* patch translations into bootgrid library */
         Object.assign(
@@ -230,12 +230,12 @@
         </script>
 
         <!-- Bootstrap type ahead -->
-        <script type="text/javascript" src="/ui/js/bootstrap3-typeahead.min.js"></script>
+        <script src="/ui/js/bootstrap3-typeahead.min.js"></script>
 
         <!-- OPNsense standard toolkit -->
-        <script type="text/javascript" src="/ui/js/opnsense.js"></script>
-        <script type="text/javascript" src="/ui/js/opnsense_ui.js"></script>
-        <script type="text/javascript" src="/ui/js/opnsense_bootgrid_plugin.js"></script>
+        <script src="/ui/js/opnsense.js"></script>
+        <script src="/ui/js/opnsense_ui.js"></script>
+        <script src="/ui/js/opnsense_bootgrid_plugin.js"></script>
         {{javascript_include_when_exists('/ui/themes/' ~ theme_name ~ '/build/js/theme.js')}}
 
   </head>
@@ -308,8 +308,8 @@
     </main>
 
     <!-- bootstrap script -->
-    <script type="text/javascript" src="/ui/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="/ui/js/bootstrap-select.min.js"></script>
+    <script src="/ui/js/bootstrap.min.js"></script>
+    <script src="/ui/js/bootstrap-select.min.js"></script>
     <!-- bootstrap dialog -->
     <script src="/ui/js/bootstrap-dialog.min.js"></script>
 

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
@@ -17,9 +17,9 @@
         <link href="css/signin.css" rel="stylesheet">
 
         <!-- static zone info -->
-        <script type="text/javascript" src="js/zone.js"></script>
+        <script src="js/zone.js"></script>
 
-        <script type="text/javascript" src="js/jquery-1.11.2.min.js"></script>
+        <script src="js/jquery-1.11.2.min.js"></script>
         <script>
             function getURLparams()
             {
@@ -199,6 +199,6 @@
         </main>
 
         <!-- bootstrap script -->
-        <script type="text/javascript" src="js/bootstrap.min.js"></script>
+        <script src="js/bootstrap.min.js"></script>
     </body>
 </html>

--- a/src/www/csrf.inc
+++ b/src/www/csrf.inc
@@ -95,7 +95,7 @@ class LegacyCSRF
             $buffer = preg_replace('#(<form[^>]*method\s*=\s*["\']post["\'][^>]*>)#i', '$1' . $inputtag, $buffer);
             // csrf token for Ajax type requests
             $script = "
-            <script type=\"text/javascript\">
+            <script>
               $( document ).ready(function() {
                   $.ajaxSetup({
                   'beforeSend': function(xhr) {

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -307,7 +307,7 @@ include("head.inc");
 <body>
 <?php include("fbegin.inc"); ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
     // show encryption password

--- a/src/www/diag_confbak.php
+++ b/src/www/diag_confbak.php
@@ -132,7 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 include("head.inc");
 ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
     // revert config dialog

--- a/src/www/diag_dump_states.php
+++ b/src/www/diag_dump_states.php
@@ -62,7 +62,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete state
     $(".act_del").click(function(event){

--- a/src/www/diag_ipsec.php
+++ b/src/www/diag_ipsec.php
@@ -87,7 +87,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
       // show / hide connection details
       $(".ipsec_info").click(function(event){

--- a/src/www/diag_limiter_info.php
+++ b/src/www/diag_limiter_info.php
@@ -49,7 +49,7 @@ include("head.inc");
 ?>
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
   function getlimiteractivity() {
     var url = "/diag_limiter_info.php";

--- a/src/www/diag_logs_filter_summary.php
+++ b/src/www/diag_logs_filter_summary.php
@@ -440,7 +440,7 @@ include("head.inc"); ?>
     </div>
   </section>
 
-<script type="text/javascript" >
+<script >
     // Generate Donut charts
 
     nv.addGraph(function() {

--- a/src/www/diag_logs_settings.php
+++ b/src/www/diag_logs_settings.php
@@ -218,7 +218,7 @@ include("head.inc");
 
 
 <body>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 function enable_change(enable_over) {
   if (document.iform.enable.checked || enable_over) {

--- a/src/www/diag_packet_capture.php
+++ b/src/www/diag_packet_capture.php
@@ -259,7 +259,7 @@ legacy_html_escape_form_data($pconfig);
 include("head.inc");
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
     $( document ).ready(function() {
         $("#view").click(function(){
           $.ajax("diag_packet_capture.php",{

--- a/src/www/diag_pf_info.php
+++ b/src/www/diag_pf_info.php
@@ -44,7 +44,7 @@ include("head.inc");
 ?>
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   function getpfinfo() {
     jQuery.ajax({

--- a/src/www/diag_system_pftop.php
+++ b/src/www/diag_system_pftop.php
@@ -58,7 +58,7 @@ include("head.inc");
 ?>
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     /**
      * fetch pftop data from backend

--- a/src/www/diag_tables.php
+++ b/src/www/diag_tables.php
@@ -86,7 +86,7 @@ include("head.inc");
 <?php include("fbegin.inc"); ?>
 
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // on change pfTable selection
      $("#tablename").change(function(){

--- a/src/www/firewall_aliases.php
+++ b/src/www/firewall_aliases.php
@@ -185,7 +185,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete buttons
   $(".act_delete").click(function(){

--- a/src/www/firewall_aliases_edit.php
+++ b/src/www/firewall_aliases_edit.php
@@ -377,7 +377,7 @@ include("head.inc");
 <?php
   include("fbegin.inc");
 ?>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      * remove host/port row or clear values on last entry

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -149,7 +149,7 @@ $main_buttons = array(
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete buttons
   $(".act_delete").click(function(){

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -99,7 +99,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(){

--- a/src/www/firewall_nat_1to1_edit.php
+++ b/src/www/firewall_nat_1to1_edit.php
@@ -167,7 +167,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
 
     // select / input combination, link behaviour

--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -376,7 +376,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // show source fields (advanced)
     $("#showadvancedboxsrc").click(function(){

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -101,7 +101,7 @@ $main_buttons = array(
 
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(){

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -105,7 +105,7 @@ include("head.inc");
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(){

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -327,7 +327,7 @@ include("head.inc");
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
 
     // select / input combination, link behaviour

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -126,7 +126,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete buttons
   $(".act_delete").click(function(event){

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -541,7 +541,7 @@ include("head.inc");
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
       // show source fields (advanced)
       $("#showadvancedboxsrc").click(function(){

--- a/src/www/firewall_schedule.php
+++ b/src/www/firewall_schedule.php
@@ -78,7 +78,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(){

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -217,7 +217,7 @@ legacy_html_escape_form_data($pconfig);
 include("head.inc");
 
 ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 var daysSelected = "";
 var month_array = <?= json_encode($monthArray) ?>;

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -116,7 +116,7 @@ legacy_html_escape_form_data($a_scrub);
 include("head.inc");
 ?>
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete buttons
   $(".act_delete").click(function(event){

--- a/src/www/firewall_scrub_edit.php
+++ b/src/www/firewall_scrub_edit.php
@@ -202,7 +202,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
       // select / input combination, link behaviour
       // when the data attribute "data-other" is selected, display related input item(s)

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -176,7 +176,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(){

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -238,7 +238,7 @@ include("head.inc");
 
 <?php include("fbegin.inc");?>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     $("#mode").change(function(){
         //$("#subnet").attr('disabled', true);

--- a/src/www/foot.inc
+++ b/src/www/foot.inc
@@ -69,13 +69,13 @@
       </div>
     </div>
     <!-- bootstrap script -->
-    <script type="text/javascript" src="/ui/js/bootstrap.min.js"></script>
+    <script src="/ui/js/bootstrap.min.js"></script>
     <!-- Fancy select with search options -->
-    <script type="text/javascript" src="/ui/js/bootstrap-select.min.js"></script>
+    <script src="/ui/js/bootstrap-select.min.js"></script>
     <!-- bootstrap dialog -->
-    <script type="text/javascript" src="/ui/js/bootstrap-dialog.min.js"></script>
+    <script src="/ui/js/bootstrap-dialog.min.js"></script>
     <!-- service control hook -->
-    <script type="text/javascript">
+    <script>
       $( document ).ready(function() {
         $('.srv_status_act').click(function(event){
           event.preventDefault();

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -98,28 +98,28 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <link  href="/ui/css/bootstrap-datepicker3.min.css" rel="stylesheet">
 
     <!-- JQuery -->
-    <script type="text/javascript" src="/ui/js/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
+    <script src="/ui/js/jquery-3.2.1.min.js"></script>
+    <script src="/ui/js/jquery-migrate-3.0.1.min.js"></script>
 
     <!-- datepicker -->
     <script src="/ui/js/bootstrap-datepicker.min.js"></script>
 
     <!-- d3 -->
-    <script type="text/javascript" src="/ui/js/d3.min.js"></script>
+    <script src="/ui/js/d3.min.js"></script>
 
     <!-- nvd3 -->
-    <script type="text/javascript" src="/ui/js/nv.d3.min.js"></script>
+    <script src="/ui/js/nv.d3.min.js"></script>
 
     <!-- append some helper functions to integrate into the legacy code -->
-    <script type="text/javascript" src="/javascript/opnsense_legacy.js"></script>
+    <script src="/javascript/opnsense_legacy.js"></script>
 
     <!-- opnsense non legacy helper functions -->
-    <script type="text/javascript" src="/ui/js/opnsense.js"></script>
+    <script src="/ui/js/opnsense.js"></script>
 
     <!-- Bootstrap type ahead -->
-    <script type="text/javascript" src="/ui/js/bootstrap3-typeahead.min.js"></script>
+    <script src="/ui/js/bootstrap3-typeahead.min.js"></script>
 
-    <script type="text/javascript">
+    <script>
     //<![CDATA[
     $( document ).ready(function() {
       $('[data-toggle="tooltip"]').tooltip();
@@ -290,7 +290,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     </script>
 <?php
     if (file_exists("/usr/local/opnsense/www/themes/".$themename."/build/js/theme.js")):?>
-    <script type="text/javascript" src="/ui/themes/<?=$themename?>/build/js/theme.js"></script>
+    <script src="/ui/themes/<?=$themename?>/build/js/theme.js"></script>
 <?php
     endif;?>
 </head>

--- a/src/www/index.php
+++ b/src/www/index.php
@@ -101,7 +101,7 @@ include("fbegin.inc");?>
 ?>
 <?php
   if (isset($config['trigger_initial_wizard']) || isset($_GET['wizard_done'])): ?>
-  <script type="text/javascript">
+  <script>
       $( document ).ready(function() {
         $(".page-content-head:first").hide();
       });
@@ -158,7 +158,7 @@ include("fbegin.inc");?>
   else:?>
 
 <script src='/ui/js/jquery-sortable.js'></script>
-<script type="text/javascript">
+<script>
   function addWidget(selectedDiv) {
       $('#'+selectedDiv).show();
       $('#add_widget_'+selectedDiv).hide();
@@ -253,7 +253,7 @@ include("fbegin.inc");?>
   }
 </script>
 
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
       // rearrange widgets to stored column
       $(".widgetdiv").each(function(){

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -1331,7 +1331,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
       function toggle_allcfg() {
           if ($("#enable").prop('checked')) {

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -358,7 +358,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_bridge.php
+++ b/src/www/interfaces_bridge.php
@@ -74,7 +74,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_bridge_edit.php
+++ b/src/www/interfaces_bridge_edit.php
@@ -207,7 +207,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
   // advanced options
   $("#show_advanced").click(function(){

--- a/src/www/interfaces_gif.php
+++ b/src/www/interfaces_gif.php
@@ -68,7 +68,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_gif_edit.php
+++ b/src/www/interfaces_gif_edit.php
@@ -140,7 +140,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     hook_ipv4v6('ipv4v6net', 'network-id');
   });

--- a/src/www/interfaces_gre.php
+++ b/src/www/interfaces_gre.php
@@ -69,7 +69,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_gre_edit.php
+++ b/src/www/interfaces_gre_edit.php
@@ -114,7 +114,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     hook_ipv4v6('ipv4v6net', 'network-id');
   });

--- a/src/www/interfaces_groups.php
+++ b/src/www/interfaces_groups.php
@@ -61,7 +61,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_lagg.php
+++ b/src/www/interfaces_lagg.php
@@ -78,7 +78,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_lagg_edit.php
+++ b/src/www/interfaces_lagg_edit.php
@@ -158,7 +158,7 @@ legacy_html_escape_form_data($pconfig);
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
     $( document ).ready(function() {
         $("#proto").change(function(){
             if ($("#proto").val() == 'lacp') {

--- a/src/www/interfaces_ppps.php
+++ b/src/www/interfaces_ppps.php
@@ -69,7 +69,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_ppps_edit.php
+++ b/src/www/interfaces_ppps_edit.php
@@ -259,7 +259,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
     $(document).ready(function() {
         // change type
         $("#type").change(function(){

--- a/src/www/interfaces_qinq.php
+++ b/src/www/interfaces_qinq.php
@@ -87,7 +87,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_vlan.php
+++ b/src/www/interfaces_vlan.php
@@ -75,7 +75,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/interfaces_wireless.php
+++ b/src/www/interfaces_wireless.php
@@ -68,7 +68,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // link delete buttons
     $(".act_delete").click(function(event){

--- a/src/www/reboot.php
+++ b/src/www/reboot.php
@@ -40,7 +40,7 @@ include("fbegin.inc");
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['Submit'])): ?>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     BootstrapDialog.show({
         type:BootstrapDialog.TYPE_INFO,

--- a/src/www/reporting_settings.php
+++ b/src/www/reporting_settings.php
@@ -73,7 +73,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $(document).ready(function() {
     // messagebox, flush all rrd graphs

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -495,7 +495,7 @@ include("head.inc");
 
 <body>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
     function show_shownumbervalue() {
         $("#shownumbervaluebox").html('');
@@ -534,7 +534,7 @@ include("head.inc");
 //]]>
 </script>
 
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      * Additional BOOTP/DHCP Options extenable table

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -296,7 +296,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
 //<![CDATA[
   function show_ddns_config() {
     $("#showddnsbox").hide();

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -324,7 +324,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      * Additional BOOTP/DHCP Options extenable table
@@ -376,7 +376,7 @@ include("head.inc");
   });
 </script>
 
-<script type="text/javascript">
+<script>
   function show_shownumbervalue() {
     $("#shownumbervaluebox").hide();
     $("#shownumbervalue").show();

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -154,7 +154,7 @@ include("head.inc");
 
 <body>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
   $("#show_advanced_dns").click(function(event){

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -143,7 +143,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      *  Aliases

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -137,7 +137,7 @@ include("head.inc");
 ?>
 <body>
 
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     $("#showstatisticsbox").click(function(event){
         $("#showstatisticsbox").parent().hide();

--- a/src/www/services_ntpd_gps.php
+++ b/src/www/services_ntpd_gps.php
@@ -79,7 +79,7 @@ include("head.inc");
 
 <body>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $( document ).ready(function() {
     $("#gpsprefer").click(function(){

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -168,7 +168,7 @@ include("head.inc");
 <body>
 <?php include("fbegin.inc"); ?>
 
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      * Additional BOOTP/DHCP Options extenable table

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -124,7 +124,7 @@ include_once("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#show_advanced_dns").click(function(){
             $(this).parent().parent().hide();

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -122,7 +122,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      *  Aliases

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -132,7 +132,7 @@ legacy_html_escape_form_data($pconfig);
 include("head.inc");
 ?>
 
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     $("#rr").change(function() {
       $(".a_aaa_rec").hide();

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -77,7 +77,7 @@ include_once("head.inc");
 
 <body>
 
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete_host").click(function(event){

--- a/src/www/status_graph.php
+++ b/src/www/status_graph.php
@@ -137,7 +137,7 @@ include("head.inc");
     margin-bottom: -5px;
 }
 </style>
-<script type="text/javascript">
+<script>
     var graphtable = {};
     function formatSizeUnits(bytes){
         if      (bytes>=1000000000) {bytes=(bytes/1000000000).toFixed(2)+'G';}

--- a/src/www/status_habackup.php
+++ b/src/www/status_habackup.php
@@ -111,7 +111,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
     //<![CDATA[
     $( document ).ready(function() {
         function perform_actions_reload(todo)

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -48,7 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 include("head.inc");
 ?>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     $("#collapse_all").click(function(){
         $(".interface_details").collapse('toggle');

--- a/src/www/status_openvpn.php
+++ b/src/www/status_openvpn.php
@@ -97,7 +97,7 @@ include("head.inc"); ?>
 <body>
 <?php include("fbegin.inc"); ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
   // link kill buttons

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -266,7 +266,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 
 $(document).ready(function() {
      $(".proto").change(function(){

--- a/src/www/system_advanced_notifications.php
+++ b/src/www/system_advanced_notifications.php
@@ -120,7 +120,7 @@ include("head.inc");
 
 ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $(document).ready(function() {
     if ($('#smtpssl').is(':checked')) {

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -105,7 +105,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // delete entry
   $(".act_delete").click(function(event){

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -308,7 +308,7 @@ if (!isset($_GET['act']) || $_GET['act'] != 'new')
 
 <body>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     $("#type").change(function(){
         $(".auth_options").addClass('hidden');

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -410,7 +410,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete entry
     $(".act_delete").click(function(event){

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -533,7 +533,7 @@ if (empty($act)) {
       overflow-y: auto;
     }
   </style>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete entry
     $(".act_delete").click(function(event){
@@ -631,7 +631,7 @@ if (empty($act)) {
   </script>
 
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
 //<![CDATA[
   function internalca_change() {

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -244,7 +244,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
 
   $( document ).ready(function() {
     // delete cert revocation list

--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -87,7 +87,7 @@ $main_buttons = array(
 );
 
 ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // remove group
     $(".act-del-group").click(function(event){

--- a/src/www/system_gateway_groups_edit.php
+++ b/src/www/system_gateway_groups_edit.php
@@ -146,7 +146,7 @@ include("head.inc");
 
 ?>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // force protocol on initial selection (only relevant for new items)
     $("select.act-tier-change").change(function(){

--- a/src/www/system_gateways.php
+++ b/src/www/system_gateways.php
@@ -207,7 +207,7 @@ $main_buttons = array(
 
 ?>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete single item buttons (by class)
   $(".act_delete").click(function(event){

--- a/src/www/system_gateways_edit.php
+++ b/src/www/system_gateways_edit.php
@@ -488,7 +488,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 function recalc_value(object, min, max) {
     if (object.val() != "") {

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -162,7 +162,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // remove group
     $(".act-del-group").click(function(event){

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -387,14 +387,14 @@ legacy_html_escape_form_data($a_user);
 include("head.inc");
 
 ?>
-<script type="text/javascript" src="/ui/js/jquery.qrcode.js"></script>
-<script type="text/javascript" src="/ui/js/qrcode.js"></script>
+<script src="/ui/js/jquery.qrcode.js"></script>
+<script src="/ui/js/qrcode.js"></script>
 
 <body>
 
 <?php include("fbegin.inc"); ?>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // unhide otp QR code if found
     $('#otp_unhide').click(function () {
@@ -890,7 +890,7 @@ $( document ).ready(function() {
                     <td>
                       <label class="btn btn-primary" id="otp_unhide"><?= gettext('Click to unhide') ?></label>
                       <div style="display:none;" id="otp_qrcode"></div>
-                      <script type="text/javascript">
+                      <script>
                         $('#otp_qrcode').qrcode('<?= $otp_url ?>');
                       </script>
                       </div>

--- a/src/www/system_usermanager_addprivs.php
+++ b/src/www/system_usermanager_addprivs.php
@@ -107,7 +107,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#search").keyup(function(event){
             event.preventDefault();

--- a/src/www/system_usermanager_import_ldap.php
+++ b/src/www/system_usermanager_import_ldap.php
@@ -129,7 +129,7 @@ include('head.inc');
  <body>
 <?php if ($exit_form) :
 ?>
-  <script type="text/javascript">
+  <script>
     // exit form and reload parent after save
     window.opener.location.href = window.opener.location.href;
   window.close();
@@ -165,8 +165,8 @@ else :
 <?php
 endif; ?>
 <!-- bootstrap script -->
-<script type="text/javascript" src="/ui/js/bootstrap.min.js"></script>
+<script src="/ui/js/bootstrap.min.js"></script>
 <!-- Fancy select with search options -->
-<script type="text/javascript" src="/ui/js/bootstrap-select.min.js"></script>
+<script src="/ui/js/bootstrap-select.min.js"></script>
  </body>
 </html>

--- a/src/www/system_usermanager_settings.php
+++ b/src/www/system_usermanager_settings.php
@@ -84,7 +84,7 @@ include("head.inc");
 
 <?php
 if ($save_and_test):?>
-<script type="text/javascript">
+<script>
     myRef = window.open('system_usermanager_settings_test.php?authserver=<?=$pconfig['authmode'];?>','mywin','left=20,top=20,width=700,height=550,toolbar=1,resizable=0');
     if (myRef==null || typeof(myRef)=='undefined') alert('<?=gettext("Popup blocker detected. Action aborted.");?>');
 </script>;

--- a/src/www/system_usermanager_settings_ldapacpicker.php
+++ b/src/www/system_usermanager_settings_ldapacpicker.php
@@ -64,7 +64,7 @@ if (isset($_GET['basedn']) && isset($_GET['host'])) {
 ?>
 
  <body>
-  <script type="text/javascript">
+  <script>
       function post_choices() {
         var ous = <?= html_safe(count($ous)) ?>;
         var i;

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -189,7 +189,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     // link move/toggle buttons (phase 1 and phase 2)
     $(".act_move").click(function(event){

--- a/src/www/vpn_ipsec_keys.php
+++ b/src/www/vpn_ipsec_keys.php
@@ -66,7 +66,7 @@ include("head.inc");
 ?>
 
 <body>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // link delete buttons
   $(".act_delete").click(function(){

--- a/src/www/vpn_ipsec_mobile.php
+++ b/src/www/vpn_ipsec_mobile.php
@@ -186,7 +186,7 @@ include("head.inc");
 
 <body>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
   pool_change();

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -431,7 +431,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#iketype").change(function(){
             if ($(this).val() == 'ikev2') {

--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -410,7 +410,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#mode").change(function(){
             $(".opt_localid").hide();

--- a/src/www/vpn_ipsec_settings.php
+++ b/src/www/vpn_ipsec_settings.php
@@ -111,12 +111,12 @@ include("head.inc");
 ?>
 
 <!-- JQuery Tokenize (http://zellerda.com/projects/tokenize) -->
-<script type="text/javascript" src="/ui/js/jquery.tokenize.js"></script>
+<script src="/ui/js/jquery.tokenize.js"></script>
 <link rel="stylesheet" type="text/css" href="/ui/css/jquery.tokenize.css" />
 
-<script type="text/javascript" src="/ui/js/opnsense_ui.js"></script>
+<script src="/ui/js/opnsense_ui.js"></script>
 
- <script type="text/javascript">
+ <script>
     $( document ).ready(function() {
         formatTokenizersUI();
     });

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -374,7 +374,7 @@ $main_buttons = array(
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
   // link delete buttons

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -233,7 +233,7 @@ include("head.inc");
 
 <body>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 $( document ).ready(function() {
   // link delete buttons

--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -1127,7 +1127,7 @@ include("head.inc");
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#server").change(function(){
             $('.server_item').hide();

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -423,7 +423,7 @@ legacy_html_escape_form_data($pconfig);
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   // watch scroll position and set to last known on page load
   watchScrollPosition();

--- a/src/www/widgets/widgets/gateways.widget.php
+++ b/src/www/widgets/widgets/gateways.widget.php
@@ -27,7 +27,7 @@
 */
 ?>
 
-<script type="text/javascript">
+<script>
   function gateways_widget_update(sender, data)
   {
       var tbody = sender.find('tbody');

--- a/src/www/widgets/widgets/interface_list.widget.php
+++ b/src/www/widgets/widgets/interface_list.widget.php
@@ -36,7 +36,7 @@ require_once("interfaces.inc");
 
 ?>
 
-<script type="text/javascript">
+<script>
   /**
    * Hybrid widget only update interface status using ajax
    */

--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -31,7 +31,7 @@
 */
 ?>
 
-<script type="text/javascript">
+<script>
   /**
    * update interface statistics
    */

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -75,7 +75,7 @@ if (isset($config['ipsec']['phase1'])) {
 
 if (isset($config['ipsec']['phase2'])) {
 ?>
-<script type="text/javascript">
+<script>
     $(document).ready(function() {
         $(".ipsec-tab").click(function(){
             $(".ipsec-tab").css('background-color', '#777777');

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -72,7 +72,7 @@ $nentriesacts       = isset($config['widgets']['filterlogentriesacts']) ?  explo
 $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? $config['widgets']['filterlogentriesinterfaces'] : 'All';
 ?>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         // needed to display the widget settings menu
         $("#log-configure").removeClass("disabled");

--- a/src/www/widgets/widgets/ntp_status.widget.php
+++ b/src/www/widgets/widgets/ntp_status.widget.php
@@ -215,7 +215,7 @@ function clockTimeString($inDate, $showSeconds)
 /*** Clock -- end of server-side support code ***/
 ?>
 
-<script type="text/javascript">
+<script>
 <!--
 /* set up variables used to init clock in BODY's onLoad handler;
    should be done as early as possible */
@@ -230,7 +230,7 @@ function clockInit() {
 </script>
 
 
-<script type="text/javascript">
+<script>
 <!--
 /*** simpleFindObj, by Andrew Shearer
 
@@ -477,7 +477,7 @@ function clockUpdate()
 </table>
 
 
-<script type="text/javascript">
+<script>
   function ntp_getstatus() {
     scroll(0,0);
     var url = "/widgets/widgets/ntp_status.widget.php";

--- a/src/www/widgets/widgets/openvpn.widget.php
+++ b/src/www/widgets/widgets/openvpn.widget.php
@@ -34,7 +34,7 @@ $sk_servers = openvpn_get_active_servers("p2p");
 $clients = openvpn_get_active_clients();
 
 ?>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         // link kill buttons
         $(".act_kill_client").click(function(event){

--- a/src/www/widgets/widgets/picture.widget.php
+++ b/src/www/widgets/widgets/picture.widget.php
@@ -94,7 +94,7 @@ if ($config['widgets']['picturewidget_filename'] != "") :?>
 <?php
 endif ?>
 <!-- needed to show the settings widget icon -->
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $("#picture-configure").removeClass("disabled");
 //]]>

--- a/src/www/widgets/widgets/rss.widget.php
+++ b/src/www/widgets/widgets/rss.widget.php
@@ -166,7 +166,7 @@ if (!empty($config['widgets']['rsswidgettextlength']) && is_numeric($config['wid
 </div>
 
 <!-- needed to display the widget settings menu -->
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $("#rss-configure").removeClass("disabled");
 //]]>

--- a/src/www/widgets/widgets/services_status.widget.php
+++ b/src/www/widgets/widgets/services_status.widget.php
@@ -100,7 +100,7 @@ if (isset($_POST['servicestatusfilter'])) {
 </table>
 
 <!-- needed to display the widget settings menu -->
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $("#services_status-configure").removeClass("disabled");
 //]]>

--- a/src/www/widgets/widgets/system_information.widget.php
+++ b/src/www/widgets/widgets/system_information.widget.php
@@ -34,8 +34,8 @@ require_once("guiconfig.inc");
 require_once("system.inc");
 
 ?>
-<script src="/ui/js/moment-with-locales.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="/ui/js/moment-with-locales.min.js"></script>
+<script>
   var system_information_widget_cpu_data = []; // reference to measures
   var system_information_widget_cpu_chart = null; // reference to chart object
   var system_information_widget_cpu_chart_data = null; // reference to chart data object

--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -75,7 +75,7 @@ require_once('diag_logs_common.inc');
 </div>
 
 <!-- needed to display the widget settings menu -->
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $("#system_log-configure").removeClass("disabled");
 //]]>

--- a/src/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/www/widgets/widgets/thermal_sensors.widget.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 }
 
 ?>
-<script type="text/javascript">
+<script>
   function thermal_sensors_widget_update(sender, data)
   {
     data.map(function(sensor) {
@@ -171,7 +171,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 </table>
 
 <!-- needed to display the widget settings menu -->
-<script type="text/javascript">
+<script>
 //<![CDATA[
   $("#thermal_sensors-configure").removeClass("disabled");
 //]]>

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -32,7 +32,7 @@
 
 ?>
 
-<script type="text/javascript">
+<script>
   var traffic_graph_widget_data = [];
   var traffic_graph_widget_chart_in = null;
   var traffic_graph_widget_chart_data_in = null;

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -270,14 +270,14 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript" src="/javascript/wizard/autosuggest.js"></script>
-<script type="text/javascript" src="/javascript/wizard/disablekeys.js"></script>
-<script type="text/javascript" src="/javascript/wizard/suggestions.js"></script>
+<script src="/javascript/wizard/autosuggest.js"></script>
+<script src="/javascript/wizard/disablekeys.js"></script>
+<script src="/javascript/wizard/suggestions.js"></script>
 
 <?php include("fbegin.inc"); ?>
 
 <?php if($pkg['step'][$stepid]['fields']['field'] <> "") { ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 
 function  FieldValidate(userinput,  regexp,  message)
@@ -899,7 +899,7 @@ function showchange() {
 </section>
 
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 	if (typeof ext_change != 'undefined') {
 		ext_change();
@@ -950,7 +950,7 @@ $fieldnames_array = Array();
 if($pkg['step'][$stepid]['disableallfieldsbydefault'] <> "") {
 	// create a fieldname loop that can be used with javascript
 	// hide and enable features.
-	echo "\n<script type=\"text/javascript\">\n";
+	echo "\n<script>\n";
 	echo "//<![CDATA[\n";
 	echo "function disableall() {\n";
 	foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
@@ -999,7 +999,7 @@ if($pkg['step'][$stepid]['disableallfieldsbydefault'] <> "") {
 }
 ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 
 // After reload/redirect functions are not loaded, so check first.
@@ -1019,7 +1019,7 @@ if($pkg['step'][$stepid]['stepafterformdisplay'] <> "") {
 
 if($pkg['step'][$stepid]['javascriptafterformdisplay'] <> "") {
 	// handle after form display event.
-	echo "\n<script type=\"text/javascript\">\n";
+	echo "\n<script>\n";
 	echo "//<![CDATA[\n";
 	echo $pkg['step'][$stepid]['javascriptafterformdisplay'] . "\n";
 	echo "//]]>\n";


### PR DESCRIPTION
Warning: The type attribute is unnecessary for JavaScript resources.

HTML5: Edition for Web Authors
http://www.w3.org/TR/2014/REC-html5-20141028/scripting-1.html
The default, which is used if the attribute is absent, is "text/javascript".

The Script element
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.