### PR TITLE
HTML Compliance - "navigation" "role" on Element <nav>

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
@@ -1,6 +1,6 @@
 <aside id="navigation" class="page-side col-xs-12 col-sm-3 col-lg-2 hidden-xs">
     <div class="row">
-        <nav class="page-side-nav" role="navigation">
+        <nav class="page-side-nav">
             <div id="mainmenu" class="panel" style="border:0px" >
                 <div class="panel list-group" style="border:0px">
                 {% for topMenuItem in menuSystem %}

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -241,7 +241,7 @@
   </head>
   <body>
   <header class="page-head">
-    <nav class="navbar navbar-default" role="navigation">
+    <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -48,7 +48,7 @@ if($need_alert_display == true) {
 ?>
 
 <header class="page-head">
-  <nav class="navbar navbar-default" role="navigation">
+  <nav class="navbar navbar-default">
     <div class="container-fluid">
       <div class="navbar-header">
         <a class="navbar-brand" href="/index.php">
@@ -82,7 +82,7 @@ if($need_alert_display == true) {
 <main class="page-content col-sm-9 col-sm-push-3 col-lg-10 col-lg-push-2">
     <aside id="navigation" class="page-side col-xs-12 col-sm-3 col-lg-2 hidden-xs">
         <div class="row">
-            <nav class="page-side-nav" role="navigation">
+            <nav class="page-side-nav">
                 <div id="mainmenu" class="panel" style="border:0px" >
                     <div class="panel list-group" style="border:0px">
 <?php


### PR DESCRIPTION
Warning: The navigation role is unnecessary for element nav.

HTML 5.1 2nd Edition
W3C Recommendation 3 October 2017
4.3.4. The nav element
http://www.w3.org/TR/html51/sections.html#the-nav-element

Allowed ARIA role attribute values: ‘navigation’ role (default - do not set) or ‘presentation’.

http://www.w3.org/TR/html51/dom.html#do-not-set
Note: In the majority of cases setting an ARIA role and/or aria-* attribute that matches the default implicit ARIA semantics is unnecessary and not recommended as these properties are already set by the browser.

In the December 2017 document "is unnecessary and not recommended" is bold emphasized.
HTML 5.2
W3C Recommendation, 14 December 2017
http://www.w3.org/TR/html5/dom.html#aria-authoring-requirements

According to HTML5 Accessibility dot com, Chrome, Edge, and Safari have full support for the &lt;nav&gt; element.  Firefox lacks only "Name/Description".  Given the state of IE in this regard it is difficult to understand why anyone using it with assistive/accessibility technology at this point.
http://html5accessibility.com/

Markup like &lt;nav role="navigation"&gt; and &lt;button role="button"&gt; is superfluous since the HTML elements themselves already explain their role.