### PR TITLE
Firewall Logs Widget - time min width

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -647,3 +647,8 @@ select {
   background-repeat: no-repeat;
   background-position: right;
   background-image: url(/ui/themes/opnsense/build/images/caret.png) !important;}
+
+#grid-log th[data-column-id="__timestamp__"], 
+#filter-log-entries th[data-column-id="__timestamp__"] {
+	min-width: 3.5em;
+}

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -5861,3 +5861,8 @@ select {
   background-repeat: no-repeat;
   background-position: right;
   background-image: url(/ui/themes/opnsense/build/images/caret.png) !important; }
+
+#grid-log th[data-column-id="__timestamp__"], 
+#filter-log-entries th[data-column-id="__timestamp__"] {
+	min-width: 3.5em;
+}


### PR DESCRIPTION
Minimum time field width so date (month day, e.g. Jan 24) doesn't wrap and consume additional line unnecessarily.  Particularly in mobile portrait view.