### PR TITLE
IPSEC Widget Tabs - Tweak

### DIFF
--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -83,20 +83,20 @@ if (isset($config['ipsec']['phase2'])) {
             $(this).css('background-color', '#EEEEEE');
             $(this).css('color', 'black');
             $(".ipsec-tab-content").hide();
-            $("#"+$(this).attr('for')).show();
+            $("#"+$(this).attr('data-for')).show();
         });
     });
 </script>
 <div id="tabs">
-    <output for="ipsec-Overview" class="ipsec-tab table-cell" style="background-color:#EEEEEE; color:black; cursor: pointer; display:table-cell">
+    <div data-for="ipsec-Overview" class="ipsec-tab table-cell" style="background-color:#EEEEEE; color:black; cursor: pointer; display:table-cell">
         <strong>&nbsp;&nbsp;<?=gettext("Overview");?>&nbsp;&nbsp;</strong>
-    </output>
-    <output for="ipsec-tunnel" class="ipsec-tab table-cell" style="background-color:#777777; color:white; cursor: pointer; display:table-cell">
+    </div>
+    <div data-for="ipsec-tunnel" class="ipsec-tab table-cell" style="background-color:#777777; color:white; cursor: pointer; display:table-cell">
         <strong>&nbsp;&nbsp;<?=gettext("Tunnels");?>&nbsp;&nbsp;</strong>
-    </output>
-    <output for="ipsec-mobile" class="ipsec-tab table-cell" style="background-color:#777777; color:white; cursor: pointer; display:table-cell">
+    </div>
+    <div data-for="ipsec-mobile" class="ipsec-tab table-cell" style="background-color:#777777; color:white; cursor: pointer; display:table-cell">
         <strong>&nbsp;&nbsp;<?=gettext("Mobile");?>&nbsp;&nbsp;</strong>
-    </output>
+    </div>
 </div>
 
 <div id="ipsec-Overview" class="ipsec-tab-content" style="display:block;background-color:#EEEEEE;">


### PR DESCRIPTION
This is more appropriate, as the tabs are more akin to a label than an output.
Also better for touch screens because some browsers select the tab label text (highlight for copying) when output element tapped.  Not a functionality issue, but looks bad and initially confusing (why is that text selected?)

Using data attributes
https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes

HTML5 is designed with extensibility in mind for data that should be associated with a particular element but need not have any defined meaning. data-* attributes allow us to store extra information on standard, semantic HTML elements without other hacks such as non-standard attributes, extra properties on DOM, or Node.setUserData().