### PR TITLE
Help For - Data For Attribute

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -789,9 +789,9 @@
                                     <div style="display:none;" id="firmware_mirror_other">
                                         <input type="text" id="firmware_mirror_value">
                                     </div>
-                                    <output class="hidden" for="help_for_mirror">
+                                    <div class="hidden" data-for="help_for_mirror">
                                         {{ lang._('Select an alternate firmware mirror.') }}
-                                    </output>
+                                    </div>
                                 </td>
                                 <td></td>
                             </tr>
@@ -803,9 +803,9 @@
                                     <div style="display:none;" id="firmware_flavour_other">
                                         <input type="text" id="firmware_flavour_value">
                                     </div>
-                                    <output class="hidden" for="help_for_flavour">
+                                    <div class="hidden" data-for="help_for_flavour">
                                         {{ lang._('Select the firmware cryptography flavour.') }}
-                                    </output>
+                                    </div>
                                 </td>
                                 <td></td>
                             </tr>
@@ -814,9 +814,9 @@
                                 <td>
                                     <select class="selectpicker" id="firmware_type">
                                     </select>
-                                    <output class="hidden" for="help_for_type">
+                                    <div class="hidden" data-for="help_for_type">
                                         {{ lang._('Select the release type. Use with care.') }}
-                                    </output>
+                                    </div>
                                 </td>
                                 <td></td>
                             </tr>
@@ -824,9 +824,9 @@
                                 <td style="width: 150px;"><a id="help_for_mirror_subscription" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> {{ lang._('Subscription') }}</td>
                                 <td>
                                     <input type="text" id="firmware_mirror_subscription">
-                                    <output class="hidden" for="help_for_mirror_subscription">
+                                    <div class="hidden" data-for="help_for_mirror_subscription">
                                         {{ lang._('Provide subscription key.') }}
-                                    </output>
+                                    </div>
                                 </td>
                                 <td></td>
                             </tr>

--- a/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
@@ -213,7 +213,7 @@
                 </div>
                 </td>
                 <td>
-                  <small class="hidden" for="help_for_proxy.forward.acl.remoteACLs.blacklist">
+                  <small class="hidden" data-for="help_for_proxy.forward.acl.remoteACLs.blacklist">
                       {{ lang._('
                       Add an item to the table to fetch a remote acl for blacklisting.%s
                       You can enable or disable the blacklist list.%s

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -70,9 +70,7 @@
             <span id="{{ id }}"></span>
         {% endif %}
         {% if help|default(false) %}
-            <output class="hidden" for="help_for_{{ id }}">
-                <small>{{help}}</small>
-            </output>
+            <small class="hidden" data-for="help_for_{{ id }}">{{help}}</small>
         {% endif %}
     </td>
     <td>

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -277,6 +277,7 @@ function initFormHelpUI() {
     // handle help messages show/hide
     $("a[class='showhelp']").click(function (event) {
         $("*[for='" + $(this).attr('id') + "']").toggleClass("hidden show");
+        $("*[data-for='" + $(this).attr('id') + "']").toggleClass("hidden show");
         event.preventDefault();
     });
 
@@ -290,9 +291,13 @@ function initFormHelpUI() {
             }
             $('[for*="help_for"]').addClass("show");
             $('[for*="help_for"]').removeClass("hidden");
+            $('[data-for*="help_for"]').addClass("show");
+            $('[data-for*="help_for"]').removeClass("hidden");
         } else {
             $('[for*="help_for"]').addClass("hidden");
             $('[for*="help_for"]').removeClass("show");
+            $('[data-for*="help_for"]').addClass("hidden");
+            $('[data-for*="help_for"]').removeClass("show");
             if (window.sessionStorage) {
                 sessionStorage.setItem('all_help_preset', 0);
             }
@@ -305,6 +310,8 @@ function initFormHelpUI() {
         $('[id*="show_all_help"]').toggleClass("text-success text-danger");
         $('[for*="help_for"]').addClass("show");
         $('[for*="help_for"]').removeClass("hidden");
+        $('[data-for*="help_for"]').addClass("show");
+        $('[data-for*="help_for"]').removeClass("hidden");
     }
 }
 

--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -677,9 +677,10 @@ label>input[type="radio"] {
   float:left;
 }
 
-output[for*="help_for"] {
-  padding-top: 0.4em;
-  padding-bottom: 0.4em;
+small[data-for*="help_for"],
+div[data-for*="help_for"] {
+  padding-top: .4em;
+  padding-bottom: .4em;
 }
 
 #log-settings label[for^="act"] {

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -5892,9 +5892,11 @@ label > input[type="radio"] {
   margin-right: .4em;
   float: left; }
 
-output[for*="help_for"] {
-  padding-top: 0.4em;
-  padding-bottom: 0.4em; }
+small[data-for*="help_for"],
+div[data-for*="help_for"] {
+  padding-top: .4em;
+  padding-bottom: .4em; }
+
 
 #log-settings label[for^="act"] {
   margin-right: 1.5em; }

--- a/src/www/diag_logs_settings.php
+++ b/src/www/diag_logs_settings.php
@@ -348,32 +348,32 @@ $(document).ready(function() {
                     <td><a id="help_for_reverse" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Reverse Display') ?></td>
                     <td>
                       <input name="reverse" type="checkbox" id="reverse" value="yes" <?=!empty($pconfig['reverse']) ? "checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_reverse">
+                      <div class="hidden" data-for="help_for_reverse">
                         <?=gettext("Show log entries in reverse order (newest entries on top)");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_nentries" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('GUI Log Entries to Display') ?></td>
                     <td>
                       <input name="nentries" type="text" value="<?=$pconfig['nentries'];?>" /><br />
-                      <output class="hidden" for="help_for_nentries">
+                      <div class="hidden" data-for="help_for_nentries">
                         <?=gettext("Hint: This is only the number of log entries displayed in the GUI. It does not affect how many entries are contained in the actual log files.") ?>
-                      </output>
+                      </div>
                       </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_logfilesize" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Log File Size (Bytes)') ?></td>
                     <td>
                       <input name="logfilesize" type="text" value="<?=$pconfig['logfilesize'];?>" />
-                      <output class="hidden" for="help_for_logfilesize">
+                      <div class="hidden" data-for="help_for_logfilesize">
                         <?=gettext("Logs are held in constant-size circular log files. This field controls how large each log file is, and thus how many entries may exist inside the log. By default this is approximately 500KB per log file, and there are nearly 20 such log files.") ?>
                         <br /><br />
                         <?=gettext("NOTE: Log sizes are changed the next time a log file is cleared or deleted. To immediately increase the size of the log files, you must first save the options to set the size, then clear all logs using the \"Reset Log Files\" option farther down this page. "); ?>
                         <?=gettext("Be aware that increasing this value increases every log file size, so disk usage will increase significantly."); ?>
                         <?=gettext("Disk space currently used by log files: ") ?><?= exec("/usr/bin/du -sh /var/log | /usr/bin/awk '{print $1;}'"); ?>.
                         <?=gettext("Remaining disk space for log files: ") ?><?= exec("/bin/df -h /var/log | /usr/bin/awk '{print $4;}'"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -381,14 +381,14 @@ $(document).ready(function() {
                     <td>
                       <input name="logdefaultblock" type="checkbox" value="yes" <?=!empty($pconfig['logdefaultblock']) ? "checked=\"checked\"" : ""; ?> />
                       <strong><?=gettext("Log packets matched from the default block rules put in the ruleset");?></strong><br />
-                      <output class="hidden" for="help_for_logdefaultblock">
+                      <div class="hidden" data-for="help_for_logdefaultblock">
                         <?=gettext("Hint: packets that are blocked by the implicit default block rule will not be logged if you uncheck this option. Per-rule logging options are still respected.");?>
-                      </output>
+                      </div>
                       <input name="logdefaultpass" type="checkbox" id="logdefaultpass" value="yes" <?=!empty($pconfig['logdefaultpass']) ? "checked=\"checked\"" :""; ?> />
                       <strong><?=gettext("Log packets matched from the default pass rules put in the ruleset");?></strong><br />
-                      <output class="hidden" for="help_for_logdefaultblock">
+                      <div class="hidden" data-for="help_for_logdefaultblock">
                         <?=gettext("Hint: packets that are allowed by the implicit default pass rule will be logged if you check this option. Per-rule logging options are still respected.");?>
-                      </output>
+                      </div>
                       <input name="logbogons" type="checkbox" id="logbogons" value="yes" <?=!empty($pconfig['logbogons']) ? "checked=\"checked\"" : ""; ?> />
                       <strong><?=gettext("Log packets blocked by 'Block Bogon Networks' rules");?></strong><br />
                       <input name="logprivatenets" type="checkbox" id="logprivatenets" value="yes" <?php if ($pconfig['logprivatenets']) echo "checked=\"checked\""; ?> />
@@ -400,9 +400,9 @@ $(document).ready(function() {
                     <td>
                       <input name="loglighttpd" type="checkbox" id="loglighttpd" value="yes" <?=!empty($pconfig['loglighttpd']) ? "checked=\"checked\"" :""; ?> />
                       <strong><?=gettext("Log errors from the web server process.");?></strong><br />
-                      <output class="hidden" for="help_for_loglighttpd">
+                      <div class="hidden" data-for="help_for_loglighttpd">
                         <?=gettext("Hint: If this is checked, errors from the lighttpd web server process for the GUI or Captive Portal will appear in the main system log.");?></td>
-                      </output>
+                      </div>
                   </tr>
                   <tr>
                       <td><a id="help_for_filterdescriptions" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Filter descriptions') ?></td>
@@ -412,11 +412,11 @@ $(document).ready(function() {
                           <option value="1"<?=($pconfig['filterdescriptions'])==="1"?" selected=\"selected\"":""?>><?=gettext('Display as column') ?></option>
                           <option value="2"<?=($pconfig['filterdescriptions'])==="2"?" selected=\"selected\"":""?>><?=gettext('Display as second row') ?></option>
                         </select>
-                        <output class="hidden" for="help_for_filterdescriptions">
+                        <div class="hidden" data-for="help_for_filterdescriptions">
                           <strong><?=gettext("Show the applied rule description below or in the firewall log rows.");?></strong>
                           <br />
                           <?=gettext("Displaying rule descriptions for all lines in the log might affect performance with large rule sets.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -428,9 +428,9 @@ $(document).ready(function() {
                       <td><a id="help_for_resetlogs" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Reset Logs') ?></td>
                       <td>
                         <input name="resetlogs" id="resetlogs" type="submit" class="btn btn-default" value="<?=gettext("Reset Log Files"); ?>"/>
-                        <output class="hidden" for="help_for_resetlogs">
+                        <div class="hidden" data-for="help_for_resetlogs">
                           <?= gettext("Note: Clears all local log files and reinitializes them as empty logs. This also restarts the DHCP daemon. Use the Save button first if you have made any setting changes."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                   </table>
@@ -460,12 +460,12 @@ $(document).ready(function() {
 <?php
                           endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_sourceip">
+                        <div class="hidden" data-for="help_for_sourceip">
                           <?= gettext("This option will allow the logging daemon to bind to a single IP address, rather than all IP addresses."); ?>
                           <?= gettext("If you pick a single IP, remote syslog severs must all be of that IP type. If you wish to mix IPv4 and IPv6 remote syslog servers, you must bind to all interfaces."); ?>
                           <br /><br />
                           <?= gettext("NOTE: If an IP address cannot be located on the chosen interface, the daemon will bind to all addresses."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -475,9 +475,9 @@ $(document).ready(function() {
                           <option value="ipv4" <?=$ipproto == "ipv4" ? 'selected="selected"' : "";?>><?=gettext("IPv4");?></option>
                           <option value="ipv6" <?=$ipproto == "ipv6" ? 'selected="selected"' : "";?>><?=gettext("IPv6");?></option>
                         </select>
-                        <output class="hidden" for="help_for_ipproto">
+                        <div class="hidden" data-for="help_for_ipproto">
                           <?= gettext("This option is only used when a non-default address is chosen as the source above. This option only expresses a preference; If an IP address of the selected type is not found on the chosen interface, the other type will be tried."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -504,9 +504,9 @@ $(document).ready(function() {
                             <td><input name="remoteserver3" id="remoteserver3" type="text" class="form-control host" size="20" value="<?=htmlspecialchars($pconfig['remoteserver3']);?>" /></td>
                           </tr>
                         </table>
-                        <output class="hidden" for="help_for_remoteserver">
+                        <div class="hidden" data-for="help_for_remoteserver">
                           <?=gettext("IP addresses of remote syslog servers, or an IP:port.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/diag_packet_capture.php
+++ b/src/www/diag_packet_capture.php
@@ -320,19 +320,19 @@ include("fbegin.inc");
 <?php
                       endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_if">
+                      <div class="hidden" data-for="help_for_if">
                         <?=gettext("Select the interface on which to capture traffic.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_promiscuous" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Promiscuous");?></td>
                     <td>
                       <input name="promiscuous" type="checkbox" <?= !empty($pconfig['promiscuous']) ? " checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_promiscuous">
+                      <div class="hidden" data-for="help_for_promiscuous">
                         <?=gettext("If checked, the");?> <a target="_blank" href="http://www.freebsd.org/cgi/man.cgi?query=tcpdump&amp;apropos=0&amp;sektion=0&amp;manpath=FreeBSD+8.3-stable&amp;arch=default&amp;format=html"><?= gettext("packet capture")?></a> <?= gettext("will be performed using promiscuous mode.");?>
                         <br /><b><?=gettext("Note");?>: </b><?=gettext("Some network adapters do not support or work well in promiscuous mode.");?>
-                      </output>
+                      </div>
                   </td>
                   </tr>
                   <tr>
@@ -347,9 +347,9 @@ include("fbegin.inc");
                           <?= gettext('IPv6 Only') ?>
                         </option>
                       </select>
-                      <output class="hidden" for="help_for_fam">
+                      <div class="hidden" data-for="help_for_fam">
                         <?=gettext("Select the type of traffic to be captured, either Any, IPv4 only or IPv6 only.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -371,48 +371,48 @@ include("fbegin.inc");
                         <option value="!carp" <?=$pconfig['proto'] == "!carp" ? "selected=\"selected\"" : ""; ?>><?= gettext('Exclude CARP (VRRP)') ?></option>
                         <option value="esp" <?=$pconfig['proto'] == "esp" ? "selected=\"selected\"" : ""; ?>><?= gettext('ESP') ?></option>
                       </select>
-                      <output class="hidden" for="help_for_proto">
+                      <div class="hidden" data-for="help_for_proto">
                           <?=gettext("Select the protocol to capture, or Any.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_host" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Host Address");?></td>
                     <td>
                       <input type="text"  name="host" value="<?=$pconfig['host'];?>" />
-                      <output class="hidden" for="help_for_host">
+                      <div class="hidden" data-for="help_for_host">
                         <?=gettext("This value is either the Source or Destination IP address or subnet in CIDR notation. The packet capture will look for this address in either field.");?>
                         <?=gettext("Matching can be negated by preceding the value with \"not\". Multiple IP addresses or CIDR subnets may be specified as boolean expresion.");?>
                         <?=gettext("If you leave this field blank, all packets on the specified interface will be captured.");?>
                         <br/><br/><?=gettext("Example:");?> not 10.0.0.0/24 not and not 11.0.0.1
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Port");?></td>
                     <td>
                       <input type="text" name="port" value="<?=$pconfig['port'];?>" />
-                      <output class="hidden" for="help_for_port">
+                      <div class="hidden" data-for="help_for_port">
                         <?=gettext("The port can be either the source or destination port. The packet capture will look for this port in either field.");?> <?=gettext("Leave blank if you do not want to filter by port.");?>
-                      </output>
+                      </div>
                   </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_snaplen" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Packet Length");?></td>
                     <td>
                       <input type="text" name="snaplen" value="<?=$pconfig['snaplen'];?>" />
-                      <output class="hidden" for="help_for_snaplen">
+                      <div class="hidden" data-for="help_for_snaplen">
                         <?=gettext("The Packet length is the number of bytes of each packet that will be captured. Default value is 0, which will capture the entire frame regardless of its size.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_count" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Count");?></td>
                     <td>
                       <input type="text" name="count" class="formfld unknown" id="count" size="5" value="<?=$pconfig['count'];?>" />
-                      <output class="hidden" for="help_for_count">
+                      <div class="hidden" data-for="help_for_count">
                         <?=gettext("This is the number of packets the packet capture will grab. Default value is 100.") . "<br />" . gettext("Enter 0 (zero) for no count limit.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -427,11 +427,11 @@ include("fbegin.inc");
                         <option value="high" <?=$pconfig['detail'] == 'high' ?  "selected=\"selected\"" : "";?> ><?=gettext("High");?></option>
                         <option value="full" <?=$pconfig['detail'] == 'full' ?  "selected=\"selected\"" : "";?> ><?=gettext("Full");?></option>
                       </select>
-                      <output class="hidden" for="help_for_detail">
+                      <div class="hidden" data-for="help_for_detail">
                         <?=gettext("This is the level of detail that will be displayed after hitting 'Stop' when the packets have been captured.") .  "<br /><b>" .
                            gettext("Note:") . "</b> " .
                            gettext("This option does not affect the level of detail when downloading the packet capture.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 
@@ -439,10 +439,10 @@ include("fbegin.inc");
                     <td><a id="help_for_dnsquery" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reverse DNS Lookup");?></td>
                     <td>
                       <input name="dnsquery" id="dnsquery" type="checkbox"/>
-                      <output class="hidden" for="help_for_dnsquery">
+                      <div class="hidden" data-for="help_for_dnsquery">
                        <?=gettext("This check box will cause the packet capture to perform a reverse DNS lookup associated with all IP addresses.");?>
                        <br /><b><?=gettext("Note");?>: </b><?=gettext("This option can cause delays for large packet captures.");?>
-                     </output>
+                     </div>
                     </td>
                   </tr>
 

--- a/src/www/diag_testport.php
+++ b/src/www/diag_testport.php
@@ -147,9 +147,9 @@ include("head.inc"); ?>
                             <?=gettext("IPv6");?>
                           </option>
                         </select>
-                        <output class="hidden" for="help_for_ipprotocol">
+                        <div class="hidden" data-for="help_for_ipprotocol">
                           <?=gettext("If you force IPv4 or IPv6 and use a hostname that does not contain a result using that protocol, it will result in an error. For example if you force IPv4 and use a hostname that only returns an AAAA IPv6 IP address, it will not work."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -168,18 +168,18 @@ include("head.inc"); ?>
                       <td><a id="help_for_srcport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Source Port"); ?></td>
                       <td>
                         <input name="srcport" type="text" value="<?=$pconfig['srcport'];?>" />
-                        <output class="hidden" for="help_for_srcport">
+                        <div class="hidden" data-for="help_for_srcport">
                           <?=gettext("This should typically be left blank."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_showtext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Show Remote Text"); ?></td>
                       <td>
                         <input name="showtext" type="checkbox" id="showtext" <?= !empty($pconfig['showtext']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_showtext">
+                        <div class="hidden" data-for="help_for_showtext">
                           <?=gettext("Shows the text given by the server when connecting to the port. Will take 10+ seconds to display if checked."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/firewall_aliases_edit.php
+++ b/src/www/firewall_aliases_edit.php
@@ -552,18 +552,18 @@ include("head.inc");
                       <input name="id" type="hidden" value="<?=$id;?>" />
                     <?php endif; ?>
                     <input name="name" type="text" id="name" class="form-control unknown" size="40" maxlength="31" value="<?=$pconfig['name'];?>" />
-                    <output class="hidden" for="help_for_name">
+                    <div class="hidden" data-for="help_for_name">
                       <?=gettext('The name of the alias may only consist of the characters "a-z, A-Z, 0-9 and _". Aliases can be nested using this name.'); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" class="form-control unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_description">
+                    <div class="hidden" data-for="help_for_description">
                       <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -587,7 +587,7 @@ include("head.inc");
                         <option value="IPv6" <?= in_array("IPv6", $pconfig['proto']) ? "selected=\"selected\"" : ""; ?>><?=gettext("IPv6");?></option>
                       </select>
                     </div>
-                    <output class="hidden" for="help_for_type">
+                    <div class="hidden" data-for="help_for_type">
                       <span class="text-info">
                         <?=gettext("Hosts")?><br/>
                       </span>
@@ -630,7 +630,7 @@ include("head.inc");
                         <?=gettext("Managed externally, the contents of this alias type could be managed by other scripts or services. ".
                                   "OPNsense only makes sure the alias exists and leaves the contents alone");?>
                       </small>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/firewall_aliases_import.php
+++ b/src/www/firewall_aliases_import.php
@@ -183,7 +183,7 @@ include("head.inc");
                       <option value="host" <?=$pconfig['type'] == "host" ? "selected=\"selected\"" : ""; ?>><?=gettext("Host(s)"); ?></option>
                       <option value="network" <?=$pconfig['type'] == "network" ? "selected=\"selected\"" : ""; ?>><?=gettext("Network(s)"); ?></option>
                     </select>
-                    <output class="hidden" for="help_for_type">
+                    <div class="hidden" data-for="help_for_type">
                       <span class="text-info">
                         <?=gettext("Networks")?><br/>
                       </span>
@@ -198,32 +198,32 @@ include("head.inc");
                         <?=gettext("Enter as many hosts as you would like. Hosts must be specified by their IP address or fully qualified domain name (FQDN). FQDN hostnames are periodically re-resolved and updated. If multiple IPs are returned by a DNS query, all are used.");?>
                         <br/>
                       </small>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td style="width:22%"><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Name') ?></td>
                   <td style="width:78%">
                     <input name="name" type="text" class="form-control unknown" size="40" maxlength="31" value="<?=$pconfig['name'];?>" />
-                    <output class="hidden" for="help_for_name">
+                    <div class="hidden" data-for="help_for_name">
                       <?=gettext("The name of the alias may only consist of the characters \"a-z, A-Z and 0-9\"."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_description">
+                    <div class="hidden" data-for="help_for_description">
                       <?=gettext("You may enter a description here for your reference (not parsed)"); ?>.
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_alias" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Aliases') ?></td>
                   <td>
                     <textarea name="aliasimport" rows="15" cols="40"><?=$pconfig['aliasimport'];?></textarea>
-                    <output class="hidden" for="help_for_alias">
+                    <div class="hidden" data-for="help_for_alias">
                       <?=gettext("Paste in the aliases to import separated by a carriage return. Common examples are lists of IPs, networks, blacklists, etc."); ?>
                       <br />
                       <?=gettext("The list may contain IP addresses, with or without CIDR prefix, IP ranges, blank lines (ignored) and an optional description after each IP. e.g.:"); ?>
@@ -235,7 +235,7 @@ include("head.inc");
                         <br/>10.20.0.0/16 Office network
                         <br/>10.40.1.10-10.40.1.19 Managed switches
                       </code>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/firewall_nat_1to1_edit.php
+++ b/src/www/firewall_nat_1to1_edit.php
@@ -249,10 +249,10 @@ include("head.inc");
                     <td><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td>
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_disabled">
+                      <div class="hidden" data-for="help_for_disabled">
                         <strong><?=gettext("Disable this rule"); ?></strong><br />
                         <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -268,10 +268,10 @@ include("head.inc");
                           <?php endforeach; ?>
                         </select>
                       </div>
-                      <output class="hidden" for="help_for_interface">
+                      <div class="hidden" data-for="help_for_interface">
                         <?=gettext("Choose which interface this rule applies to"); ?>.<br />
                         <?=gettext("Hint: in most cases, you'll want to use WAN here"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -285,31 +285,31 @@ include("head.inc");
                             <?=gettext("NAT");?>
                           </option>
                       </select>
-                      <output class="hidden" for="help_for_type">
+                      <div class="hidden" data-for="help_for_type">
                         <?=gettext("Select BINAT (default) or NAT here, when nets are equally sized binat is usually the best option.".
                                    "Using NAT we can also map unequal sized networks.");?><br />
                         <?=gettext("A BINAT rule specifies a bidirectional mapping between an external and internal network and can be used from both ends, nat only applies in one direction.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_external" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("External network"); ?></td>
                     <td>
                       <input name="external" type="text" value="<?=$pconfig['external'];?>" />
-                      <output class="hidden" for="help_for_external">
+                      <div class="hidden" data-for="help_for_external">
                         <?=gettext("Enter the external subnet's starting address for the 1:1 mapping or network.");?><br />
                         <?=gettext("The subnet mask from the internal address below will be applied to this IP address, when none is provided."); ?><br />
                         <?=gettext("This is the address or network the traffic will translate to/from.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                       <td><a id="help_for_src_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ".gettext("Invert");?> </td>
                       <td>
                         <input name="srcnot" type="checkbox" id="srcnot" value="yes" <?= !empty($pconfig['srcnot']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_src_invert">
+                        <div class="hidden" data-for="help_for_src_invert">
                           <?=gettext("Use this option to invert the sense of the match."); ?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr>
@@ -349,18 +349,18 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_src">
+                      <div class="hidden" data-for="help_for_src">
                         <?=gettext("Enter the internal subnet for the 1:1 mapping. The subnet size specified for the source will be applied to the external subnet, when none is provided."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td> <a id="help_for_dst_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input name="dstnot" type="checkbox" id="srcnot" value="yes" <?= !empty($pconfig['dstnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_dst_invert">
+                      <div class="hidden" data-for="help_for_dst_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -400,19 +400,19 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_dst">
+                      <div class="hidden" data-for="help_for_dst">
                         <?=gettext("The 1:1 mapping will only be used for connections to or from the specified destination."); ?><br />
                         <?=gettext("Hint: this is usually 'any'."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here " ."for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                   </tr>
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("NAT reflection"); ?></td>

--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -518,20 +518,20 @@ $( document ).ready(function() {
                   <td><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                   <td>
                     <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
-                    <output class="hidden" for="help_for_disabled">
+                    <div class="hidden" data-for="help_for_disabled">
                       <strong><?=gettext("Disable this rule"); ?></strong><br />
                       <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_nordr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("No RDR (NOT)"); ?></td>
                   <td>
                     <input type="checkbox" name="nordr" id="nordr" <?= !empty($pconfig['nordr']) ? "checked=\"checked\"" : ""; ?> />
-                    <output class="hidden" for="help_for_nordr">
+                    <div class="hidden" data-for="help_for_nordr">
                       <?=gettext("Enabling this option will disable redirection for traffic matching this rule."); ?>
                       <br /><?=gettext("Hint: this option is rarely needed, don't use this unless you know what you're doing."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -547,10 +547,10 @@ $( document ).ready(function() {
                         <?php endforeach; ?>
                       </select>
                     </div>
-                    <output class="hidden" for="help_for_interface">
+                    <div class="hidden" data-for="help_for_interface">
                       <?=gettext("Choose which interface this rule applies to."); ?><br />
                       <?=gettext("Hint: in most cases, you'll want to use WAN here."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -565,9 +565,9 @@ $( document ).ready(function() {
 <?php
                     endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_ipv46">
+                    <div class="hidden" data-for="help_for_ipv46">
                       <?=gettext("Select the Internet Protocol version this rule applies to");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -583,28 +583,28 @@ $( document ).ready(function() {
 <?php                endforeach; ?>
               </select>
                     </div>
-                    <output class="hidden" for="help_for_proto">
+                    <div class="hidden" data-for="help_for_proto">
                       <?=gettext("Choose which IP protocol " ."this rule should match."); ?><br/>
                       <?=gettext("Hint: in most cases, you should specify"); ?> <em><?=gettext("TCP"); ?></em> &nbsp;<?=gettext("here."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced_opt_src visible">
                   <td><?=gettext("Source"); ?></td>
                   <td>
                     <input type="button" class="btn btn-default" value="<?=gettext("Advanced"); ?>" id="showadvancedboxsrc" />
-                    <output class="hidden" for="help_for_source">
+                    <div class="hidden" data-for="help_for_source">
                       <?=gettext("Show source address and port range"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced_opt_src hidden">
                     <td> <a id="help_for_src_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input name="srcnot" type="checkbox" id="srcnot" value="yes" <?= !empty($pconfig['srcnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_src_invert">
+                      <div class="hidden" data-for="help_for_src_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                 </tr>
                 <tr class="advanced_opt_src hidden">
@@ -703,22 +703,22 @@ $( document ).ready(function() {
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_srcport">
+                    <div class="hidden" data-for="help_for_srcport">
                       <?=gettext("When using the TCP or UDP protocols, specify the source port or port range for this rule"); ?>.
                       <b><?=gettext("This is usually"); ?>
                         <em><?=gettext("random"); ?></em>
                          <?=gettext("and almost never equal to the destination port range (and should usually be 'any')"); ?>.
                        </b>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td> <a id="help_for_dst_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ".gettext("Invert");?> </td>
                   <td>
                     <input name="dstnot" type="checkbox" id="dstnot" value="yes" <?= !empty($pconfig['dstnot']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_dst_invert">
+                    <div class="hidden" data-for="help_for_dst_invert">
                       <?=gettext("Use this option to invert the sense of the match."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -847,9 +847,9 @@ $( document ).ready(function() {
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_dstport">
+                    <div class="hidden" data-for="help_for_dstport">
                       <?=gettext("When using the TCP or UDP protocols, specify the port or port range for the destination of the packet for this mapping."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="act_no_rdr">
@@ -879,11 +879,11 @@ $( document ).ready(function() {
                         </td>
                       </tr>
                     </table>
-                    <output class="hidden" for="help_for_localip">
+                    <div class="hidden" data-for="help_for_localip">
                       <?=gettext("Enter the internal IP address of " .
                       "the server on which you want to map the ports."); ?><br/>
                       <?=gettext("e.g."); ?> <em>192.168.1.12</em>
-                    </output>
+                    </div>
                 </tr>
                 <tr class="act_no_rdr">
                   <td><a id="help_for_localbeginport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Redirect target port"); ?></td>
@@ -916,13 +916,13 @@ $( document ).ready(function() {
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_localbeginport">
+                    <div class="hidden" data-for="help_for_localbeginport">
                       <?=gettext("Specify the port on the machine with the " .
                       "IP address entered above. In case of a port range, specify " .
                       "the beginning port of the range (the end port will be calculated " .
                       "automatically)."); ?><br />
                       <?=gettext("Hint: this is usually identical to the 'from' port above"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="act_no_rdr">
@@ -951,49 +951,49 @@ $( document ).ready(function() {
                         <?=gettext("Bitmask");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_poolopts">
+                    <div class="hidden" data-for="help_for_poolopts">
                       <?=gettext("Only Round Robin types work with Host Aliases. Any type can be used with a Subnet.");?><br />
                       * <?=gettext("Round Robin: Loops through the translation addresses.");?><br />
                       * <?=gettext("Random: Selects an address from the translation address pool at random.");?><br />
                       * <?=gettext("Source Hash: Uses a hash of the source address to determine the translation address, ensuring that the redirection address is always the same for a given source.");?><br />
                       * <?=gettext("Bitmask: Applies the subnet mask and keeps the last portion identical; 10.0.1.50 -&gt; x.x.x.50.");?><br />
                       * <?=gettext("Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.");?><br />
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here " ."for your reference (not parsed)."); ?>
-                    </output>
+                    </div>
                 </tr>
                 <tr>
                     <td><a id="help_for_tag" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Set local tag"); ?></td>
                     <td>
                       <input name="tag" type="text" value="<?=$pconfig['tag'];?>" />
-                      <output class="hidden" for="help_for_tag">
+                      <div class="hidden" data-for="help_for_tag">
                         <?= gettext("You can mark a packet matching this rule and use this mark to match on other NAT/filter rules.") ?>
-                      </output>
+                      </div>
                     </td>
                 </tr>
                 <tr>
                     <td><a id="help_for_tagged" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Match local tag"); ?>   </td>
                     <td>
                       <input name="tagged" type="text" value="<?=$pconfig['tagged'];?>" />
-                      <output class="hidden" for="help_for_tagged">
+                      <div class="hidden" data-for="help_for_tagged">
                         <?=gettext("You can match packet on a mark placed before on another rule.")?>
-                      </output>
+                      </div>
                     </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_nosync" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("No XMLRPC Sync"); ?></td>
                   <td>
                     <input type="checkbox" value="yes" name="nosync" <?=!empty($pconfig['nosync']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_nosync">
+                    <div class="hidden" data-for="help_for_nosync">
                       <?=gettext("Hint: This prevents the rule on Master from automatically syncing to other CARP members. This does NOT prevent the rule from being overwritten on Slave.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -1046,9 +1046,9 @@ $( document ).ready(function() {
                       <option value="add-unassociated"><?=gettext("Add unassociated filter rule"); ?></option>
                       <option value="pass"><?=gettext("Pass"); ?></option>
                     </select>
-                    <output class="hidden" for="help_for_fra">
+                    <div class="hidden" data-for="help_for_fra">
                       <?=gettext("NOTE: The \"pass\" selection does not work properly with Multi-WAN. It will only work on an interface containing the default gateway.")?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php          endif;

--- a/src/www/firewall_nat_npt_edit.php
+++ b/src/www/firewall_nat_npt_edit.php
@@ -154,10 +154,10 @@ include("head.inc");
                     <td><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td>
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_disabled">
+                      <div class="hidden" data-for="help_for_disabled">
                         <strong><?=gettext("Disable this rule"); ?></strong><br />
                         <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -173,10 +173,10 @@ include("head.inc");
                           <?php endforeach; ?>
                         </select>
                       </div>
-                      <output class="hidden" for="help_for_interface">
+                      <div class="hidden" data-for="help_for_interface">
                         <?=gettext("Choose which interface this rule applies to"); ?>.<br />
                         <?=gettext("Hint: in most cases, you'll want to use WAN here"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -186,9 +186,9 @@ include("head.inc");
                       <td><a id="help_for_srcnot" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ".gettext("Invert");?> </td>
                       <td>
                         <input name="srcnot" type="checkbox" value="yes" <?= !empty($pconfig['srcnot']) ? "checked=\"checked\"" :"";?> />
-                        <output class="hidden" for="help_for_srcnot">
+                        <div class="hidden" data-for="help_for_srcnot">
                             <?=gettext("Use this option to invert the sense of the match."); ?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr>
@@ -208,9 +208,9 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_src">
+                      <div class="hidden" data-for="help_for_src">
                         <?=gettext("Enter the internal (LAN) ULA IPv6 Prefix for the Network Prefix translation. The prefix size specified for the internal IPv6 prefix will be applied to the external prefix.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 
@@ -224,9 +224,9 @@ include("head.inc");
                       <td><a id="help_for_dstnot" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ".gettext("Invert");?> </td>
                       <td>
                         <input name="dstnot" type="checkbox" value="yes" <?= !empty($pconfig['dstnot']) ? "checked=\"checked\"" :"";?> />
-                        <output class="hidden" for="help_for_dstnot">
+                        <div class="hidden" data-for="help_for_dstnot">
                             <?=gettext("Use this option to invert the sense of the match."); ?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr>
@@ -246,18 +246,18 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_dst">
+                      <div class="hidden" data-for="help_for_dst">
                         <?=gettext("Enter the Global Unicast routable IPv6 prefix here"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here " ."for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                   </tr>
                   <tr>
                     <td>&nbsp;</td>

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -403,19 +403,19 @@ include("head.inc");
                   <td>
                     <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
                     <strong><?=gettext("Disable this rule"); ?></strong>
-                    <output class="hidden" for="help_for_disabled">
+                    <div class="hidden" data-for="help_for_disabled">
                       <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_do_not_nat" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not NAT");?></td>
                   <td style="width:78%" class="vtable">
                     <input type="checkbox" name="nonat" <?=!empty($pconfig['nonat']) ? " checked=\"checked\"" : ""; ?> />
-                    <output class="hidden" for="help_for_do_not_nat">
+                    <div class="hidden" data-for="help_for_do_not_nat">
                       <?=gettext("Enabling this option will disable NAT for traffic matching this rule and stop processing Outbound NAT rules.");?><br />
                       <?=gettext("Hint: in most cases, you won't use this option.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -431,10 +431,10 @@ include("head.inc");
                         <?php endforeach; ?>
                       </select>
                     </div>
-                    <output class="hidden" for="help_for_interface">
+                    <div class="hidden" data-for="help_for_interface">
                       <?=gettext("Choose which interface this rule applies to"); ?>.<br />
                       <?=gettext("Hint: in most cases, you'll want to use WAN here"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -449,9 +449,9 @@ include("head.inc");
 <?php
                     endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_ipv46">
+                    <div class="hidden" data-for="help_for_ipv46">
                       <?=gettext("Select the Internet Protocol version this rule applies to");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -465,19 +465,19 @@ include("head.inc");
 <?php                endforeach; ?>
               </select>
                     </div>
-                    <output class="hidden" for="help_for_proto">
+                    <div class="hidden" data-for="help_for_proto">
                       <?=gettext("Choose which IP protocol " ."this rule should match."); ?><br/>
                       <?=gettext("Hint: in most cases, you should specify"); ?> <em><?=gettext("TCP"); ?></em> &nbsp;<?=gettext("here."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td> <a id="help_for_src_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Source invert') ?></td>
                   <td>
                     <input name="source_not" type="checkbox" value="yes" <?= !empty($pconfig['source_not']) ? 'checked="checked"' : '' ?> />
-                    <output class="hidden" for="help_for_src_invert">
+                    <div class="hidden" data-for="help_for_src_invert">
                       <?=gettext("Use this option to invert the sense of the match."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -513,9 +513,9 @@ include("head.inc");
                         </td>
                       </tr>
                     </table>
-                    <output class="hidden" for="help_for_source">
+                    <div class="hidden" data-for="help_for_source">
                       <?=gettext("Enter the source network for the outbound NAT mapping.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -549,18 +549,18 @@ include("head.inc");
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_src_port">
+                    <div class="hidden" data-for="help_for_src_port">
                       <?=gettext("(leave blank for any)");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td> <a id="help_for_dst_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Destination invert') ?></td>
                   <td>
                     <input name="destination_not" type="checkbox" value="yes" <?= !empty($pconfig['destination_not']) ? 'checked="checked"' : '' ?> />
-                    <output class="hidden" for="help_for_dst_invert">
+                    <div class="hidden" data-for="help_for_dst_invert">
                       <?=gettext("Use this option to invert the sense of the match."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -595,9 +595,9 @@ include("head.inc");
                         </td>
                       </tr>
                     </table>
-                    <output class="hidden" for="help_for_destination">
+                    <div class="hidden" data-for="help_for_destination">
                       <?=gettext("Enter the source network for the outbound NAT mapping.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -631,9 +631,9 @@ include("head.inc");
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_dstport">
+                    <div class="hidden" data-for="help_for_dstport">
                       <?=gettext("(leave blank for any)");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -667,11 +667,11 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_target">
+                      <div class="hidden" data-for="help_for_target">
                         <?=gettext("Packets matching this rule will be mapped to the IP address given here.");?><br />
                         <?=sprintf(gettext("If you want this rule to apply to another IP address rather than the IP address of the interface chosen above, ".
                                 "select it here (you will need to define %sVirtual IP addresses%s on the interface first)."),'<a href="firewall_virtual_ip.php">','</a>')?>
-                      </output>
+                      </div>
                   </td>
                 </tr>
                 <tr>
@@ -679,18 +679,18 @@ include("head.inc");
                   <td>
                     <input name="log" type="checkbox" id="log" value="yes" <?= !empty($pconfig['log']) ? "checked=\"checked\"" : ""; ?> />
                     <strong><?=gettext("Log packets that are handled by this rule");?></strong>
-                    <output class="hidden" for="help_for_log">
+                    <div class="hidden" data-for="help_for_log">
                       <?=sprintf(gettext("Hint: the firewall has limited local log space. Don't turn on logging for everything. If you want to do a lot of logging, consider using a %sremote syslog server%s."),'<a href="diag_logs_settings.php">','</a>') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_natport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Translation") . " / " .gettext("port:");?></td>
                   <td>
                     <input name="natport" type="text" value="<?=$pconfig['natport'];?>" />
-                    <output class="hidden" for="help_for_natport">
+                    <div class="hidden" data-for="help_for_natport">
                       <?=gettext("Enter the source port for the outbound NAT mapping.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -725,50 +725,50 @@ include("head.inc");
                         <?=gettext("Bitmask");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_poolopts">
+                    <div class="hidden" data-for="help_for_poolopts">
                       <?=gettext("Only Round Robin types work with Host Aliases. Any type can be used with a Subnet.");?><br />
                       * <?=gettext("Round Robin: Loops through the translation addresses.");?><br />
                       * <?=gettext("Random: Selects an address from the translation address pool at random.");?><br />
                       * <?=gettext("Source Hash: Uses a hash of the source address to determine the translation address, ensuring that the redirection address is always the same for a given source.");?><br />
                       * <?=gettext("Bitmask: Applies the subnet mask and keeps the last portion identical; 10.0.1.50 -&gt; x.x.x.50.");?><br />
                       * <?=gettext("Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.");?><br />
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                     <td><a id="help_for_tag" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Set local tag"); ?></td>
                     <td>
                       <input name="tag" type="text" value="<?=$pconfig['tag'];?>" />
-                      <output class="hidden" for="help_for_tag">
+                      <div class="hidden" data-for="help_for_tag">
                         <?= gettext("You can mark a packet matching this rule and use this mark to match on other NAT/filter rules.") ?>
-                      </output>
+                      </div>
                     </td>
                 </tr>
                 <tr>
                     <td><a id="help_for_tagged" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Match local tag"); ?>   </td>
                     <td>
                       <input name="tagged" type="text" value="<?=$pconfig['tagged'];?>" />
-                      <output class="hidden" for="help_for_tagged">
+                      <div class="hidden" data-for="help_for_tagged">
                         <?=gettext("You can match packet on a mark placed before on another rule.")?>
-                      </output>
+                      </div>
                     </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_nosync" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("No XMLRPC Sync"); ?></td>
                   <td>
                     <input type="checkbox" value="yes" name="nosync" <?=!empty($pconfig['nosync']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_nosync">
+                    <div class="hidden" data-for="help_for_nosync">
                       <?=gettext("Hint: This prevents the rule on Master from automatically syncing to other CARP members. This does NOT prevent the rule from being overwritten on Slave.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here " ."for your reference (not parsed)."); ?>
-                    </output>
+                    </div>
                 </tr>
 <?php
                 $has_created_time = (isset($a_out[$id]['created']) && is_array($a_out[$id]['created']));

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -695,10 +695,10 @@ include("head.inc");
 <?php
                         endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_action">
+                      <div class="hidden" data-for="help_for_action">
                         <?=gettext("Choose what to do with packets that match the criteria specified below.");?> <br />
                         <?=gettext("Hint: the difference between block and reject is that with reject, a packet (TCP RST or ICMP port unreachable for UDP) is returned to the sender, whereas with block the packet is dropped silently. In either case, the original packet is discarded.");?>
-                      </output>
+                      </div>
                       <br />
                     </td>
                   </tr>
@@ -707,9 +707,9 @@ include("head.inc");
                     <td>
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
                       <strong><?=gettext("Disable this rule"); ?></strong>
-                      <output class="hidden" for="help_for_disabled">
+                      <div class="hidden" data-for="help_for_disabled">
                         <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php             if (!empty($pconfig['floating'])):
@@ -720,9 +720,9 @@ include("head.inc");
                     <td>
                       <input name="quick" type="checkbox" id="quick" value="yes" <?php if ($pconfig['quick']) echo "checked=\"checked\""; ?> />
                       <strong><?=gettext("Apply the action immediately on match.");?></strong>
-                      <output class="hidden" for="help_for_quick">
+                      <div class="hidden" data-for="help_for_quick">
                         <?=gettext("Set this option if you need to apply this action to traffic that matches this rule immediately.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -777,9 +777,9 @@ include("head.inc");
 <?php
                     endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_interface">
+                        <div class="hidden" data-for="help_for_interface">
                           <?=gettext("Choose on which interface packets must come in to match this rule.");?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
 <?php
@@ -812,9 +812,9 @@ include("head.inc");
 <?php
                       endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_ipv46">
+                      <div class="hidden" data-for="help_for_ipv46">
                         <?=gettext("Select the Internet Protocol version this rule applies to");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -829,10 +829,10 @@ include("head.inc");
 <?php
                       endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_protocol">
+                      <div class="hidden" data-for="help_for_protocol">
                         <?=gettext("Choose which IP protocol this rule should match.");?> <br />
                         <?= gettext("Hint: in most cases, you should specify TCP here.") ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="icmpbox">
@@ -868,18 +868,18 @@ include("head.inc");
                       endforeach; ?>
                       </select>
                       <br />
-                      <output class="hidden" for="help_for_icmptype">
+                      <div class="hidden" data-for="help_for_icmptype">
                         <?=gettext("If you selected ICMP for the protocol above, you may specify an ICMP type here.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td> <a id="help_for_src_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input <?=!empty($pconfig['associated-rule-id']) ? "disabled" : "";?>  name="srcnot" type="checkbox" value="yes" <?= !empty($pconfig['srcnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_src_invert">
+                      <div class="hidden" data-for="help_for_src_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -935,9 +935,9 @@ include("head.inc");
                     <td><?=gettext("Source"); ?></td>
                     <td>
                       <input type="button" class="btn btn-default" value="<?=gettext("Advanced"); ?>" id="showadvancedboxsrc" />
-                      <output class="hidden" for="help_for_source">
+                      <div class="hidden" data-for="help_for_source">
                         <?=gettext("Show source address and port range"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="hidden advanced_opt_src">
@@ -997,19 +997,19 @@ include("head.inc");
                           </tr>
                         </tbody>
                       </table>
-                      <output class="hidden" for="help_for_srcport">
+                      <div class="hidden" data-for="help_for_srcport">
                         <?=gettext("Specify the source port or port range for this rule."); ?>
                         <b><?= gettext("This is usually random and almost never equal to the destination port range (and should usually be 'any').") ?></b>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td> <a id="help_for_dst_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input <?=!empty($pconfig['associated-rule-id']) ? "disabled" : "";?> name="dstnot" type="checkbox" id="srcnot" value="yes" <?= !empty($pconfig['dstnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_dst_invert">
+                      <div class="hidden" data-for="help_for_dst_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -1116,9 +1116,9 @@ include("head.inc");
                           </tr>
                         </tbody>
                       </table>
-                      <output class="hidden" for="help_for_dstport">
+                      <div class="hidden" data-for="help_for_dstport">
                         <?=gettext("Specify the port or port range for the destination of the packet for this mapping."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -1126,18 +1126,18 @@ include("head.inc");
                     <td>
                       <input name="log" type="checkbox" id="log" value="yes" <?= !empty($pconfig['log']) ? "checked=\"checked\"" : ""; ?> />
                       <strong><?=gettext("Log packets that are handled by this rule");?></strong>
-                      <output class="hidden" for="help_for_log">
+                      <div class="hidden" data-for="help_for_log">
                         <?=sprintf(gettext("Hint: the firewall has limited local log space. Don't turn on logging for everything. If you want to do a lot of logging, consider using a %sremote syslog server%s."),'<a href="diag_logs_settings.php">','</a>') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_category" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Category"); ?></td>
                     <td>
                       <input name="category" type="text" class="formfld unknown" id="category" size="40" value="<?=$pconfig['category'];?>" />
-                      <output class="hidden" for="help_for_category">
+                      <div class="hidden" data-for="help_for_category">
                         <?=gettext("You may enter or select a category here to group firewall rules (not parsed)."); ?>
-                      </output>
+                      </div>
                       <select class="hidden" id="existing_categories">
 <?php
                       $categories = array();
@@ -1156,9 +1156,9 @@ include("head.inc");
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                   </tr>
                   <tr>
                     <th colspan="2"><?=gettext("Advanced features");?></th>
@@ -1176,19 +1176,19 @@ include("head.inc");
 <?php
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_sourceos">
+                        <div class="hidden" data-for="help_for_sourceos">
                           <strong><?=gettext("OS Type:");?></strong><br/>
                           <?=gettext("Note: this only works for TCP rules. General OS choice matches all subtypes.");?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_nosync" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("No XMLRPC Sync"); ?></td>
                     <td>
                       <input type="checkbox" value="yes" name="nosync" <?=!empty($pconfig['nosync']) ? "checked=\"checked\"" :"";?> />
-                      <output class="hidden" for="help_for_nosync">
+                      <div class="hidden" data-for="help_for_nosync">
                         <?=gettext("Hint: This prevents the rule on Master from automatically syncing to other CARP members. This does NOT prevent the rule from being overwritten on Slave.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -1209,9 +1209,9 @@ include("head.inc");
                         endforeach;
                         endif;?>
                         </select>
-                        <output class="hidden" for="help_for_schedule">
+                        <div class="hidden" data-for="help_for_schedule">
                             <p><?=gettext("Leave as 'none' to leave the rule enabled all the time.");?></p>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -1237,9 +1237,9 @@ include("head.inc");
 <?php
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_gateway">
+                        <div class="hidden" data-for="help_for_gateway">
                           <?=gettext("Leave as 'default' to use the system routing table. Or choose a gateway to utilize policy based routing.");?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -1256,18 +1256,18 @@ include("head.inc");
                       <td><a id="help_for_allowopts" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("allow options");?> </td>
                       <td>
                         <input type="checkbox" value="yes" name="allowopts"<?= !empty($pconfig['allowopts']) ? " checked=\"checked\"" : ""; ?> />
-                        <output class="hidden" for="help_for_allowopts">
+                        <div class="hidden" data-for="help_for_allowopts">
                           <?=gettext("This allows packets with IP options to pass. Otherwise they are blocked by default. This is usually only seen with multicast traffic.");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_disable_replyto" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("disable reply-to");?> </td>
                       <td>
                         <input type="checkbox" value="yes" name="disablereplyto"<?= !empty($pconfig['disablereplyto']) ? " checked=\"checked\"" :""; ?> />
-                        <output class="hidden" for="help_for_disable_replyto">
+                        <div class="hidden" data-for="help_for_disable_replyto">
                           <?=gettext("This will disable auto generated reply-to for this rule.");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
@@ -1297,9 +1297,9 @@ include("head.inc");
                                   </td>
                               </tr>
                           </table>
-                          <output class="hidden" for="help_for_set-prio">
+                          <div class="hidden" data-for="help_for_set-prio">
                               <?= gettext('Set the priority of packets matching this rule. If both priorities are set here, packets with a TOS of "lowdelay" or TCP ACKs with no data payload will be assigned the latter. If the packets are transmitted on a VLAN interface, the queueing priority will be written as the priority code point in the 802.1Q VLAN header.') ?>
-                          </output>
+                          </div>
                     </td>
                   </tr>
                   <tr class="opt_advanced hidden">
@@ -1311,63 +1311,63 @@ include("head.inc");
                             <option value="<?=$prio;?>"<?=(isset($pconfig['prio']) && $pconfig['prio'] !== '' && $pconfig['prio'] == $prio ? ' selected="selected"' : '');?>><?=htmlspecialchars($priority);?></option>
 <? endforeach ?>
                         </select>
-                        <output class="hidden" for="help_for_prio">
+                        <div class="hidden" data-for="help_for_prio">
                           <?=gettext('Match on the priority of packets.');?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_tag" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Set local tag"); ?></td>
                       <td>
                         <input name="tag" type="text" value="<?=$pconfig['tag'];?>" />
-                        <output class="hidden" for="help_for_tag">
+                        <div class="hidden" data-for="help_for_tag">
                           <?= gettext("You can mark a packet matching this rule and use this mark to match on other NAT/filter rules.") ?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_tagged" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Match local tag"); ?>   </td>
                       <td>
                         <input name="tagged" type="text" value="<?=$pconfig['tagged'];?>" />
-                        <output class="hidden" for="help_for_tagged">
+                        <div class="hidden" data-for="help_for_tagged">
                           <?=gettext("You can match packet on a mark placed before on another rule.")?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max states");?> </td>
                       <td>
                         <input name="max" type="text" value="<?=$pconfig['max'];?>" />
-                        <output class="hidden" for="help_for_max">
+                        <div class="hidden" data-for="help_for_max">
                           <?=gettext("Maximum state entries this rule can create");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max-src-nodes" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max source nodes");?> </td>
                       <td>
                         <input name="max-src-nodes" type="text" value="<?=$pconfig['max-src-nodes'];?>"/>
-                        <output class="hidden" for="help_for_max-src-nodes">
+                        <div class="hidden" data-for="help_for_max-src-nodes">
                           <?=gettext(" Maximum number of unique source hosts");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max-src-conn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max established");?> </td>
                       <td>
                         <input name="max-src-conn" type="text" value="<?= $pconfig['max-src-conn'];?>" />
-                        <output class="hidden" for="help_for_max-src-conn">
+                        <div class="hidden" data-for="help_for_max-src-conn">
                             <?=gettext(" Maximum number of established connections per host (TCP only)");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max-src-states" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max source states");?> </td>
                       <td>
                         <input name="max-src-states" type="text" value="<?=$pconfig['max-src-states'];?>" />
-                        <output class="hidden" for="help_for_max-src-states">
+                        <div class="hidden" data-for="help_for_max-src-states">
                             <?=gettext(" Maximum state entries per host");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
@@ -1395,18 +1395,18 @@ include("head.inc");
                             </tr>
                           </tbody>
                         </table>
-                        <output class="hidden" for="help_for_max-src-conn-rate">
+                        <div class="hidden" data-for="help_for_max-src-conn-rate">
                             <?=gettext("Maximum new connections per host / per second(s) (TCP only)");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_statetimeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("State timeout");?></td>
                       <td>
                         <input name="statetimeout" type="text" value="<?=$pconfig['statetimeout'];?>" /><br />
-                        <output class="hidden" for="help_for_statetimeout">
+                        <div class="hidden" data-for="help_for_statetimeout">
                           <?=gettext("State Timeout in seconds (TCP only)");?><br/>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr class="opt_advanced hidden">
@@ -1442,18 +1442,18 @@ include("head.inc");
                           </td>
                         <tr>
                         </table>
-                        <output class="hidden" for="help_for_tcpflags">
+                        <div class="hidden" data-for="help_for_tcpflags">
                             <?=gettext("Use this to choose TCP flags that must be set or cleared for this rule to match.");?>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                     <tr class="opt_advanced hidden">
                         <td><a id="help_for_nopfsync" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("State Type");?> / <?=gettext("NO pfsync");?> </td>
                         <td>
                           <input name="nopfsync" type="checkbox" value="yes" <?= !empty($pconfig['nopfsync']) ? "checked=\"checked\"" : "";?> />
-                          <output class="hidden" for="help_for_nopfsync">
+                          <div class="hidden" data-for="help_for_nopfsync">
                             <?=gettext("Hint: This prevents states created by this rule to be sync'ed over pfsync.");?><br />
-                          </output>
+                          </div>
                         </td>
                     </tr>
                     <tr class="opt_advanced hidden">
@@ -1476,7 +1476,7 @@ include("head.inc");
                               <?=gettext("none");?>
                             </option>
                           </select>
-                          <output class="hidden" for="help_for_statetype">
+                          <div class="hidden" data-for="help_for_statetype">
                             <span>
                               <?=gettext("Hint: Select which type of state tracking mechanism you would like to use. If in doubt, use keep state.");?>
                             </span>
@@ -1487,7 +1487,7 @@ include("head.inc");
                                 <li><?= sprintf(gettext("%sNone%s: Do not use state mechanisms to keep track. This is only useful if you're doing advanced queueing in certain situations. Please check the documentation."),'<strong>', '</strong>') ?></li>
                               </ul>
                               <p><?= sprintf(gettext('Source and more information can be found %shere%s.'),'<a href="https://www.freebsd.org/cgi/man.cgi?query=pf.conf&amp;sektion=5">','</a>') ?></p>
-                          </output>
+                          </div>
                         </td>
                     </tr>
 <?php

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -811,9 +811,9 @@ function removeRow(el) {
                         <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                         <td>
                           <input name="descr" type="text" id="descr" value="<?=$pconfig['descr'];?>" /><br />
-                          <output class="hidden" for="help_for_name">
+                          <div class="hidden" data-for="help_for_name">
                             <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -911,10 +911,10 @@ function removeRow(el) {
                               }
                             } //end for loop
 ?>
-                          <output class="hidden" for="help_for_month">
+                          <div class="hidden" data-for="help_for_month">
                             <br />
                             <?=gettext("Click individual date to select that date only. Click the appropriate weekday Header to select all occurrences of that weekday.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -964,19 +964,19 @@ function removeRow(el) {
                               </td>
                             </tr>
                           </table>
-                          <output class="hidden" for="help_for_time">
+                          <div class="hidden" data-for="help_for_time">
                             <br />
                           <?=gettext("Select the time range for the day(s) selected on the Month(s) above. A full day is 0:00-23:59.")?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_timerange_desc" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Time Range Description")?></td>
                         <td>
                           <input name="timerangedescr" type="text" id="timerangedescr"/>
-                          <output class="hidden" for="help_for_timerange_desc">
+                          <div class="hidden" data-for="help_for_timerange_desc">
                             <?=gettext("You may enter a description here for your reference (not parsed).")?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -235,35 +235,35 @@ $( document ).ready(function() {
                       <td><a id="help_for_scrub_interface_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable interface scrub");?></td>
                       <td>
                         <input id="scrub_interface_disable" name="scrub_interface_disable" type="checkbox" value="yes" <?=!empty($pconfig['scrub_interface_disable']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_scrub_interface_disable">
+                        <div class="hidden" data-for="help_for_scrub_interface_disable">
                           <?=gettext("Disable all default interface scrubing rules,".
                                      " mss clamping will also be disabled when you check this.".
                                      " Detailed settings specified below will still be used.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="scrub_settings">
                       <td><a id="help_for_scrubnodf" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP Do-Not-Fragment");?></td>
                       <td>
                         <input name="scrubnodf" type="checkbox" value="yes" <?=!empty($pconfig['scrubnodf']) ? "checked=\"checked\"" : ""; ?>/>
-                        <output class="hidden" for="help_for_scrubnodf">
+                        <div class="hidden" data-for="help_for_scrubnodf">
                           <?=gettext("This allows for communications with hosts that generate fragmented " .
                                               "packets with the don't fragment (DF) bit set. Linux NFS is known to " .
                                               "do this. This will cause the filter to not drop such packets but " .
                                               "instead clear the don't fragment bit.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="scrub_settings">
                       <td><a id="help_for_scrubrnid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP Random id");?></td>
                       <td>
                         <input name="scrubrnid" type="checkbox" value="yes" <?= !empty($pconfig['scrubrnid']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_scrubrnid">
+                        <div class="hidden" data-for="help_for_scrubrnid">
                           <?=gettext("Replaces the IP identification field of packets with random values to " .
                                               "compensate for operating systems that use predictable values. " .
                                               "This option only applies to packets that are not fragmented after the " .
                                               "optional packet reassembly.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/firewall_scrub_edit.php
+++ b/src/www/firewall_scrub_edit.php
@@ -299,10 +299,10 @@ include("head.inc");
                     <td style="width:22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td style="width:78%">
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_disabled">
+                      <div class="hidden" data-for="help_for_disabled">
                         <strong><?=gettext("Disable this rule"); ?></strong><br />
                         <?=gettext("Set this option to disable this rule without removing it from the list."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -323,9 +323,9 @@ include("head.inc");
 <?php
                     endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_interface">
+                        <div class="hidden" data-for="help_for_interface">
                           <?=gettext("Choose on which interface packets must come in to match this rule.");?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -356,18 +356,18 @@ include("head.inc");
 <?php
                       endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_protocol">
+                      <div class="hidden" data-for="help_for_protocol">
                         <?=gettext("Choose which IP protocol this rule should match.");?> <br />
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td> <a id="help_for_src_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input name="srcnot" type="checkbox" value="yes" <?= !empty($pconfig['srcnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_src_invert">
+                      <div class="hidden" data-for="help_for_src_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -455,19 +455,19 @@ include("head.inc");
                         </tbody>
                       </table>
                       </div>
-                      <output class="hidden" for="help_for_srcport">
+                      <div class="hidden" data-for="help_for_srcport">
                         <?=gettext("Specify the port or port range for the destination of the packet for this mapping."); ?><br/>
                         <?=gettext("To specify a range, use from:to (example 81:85).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td> <a id="help_for_dst_invert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ".gettext("Invert");?> </td>
                     <td>
                       <input name="dstnot" type="checkbox" value="yes" <?= !empty($pconfig['dstnot']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_dst_invert">
+                      <div class="hidden" data-for="help_for_dst_invert">
                         <?=gettext("Use this option to invert the sense of the match."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -548,19 +548,19 @@ include("head.inc");
                           </tr>
                         </tbody>
                       </table>
-                      <output class="hidden" for="help_for_dstport">
+                      <div class="hidden" data-for="help_for_dstport">
                         <?=gettext("Specify the port or port range for the destination of the packet for this mapping."); ?><br/>
                         <?=gettext("To specify a range, use from:to (example 81:85).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                 </table>
@@ -578,9 +578,9 @@ include("head.inc");
                       <td style="width:22%"><a id="help_for_maxmss" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max mss"); ?></td>
                       <td style="width:78%">
                           <input name="max-mss" type="text" value="<?=$pconfig['max-mss'];?>" />
-                          <output class="hidden" for="help_for_maxmss">
+                          <div class="hidden" data-for="help_for_maxmss">
                             <?=gettext("Enforces a maximum MSS for matching TCP packets."); ?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
                   <tr>
@@ -601,29 +601,29 @@ include("head.inc");
                       <td style="width:22%"><a id="help_for_minttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Minimum TTL') ?></td>
                       <td style="width:78%">
                           <input name="min-ttl" type="text" value="<?=$pconfig['min-ttl'];?>" />
-                          <output class="hidden" for="help_for_minttl">
+                          <div class="hidden" data-for="help_for_minttl">
                             <?=gettext("Enforces a minimum TTL for matching IP packets."); ?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
                   <tr>
                       <td style="width:22%"><a id="help_for_nodf" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not fragment"); ?></td>
                       <td style="width:78%">
                           <input name="no-df" type="checkbox" value="1" <?= !empty($pconfig['no-df']) ? "checked=\"checked\"" : ""; ?> />
-                          <output class="hidden" for="help_for_nodf">
+                          <div class="hidden" data-for="help_for_nodf">
                             <?=gettext("Clears the dont-fragment bit from a matching IP packet."); ?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
                   <tr>
                       <td style="width:22%"><a id="help_for_randomid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Random ID') ?></td>
                       <td style="width:78%">
                           <input name="random-id" type="checkbox" value="1" <?= !empty($pconfig['random-id']) ? "checked=\"checked\"" : ""; ?> />
-                          <output class="hidden" for="help_for_randomid">
+                          <div class="hidden" data-for="help_for_randomid">
                             <?=gettext("Replaces the IP identification field with random values to compensate for ".
                                        "predictable values generated by many hosts. This option only applies to packets ".
                                        "that are not fragmented after the optional fragment reassembly."); ?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
 

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -333,9 +333,9 @@ $( document ).ready(function() {
                         <option value="proxyarp" <?=$pconfig['mode'] == "proxyarp" ? "selected=\"selected\"" : ""; ?>><?=gettext("Proxy ARP");?></option>
                         <option value="other" <?=$pconfig['mode'] == "other" ? "selected=\"selected\"" : ""; ?>><?=gettext("Other");?></option>
                       </select>
-                      <output class="hidden" for="help_for_mode">
+                      <div class="hidden" data-for="help_for_mode">
                         <?=gettext("Proxy ARP and other type Virtual IPs cannot be bound to by anything running on the firewall, such as IPsec, OpenVPN, etc. Use a CARP or IP Alias type address for these cases.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -392,35 +392,35 @@ $( document ).ready(function() {
                             </td>
                           </tr>
                         </table>
-                        <output class="hidden" for="help_for_address">
+                        <div class="hidden" data-for="help_for_address">
                             <i id="typenote"></i>
-                        </output>
+                        </div>
                       </td>
                   </tr>
                   <tr>
                       <td><a id="help_for_gateway" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?></td>
                       <td>
                           <input name="gateway" type="text" class="form-control" id="gateway" value="<?=$pconfig['gateway'];?>" />
-                          <output class="hidden" for="help_for_gateway">
+                          <div class="hidden" data-for="help_for_gateway">
                             <?=gettext("For some interface types a gateway is required to configure an IP Alias (ppp/pppoe/tun), leave this field empty for all other interface types.");?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
                   <tr id="noexpandrow">
                       <td><a id="help_for_noexpand" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Expansion");?> </td>
                       <td>
                           <input id="noexpand" name="noexpand" type="checkbox" class="form-control unknown" id="noexpand" <?= !empty($pconfig['noexpand']) ? "checked=\"checked\"" : "" ; ?> />
-                          <output class="hidden" for="help_for_noexpand">
+                          <div class="hidden" data-for="help_for_noexpand">
                             <?=gettext("Disable expansion of this entry into IPs on NAT lists (e.g. 192.168.1.0/24 expands to 256 entries.");?>
-                          </output>
+                          </div>
                   </tr>
                   <tr>
                     <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Virtual IP Password");?></td>
                     <td>
                       <input type='password'  name='password' id="password" value="<?=$pconfig['password'];?>" />
-                      <output class="hidden" for="help_for_password">
+                      <div class="hidden" data-for="help_for_password">
                         <?=gettext("Enter the VHID group password.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -437,9 +437,9 @@ $( document ).ready(function() {
                       <button type="button" data-vhid="<?=find_last_used_vhid() + 1;?>" id="max_vhid" class="btn btn-default btn-cs">
                         <?=gettext("Select an unassigned VHID");?>
                       </button>
-                      <output class="hidden" for="help_for_vhid">
+                      <div class="hidden" data-for="help_for_vhid">
                         <?=gettext("Enter the VHID group that the machines will share.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -462,19 +462,19 @@ $( document ).ready(function() {
                         <?php endfor; ?>
                       </select>
 
-                      <output class="hidden" for="help_for_adv">
+                      <div class="hidden" data-for="help_for_adv">
                         <br/>
                         <?=gettext("The frequency that this machine will advertise. 0 usually means master. Otherwise the lowest combination of both values in the cluster determines the master.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                     <td>
                       <input name="descr" type="text" class="form-control unknown" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_adv">
+                      <div class="hidden" data-for="help_for_adv">
                         <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -143,6 +143,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
       // link showhelp class behavior
       $("a[class='showhelp']").click(function (event) {
         $("*[for='" + $(this).attr('id') + "']").toggleClass("hidden show");
+        $("*[data-for='" + $(this).attr('id') + "']").toggleClass("hidden show");
         event.preventDefault();
       });
 
@@ -156,12 +157,16 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
           }
           $('[for*="help_for"]').addClass("show");
           $('[for*="help_for"]').removeClass("hidden");
+          $('[data-for*="help_for"]').addClass("show");
+          $('[data-for*="help_for"]').removeClass("hidden");
         } else {
           if (window.sessionStorage) {
             sessionStorage.setItem('all_help_preset', 0);
           }
           $('[for*="help_for"]').addClass("hidden");
           $('[for*="help_for"]').removeClass("show");
+          $('[data-for*="help_for"]').addClass("hidden");
+          $('[data-for*="help_for"]').removeClass("show");
         }
         event.preventDefault();
       });
@@ -171,6 +176,8 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
           $('[id*="show_all_help"]').toggleClass("text-success text-danger");
           $('[for*="help_for"]').addClass("show");
           $('[for*="help_for"]').removeClass("hidden");
+          $('[data-for*="help_for"]').addClass("show");
+          $('[data-for*="help_for"]').removeClass("hidden");
       }
 
       // hide submenu items

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -1698,33 +1698,33 @@ include("head.inc");
                           <td style="width:22%"><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                           <td style="width:78%">
                             <input name="descr" type="text" id="descr" value="<?=$pconfig['descr'];?>" />
-                            <output class="hidden" for="help_for_descr">
+                            <div class="hidden" data-for="help_for_descr">
                               <?= gettext("Enter a description (name) for the interface here."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td style="width:22%"><a id="help_for_blockpriv" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Block private networks"); ?></td>
                           <td style="width:78%">
                             <input name="blockpriv" type="checkbox" id="blockpriv" value="yes" <?=!empty($pconfig['blockpriv']) ? "checked=\"checked\"" : ""; ?> />
-                            <output class="hidden" for="help_for_blockpriv">
+                            <div class="hidden" data-for="help_for_blockpriv">
                               <?=gettext("When set, this option blocks traffic from IP addresses that are reserved " .
                                 "for private networks as per RFC 1918 (10/8, 172.16/12, 192.168/16) as well as loopback " .
                                 "addresses (127/8). This option should only be set for WAN type interfaces that use " .
                                 "public IP address space.");?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_blockbogons" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Block bogon networks"); ?></td>
                           <td>
                             <input name="blockbogons" type="checkbox" id="blockbogons" value="yes" <?=!empty($pconfig['blockbogons']) ? "checked=\"checked\"" : ""; ?> />
-                            <output class="hidden" for="help_for_blockbogons">
+                            <div class="hidden" data-for="help_for_blockbogons">
                               <?=gettext("When set, this option blocks traffic from IP addresses that are reserved " .
                               "(but not RFC 1918) or not yet assigned by IANA."); ?>
                               <?=gettext("Bogons are prefixes that should never appear in the Internet routing table, " .
                               "and obviously should not appear as the source address in any packets you receive."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -1757,7 +1757,7 @@ include("head.inc");
                           <td><a id="help_for_spoofmac" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MAC address"); ?></td>
                           <td>
                             <input name="spoofmac" type="text" id="spoofmac" value="<?=htmlspecialchars($pconfig['spoofmac']);?>" />
-                            <output class="hidden" for="help_for_spoofmac">
+                            <div class="hidden" data-for="help_for_spoofmac">
                               <?= gettext('This field can be used to spoof the MAC address of the interface. Enter a ' .
                                   'MAC address in the following format: xx:xx:xx:xx:xx:xx or leave blank if unsure. ' .
                                   'This may only be required e.g. with certain cable connections on a WAN interface.') ?><br />
@@ -1770,33 +1770,33 @@ include("head.inc");
                               <a onclick="document.getElementById('spoofmac').value='<?= html_safe($mac) ?>';" href="#"><?=gettext("Insert my currently connected MAC address (use with care)"); ?></a><br />
 <?php
                               endif; ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_mtu" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MTU"); ?></td>
                           <td>
                             <input name="mtu" id="mtu" type="text" value="<?=$pconfig['mtu'];?>" />
-                            <output id="mtu_calc" style="display:none" for="mtu">
+                            <div id="mtu_calc" style="display:none" data-for="mtu">
                               <i class="fa fa-info-circle"></i>
                               <?=gettext("calculated ppp mtu :");?>
                               <label></label>
-                            </output>
-                            <output class="hidden" for="help_for_mtu">
+                            </div>
+                            <div class="hidden" data-for="help_for_mtu">
                               <?= gettext("If you leave this field blank, the adapter's default MTU will " .
                                 "be used. This is typically 1500 bytes but can vary in some circumstances.");?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_mss" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MSS"); ?></td>
                           <td>
                             <input name="mss" type="text" id="mss" value="<?=$pconfig['mss'];?>" />
-                            <output class="hidden" for="help_for_mss">
+                            <div class="hidden" data-for="help_for_mss">
                               <?=gettext("If you enter a value in this field, then MSS clamping for " .
                               "TCP connections to the value entered above minus 40 (TCP/IP " .
                               "header size) will be in effect."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -1814,9 +1814,9 @@ include("head.inc");
 <?php
                                   endforeach;?>
                                 </select>
-                                <output class="hidden" for="help_for_mediaopt">
+                                <div class="hidden" data-for="help_for_mediaopt">
                                   <?=gettext("Here you can explicitly set speed and duplex mode for this interface. WARNING: You MUST leave this set to autoselect (automatically negotiate speed) unless the port this interface connects to has its speed and duplex forced.");?>
-                                </output>
+                                </div>
                             </td>
                         </tr>
 <?php
@@ -1911,11 +1911,11 @@ include("head.inc");
                                 </tbody>
                               </table>
                             </div>
-                            <output class="hidden" for="help_for_gateway">
+                            <div class="hidden" data-for="help_for_gateway">
                               <?=gettext("If this interface is an Internet connection, select an existing Gateway from the list or add a new one using the link above."); ?><br />
                               <?=gettext("On local LANs the upstream gateway should be \"none\"."); ?>
                               <p><?= sprintf(gettext("You can manage Gateways %shere%s."),'<a target="_blank" href="system_gateways.php">','</a>') ?></p>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                       </tbody>
@@ -1949,11 +1949,11 @@ include("head.inc");
                                 <?=gettext("Config File Override");?>
                               </label>
                             </div>
-                            <output class="hidden" for="help_for_dhcp_mode">
+                            <div class="hidden" data-for="help_for_dhcp_mode">
                               <?= gettext('The basic mode auto-configures DHCP using default values and optional user input.') ?><br/>
                               <?= gettext('The advanced mode does not provide any default values, you will need to fill out any values you would like to use.') ?></br>
                               <?= gettext('The configuration file override mode may point to a fully customised file on the system instead.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_basic">
@@ -1977,31 +1977,31 @@ include("head.inc");
                                 </td>
                               </tr>
                             </table>
-                            <output class="hidden" for="help_for_alias_address">
+                            <div class="hidden" data-for="help_for_alias_address">
                               <?=gettext("The value in this field is used as a fixed alias IPv4 address by the " .
                               "DHCP client."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_basic dhcp_advanced">
                           <td><a id="help_for_dhcprejectfrom" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reject Leases From"); ?></td>
                           <td>
                             <input name="dhcprejectfrom" type="text" id="dhcprejectfrom" value="<?=htmlspecialchars($pconfig['dhcprejectfrom']);?>" />
-                            <output class="hidden" for="help_for_dhcprejectfrom">
+                            <div class="hidden" data-for="help_for_dhcprejectfrom">
                               <?=gettext("If there is a certain upstream DHCP server that should be ignored, place the IP address or subnet of the DHCP server to be ignored here."); ?>
                               <?=gettext("This is useful for rejecting leases from cable modems that offer private IPs when they lose upstream sync."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_basic dhcp_advanced">
                           <td><a id="help_for_dhcphostname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname"); ?></td>
                           <td>
                             <input name="dhcphostname" type="text" id="dhcphostname" value="<?=$pconfig['dhcphostname'];?>" />
-                            <output class="hidden" for="help_for_dhcphostname">
+                            <div class="hidden" data-for="help_for_dhcphostname">
                               <?=gettext("The value in this field is sent as the DHCP client identifier " .
                               "and hostname when requesting a DHCP lease. Some ISPs may require " .
                               "this (for client identification)."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_advanced">
@@ -2029,56 +2029,56 @@ include("head.inc");
                                 <input name="adv_dhcp_pt_values" type="radio" value="SavedCfg" checked="checked"/><?=gettext("Saved Cfg");?>
                               </label>
                             </div>
-                            <output class="hidden" for="help_for_dhcpprotocol_timing">
+                            <div class="hidden" data-for="help_for_dhcpprotocol_timing">
                               <?=sprintf(gettext("The values in these fields are DHCP %sprotocol timings%s used when requesting a lease."),'<a target="_blank" href="http://www.freebsd.org/cgi/man.cgi?query=dhclient.conf&amp;sektion=5#PROTOCOL_TIMING">','</a>') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_advanced">
                           <td><a id="help_for_dhcp_lease_requirements_and_requests" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Lease Requirements");?> </td>
                           <td>
-                            <output class="hidden" for="help_for_dhcp_lease_requirements_and_requests">
+                            <div class="hidden" data-for="help_for_dhcp_lease_requirements_and_requests">
                               <?=sprintf(gettext("More detailed information about lease requirements and requests can be found in the %sFreeBSD Manual%s."),'<a target="FreeBSD_DHCP" href="http://www.freebsd.org/cgi/man.cgi?query=dhclient.conf&amp;sektion=5#LEASE_REQUIREMENTS_AND_REQUESTS">','</a>')?><br/>
                               <hr/>
-                            </output>
+                            </div>
                             <?=gettext("Send Options"); ?><br />
                             <input name="adv_dhcp_send_options" type="text" id="adv_dhcp_send_options" value="<?=$pconfig['adv_dhcp_send_options'];?>" />
-                            <output class="hidden" for="help_for_dhcp_lease_requirements_and_requests">
+                            <div class="hidden" data-for="help_for_dhcp_lease_requirements_and_requests">
                               <?=gettext("The values in this field are DHCP options to be sent when requesting a DHCP lease. [option declaration [, ...]] <br />" .
                               "Value Substitutions: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD} <br />" .
                               "Where C is U(pper) or L(ower) Case, and D is \" :-.\" Delimiter (space, colon, hyphen, or period) (omitted for none).") ?>
-                            </output>
+                            </div>
                             <hr/>
                             <?=gettext("Request Options");?>
                             <input name="adv_dhcp_request_options" type="text" id="adv_dhcp_request_options" value="<?=$pconfig['adv_dhcp_request_options'];?>" />
-                            <output class="hidden" for="help_for_dhcp_lease_requirements_and_requests">
+                            <div class="hidden" data-for="help_for_dhcp_lease_requirements_and_requests">
                               <?=gettext("The values in this field are DHCP option 55 to be sent when requesting a DHCP lease. [option [, ...]]") ?>
-                            </output>
+                            </div>
                             <hr/>
                             <?=gettext("Require Options");?>
                             <input name="adv_dhcp_required_options" type="text" id="adv_dhcp_required_options" value="<?=htmlspecialchars($pconfig['adv_dhcp_required_options']);?>" />
-                            <output class="hidden" for="help_for_dhcp_lease_requirements_and_requests">
+                            <div class="hidden" data-for="help_for_dhcp_lease_requirements_and_requests">
                               <?=gettext("The values in this field are DHCP options required by the client when requesting a DHCP lease. [option [, ...]]"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_advanced">
                           <td><a id="help_for_dhcp_option_modifiers" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Option Modifiers");?></td>
                           <td>
                             <input name="adv_dhcp_option_modifiers" type="text" id="adv_dhcp_option_modifiers" value="<?=$pconfig['adv_dhcp_option_modifiers'];?>" />
-                            <output class="hidden" for="help_for_dhcp_option_modifiers">
+                            <div class="hidden" data-for="help_for_dhcp_option_modifiers">
                               <?=gettext("The values in this field are DHCP option modifiers applied to obtained DHCP lease. [modifier option declaration [, ...]] <br />" .
                               "modifiers: (default, supersede, prepend, append)"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcp_file_override">
                           <td><a id="help_for_dhcp_config_file_override_path" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration File Override");?>
                           <td>
                             <input name="adv_dhcp_config_file_override_path"   type="text" id="adv_dhcp_config_file_override_path"  value="<?=$pconfig['adv_dhcp_config_file_override_path'];?>" />
-                            <output class="hidden" for="help_for_dhcp_config_file_override_path">
+                            <div class="hidden" data-for="help_for_dhcp_config_file_override_path">
                               <?= gettext('The value in this field is the full absolute path to a DHCP client configuration file.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                       </tbody>
@@ -2124,9 +2124,9 @@ include("head.inc");
                                 </td>
                               </tr>
                             </table>
-                            <output class="hidden" for="help_for_country">
+                            <div class="hidden" data-for="help_for_country">
                               <?=gettext("Select to fill in data for your service provider."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2213,18 +2213,18 @@ include("head.inc");
                           <td><a id="help_for_provider" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Service name"); ?></td>
                           <td>
                             <input name="provider" type="text" id="provider" value="<?=$pconfig['provider'];?>" />
-                            <output class="hidden" for="help_for_provider">
+                            <div class="hidden" data-for="help_for_provider">
                               <?=gettext("Hint: this field can usually be left empty"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_pppoe_hostuniq" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Host-Uniq"); ?></td>
                           <td>
                             <input name="pppoe_hostuniq" type="text" id="pppoe_hostuniq" value="<?=$pconfig['pppoe_hostuniq'];?>" />
-                            <output class="hidden" for="help_for_pppoe_hostuniq">
+                            <div class="hidden" data-for="help_for_pppoe_hostuniq">
                               <?= gettext('This field can usually be left empty unless specified by the provider.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2232,18 +2232,18 @@ include("head.inc");
                           <td>
                             <input name="pppoe_dialondemand" type="checkbox" id="pppoe_dialondemand" value="enable" <?= !empty($pconfig['pppoe_dialondemand']) ? "checked=\"checked\"" : ""; ?> />
                             <strong><?=gettext("Enable Dial-On-Demand mode"); ?></strong><br />
-                            <output class="hidden" for="help_for_pppoe_dialondemand">
+                            <div class="hidden" data-for="help_for_pppoe_dialondemand">
                               <?=gettext("This option causes the interface to operate in dial-on-demand mode, allowing you to have a 'virtual full time' connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_pppoe_idletimeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Idle timeout"); ?></td>
                           <td>
                             <input name="pppoe_idletimeout" type="text" id="pppoe_idletimeout" value="<?=$pconfig['pppoe_idletimeout'];?>" /> <?=gettext("seconds"); ?>
-                            <output class="hidden" for="help_for_pppoe_idletimeout">
+                            <div class="hidden" data-for="help_for_pppoe_idletimeout">
                               <?=gettext("If no qualifying outgoing packets are transmitted for the specified number of seconds, the connection is brought down. An idle timeout of zero disables this feature."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2316,9 +2316,9 @@ include("head.inc");
                           <td>
                             <input name="pptp_dialondemand" type="checkbox" id="pptp_dialondemand" value="enable" <?=!empty($pconfig['pptp_dialondemand']) ? 'checked="checked"' : '' ?> />
                             <strong><?=gettext("Enable Dial-On-Demand mode"); ?></strong><br />
-                            <output class="hidden" for="help_for_pptp_dialondemand">
+                            <div class="hidden" data-for="help_for_pptp_dialondemand">
                               <?=gettext("This option causes the interface to operate in dial-on-demand mode, allowing you to have a 'virtual full time' connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2376,9 +2376,9 @@ include("head.inc");
                           <td><a id="help_for_staticv6usev4iface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use IPv4 connectivity"); ?></td>
                           <td>
                             <input name="staticv6usev4iface" type="checkbox" id="staticv6usev4iface" value="yes" <?=!empty($pconfig['staticv6usev4iface']) ? "checked=\"checked\"" : ""; ?> />
-                            <output class="hidden" for="help_for_staticv6usev4iface">
+                            <div class="hidden" data-for="help_for_staticv6usev4iface">
                                 <?=gettext("Use the IPv4 connectivity link.");?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2400,11 +2400,11 @@ include("head.inc");
                               endif;?>
                             </select>
                             <button type="button" class="btn btn-sm" id="btn_show_add_gatewayv6" title="<?=gettext("Add a new one.");?>"  data-toggle="tooltip"><span class="glyphicon glyphicon-plus"></span></button>
-                            <output class="hidden" for="help_for_gatewayv6">
+                            <div class="hidden" data-for="help_for_gatewayv6">
                               <?=gettext("If this interface is an Internet connection, select an existing Gateway from the list or add a new one using the link above."); ?><br />
                               <?=gettext('On local LANs the upstream gateway should be "none".'); ?>
                               <p><?= sprintf(gettext("You can manage Gateways %shere%s."),'<a target="_blank" href="system_gateways.php">','</a>') ?></p>
-                            </output>
+                            </div>
                             <div class="hidden" id="addgatewayv6">
                               <br/>
                               <table class="table table-striped table-condensed">
@@ -2473,20 +2473,20 @@ include("head.inc");
                                 <?=gettext("Config File Override");?>
                               </label>
                             </div>
-                            <output class="hidden" for="help_for_dhcpv6_mode">
+                            <div class="hidden" data-for="help_for_dhcpv6_mode">
                               <?= gettext('The basic mode auto-configures DHCP using default values and optional user input.') ?><br/>
                               <?= gettext('The advanced mode does not provide any default values, you will need to fill out any values you would like to use.') ?></br>
                               <?= gettext('The configuration file override mode may point to a fully customised file on the system instead.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcpv6_basic">
                           <td><a id="help_for_dhcp6prefixonly" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Request only a IPv6 prefix"); ?></td>
                           <td>
                             <input name="dhcp6prefixonly" type="checkbox" id="dhcp6prefixonly" value="yes" <?=!empty($pconfig['dhcp6prefixonly']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_dhcp6prefixonly">
+                            <div class="hidden" data-for="help_for_dhcp6prefixonly">
                               <?=gettext("Only request a IPv6 prefix, do not request a IPv6 address"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcpv6_basic">
@@ -2501,54 +2501,54 @@ include("head.inc");
 <?php
                             endforeach;?>
                             </select>
-                            <output class="hidden" for="help_for_dhcp6-ia-pd-len">
+                            <div class="hidden" data-for="help_for_dhcp6-ia-pd-len">
                               <?=gettext("The value in this field is the delegated prefix length provided by the DHCPv6 server. Normally specified by the ISP."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcpv6_basic">
                           <td><a id="help_for_dhcp6-ia-pd-send-hint" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Send IPv6 prefix hint"); ?></td>
                           <td>
                             <input name="dhcp6-ia-pd-send-hint" type="checkbox" id="dhcp6-ia-pd-send-hint" value="yes" <?=!empty($pconfig['dhcp6-ia-pd-send-hint']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_dhcp6-ia-pd-send-hint">
+                            <div class="hidden" data-for="help_for_dhcp6-ia-pd-send-hint">
                               <?=gettext("Send an IPv6 prefix hint to indicate the desired prefix size for delegation"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_dhcp6sendsolicit" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Directly send SOLICIT'); ?></td>
                           <td>
                             <input name="dhcp6sendsolicit" type="checkbox" id="dhcp6sendsolicit" value="yes" <?= !empty($pconfig['dhcp6sendsolicit']) ? 'checked="checked"' : '' ?>/>
-                            <output class="hidden" for="help_for_dhcp6sendsolicit">
+                            <div class="hidden" data-for="help_for_dhcp6sendsolicit">
                               <?= gettext('In case the ISP requires a SOLICIT message for authentication, select this option to prevent indefinite waiting for a router advertisement.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_dhcp6norelease" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Prevent release"); ?></td>
                           <td>
                             <input name="dhcp6norelease" type="checkbox" id="dhcp6norelease" value="yes" <?= !empty($pconfig['dhcp6norelease']) ? 'checked="checked"' : '' ?> />
-                            <output class="hidden" for="help_for_dhcp6norelease">
+                            <div class="hidden" data-for="help_for_dhcp6norelease">
                               <?=gettext("Do not send a release message on client exit to prevent the release of an allocated address or prefix on the server."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                             <td><a id="help_for_dhcp6_debug" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable debug"); ?></td>
                             <td>
                               <input name="adv_dhcp6_debug" type="checkbox" id="adv_dhcp6_debug" value="yes" <?=!empty($pconfig['adv_dhcp6_debug']) ? "checked=\"checked\"" : ""; ?> />
-                              <output class="hidden" for="help_for_dhcp6_debug">
+                              <div class="hidden" data-for="help_for_dhcp6_debug">
                                 <?=gettext("Enable debug mode for DHCPv6 client"); ?>
-                              </output>
+                              </div>
                             </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_dhcp6usev4iface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use IPv4 connectivity"); ?></td>
                           <td>
                             <input name="dhcp6usev4iface" type="checkbox" id="dhcp6usev4iface" value="yes" <?=!empty($pconfig['dhcp6usev4iface']) ? "checked=\"checked\"" : ""; ?> />
-                            <output class="hidden" for="help_for_dhcp6usev4iface">
+                            <div class="hidden" data-for="help_for_dhcp6usev4iface">
                               <?=gettext("Request a IPv6 prefix/information through the IPv4 connectivity link"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2562,9 +2562,9 @@ include("head.inc");
 <?php
                               endforeach ?>
                             </select>
-                            <output class="hidden" for="help_for_dhcp6vlanprio">
+                            <div class="hidden" data-for="help_for_dhcp6vlanprio">
                               <?= gettext('Certain ISPs may require that DHCPv6 requests are sent with a specific VLAN priority.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcpv6_advanced">
@@ -2572,7 +2572,7 @@ include("head.inc");
                           <td>
                             <input name="adv_dhcp6_interface_statement_information_only_enable" type="checkbox" id="adv_dhcp6_interface_statement_information_only_enable" <?=!empty($pconfig['adv_dhcp6_interface_statement_information_only_enable']) ? "checked=\"checked\"" : "";?> />
                             <strong><?=gettext("Information Only"); ?></strong><br/>
-                            <output class="hidden" for="help_for_dhcp6_intf_stmt">
+                            <div class="hidden" data-for="help_for_dhcp6_intf_stmt">
                               <?=gettext("This statement specifies dhcp6c to only exchange informational configuration parameters with servers. ".
                               "A list of DNS server addresses is an example of such parameters. ".
                               "This statement is useful when the client does not need ".
@@ -2580,29 +2580,29 @@ include("head.inc");
                               <small>
                                 <?=gettext("Source: FreeBSD man page");?>
                               </small>
-                            </output>
+                            </div>
                             <br/>
                             <strong><?=gettext("Send Options"); ?></strong><br />
                             <input name="adv_dhcp6_interface_statement_send_options" type="text" id="adv_dhcp6_interface_statement_send_options" value="<?=$pconfig['adv_dhcp6_interface_statement_send_options'];?>" />
-                            <output class="hidden" for="help_for_dhcp6_intf_stmt">
+                            <div class="hidden" data-for="help_for_dhcp6_intf_stmt">
                               <?=gettext("The values in this field are DHCP send options to be sent when requesting a DHCP lease. [option declaration [, ...]] <br />" .
                               "Value Substitutions: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD} <br />" .
                               "Where C is U(pper) or L(ower) Case, and D is \" :-.\" Delimiter (space, colon, hyphen, or period) (omitted for none).") ?>
-                            </output>
+                            </div>
                             <br />
                             <br />
                             <strong><?=gettext("Request Options"); ?></strong><br />
                             <input name="adv_dhcp6_interface_statement_request_options" type="text" id="adv_dhcp6_interface_statement_request_options" value="<?=$pconfig['adv_dhcp6_interface_statement_request_options'];?>" />
-                            <output class="hidden" for="help_for_dhcp6_intf_stmt">
+                            <div class="hidden" data-for="help_for_dhcp6_intf_stmt">
                               <?=gettext('The values in this field are DHCP request options to be sent when requesting a DHCP lease. [option [, ...]]') ?>
-                            </output>
+                            </div>
                             <br />
                             <br />
                             <strong><?=gettext("Script"); ?></strong><br />
                             <input name="adv_dhcp6_interface_statement_script" type="text" id="adv_dhcp6_interface_statement_script" value="<?=htmlspecialchars($pconfig['adv_dhcp6_interface_statement_script']);?>" />
-                            <output class="hidden" for="help_for_dhcp6_intf_stmt">
+                            <div class="hidden" data-for="help_for_dhcp6_intf_stmt">
                               <?= gettext('The value in this field is the absolute path to a script invoked on certain conditions including when a reply message is received.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr class="dhcpv6_advanced">
@@ -2684,9 +2684,9 @@ include("head.inc");
                           <td><a id="help_for_adv_dhcp6_config_file_override_path" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Configuration File Override");?></td>
                           <td>
                             <input name="adv_dhcp6_config_file_override_path" type="text" id="adv_dhcp6_config_file_override_path"  value="<?=$pconfig['adv_dhcp6_config_file_override_path'];?>" />
-                            <output class="hidden" for="help_for_adv_dhcp6_config_file_override_path">
+                            <div class="hidden" data-for="help_for_adv_dhcp6_config_file_override_path">
                               <?= gettext('The value in this field is the full absolute path to a DHCP client configuration file.') ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                       </tbody>
@@ -2707,9 +2707,9 @@ include("head.inc");
                           <td style="width:22%"><a id="help_for_prefix-6rd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("6RD prefix"); ?></td>
                           <td style="width:78%">
                             <input name="prefix-6rd" type="text" id="prefix-6rd" value="<?=$pconfig['prefix-6rd'];?>" />
-                            <output class="hidden" for="help_for_prefix-6rd">
+                            <div class="hidden" data-for="help_for_prefix-6rd">
                               <?=gettext("The value in this field is the 6RD IPv6 prefix assigned by your ISP. e.g. '2001:db8::/32'") ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2733,9 +2733,9 @@ include("head.inc");
 <?php
                               endfor;?>
                             </select>
-                            <output class="hidden" for="help_for_prefix-6rd-v4plen">
+                            <div class="hidden" data-for="help_for_prefix-6rd-v4plen">
                               <?=gettext("The value in this field is the 6RD IPv4 prefix length. Normally specified by the ISP. A value of 0 means we embed the entire IPv4 address in the 6RD prefix."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                       </tbody>
@@ -2770,9 +2770,9 @@ include("head.inc");
 <?php
                             endforeach;?>
                             </select>
-                            <output class="hidden" for="help_for_track6-interface">
+                            <div class="hidden" data-for="help_for_track6-interface">
                               <?=gettext("This selects the dynamic IPv6 WAN interface to track for configuration") ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2784,11 +2784,11 @@ include("head.inc");
                             }
                             $track6_prefix_id_hex = !empty($pconfig['track6-prefix-id--hex']) ? $pconfig['track6-prefix-id--hex']: sprintf("%x", $pconfig['track6-prefix-id']);?>
                             <input name="track6-prefix-id--hex" type="text" id="track6-prefix-id--hex" value="<?= $track6_prefix_id_hex ?>" />
-                            <output class="hidden" for="help_for_track6-prefix-id">
+                            <div class="hidden" data-for="help_for_track6-prefix-id">
                               <?= gettext("The value in this field is the (Delegated) IPv6 prefix id. This determines the configurable network ID based on the dynamic IPv6 connection"); ?>
                               <br />
                               <?= sprintf(gettext("Enter a hexadecimal value between %x and %x here, default value is 0."), 0, pow(2, calculate_ipv6_delegation_length($pconfig['track6-interface'])) - 1); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                       </tbody>
@@ -2812,9 +2812,9 @@ include("head.inc");
                           <td style="width:22%"><a id="help_for_persistcommonwireless" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Persist common settings");?></td>
                           <td style="width:78%">
                             <input name="persistcommonwireless" type="checkbox" value="yes"  id="persistcommonwireless" <?=!empty($pconfig['persistcommonwireless']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_persistcommonwireless">
+                            <div class="hidden" data-for="help_for_persistcommonwireless">
                               <?=gettext("Enabling this preserves the common wireless configuration through interface deletions and reassignments.");?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2841,9 +2841,9 @@ include("head.inc");
                               <option <?=$pconfig['protmode'] == 'cts' ? "selected=\"selected\"" : "";?> value="cts"><?=gettext("Protection mode CTS to self"); ?></option>
                               <option <?=$pconfig['protmode'] == 'rtscts' ? "selected=\"selected\"" : "";?> value="rtscts"><?=gettext("Protection mode RTS and CTS"); ?></option>
                             </select>
-                            <output class="hidden" for="help_for_protmode">
+                            <div class="hidden" data-for="help_for_protmode">
                               <?=gettext("For IEEE 802.11g, use the specified technique for protecting OFDM frames in a mixed 11b/11g network."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -2862,9 +2862,9 @@ include("head.inc");
 <?php
                               endfor;?>
                             </select>
-                            <output class="hidden" for="help_for_txpower">
+                            <div class="hidden" data-for="help_for_txpower">
                               <?=gettext("Typically only a few discreet power settings are available and the driver will use the setting closest to the specified value. Not all adapters support changing the transmit power setting."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -2884,11 +2884,11 @@ include("head.inc");
                                 endforeach;
                               endforeach;?>
                             </select>
-                            <output class="hidden" for="help_for_channel">
+                            <div class="hidden" data-for="help_for_channel">
                               <?=gettext("Legend: wireless standards - channel # (frequency @ max TX power / TX power allowed in reg. domain)"); ?>
                               <br />
                               <?=gettext("Not all channels may be supported by your card. Auto may override the wireless standard selected above."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -2938,9 +2938,9 @@ include("head.inc");
                               endif; ?>
                               </tr>
                             </table>
-                            <output class="hidden" for="help_for_antenna_settings">
+                            <div class="hidden" data-for="help_for_antenna_settings">
                               <?=gettext("Note: The antenna numbers do not always match up with the labels on the card."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -2959,9 +2959,9 @@ include("head.inc");
 <?php
                               endforeach;?>
                             </select>
-                            <output class="hidden" for="help_for_regdomain">
+                            <div class="hidden" data-for="help_for_regdomain">
                               <?=gettext("Note: Some cards have a default that is not recognized and require changing the regulatory domain to one in this list for the changes to other regulatory settings to work."); ?>
-                            </output>
+                            </div>
 
                             <br /><br />
                             <?=gettext("Country (listed with country code and regulatory domain)"); ?><br />
@@ -2976,9 +2976,9 @@ include("head.inc");
                             endforeach;?>
                             </select>
                             <br />
-                            <output class="hidden" for="help_for_regdomain">
+                            <div class="hidden" data-for="help_for_regdomain">
                               <?=gettext("Note: Any country setting other than \"Default\" will override the regulatory domain setting"); ?>.
-                            </output>
+                            </div>
                             <br /><br />
                             <?=gettext("Location"); ?><br />
                             <select name="reglocation" class="selectpicker" data-style="btn-default" id="reglocation">
@@ -2988,11 +2988,11 @@ include("head.inc");
                               <option <?=$pconfig['reglocation'] == 'anywhere' ? "selected=\"selected\"" : ""; ?> value="anywhere"><?=gettext("Anywhere"); ?></option>
                             </select>
                             <br /><br />
-                            <output class="hidden" for="help_for_regdomain">
+                            <div class="hidden" data-for="help_for_regdomain">
                               <?=gettext("These settings may affect which channels are available and the maximum transmit power allowed on those channels. Using the correct settings to comply with local regulatory requirements is recommended."); ?>
                               <br />
                               <?=gettext("All wireless networks on this interface will be temporarily brought down when changing regulatory settings. Some of the regulatory domains or country codes may not be allowed by some cards. These settings may not be able to add additional channels that are not already supported."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3020,9 +3020,9 @@ include("head.inc");
                           <td><a id="help_for_ssid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("SSID"); ?></td>
                           <td>
                             <input name="ssid" type="text" id="ssid" value="<?=$pconfig['ssid'];?>" />
-                            <output class="hidden" for="help_for_ssid">
+                            <div class="hidden" data-for="help_for_ssid">
                               <?=gettext("Note: Only required in Access Point mode. If left blank in Ad-hoc or Infrastructure mode, this interface will connect to any available SSID"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -3039,9 +3039,9 @@ include("head.inc");
                               endif; ?>
                               <option <?=$pconfig['puremode'] == '11n' ? "selected=\"selected\"" : "";?> value="11n"><?=gettext("802.11n"); ?></option>
                             </select>
-                            <output class="hidden" for="help_for_puremode">
+                            <div class="hidden" data-for="help_for_puremode">
                               <?=gettext("When operating as an access point, allow only stations capable of the selected wireless standard to associate (stations not capable are not permitted to associate)."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -3050,9 +3050,9 @@ include("head.inc");
                           <td><a id="help_for_puremode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.11g only"); ?></td>
                           <td>
                             <input name="puremode" type="checkbox" value="11g"  id="puremode" <?php if ($pconfig['puremode'] == '11g') echo "checked=\"checked\"";?> />
-                            <output class="hidden" for="help_for_puremode">
+                            <div class="hidden" data-for="help_for_puremode">
                               <?=gettext("When operating as an access point in 802.11g mode, allow only 11g-capable stations to associate (11b-only stations are not permitted to associate)."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
 <?php
@@ -3061,29 +3061,29 @@ include("head.inc");
                           <td><a id="help_for_apbridge_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Allow intra-BSS communication"); ?></td>
                           <td>
                             <input name="apbridge_enable" type="checkbox" value="yes"  id="apbridge_enable" <?=!empty($pconfig['apbridge_enable']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_apbridge_enable">
+                            <div class="hidden" data-for="help_for_apbridge_enable">
                               <?=gettext("When operating as an access point, enable this if you want to pass packets between wireless clients directly."); ?>
                               <br />
                               <?=gettext("Disabling the internal bridging is useful when traffic is to be processed with packet filtering."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_wme_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable WME"); ?></td>
                           <td>
                             <input name="wme_enable" type="checkbox" id="wme_enable" value="yes" <?=!empty($pconfig['wme_enable']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_wme_enable">
+                            <div class="hidden" data-for="help_for_wme_enable">
                               <?=gettext("Setting this option will force the card to use WME (wireless QoS)."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_hidessid_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable Hide SSID"); ?></td>
                           <td>
                             <input name="hidessid_enable" type="checkbox" id="hidessid_enable" value="yes" <?=!empty($pconfig['hidessid_enable']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_hidessid_enable">
+                            <div class="hidden" data-for="help_for_hidessid_enable">
                               <?=gettext("Setting this option will force the card to NOT broadcast its SSID (this might create problems for some clients)."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3134,10 +3134,10 @@ include("head.inc");
                                 </td>
                               </tr>
                             </table>
-                            <output class="hidden" for="help_for_wep">
+                            <div class="hidden" data-for="help_for_wep">
                               <?=gettext("40 (64) bit keys may be entered as 5 ASCII characters or 10 hex digits preceded by '0x'."); ?><br />
                               <?=gettext("104 (128) bit keys may be entered as 13 ASCII characters or 26 hex digits preceded by '0x'."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3148,9 +3148,9 @@ include("head.inc");
                             <hr/>
                             <?=gettext("WPA Pre-Shared Key"); ?><br/>
                             <input name="passphrase" type="text" id="passphrase" value="<?=$pconfig['passphrase'];?>" />
-                            <output class="hidden" for="help_for_wpa_enable">
+                            <div class="hidden" data-for="help_for_wpa_enable">
                               <?=gettext("Passphrase must be from 8 to 63 characters."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3181,9 +3181,9 @@ include("head.inc");
                               <option <?=$pconfig['auth_algs'] == '2' ? "selected=\"selected\"" : "";?> value="2"><?=gettext("Shared Key Authentication"); ?></option>
                               <option <?=$pconfig['auth_algs'] == '3' ? "selected=\"selected\"" : "";?> value="3"><?=gettext("Both"); ?></option>
                             </select>
-                            <output class="hidden" for="help_for_auth_algs">
+                            <div class="hidden" data-for="help_for_auth_algs">
                               <?=gettext("Note: Shared Key Authentication requires WEP."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3200,55 +3200,55 @@ include("head.inc");
                           <td><a id="help_for_wpa_group_rekey" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Key Rotation"); ?></td>
                           <td>
                             <input name="wpa_group_rekey" type="text" id="wpa_group_rekey" value="<?=!empty($pconfig['wpa_group_rekey']) ? $pconfig['wpa_group_rekey'] : "60";?>" />
-                            <output class="hidden" for="help_for_wpa_group_rekey">
+                            <div class="hidden" data-for="help_for_wpa_group_rekey">
                               <?=gettext("Allowed values are 1-9999 but should not be longer than Master Key Regeneration time."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_wpa_gmk_rekey" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Master Key Regeneration"); ?></td>
                           <td>
                             <input name="wpa_gmk_rekey" type="text" id="wpa_gmk_rekey" value="<?=!empty($pconfig['wpa_gmk_rekey']) ? $pconfig['wpa_gmk_rekey'] : "3600";?>" />
-                            <output class="hidden" for="help_for_wpa_gmk_rekey">
+                            <div class="hidden" data-for="help_for_wpa_gmk_rekey">
                               <?=gettext("Allowed values are 1-9999 but should not be shorter than Key Rotation time."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_wpa_strict_rekey" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Strict Key Regeneration"); ?></td>
                           <td>
                             <input name="wpa_strict_rekey" type="checkbox" value="yes"  id="wpa_strict_rekey" <?php if ($pconfig['wpa_strict_rekey']) echo "checked=\"checked\""; ?> />
-                            <output class="hidden" for="help_for_wpa_strict_rekey">
+                            <div class="hidden" data-for="help_for_wpa_strict_rekey">
                               <?=gettext("Setting this option will force the AP to rekey whenever a client disassociates."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_ieee8021x" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable IEEE802.1X Authentication"); ?></td>
                           <td>
                             <input name="ieee8021x" type="checkbox" value="yes"  id="ieee8021x" <?=!empty($pconfig['ieee8021x']) ? "checked=\"checked\"" : "";?> />
-                            <output class="hidden" for="help_for_ieee8021x">
+                            <div class="hidden" data-for="help_for_ieee8021x">
                               <?=gettext("Setting this option will enable 802.1x authentication."); ?><br/>
                               <span class="text-danger"><strong><?=gettext("NOTE"); ?>:</strong></span> <?=gettext("this option requires checking the \"Enable WPA box\"."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_auth_server_addr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.1X Server IP Address"); ?></td>
                           <td>
                             <input name="auth_server_addr" id="auth_server_addr" type="text" value="<?=$pconfig['auth_server_addr'];?>" />
-                            <output class="hidden" for="help_for_auth_server_addr">
+                            <div class="hidden" data-for="help_for_auth_server_addr">
                               <?=gettext("Enter the IP address of the 802.1X Authentication Server. This is commonly a Radius server (FreeRadius, Internet Authentication Services, etc.)"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_auth_server_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.1X Server Port"); ?></td>
                           <td>
                             <input name="auth_server_port" id="auth_server_port" type="text" value="<?=$pconfig['auth_server_port'];?>" />
-                            <output class="hidden" for="help_for_auth_server_port">
+                            <div class="hidden" data-for="help_for_auth_server_port">
                               <?=gettext("Leave blank for the default 1812 port."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
@@ -3261,29 +3261,29 @@ include("head.inc");
                           <td><a id="help_for_auth_server_addr2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.1X Server IP Address (2)"); ?></td>
                           <td>
                             <input name="auth_server_addr2" id="auth_server_addr2" type="text" value="<?=$pconfig['auth_server_addr2'];?>" />
-                            <output class="hidden" for="help_for_auth_server_addr2">
+                            <div class="hidden" data-for="help_for_auth_server_addr2">
                               <?=gettext("Secondary 802.1X Authentication Server IP Address"); ?></br>
                               <?=gettext("Enter the IP address of the 802.1X Authentication Server. This is commonly a Radius server (FreeRadius, Internet Authentication Services, etc.)"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_auth_server_port2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.1X Server Port (2)"); ?></td>
                           <td>
                             <input name="auth_server_port2" id="auth_server_port2" type="text" value="<?=$pconfig['auth_server_port2'];?>" />
-                            <output class="hidden" for="help_for_auth_server_port2">
+                            <div class="hidden" data-for="help_for_auth_server_port2">
                               <?=gettext("Secondary 802.1X Authentication Server Port"); ?><br />
                               <?=gettext("Leave blank for the default 1812 port."); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>
                           <td><a id="help_for_auth_server_shared_secret2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("802.1X Server Shared Secret (2)"); ?></td>
                           <td>
                             <input name="auth_server_shared_secret2" id="auth_server_shared_secret2" type="text" value="<?=$pconfig['auth_server_shared_secret2'];?>" />
-                            <output class="hidden" for="help_for_auth_server_shared_secret2">
+                            <div class="hidden" data-for="help_for_auth_server_shared_secret2">
                               <?=gettext("Secondary 802.1X Authentication Server Shared Secret"); ?>
-                            </output>
+                            </div>
                           </td>
                         </tr>
                         <tr>

--- a/src/www/interfaces_bridge_edit.php
+++ b/src/www/interfaces_bridge_edit.php
@@ -258,18 +258,18 @@ $(document).ready(function() {
                             endif;
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_members">
+                        <div class="hidden" data-for="help_for_members">
                           <?=gettext("Interfaces participating in the bridge."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                       <td>
                         <input type="text" name="descr" value="<?=$pconfig['descr'];?>" />
-                        <output class="hidden" for="help_for_descr">
+                        <div class="hidden" data-for="help_for_descr">
                           <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr id="show_advanced_opt">
@@ -296,9 +296,9 @@ $(document).ready(function() {
                       <td style="width:22%"><a id="help_for_enablestp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable");?></td>
                       <td style="width:78%">
                         <input type="checkbox" name="enablestp" <?= !empty($pconfig['enablestp']) ? 'checked="checked"' : "";?> />
-                        <output class="hidden" for="help_for_enablestp">
+                        <div class="hidden" data-for="help_for_enablestp">
                           <?=gettext("Enable spanning tree options for this bridge."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -312,9 +312,9 @@ $(document).ready(function() {
                             <?=gettext("STP");?>
                           </option>
                         </select>
-                        <output class="hidden" for="help_for_proto">
+                        <div class="hidden" data-for="help_for_proto">
                           <?=gettext("Protocol used for spanning tree."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -329,64 +329,64 @@ $(document).ready(function() {
 <?php
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_stp" >
+                        <div class="hidden" data-for="help_for_stp" >
                          <?=gettext("Enable Spanning Tree Protocol on interface. The if_bridge(4) " .
                          "driver has support for the IEEE 802.1D Spanning Tree Protocol " .
                          "(STP). STP is used to detect and remove loops in a " .
                          "network topology."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_maxage" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Valid time"); ?> (<?=gettext("seconds"); ?>)</td>
                       <td>
                         <input name="maxage" type="text" value="<?=$pconfig['maxage'];?>" />
-                        <output class="hidden" for="help_for_maxage">
+                        <div class="hidden" data-for="help_for_maxage">
                          <?=gettext("Set the time that a Spanning Tree Protocol configuration is " .
                          "valid. The default is 20 seconds. The minimum is 6 seconds and " .
                          "the maximum is 40 seconds."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_fwdelay" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Forward time"); ?> (<?=gettext("seconds"); ?>)</td>
                       <td>
                         <input name="fwdelay" type="text" value="<?=$pconfig['fwdelay'];?>" />
-                        <output class="hidden" for="help_for_fwdelay">
+                        <div class="hidden" data-for="help_for_fwdelay">
                          <?=gettext("Set the time that must pass before an interface begins forwarding " .
                          "packets when Spanning Tree is enabled. The default is 15 seconds. The minimum is 4 seconds and the maximum is 30 seconds."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_hellotime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hello time"); ?> (<?=gettext("seconds"); ?>)</td>
                       <td>
                         <input name="hellotime" type="text" value="<?=$pconfig['hellotime'];?>" />
-                        <output class="hidden" for="help_for_hellotime">
+                        <div class="hidden" data-for="help_for_hellotime">
                          <?=gettext("Set the time between broadcasting of Spanning Tree Protocol configuration messages. The hello time may only be changed when " .
                          "operating in legacy STP mode. The default is 2 seconds. The minimum is 1 second and the maximum is 2 seconds."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_priority" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Priority"); ?></td>
                       <td>
                         <input name="priority" type="text" value="<?=$pconfig['priority'];?>" />
-                        <output class="hidden" for="help_for_priority">
+                        <div class="hidden" data-for="help_for_priority">
                          <?=gettext("Set the bridge priority for Spanning Tree. The default is 32768. " .
                          "The minimum is 0 and the maximum is 61440."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_holdcnt" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hold count"); ?></td>
                       <td>
                         <input name="holdcnt" type="text" value="<?=$pconfig['holdcnt'];?>" />
-                        <output class="hidden" for="help_for_holdcnt">
+                        <div class="hidden" data-for="help_for_holdcnt">
                          <?=gettext("Set the transmit hold count for Spanning Tree. This is the number " .
                          "of packets transmitted before being rate limited. The " .
                          "default is 6. The minimum is 1 and the maximum is 10."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -404,10 +404,10 @@ $(document).ready(function() {
 <?php
                         endforeach;?>
                         </table>
-                        <output class="hidden" for="help_for_intf_priority">
+                        <div class="hidden" data-for="help_for_intf_priority">
                          <?=gettext("Set the Spanning Tree priority of interface to value. " .
                          "The default is 128. The minimum is 0 and the maximum is 240. Increments of 16."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -425,11 +425,11 @@ $(document).ready(function() {
 <?php
                         endforeach;?>
                         </table>
-                        <output class="hidden" for="help_for_intf_pathcost">
+                        <div class="hidden" data-for="help_for_intf_pathcost">
                          <?=gettext("Set the Spanning Tree path cost of interface to value. The " .
                          "default is calculated from the link speed. To change a previously selected path cost back to automatic, set the cost to 0. ".
                          "The minimum is 1 and the maximum is 200000000."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                   </tbody>
@@ -450,20 +450,20 @@ $(document).ready(function() {
                       <td style="width:22%"><a id="help_for_maxaddr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Cache size"); ?> (<?=gettext("entries"); ?>)</td>
                       <td style="width:78%">
                         <input name="maxaddr" type="text" value="<?=$pconfig['maxaddr'];?>" />
-                      <output class="hidden" for="help_for_maxaddr">
+                      <div class="hidden" data-for="help_for_maxaddr">
                         <?=gettext("Set the size of the bridge address cache to size. The default is .100 entries."); ?>
-                      </output>
+                      </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Cache entry expire time"); ?> (<?=gettext("seconds"); ?>)</td>
                       <td>
                         <input name="timeout" type="text" value="<?=$pconfig['timeout'];?>" />
-                        <output class="hidden" for="help_for_timeout">
+                        <div class="hidden" data-for="help_for_timeout">
                          <?=gettext("Set the timeout of address cache entries to this number of seconds. If " .
                          "seconds is zero, then address cache entries will not be expired. " .
                          "The default is 240 seconds."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -479,7 +479,7 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_span">
+                        <div class="hidden" data-for="help_for_span">
                          <?=gettext("Add the interface named by interface as a span port on the " .
                          "bridge. Span ports transmit a copy of every frame received by " .
                          "the bridge. This is most useful for snooping a bridged network " .
@@ -487,7 +487,7 @@ $(document).ready(function() {
                          "the bridge."); ?><br/>
                          <span class="text-warning"><strong><?=gettext("Note:"); ?><br /></strong></span>
                          <?=gettext("The span interface cannot be part of the bridge member interfaces."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -502,11 +502,11 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_edge">
+                        <div class="hidden" data-for="help_for_edge">
                           <?=gettext("Set interface as an edge port. An edge port connects directly to " .
                           "end stations and cannot create bridging loops in the network; this " .
                           "allows it to transition straight to forwarding."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -521,12 +521,12 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_autoedge">
+                        <div class="hidden" data-for="help_for_autoedge">
                           <?=gettext("Allow interface to automatically detect edge status. This is the " .
                             "default for all interfaces added to a bridge."); ?><br/>
                             <span class="text-warning"><strong><?=gettext("Note:"); ?><br /></strong></span>
                             <?=gettext("This will disable the autoedge status of interfaces."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -541,11 +541,11 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_ptp">
+                        <div class="hidden" data-for="help_for_ptp">
                          <?=gettext("Set the interface as a point-to-point link. This is required for " .
                          "straight transitions to forwarding and should be enabled on a " .
                          "direct link to another RSTP-capable switch."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -560,13 +560,13 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_autoptp">
+                        <div class="hidden" data-for="help_for_autoptp">
                          <?=gettext("Automatically detect the point-to-point status on interface by " .
                          "checking the full duplex link status. This is the default for " .
                          "interfaces added to the bridge."); ?><br/>
                          <span class="text-warning"><strong><?=gettext("Note:"); ?><br /></strong></span>
                          <?=gettext("The interfaces selected here will be removed from default autoedge status."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -581,12 +581,12 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_static">
+                        <div class="hidden" data-for="help_for_static">
                           <?=gettext('Mark an interface as a "sticky" interface. Dynamically learned ' .
                           "address entries are treated as static once entered into the cache. " .
                           "Sticky entries are never aged out of the cache or " .
                           "replaced, even if the address is seen on a different interface."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -601,10 +601,10 @@ $(document).ready(function() {
 <?php
                           endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_private">
+                        <div class="hidden" data-for="help_for_private">
                           <?=gettext('Mark an interface as a "private" interface. A private interface does not forward any traffic to any other port that is also ' .
                           "a private interface."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                   </tbody>

--- a/src/www/interfaces_gif_edit.php
+++ b/src/www/interfaces_gif_edit.php
@@ -187,27 +187,27 @@ include("head.inc");
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_if">
+                      <div class="hidden" data-for="help_for_if">
                         <?=gettext("The interface here serves as the local address to be used for the gif tunnel."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_remote-addr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("GIF remote address"); ?></td>
                     <td>
                       <input name="remote-addr" type="text" value="<?=$pconfig['remote-addr'];?>" />
-                      <output class="hidden" for="help_for_remote-addr">
+                      <div class="hidden" data-for="help_for_remote-addr">
                         <?=gettext("Peer address where encapsulated gif packets will be sent. "); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tunnel-local-addr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("GIF tunnel local address"); ?></td>
                     <td>
                       <input name="tunnel-local-addr" type="text" value="<?=$pconfig['tunnel-local-addr'];?>" />
-                      <output class="hidden" for="help_for_tunnel-local-addr">
+                      <div class="hidden" data-for="help_for_tunnel-local-addr">
                         <?=gettext("Local gif tunnel endpoint"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -231,36 +231,36 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_tunnel-remote-addr">
+                      <div class="hidden" data-for="help_for_tunnel-remote-addr">
                         <?=gettext("Remote gif address endpoint. The subnet part is used for determining the network that is tunnelled."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_link0" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Route caching"); ?></td>
                     <td>
                       <input name="link0" type="checkbox" id="link0" <?=!empty($pconfig['link0']) ? "checked=\"checked\"" :"";?> />
-                      <output class="hidden" for="help_for_link0">
+                      <div class="hidden" data-for="help_for_link0">
                         <?=gettext("Specify if route caching can be enabled. Be careful with these settings on dynamic networks."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_link1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("ECN friendly behavior"); ?></td>
                     <td>
                       <input name="link1" type="checkbox" id="link1" <?=!empty($pconfig['link1']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_link1">
+                      <div class="hidden" data-for="help_for_link1">
                         <?=gettext("Note that the ECN friendly behavior violates RFC2893. This should be used in mutual agreement with the peer."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_gre_edit.php
+++ b/src/www/interfaces_gre_edit.php
@@ -164,27 +164,27 @@ include("head.inc");
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_if">
+                      <div class="hidden" data-for="help_for_if">
                           <?=gettext("The interface here serves as the local address to be used for the GRE tunnel.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_remote-addr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("GRE remote address");?></td>
                     <td>
                       <input name="remote-addr" type="text" value="<?=$pconfig['remote-addr'];?>" />
-                      <output class="hidden" for="help_for_remote-addr">
+                      <div class="hidden" data-for="help_for_remote-addr">
                         <?=gettext("Peer address where encapsulated GRE packets will be sent.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tunnel-local-addr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("GRE tunnel local address");?></td>
                     <td>
                       <input name="tunnel-local-addr" type="text" value="<?=$pconfig['tunnel-local-addr'];?>" />
-                      <output class="hidden" for="help_for_tunnel-local-addr">
+                      <div class="hidden" data-for="help_for_tunnel-local-addr">
                         <?=gettext("Local GRE tunnel endpoint");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -208,48 +208,48 @@ include("head.inc");
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_tunnel-remote-addr">
+                      <div class="hidden" data-for="help_for_tunnel-remote-addr">
                         <?=gettext("Remote GRE address endpoint. The subnet part is used for the determining the network that is tunneled.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_link0" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Mobile tunnel");?></td>
                     <td>
                       <input name="link0" type="checkbox" id="link0" <?= !empty($pconfig['link0']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_link0">
+                      <div class="hidden" data-for="help_for_link0">
                         <?=gettext("Specify which encapsulation method the tunnel should use.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_link1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Route search type");?></td>
                     <td>
                       <input name="link1" type="checkbox" id="link1" <?= !empty($pconfig['link1']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_link1">
+                      <div class="hidden" data-for="help_for_link1">
                         <?=gettext("For correct operation, the GRE device needs a route to the destination ".
                        "that is less specific than the one over the tunnel. (Basically, there ".
                        "needs to be a route to the decapsulating host that does not run over the ".
                        "tunnel, as this would be a loop.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_link2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("WCCP version");?></td>
                     <td>
                       <input name="link2" type="checkbox" id="link2" <?= !empty($pconfig['link2']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_link2">
+                      <div class="hidden" data-for="help_for_link2">
                         <?=gettext("Check this box for WCCP encapsulation version 2, or leave unchecked for version 1.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_groups_edit.php
+++ b/src/www/interfaces_groups_edit.php
@@ -156,19 +156,19 @@ legacy_html_escape_form_data($pconfig);
                     <td><a id="help_for_ifname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Group Name");?></td>
                     <td>
                       <input type="text" name="ifname" value="<?=$pconfig['ifname'];?>" />
-                      <output class="hidden" for="help_for_ifname">
+                      <div class="hidden" data-for="help_for_ifname">
                         <?=gettext("No numbers or spaces are allowed. Only characters in a-zA-Z");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here " .
                         "for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -187,10 +187,10 @@ legacy_html_escape_form_data($pconfig);
 <?php
                         endforeach;?>
                         </select>
-                      <output class="hidden" for="help_for_members">
+                      <div class="hidden" data-for="help_for_members">
                       <strong><?= gettext('NOTE:') ?></strong>
                       <?= gettext('Rules for WAN type interfaces in groups do not contain the reply-to mechanism upon which Multi-WAN typically relies.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_lagg_edit.php
+++ b/src/www/interfaces_lagg_edit.php
@@ -206,9 +206,9 @@ legacy_html_escape_form_data($pconfig);
 <?php
                         endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_members">
+                      <div class="hidden" data-for="help_for_members">
                         <?=gettext("Choose the members that will be used for the link aggregation"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -223,7 +223,7 @@ legacy_html_escape_form_data($pconfig);
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_proto">
+                      <div class="hidden" data-for="help_for_proto">
                         <ul>
                           <li><b><?=gettext("failover"); ?></b></li>
                                 <?=gettext("Sends and receives traffic only through the master port. " .
@@ -263,34 +263,34 @@ legacy_html_escape_form_data($pconfig);
                                    "traffic without disabling the lagg interface itself."); ?>
 
                         </ul>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_lacp_fast_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Fast timeout"); ?></td>
                     <td>
                       <input name="lacp_fast_timeout" id="lacp_fast_timeout" type="checkbox" value="yes" <?=!empty($pconfig['lacp_fast_timeout']) ? "checked=\"checked\"" : "" ;?>/>
-                      <output class="hidden" for="help_for_lacp_fast_timeout">
+                      <div class="hidden" data-for="help_for_lacp_fast_timeout">
                         <?=gettext("Enable lacp fast-timeout on the interface."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_mtu" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MTU"); ?></td>
                     <td>
                       <input name="mtu" id="mtu" type="text" value="<?=$pconfig['mtu'];?>" />
-                      <output class="hidden" for="help_for_mtu">
+                      <div class="hidden" data-for="help_for_mtu">
                         <?= gettext("If you leave this field blank, the smallest mtu of this laggs children will be used.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_ppps_edit.php
+++ b/src/www/interfaces_ppps_edit.php
@@ -460,18 +460,18 @@ include("head.inc");
 <?php
                           endforeach;?>
                           </select>
-                          <output class="hidden" for="help_for_ports">
+                          <div class="hidden" data-for="help_for_ports">
                             <?= gettext("Select at least two interfaces for Multilink (MLPPP) connections."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Description"); ?></td>
                         <td>
                           <input name="descr" type="text"  value="<?=$pconfig['descr'];?>" />
-                          <output class="hidden" for="help_for_descr">
+                          <div class="hidden" data-for="help_for_descr">
                             <?= gettext("You may enter a description here for your reference. Description will appear in the \"Interfaces Assign\" select lists."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr id="ppp_provider">
@@ -503,9 +503,9 @@ include("head.inc");
                               </td>
                             </tr>
                           </table>
-                          <output class="hidden" for="help_for_country">
+                          <div class="hidden" data-for="help_for_country">
                             <?=gettext("Select to fill in data for your service provider."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -524,9 +524,9 @@ include("head.inc");
                         <td><a id="help_for_phone" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Phone Number"); ?></td>
                         <td>
                           <input name="phone" type="text" id="phone" value="<?=$pconfig['phone'];?>" />
-                          <output class="hidden" for="help_for_phone">
+                          <div class="hidden" data-for="help_for_phone">
                             <?= gettext("Note: Typically *99# for GSM networks and #777 for CDMA networks"); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" name="apn_" id="apn_">
@@ -540,18 +540,18 @@ include("head.inc");
                         <td>
                           <input name="provider" type="text" id="provider" value="<?=$pconfig['provider'];?>" />&nbsp;&nbsp;
                           <input type="checkbox" value="on" id="null_service" name="null_service" <?=!empty($pconfig['null_service']) ? "checked=\"checked\"" : ""; ?> /> <?= gettext("Configure a NULL Service name"); ?>
-                          <output class="hidden" for="help_for_provider">
+                          <div class="hidden" data-for="help_for_provider">
                             <?= gettext("Hint: this field can usually be left empty. Service name will not be configured if this field is empty. Check the \"Configure NULL\" box to configure a blank Service name."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" name="hostuniqopt" id="hostuniqopt">
                         <td><a id="help_for_hostuniq" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Host-Uniq"); ?></td>
                         <td>
                           <input name="hostuniq" type="text" id="hostuniq" value="<?=$pconfig['hostuniq'];?>" />
-                          <output class="hidden" for="help_for_hostuniq">
+                          <div class="hidden" data-for="help_for_hostuniq">
                             <?= gettext('This field can usually be left empty unless specified by the provider.') ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                     </tbody>
@@ -572,18 +572,18 @@ include("head.inc");
                             </option>
                           <?php endfor; ?>
                           </select>
-                          <output class="hidden" for="help_for_localip_<?=$intf_idx;?>">
+                          <div class="hidden" data-for="help_for_localip_<?=$intf_idx;?>">
                             <?= gettext("IP Address"); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="intf_select_<?=$intf_idx;?>">
                         <td style="width:22%"><a id="help_for_gateway_<?=$intf_idx;?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?> <span class="intf_select_txt_<?=$intf_idx;?>"> </span></td>
                         <td style="width:78%">
                           <input name="gateway[]" type="text" class="intf_select_<?=$intf_idx;?>" value="<?=isset($pconfig['gateway'][$intf_idx]) ? $pconfig['gateway'][$intf_idx] : "";?>" />
-                          <output class="hidden" for="help_for_gateway_<?=$intf_idx;?>">
+                          <div class="hidden" data-for="help_for_gateway_<?=$intf_idx;?>">
                             <?= gettext("IP Address OR Hostname"); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
 <?php
@@ -622,9 +622,9 @@ include("head.inc");
                         <td style="width:22%"><a id="help_for_apnum" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("APN number (optional)"); ?></td>
                         <td style="width:78%">
                           <input name="apnum" type="text" id="apnum" value="<?=$pconfig['apnum'];?>" />
-                          <output class="hidden" for="help_for_apnum">
+                          <div class="hidden" data-for="help_for_apnum">
                             <?= gettext("Note: Defaults to 1 if you set APN above. Ignored if you set no APN above."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -637,28 +637,28 @@ include("head.inc");
                         <td><a id="help_for_pin-wait" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("SIM PIN wait"); ?></td>
                         <td>
                           <input name="pin-wait" type="text" cid="pin-wait"  value="<?=$pconfig['pin-wait'];?>" />
-                          <output class="hidden" for="help_for_pin-wait">
+                          <div class="hidden" data-for="help_for_pin-wait">
                             <?= gettext("Note: Time to wait for SIM to discover network after PIN is sent to SIM (seconds)."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
                         <td><a id="help_for_initstr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Init String"); ?></td>
                         <td>
                           <input type="text" id="initstr" name="initstr" value="<?=$pconfig['initstr'];?>" />
-                          <output class="hidden" for="help_for_initstr">
+                          <div class="hidden" data-for="help_for_initstr">
                             <?= gettext("Note: Enter the modem initialization string here. Do NOT include the \"AT\"" .
                           " string at the beginning of the command. Many modern USB 3G modems don't need an initialization string."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
                         <td><a id="help_for_connect-timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Connection Timeout"); ?></td>
                         <td>
                           <input name="connect-timeout" type="text" id="connect-timeout" value="<?=$pconfig['connect-timeout'];?>" />
-                          <output class="hidden" for="help_for_connect-timeout">
+                          <div class="hidden" data-for="help_for_connect-timeout">
                             <?= gettext("Note: Enter timeout in seconds for connection to be established (sec.) Default is 45 sec."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -666,9 +666,9 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="uptime" name="uptime" <?=!empty($pconfig['uptime']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Enable persistent logging of connection uptime."); ?>
-                          <output class="hidden" for="help_for_uptime">
+                          <div class="hidden" data-for="help_for_uptime">
                             <?= gettext("This option causes cumulative uptime to be recorded and displayed on the Status Interfaces page."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                     </tbody>
@@ -681,21 +681,21 @@ include("head.inc");
                         <td style="width:78%">
                           <input type="checkbox" value="on" id="ondemand" name="ondemand" <?=!empty($pconfig['ondemand']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Enable Dial-on-Demand mode"); ?>
-                          <output class="hidden" for="help_for_ondemand">
+                          <div class="hidden" data-for="help_for_ondemand">
                             <?= gettext("This option causes the interface to operate in dial-on-demand mode. Do NOT enable if you want your link to be always up. " .
                             "The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected."); ?> </span>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
                         <td><a id="help_for_idletimeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Idle Timeout"); ?></td>
                         <td>
                           <input name="idletimeout" type="text" id="idletimeout" value="<?=$pconfig['idletimeout'];?>" />
-                          <output class="hidden" for="help_for_idletimeout">
+                          <div class="hidden" data-for="help_for_idletimeout">
                             <?= gettext("(seconds) Default is 0, which disables the timeout feature."); ?><br /><br />
                             <?= gettext("If no incoming or outgoing packets are transmitted for the entered number of seconds the connection is brought down.");?>
                             <br /><?=gettext("When the idle timeout occurs, if the dial-on-demand option is enabled, mpd goes back into dial-on-demand mode. Otherwise, the interface is brought down and all associated routes removed."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -703,11 +703,11 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="vjcomp" name="vjcomp" <?= !empty($pconfig['vjcomp']) ? 'checked="checked"' : '' ?> />
                           <?= gettext("Disable vjcomp(compression) (auto-negotiated by default)."); ?>
-                          <output class="hidden" for="help_for_vjcomp">
+                          <div class="hidden" data-for="help_for_vjcomp">
                             <?=gettext("This option enables Van Jacobson TCP header compression, which saves several bytes per TCP data packet. " .
                               "You almost always want this option. This compression ineffective for TCP connections with enabled modern extensions like time " .
                               "stamping or SACK, which modify TCP options between sequential packets.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -715,13 +715,13 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="tcpmssfix" name="tcpmssfix" <?=!empty($pconfig['tcpmssfix']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Disable tcpmssfix (enabled by default)."); ?>
-                          <output class="hidden" for="help_for_tcpmssfix">
+                          <div class="hidden" data-for="help_for_tcpmssfix">
                             <?=gettext("This option causes mpd to adjust incoming and outgoing TCP SYN segments so that the requested maximum segment size is not greater than the amount ".
                               "allowed by the interface MTU. This is necessary in many setups to avoid problems caused by routers that drop ICMP Datagram Too Big messages. Without these messages, ".
                               "the originating machine sends data, it passes the rogue router then hits a machine that has an MTU that is not big enough for the data. Because the IP Don't Fragment option is set, ".
                               "this machine sends an ICMP Datagram Too Big message back to the originator and drops the packet. The rogue router drops the ICMP message and the originator never ".
                               "gets to discover that it must reduce the fragment size or drop the IP Don't Fragment option from its outgoing data.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -729,10 +729,10 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="shortseq" name="shortseq" <?=!empty($pconfig['shortseq']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Disable shortseq (auto-negotiated by default)."); ?>
-                          <output class="hidden" for="help_for_shortseq">
+                          <div class="hidden" data-for="help_for_shortseq">
                             <?= gettext("This option is only meaningful if multi-link PPP is negotiated. It proscribes shorter multi-link fragment headers, saving two bytes on every frame. " .
                             "It is not necessary to disable this for connections that are not multi-link."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -740,9 +740,9 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="acfcomp" name="acfcomp" <?=!empty($pconfig['acfcomp']) ? "checked=\"checked\"" : ""; ?> />
                           <?= gettext("Disable acfcomp (compression) (auto-negotiated by default)."); ?>
-                          <output class="hidden" for="help_for_acfcomp">
+                          <div class="hidden" data-for="help_for_acfcomp">
                             <?= gettext("Address and control field compression. This option only applies to asynchronous link types. It saves two bytes per frame."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr style="display:none" class="act_show_advanced">
@@ -750,9 +750,9 @@ include("head.inc");
                         <td>
                           <input type="checkbox" value="on" id="protocomp" name="protocomp" <?=!empty($pconfig['protocomp']) ? "checked=\"checked\"" :""; ?> />
                           <?= gettext("Disable protocomp (compression) (auto-negotiated by default)."); ?>
-                          <output class="hidden" for="help_for_protocomp">
+                          <div class="hidden" data-for="help_for_protocomp">
                             <?= gettext("Protocol field compression. This option saves one byte per frame for most frames."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                     </tbody>
@@ -790,14 +790,14 @@ include("head.inc");
                               </td>
                             </tr>
                           </table>
-                          <output class="hidden" for="help_for_link_<?=$intf_idx;?>">
+                          <div class="hidden" data-for="help_for_link_<?=$intf_idx;?>">
                             <ul>
                               <li><?=gettext("Bandwidth: Set ONLY for MLPPP connections and ONLY when links have different bandwidths.");?></li>
                               <li><?=gettext("MTU: MTU will default to 1492.");?></li>
                               <li><?=gettext("MRU: MRU will be auto-negotiated by default.");?></li>
                               <li><?=gettext("MRRU: Set ONLY for MLPPP connections. MRRU will be auto-negotiated by default.");?></li>
                             </ul>
-                          </output>
+                          </div>
                         </td>
                       </tr>
 <?php

--- a/src/www/interfaces_qinq_edit.php
+++ b/src/www/interfaces_qinq_edit.php
@@ -162,27 +162,27 @@ include("head.inc");
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_if">
+                      <div class="hidden" data-for="help_for_if">
                         <?=gettext("Only QinQ capable interfaces will be shown.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tag" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("First level tag");?></td>
                     <td>
                       <input name="tag" type="text" value="<?=$pconfig['tag'];?>" />
-                      <output class="hidden" for="help_for_tag">
+                      <div class="hidden" data-for="help_for_tag">
                         <?=gettext("This is the first level VLAN tag. On top of this are stacked the member VLANs defined below.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_vlan_edit.php
+++ b/src/www/interfaces_vlan_edit.php
@@ -190,18 +190,18 @@ include("head.inc");
                       endforeach;?>
 
                       </select>
-                      <output class="hidden" for="help_for_if">
+                      <div class="hidden" data-for="help_for_if">
                         <?=gettext("Only VLAN capable interfaces will be shown.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tag" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("VLAN tag");?></td>
                     <td>
                       <input name="tag" type="text" value="<?=$pconfig['tag'];?>" />
-                      <output class="hidden" for="help_for_tag">
+                      <div class="hidden" data-for="help_for_tag">
                         <?=gettext("802.1Q VLAN tag (between 1 and 4094)");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -212,18 +212,18 @@ include("head.inc");
                         <option value="<?=$pcp;?>"<?=($pconfig['pcp'] == $pcp ? ' selected="selected"' : '');?>><?=htmlspecialchars($priority);?></option>
 <? endforeach ?>
                       </select>
-                      <output class="hidden" for="help_for_pcp">
+                      <div class="hidden" data-for="help_for_pcp">
                         <?=gettext('802.1Q VLAN PCP (priority code point)');?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/interfaces_wireless_edit.php
+++ b/src/www/interfaces_wireless_edit.php
@@ -171,9 +171,9 @@ include("head.inc");
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                   <td>
                     <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                    </output>
+                    </div>
                   </div>
                 </tr>
                 <tr>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -661,9 +661,9 @@ include("head.inc");
                       <td><a id="help_for_denyunknown" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Deny unknown clients");?></td>
                       <td>
                         <input name="denyunknown" type="checkbox" value="yes" <?=!empty($pconfig['denyunknown']) ? "checked=\"checked\"" : ""; ?> />
-                        <output class="hidden" for="help_for_denyunknown">
+                        <div class="hidden" data-for="help_for_denyunknown">
                           <?=gettext("If this is checked, only the clients defined below will get DHCP leases from this server.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -748,9 +748,9 @@ include("head.inc");
                             endforeach;?>
                             </tbody>
                         </table>
-                        <output class="hidden" for="help_for_additionalpools">
+                        <div class="hidden" data-for="help_for_additionalpools">
                             <?=gettext("If you need additional pools of addresses inside of this subnet outside the above Range, they may be specified here."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -767,65 +767,65 @@ include("head.inc");
                       <td>
                         <input name="dns1" type="text" value="<?=$pconfig['dns1'];?>" /><br />
                         <input name="dns2" type="text" value="<?=$pconfig['dns2'];?>" />
-                        <output class="hidden" for="help_for_dns">
+                        <div class="hidden" data-for="help_for_dns">
                           <?=gettext("NOTE: leave blank to use the system default DNS servers - this interface's IP if DNS forwarder is enabled, otherwise the servers configured on the General page.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_gateway" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?></td>
                       <td>
                         <input name="gateway" type="text" class="form-control host" value="<?=$pconfig['gateway'];?>" />
-                        <output class="hidden" for="help_for_gateway">
+                        <div class="hidden" data-for="help_for_gateway">
                           <?=gettext('The default is to use the IP on this interface of the firewall as the gateway. Specify an alternate gateway here if this is not the correct gateway for your network. Type "none" for no gateway assignment.');?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain name");?></td>
                       <td>
                         <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                        <output class="hidden" for="help_for_domain">
+                        <div class="hidden" data-for="help_for_domain">
                           <?=gettext("The default is to use the domain name of this system as the default domain name provided by DHCP. You may specify an alternate domain name here.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_domainsearchlist" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain search list");?></td>
                       <td>
                         <input name="domainsearchlist" type="text" id="domainsearchlist" value="<?=$pconfig['domainsearchlist'];?>" />
-                        <output class="hidden" for="help_for_domainsearchlist">
+                        <div class="hidden" data-for="help_for_domainsearchlist">
                           <?=gettext("The DHCP server can optionally provide a domain search list. Use the semicolon character as separator.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_defaultleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Default lease time (seconds)")?></td>
                       <td>
                         <input name="defaultleasetime" type="text" id="defaultleasetime" value="<?=$pconfig['defaultleasetime'];?>" />
-                        <output class="hidden" for="help_for_defaultleasetime">
+                        <div class="hidden" data-for="help_for_defaultleasetime">
                           <?=gettext("This is used for clients that do not ask for a specific expiration time."); ?><br />
                           <?=gettext("The default is 7200 seconds.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_maxleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Maximum lease time");?> (<?=gettext("seconds");?>)</td>
                       <td>
                         <input name="maxleasetime" type="text" id="maxleasetime" value="<?=$pconfig['maxleasetime'];?>" />
-                        <output class="hidden" for="help_for_maxleasetime">
+                        <div class="hidden" data-for="help_for_maxleasetime">
                           <?=gettext("This is the maximum lease time for clients that ask for a specific expiration time."); ?><br />
                           <?=gettext("The default is 86400 seconds.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_interface_mtu" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Interface MTU");?></td>
                       <td>
                         <input name="interface_mtu"  type="text" value="<?=$pconfig['interface_mtu']?>" />
-                        <output class="hidden" for="help_for_interface_mtu">
+                        <div class="hidden" data-for="help_for_interface_mtu">
                           <?=gettext('This option specifies the MTU to use on this interface. The minimum legal value for the MTU is 68.');?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -834,9 +834,9 @@ include("head.inc");
                       <td><a id="help_for_failover_peerip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Failover peer IP:");?></td>
                       <td>
                         <input name="failover_peerip" type="text" class="form-control host" id="failover_peerip" value="<?=$pconfig['failover_peerip'];?>" />
-                        <output class="hidden" for="help_for_failover_peerip">
+                        <div class="hidden" data-for="help_for_failover_peerip">
                           <?=gettext("Leave blank to disable. Enter the interface IP address of the other machine. Machines must be using CARP. Interface's advskew determines whether the DHCPd process is Primary or Secondary. Ensure one machine's advskew<20 (and the other is >20).");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -844,9 +844,9 @@ include("head.inc");
                       <td>
                         <input type="checkbox" value="yes" name="staticarp" <?=!empty($pconfig['staticarp']) ? " checked=\"checked\"" : ""; ?> />&nbsp;
                         <strong><?=gettext("Enable Static ARP entries");?></strong>
-                        <output class="hidden" for="help_for_failover_staticarp">
+                        <div class="hidden" data-for="help_for_failover_staticarp">
                           <?=gettext("Warning: This option persists even if DHCP server is disabled. Only the machines listed below will be able to communicate with the firewall on this NIC.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -855,11 +855,11 @@ include("head.inc");
                         <input name="dhcpleaseinlocaltime" type="checkbox" id="dhcpleaseinlocaltime" value="yes" <?= !empty($pconfig['dhcpleaseinlocaltime']) ? "checked=\"checked\"" : ""; ?> />
                         <strong><?=gettext("Change DHCP display lease time from UTC to local time."); ?></strong>
 
-                        <output class="hidden" for="help_for_failover_dhcpleaseinlocaltime">
+                        <div class="hidden" data-for="help_for_failover_dhcpleaseinlocaltime">
                           <?=gettext("Warning: By default DHCP leases are displayed in UTC time. By checking this " .
                           "box DHCP lease time will be displayed in local time and set to time zone selected. This " .
                           "will be used for all DHCP interfaces lease time."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -1043,9 +1043,9 @@ include("head.inc");
                               </tr>
                             </tfoot>
                           </table>
-                          <output class="hidden" for="help_for_numberoptions">
+                          <div class="hidden" data-for="help_for_numberoptions">
                           <?= sprintf(gettext("Enter the DHCP option number and the value for each item you would like to include in the DHCP lease information. For a list of available options please visit this %sURL%s."), '<a href="http://www.iana.org/assignments/bootp-dhcp-parameters/" target="_blank">', '</a>') ?>
-                          </output>
+                          </div>
                         </div>
                       </td>
                     </tr>

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -340,9 +340,9 @@ include("head.inc");
                     $mac = `/usr/sbin/arp -an | grep {$ip} | /usr/bin/head -n1 | /usr/bin/cut -d" " -f4`;
                     $mac = str_replace("\n","",$mac);?>
                     <a onclick="$('#mac').val('<?=$mac?>');" href="#"><?=gettext("Copy my MAC address");?></a>
-                    <output class="hidden" for="help_for_mac">
+                    <div class="hidden" data-for="help_for_mac">
                       <?=gettext("Enter a MAC address in the following format: "."xx:xx:xx:xx:xx:xx");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -355,20 +355,20 @@ include("head.inc");
                   <td><a id="help_for_ipaddr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP address");?></td>
                   <td>
                     <input name="ipaddr" type="text" value="<?=$pconfig['ipaddr'];?>" />
-                    <output class="hidden" for="help_for_ipaddr">
+                    <div class="hidden" data-for="help_for_ipaddr">
                       <?=gettext("If an IPv4 address is entered, the address must be outside of the pool.");?>
                       <br />
                       <?=gettext("If no IPv4 address is given, one will be dynamically allocated from the pool.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_hostname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname");?></td>
                   <td>
                     <input name="hostname" type="text" value="<?=$pconfig['hostname'];?>" />
-                    <output class="hidden" for="help_for_hostname">
+                    <div class="hidden" data-for="help_for_hostname">
                       <?=gettext("Name of the host, without domain part.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php
@@ -377,18 +377,18 @@ include("head.inc");
                   <td><a id="help_for_filename" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Netboot Filename') ?></td>
                   <td>
                     <input name="filename" type="text" id="filename" size="20" value="<?=$pconfig['filename'];?>" />
-                    <output class="hidden" for="help_for_filename">
+                    <div class="hidden" data-for="help_for_filename">
                       <?= gettext('Name of the file that should be loaded when this host boots off of the network, overrides setting on main page.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_rootpath" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Root Path') ?></td>
                   <td>
                     <input name="rootpath" type="text" value="<?=$pconfig['rootpath'];?>" />
-                    <output class="hidden" for="help_for_rootpath">
+                    <div class="hidden" data-for="help_for_rootpath">
                       <?= gettext("Enter the root-path-string, overrides setting on main page.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php
@@ -397,18 +397,18 @@ include("head.inc");
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                   <td>
                     <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here ". "for your reference (not parsed).");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_arp_table_static_entry" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("ARP Table Static Entry");?></td>
                   <td>
                     <input name="arp_table_static_entry" id="arp_table_static_entry" type="checkbox" value="yes" <?=!empty($pconfig['arp_table_static_entry']) ? "checked=\"checked\"" : ""; ?> />
-                    <output class="hidden" for="help_for_arp_table_static_entry">
+                    <div class="hidden" data-for="help_for_arp_table_static_entry">
                       <?=gettext('Create a static ARP table entry for this MAC and IP address pair.');?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -423,56 +423,56 @@ include("head.inc");
                   <td>
                     <input name="dns1" type="text" value="<?=$pconfig['dns1'];?>" /><br/>
                     <input name="dns2" type="text" value="<?=$pconfig['dns2'];?>" />
-                    <output class="hidden" for="help_for_dns">
+                    <div class="hidden" data-for="help_for_dns">
                       <?=gettext("NOTE: leave blank to use the system default DNS servers - this interface's IP if DNS forwarder is enabled, otherwise the servers configured on the General page.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_gateway" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway");?></td>
                   <td>
                     <input name="gateway" type="text" value="<?=$pconfig['gateway'];?>" />
-                    <output class="hidden" for="help_for_gateway">
+                    <div class="hidden" data-for="help_for_gateway">
                       <?=gettext("The default is to use the IP on this interface of the firewall as the gateway. Specify an alternate gateway here if this is not the correct gateway for your network.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain name");?></td>
                   <td>
                     <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                    <output class="hidden" for="help_for_domain">
+                    <div class="hidden" data-for="help_for_domain">
                       <?=gettext("The default is to use the domain name of this system as the default domain name provided by DHCP. You may specify an alternate domain name here.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_domainsearchlist" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain search list");?></td>
                   <td>
                     <input name="domainsearchlist" type="text" id="domainsearchlist" size="20" value="<?=$pconfig['domainsearchlist'];?>" />
-                    <output class="hidden" for="help_for_domainsearchlist">
+                    <div class="hidden" data-for="help_for_domainsearchlist">
                       <?=gettext("The DHCP server can optionally provide a domain search list. Use the semicolon character as separator ");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_defaultleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Default lease time");?> (<?=gettext("seconds");?>)</td>
                   <td>
                     <input name="defaultleasetime" type="text" id="deftime" size="10" value="<?=$pconfig['defaultleasetime'];?>" />
-                    <output class="hidden" for="help_for_defaultleasetime">
+                    <div class="hidden" data-for="help_for_defaultleasetime">
                       <?=gettext("This is used for clients that do not ask for a specific " ."expiration time."); ?><br />
                       <?=gettext("The default is 7200 seconds.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_maxleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Maximum lease time");?> (<?=gettext("seconds");?>)</td>
                   <td>
                     <input name="maxleasetime" type="text" value="<?=$pconfig['maxleasetime'];?>" />
-                    <output class="hidden" for="help_for_maxleasetime">
+                    <div class="hidden" data-for="help_for_maxleasetime">
                       <?=gettext("This is the maximum lease time for clients that ask"." for a specific expiration time."); ?><br />
                       <?=gettext("The default is 86400 seconds.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/services_dhcp_relay.php
+++ b/src/www/services_dhcp_relay.php
@@ -144,9 +144,9 @@ include("head.inc");
 <?php
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_interface">
+                        <div class="hidden" data-for="help_for_interface">
                           <?= gettext('Interfaces without an IP address will not be shown.') ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -154,18 +154,18 @@ include("head.inc");
                       <td>
                           <input name="agentoption" type="checkbox" value="yes" <?=!empty($pconfig['agentoption']) ? "checked=\"checked\"" : ""; ?> />
                           <strong><?=gettext("Append circuit ID and agent ID to requests"); ?></strong><br />
-                          <output class="hidden" for="help_for_agentoption">
+                          <div class="hidden" data-for="help_for_agentoption">
                             <?= gettext('If this is checked, the DHCP relay will append the circuit ID (interface number) and the agent ID to the DHCP request.') ?>
-                          </output>
+                          </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination servers");?></td>
                       <td>
                         <input name="server" type="text" value="<?=!empty($pconfig['server']) ? htmlspecialchars($pconfig['server']):"";?>" />
-                        <output class="hidden" for="help_for_server">
+                        <div class="hidden" data-for="help_for_server">
                           <?=gettext("These are the IP addresses of servers to which DHCP requests are relayed. You can enter multiple server IP addresses, separated by commas. Select \"Proxy requests to DHCP server on WAN subnet\" to relay DHCP packets to the server that was used on the WAN interface.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -506,10 +506,10 @@ include("head.inc");
                               <td></td>
                           </tbody>
                         </table>
-                        <output class="hidden" for="help_for_prefixrange">
+                        <div class="hidden" data-for="help_for_prefixrange">
                           <?= gettext("You can define a Prefix range here for DHCP Prefix Delegation. This allows for assigning networks to subrouters. " .
                           "The start and end of the range must end on boundaries of the prefix delegation size."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -517,47 +517,47 @@ include("head.inc");
                       <td>
                         <input name="dns1" type="text" id="dns1" value="<?=$pconfig['dns1'];?>" /><br />
                         <input name="dns2" type="text" id="dns2" value="<?=$pconfig['dns2'];?>" />
-                        <output class="hidden" for="help_for_dns">
+                        <div class="hidden" data-for="help_for_dns">
                           <?=gettext("Leave blank to use the system default DNS servers - this interface's IP if DNS forwarder is enabled, otherwise the servers configured on the General page.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain name");?></td>
                       <td>
                         <input name="domain" type="text" id="domain" value="<?=$pconfig['domain'];?>" /><br />
-                        <output class="hidden" for="help_for_domain">
+                        <div class="hidden" data-for="help_for_domain">
                           <?=gettext("The default is to use the domain name of this system as the default domain name provided by DHCP. You may specify an alternate domain name here.");?>
-                        </output>
+                        </div>
                      </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_domainsearchlist" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain search list");?></td>
                       <td>
                         <input name="domainsearchlist" type="text" id="domainsearchlist" value="<?=$pconfig['domainsearchlist'];?>" /><br />
-                        <output class="hidden" for="help_for_domainsearchlist">
+                        <div class="hidden" data-for="help_for_domainsearchlist">
                           <?=gettext("The DHCP server can optionally provide a domain search list. Use the semicolon character as separator");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_defaultleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Default lease time");?> (<?=gettext("seconds");?>)</td>
                       <td>
                         <input name="defaultleasetime" type="text" value="<?=$pconfig['defaultleasetime'];?>" />
-                        <output class="hidden" for="help_for_defaultleasetime">
+                        <div class="hidden" data-for="help_for_defaultleasetime">
                           <?=gettext("This is used for clients that do not ask for a specific expiration time."); ?><br />
                           <?=gettext("The default is 7200 seconds.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_maxleasetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Maximum lease time");?> (<?=gettext("seconds");?>)</td>
                       <td>
                         <input name="maxleasetime" type="text" id="maxleasetime" size="10" value="<?=$pconfig['maxleasetime'];?>" />
-                        <output class="hidden" for="help_for_maxleasetime">
+                        <div class="hidden" data-for="help_for_maxleasetime">
                           <?=gettext("This is the maximum lease time for clients that ask for a specific expiration time."); ?><br />
                           <?=gettext("The default is 86400 seconds.");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -567,9 +567,9 @@ include("head.inc");
                         <strong>
                           <?=gettext("Change DHCPv6 display lease time from UTC to local time."); ?>
                         </strong>
-                        <output class="hidden" for="help_for_dhcpv6leaseinlocaltime">
+                        <div class="hidden" data-for="help_for_dhcpv6leaseinlocaltime">
                           <?=gettext("By default DHCPv6 leases are displayed in UTC time. By checking this box DHCPv6 lease time will be displayed in local time and set to time zone selected. This will be used for all DHCPv6 interfaces lease time."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -711,9 +711,9 @@ include("head.inc");
                               </tr>
                             </tfoot>
                           </table>
-                          <output class="hidden" for="help_for_numberoptions">
+                          <div class="hidden" data-for="help_for_numberoptions">
                           <?= sprintf(gettext("Enter the DHCP option number and the value for each item you would like to include in the DHCP lease information. For a list of available options please visit this %sURL%s."),'<a href="http://www.iana.org/assignments/bootp-dhcp-parameters/" target="_blank">','</a>') ?>
-                          </output>
+                          </div>
                         </div>
                       </td>
                     </tr>

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -165,40 +165,40 @@ include("head.inc");
                     <td><a id="help_for_duid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DUID Identifier");?></td>
                     <td>
                       <input name="duid" type="text" value="<?=$pconfig['duid'];?>" />
-                      <output class="hidden" for="help_for_duid">
+                      <div class="hidden" data-for="help_for_duid">
                         <?=gettext("Enter a DUID Identifier in the following format: ");?><br />
                         "<?= gettext('DUID-LLT - ETH -- TIME --- ---- ADDR ----') ?>" <br />
                         "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_ipaddrv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 address");?></td>
                     <td>
                       <input name="ipaddrv6" type="text" value="<?=$pconfig['ipaddrv6'];?>" />
-                      <output class="hidden" for="help_for_ipaddrv6">
+                      <div class="hidden" data-for="help_for_ipaddrv6">
                         <?=gettext("If an IPv6 address is entered, the address must be outside of the pool.");?>
                         <br />
                         <?=gettext("If no IPv6 address is given, one will be dynamically allocated from the pool.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_hostname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname");?></td>
                     <td>
                       <input name="hostname" type="text" value="<?=$pconfig['hostname'];?>" />
-                      <output class="hidden" for="help_for_hostname">
+                      <div class="hidden" data-for="help_for_hostname">
                         <?=gettext("Name of the host, without domain part.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain name");?></td>
                     <td>
                       <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                      <output class="hidden" for="help_for_domain">
+                      <div class="hidden" data-for="help_for_domain">
                         <?=gettext("The default is to use the domain name of this system as the default domain name provided by DHCP. You may specify an alternate domain name here.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php if (isset($config['dhcpdv6'][$if]['netboot'])): ?>
@@ -206,18 +206,18 @@ include("head.inc");
                     <td><a id="help_for_filename" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Netboot filename') ?></td>
                     <td>
                       <input name="filename" type="text" value="<?=$pconfig['filename'];?>" />
-                      <output class="hidden" for="help_for_filename">
+                      <div class="hidden" data-for="help_for_filename">
                         <?= gettext('Name of the file that should be loaded when this host boots off of the network, overrides setting on main page.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_rootpath" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Root Path') ?></td>
                     <td>
                       <input name="rootpath" type="text" value="<?=$pconfig['rootpath'];?>" />
-                      <output class="hidden" for="help_for_rootpath">
+                      <div class="hidden" data-for="help_for_rootpath">
                         <?= gettext('Enter the root-path-string, overrides setting on main page.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -226,9 +226,9 @@ include("head.inc");
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here "."for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_dhcpv6_relay.php
+++ b/src/www/services_dhcpv6_relay.php
@@ -147,27 +147,27 @@ include("head.inc");
 <?php
                         endforeach;?>
                         </select>
-                        <output class="hidden" for="help_for_interface">
+                        <div class="hidden" data-for="help_for_interface">
                           <?=gettext("Interfaces without an IPv6 address will not be shown."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_agentoption" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Append circuit ID");?></td>
                       <td>
                         <input name="agentoption" type="checkbox" value="yes" <?=!empty($pconfig['agentoption']) ? "checked=\"checked\"" : ""; ?> />
-                        <output class="hidden" for="help_for_agentoption">
+                        <div class="hidden" data-for="help_for_agentoption">
                           <?= gettext('If this is checked, the DHCPv6 relay will append the circuit ID (interface number) and the agent ID to the DHCPv6 request.') ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination server");?></td>
                       <td>
                         <input name="server" type="text" value="<?=!empty($pconfig['server']) ? htmlspecialchars($pconfig['server']):"";?>" />
-                        <output class="hidden" for="help_for_server">
+                        <div class="hidden" data-for="help_for_server">
                           <?=gettext("This is the IPv6 address of the server to which DHCPv6 requests are relayed. You can enter multiple server IPv6 addresses, separated by commas. ");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -248,23 +248,23 @@ $( document ).ready(function() {
                   <td>
                     <input name="regdhcp" type="checkbox" id="regdhcp" value="yes" <?=!empty($pconfig['regdhcp']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Register DHCP leases in DNS forwarder");?></strong>
-                    <output class="hidden" for="help_for_regdhcp">
+                    <div class="hidden" data-for="help_for_regdhcp">
                       <?= gettext("If this option is set, then machines that specify " .
                         "their hostname when requesting a DHCP lease will be registered " .
                         "in the DNS forwarder, so that their name can be resolved.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_regdhcpdomain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Domain Override");?></td>
                   <td>
                     <input name="regdhcpdomain" type="text" id="regdhcpdomain" value="<?= $pconfig['regdhcpdomain'] ?>"/>
-                    <output class="hidden" for="help_for_regdhcpdomain">
+                    <div class="hidden" data-for="help_for_regdhcpdomain">
                       <?= gettext("The domain name to use for DHCP hostname registration. " .
                         "If empty, the default system domain is used. Note that all DHCP " .
                         "leases will be assigned to the same domain. If this is undesired, " .
                         "static DHCP lease registration is able to provide coherent mappings.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -272,12 +272,12 @@ $( document ).ready(function() {
                   <td>
                     <input name="regdhcpstatic" type="checkbox" id="regdhcpstatic" value="yes" <?=!empty($pconfig['regdhcpstatic']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Register DHCP static mappings in DNS forwarder");?></strong>
-                    <output class="hidden" for="help_for_regdhcpstatic">
+                    <div class="hidden" data-for="help_for_regdhcpstatic">
                       <?= sprintf(gettext("If this option is set, then DHCP static mappings will ".
                           "be registered in the DNS forwarder, so that their name can be ".
                           "resolved. You should also set the domain in %s".
                           "System: General setup%s to the proper value."),'<a href="system_general.php">','</a>');?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -285,11 +285,11 @@ $( document ).ready(function() {
                   <td>
                     <input name="dhcpfirst" type="checkbox" id="dhcpfirst" value="yes" <?=!empty($pconfig['dhcpfirst']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Resolve DHCP mappings first");?></strong>
-                    <output class="hidden" for="help_for_dhcpfirst">
+                    <div class="hidden" data-for="help_for_dhcpfirst">
                       <?= sprintf(gettext("If this option is set, then DHCP mappings will ".
                           "be resolved before the manual list of names below. This only ".
                           "affects the name given for a reverse lookup (PTR)."));?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -300,30 +300,30 @@ $( document ).ready(function() {
                         <td>
                           <input name="strict_order" type="checkbox" id="strict_order" value="yes" <?=!empty($pconfig['strict_order']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Query DNS servers sequentially");?></strong>
-                          <output class="hidden" for="help_for_strict_order">
+                          <div class="hidden" data-for="help_for_strict_order">
                             <?= gettext("If this option is set, the DNS Forwarder (dnsmasq) will ".
                               "query the DNS servers sequentially in the order specified (System: " .
                               "General Setup: DNS Servers), rather than all at once in parallel.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td>
                           <input name="domain_needed" type="checkbox" id="domain_needed" value="yes" <?=!empty($pconfig['domain_needed']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Require domain");?></strong>
-                          <output class="hidden" for="help_for_strict_order">
+                          <div class="hidden" data-for="help_for_strict_order">
                             <?= gettext('If this option is set, the DNS Forwarder (dnsmasq) will '.
                               'not forward A or AAAA queries for plain names, without dots or ' .
                               'domain parts, to upstream name servers. If the name is not known ' .
                               'from /etc/hosts or DHCP then a "not found" answer is returned.') ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td>
                           <input name="no_private_reverse" type="checkbox" id="no_private_reverse" value="yes" <?=!empty($pconfig['no_private_reverse']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Do not forward private reverse lookups");?></strong>
-                          <output class="hidden" for="help_for_strict_order">
+                          <div class="hidden" data-for="help_for_strict_order">
                             <?= gettext('If this option is set, the DNS Forwarder (dnsmasq) will '.
                               'not forward reverse DNS lookups (PTR) for private addresses ' .
                               '(RFC 1918) to upstream name servers. Any entries in the Domain ' .
@@ -331,7 +331,7 @@ $( document ).ready(function() {
                               'to a specific server are still forwarded. If the IP to name is ' .
                               'not known from /etc/hosts, DHCP or a specific domain override ' .
                               'then a "not found" answer is immediately returned.') ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                     </table>
@@ -341,9 +341,9 @@ $( document ).ready(function() {
                   <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>
                   <td>
                     <input name="port" type="text" id="port" size="6" <?=!empty($pconfig['port']) ? "value=\"{$pconfig['port']}\"" : "";?> />
-                    <output class="hidden" for="help_for_port">
+                    <div class="hidden" data-for="help_for_port">
                       <?=gettext("The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -361,17 +361,17 @@ $( document ).ready(function() {
 <?php
                       endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_interfaces">
+                    <div class="hidden" data-for="help_for_interfaces">
                       <?=gettext("Interface IPs used by the DNS Forwarder for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
-                    </output>
+                    </div>
                     <br/>
                     <input name="strictbind" type="checkbox" id="strictbind" value="yes" <?= !empty($pconfig['strictbind']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Strict Interface Binding");?></strong>
-                    <output class="hidden" for="help_for_interfaces">
+                    <div class="hidden" data-for="help_for_interfaces">
                       <?= gettext("If this option is set, the DNS forwarder will only bind to the interfaces containing the IP addresses selected above, rather than binding to all interfaces and discarding queries to other addresses."); ?>
                       <br /><br />
                       <?= gettext("NOTE: This option does NOT work with IPv6. If set, dnsmasq will not bind to IPv6 addresses."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/www/services_dnsmasq_domainoverride_edit.php
@@ -147,48 +147,48 @@ include("head.inc");
                       <td style="width:22%"><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
                       <td style="width:78%">
                         <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                        <output class="hidden" for="help_for_domain">
+                        <div class="hidden" data-for="help_for_domain">
                           <?=gettext("Domain to override (NOTE: this does not have to be a valid TLD!)"); ?><br />
                           <?=gettext("e.g."); ?> <em><?=gettext("test"); ?></em> <?=gettext("or"); ?> <em>mycompany.localdomain</em> <?=gettext("or"); ?> <em>1.168.192.in-addr.arpa</em>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP address");?></td>
                       <td>
                         <input name="ip" type="text" value="<?=$pconfig['ip'];?>" />
-                        <output class="hidden" for="help_for_ip">
+                        <div class="hidden" data-for="help_for_ip">
                           <?=gettext("IP address of the authoritative DNS server for this domain"); ?><br />
                           <?=gettext("e.g."); ?> <em>192.168.100.100</em><br /><?=gettext("Or enter # for an exclusion to pass through this host/subdomain to standard nameservers instead of a previous override."); ?><br /><?=gettext("Or enter ! for lookups for this host/subdomain to NOT be forwarded anywhere."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Port");?></td>
                       <td>
                         <input name="port" type="text" value="<?=$pconfig['port'];?>" />
-                        <output class="hidden" for="help_for_port">
+                        <div class="hidden" data-for="help_for_port">
                           <?=gettext("Specify a non standard port number here, leave blank for default"); ?><br />
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_dnssrcip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source IP");?></td>
                       <td>
                         <input name="dnssrcip" type="text" value="<?=$pconfig['dnssrcip'];?>" />
-                        <output class="hidden" for="help_for_dnssrcip">
+                        <div class="hidden" data-for="help_for_dnssrcip">
                           <?=gettext("Source IP address for queries to the DNS server for the override domain."); ?><br />
                           <?=gettext("Leave blank unless your DNS server is accessed through a VPN tunnel."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                       <td>
                         <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                        <output class="hidden" for="help_for_descr">
+                        <div class="hidden" data-for="help_for_descr">
                           <?=gettext("You may enter a description here"." for your reference (not parsed).");?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -190,39 +190,39 @@ include("head.inc");
                   <td><a id="help_for_host" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Host");?></td>
                   <td>
                     <input name="host" type="text" id="host" value="<?=$pconfig['host'];?>" />
-                    <output class="hidden" for="help_for_host">
+                    <div class="hidden" data-for="help_for_host">
                       <?=gettext("Name of the host, without"." domain part"); ?><br />
                       <?=gettext("e.g."); ?> <em><?=gettext("myhost"); ?></em>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
                   <td>
                     <input name="domain" type="text" id="domain" value="<?=$pconfig['domain'];?>" />
-                    <output class="hidden" for="help_for_domain">
+                    <div class="hidden" data-for="help_for_domain">
                       <?=gettext("Domain of the host"); ?><br />
                       <?=gettext("e.g."); ?> <em><?=gettext("example.com"); ?></em>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP address");?></td>
                   <td>
                     <input name="ip" type="text" id="ip" value="<?=$pconfig['ip'];?>" />
-                    <output class="hidden" for="help_for_ip">
+                    <div class="hidden" data-for="help_for_ip">
                       <?=gettext("IP address of the host"); ?><br />
                       <?=gettext("e.g."); ?> <em>192.168.100.100</em> <?=gettext("or"); ?> <em>fd00:abcd::1</em><
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                   <td>
                     <input name="descr" type="text" id="descr" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here"." for your reference (not parsed).");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -271,9 +271,9 @@ include("head.inc");
                         </tr>
                       </tfoot>
                     </table>
-                    <output class="hidden" for="help_for_alias">
+                    <div class="hidden" data-for="help_for_alias">
                       <?=gettext("Enter additional names for this host."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -244,12 +244,12 @@ include("head.inc");
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_interfaces">
+                      <div class="hidden" data-for="help_for_interfaces">
                         <?=gettext("Interfaces without an IP address will not be shown."); ?>
                         <br />
                         <br /><?=gettext("Selecting no interfaces will listen on all interfaces with a wildcard."); ?>
                         <br /><?=gettext("Selecting all interfaces will explicitly listen on only the interfaces/IPs specified."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -295,32 +295,32 @@ include("head.inc");
                           </tr>
                         </tfoot>
                       </table>
-                      <output class="hidden" for="help_for_timeservers">
+                      <div class="hidden" data-for="help_for_timeservers">
                         <?=gettext('For best results three to five servers should be configured here.'); ?>
                         <br />
                         <?= gettext('The "prefer" option indicates that NTP should favor the use of this server more than all others.') ?>
                         <br />
                         <?= gettext('The "do not use" option indicates that NTP should not use this server for time, but stats for this server will be collected and displayed.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_orphan" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Orphan mode') ?></td>
                     <td>
                       <input name="orphan" type="text" value="<?=$pconfig['orphan']?>" />
-                      <output class="hidden" for="help_for_orphan">
+                      <div class="hidden" data-for="help_for_orphan">
                         <?=gettext("(0-15)");?><br />
                         <?=gettext("Orphan mode allows the system clock to be used when no other clocks are available. The number here specifies the stratum reported during orphan mode and should normally be set to a number high enough to insure that any other servers available to clients are preferred over this server. (default: 12)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_statsgraph" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('NTP graphs') ?></td>
                     <td>
                       <input name="statsgraph" type="checkbox" id="statsgraph" <?=!empty($pconfig['statsgraph']) ? " checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_statsgraph">
+                      <div class="hidden" data-for="help_for_statsgraph">
                         <?=gettext("Enable rrd graphs of NTP statistics (default: disabled)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -331,9 +331,9 @@ include("head.inc");
                       <br />
                       <input name="logsys" type="checkbox" <?=!empty($pconfig['logsys']) ? " checked=\"checked\"" : ""; ?> />
                       <?=gettext("Enable logging of system messages (default: disabled)."); ?>
-                      <output class="hidden" for="help_for_syslog">
+                      <div class="hidden" data-for="help_for_syslog">
                         <?=gettext("These options enable additional messages from NTP to be written to the System Log");?> (<a href="diag_logs_ntpd.php"><?=gettext("Status > System Logs > NTP"); ?></a>).
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_ntpd_gps.php
+++ b/src/www/services_ntpd_gps.php
@@ -325,12 +325,12 @@ SureGPS =    #Sure Electronics SKG16B
                           <option value="SureGPS" title="$PMTK... Sure Electronics SKG16B"<?=$pconfig['type'] == 'SureGPS' ? " selected=\"selected\"" : "";?>><?=gettext('SureGPS') ?></option>
                           <option value="Custom"<?=$pconfig['type'] == 'Custom' ? " selected=\"selected\"" : ""; ?>><?=gettext('Custom') ?></option>
                         </select>
-                        <output class="hidden" for="help_for_gps">
+                        <div class="hidden" data-for="help_for_gps">
                           <?=gettext("This option allows you to select a predefined configuration.");?>
                           <br />
                           <strong><?=gettext("Note: ");?></strong><?=gettext("Select Generic if your GPS is not listed."); ?><br />
                           <strong><?=gettext("Note: ");?></strong><?=gettext("The predefined configurations assume your GPS has already been set to NMEA mode."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -350,9 +350,9 @@ SureGPS =    #Sure Electronics SKG16B
 <?php
                           endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_gpsport">
+                        <div class="hidden" data-for="help_for_gpsport">
                           <?=gettext("All serial ports are listed, be sure to pick the port with the GPS attached."); ?>
-                        </output>
+                        </div>
                         <br/>
                         <?=gettext("Serial port baud rate."); ?><br />
                         <select id="gpsspeed" name="speed" class="selectpicker">
@@ -363,9 +363,9 @@ SureGPS =    #Sure Electronics SKG16B
                           <option value="64" <?=$pconfig['speed'] === '64' ? " selected=\"selected\"" : "";?>>57600</option>
                           <option value="80" <?=$pconfig['speed'] === '80' ? " selected=\"selected\"" : "";?>>115200</option>
                         </select>
-                        <output class="hidden" for="help_for_gpsport">
+                        <div class="hidden" data-for="help_for_gpsport">
                           <?=gettext("Note: A higher baud rate is generally only helpful if the GPS is sending too many sentences. It is recommended to configure the GPS to send only one sentence at a baud rate of 4800 or 9600."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -382,36 +382,36 @@ SureGPS =    #Sure Electronics SKG16B
                           <option value="4" <?=intval($pconfig['nmea']) & 4 ? " selected=\"selected\"" : "";?>><?=gettext("GLL");?></option>
                           <option value="8" <?=intval($pconfig['nmea']) & 8 ? " selected=\"selected\"" : "";?>><?=gettext("ZDA or ZDG");?></option>
                         </select>
-                        <output class="hidden" for="help_for_nmea">
+                        <div class="hidden" data-for="help_for_nmea">
                           <?=gettext("By default NTP will listen for all supported NMEA sentences. Here one or more sentences to listen for may be specified."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_fudge1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Fudge time 1 (seconds)') ?></td>
                       <td>
                         <input name="fudge1" type="text" id="gpsfudge1" min="-1" max="1" size="20" value="<?=$pconfig['fudge1'];?>" />
-                        <output class="hidden" for="help_for_fudge1">
+                        <div class="hidden" data-for="help_for_fudge1">
                           <?= gettext("Fudge time 1 is used to specify the GPS PPS signal offset (default: 0.0).") ?>
-                        </output>
+                        </div>
                     </tr>
                     <tr>
                       <td><a id="help_for_fudge2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Fudge time 2 (seconds)');?></td>
                       <td>
                         <input name="fudge2" type="text" id="gpsfudge2" min="-1" max="1" size="20" value="<?=$pconfig['fudge2'];?>" />
-                        <output class="hidden" for="help_for_fudge2">
+                        <div class="hidden" data-for="help_for_fudge2">
                           <?= gettext("Fudge time 2 is used to specify the GPS time offset (default: 0.0).") ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_stratum" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Stratum') ?></td>
                       <td>
                         <input name="stratum" type="text" id="gpsstratum"  value="<?=$pconfig['stratum'];?>" />
-                        <output class="hidden" for="help_for_stratum">
+                        <div class="hidden" data-for="help_for_stratum">
                           <?=gettext("(0-16)");?><br />
                           <?=gettext("This may be used to change the GPS Clock stratum (default: 0). This may be useful if, for some reason, you want ntpd to prefer a different clock"); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -487,10 +487,10 @@ SureGPS =    #Sure Electronics SKG16B
                       <td><a id="help_for_refid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Clock ID') ?></td>
                       <td>
                         <input name="refid" type="text" id="gpsrefid" value="<?=$pconfig['refid'];?>" />
-                        <output class="hidden" for="help_for_refid">
+                        <div class="hidden" data-for="help_for_refid">
                           <?=gettext("(1 to 4 characters)");?><br />
                           <?=gettext("This may be used to change the GPS Clock ID (default: GPS).") ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_ntpd_pps.php
+++ b/src/www/services_ntpd_pps.php
@@ -112,9 +112,9 @@ include("head.inc");
 <?php
                           endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_gpsport">
+                        <div class="hidden" data-for="help_for_gpsport">
                           <?=gettext("All serial ports are listed, be sure to pick the port with the PPS source attached."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 <?php
@@ -123,18 +123,18 @@ include("head.inc");
                       <td><a id="help_for_fudge1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Fudge time') ?> (<?=gettext("seconds");?>)</td>
                       <td>
                         <input name="fudge1" type="text" value="<?=$pconfig['fudge1'];?>" />
-                        <output class="hidden" for="help_for_fudge1">
+                        <div class="hidden" data-for="help_for_fudge1">
                           <?=gettext("Fudge time is used to specify the PPS signal offset from the actual second such as the transmission delay between the transmitter and the receiver.");?> (<?=gettext("default");?>: 0.0).</td>
-                        </output>
+                        </div>
                     </tr>
                     <tr>
                       <td><a id="help_for_stratum" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Stratum') ?></td>
                       <td>
                         <input name="stratum" type="text" value="<?=$pconfig['stratum'];?>" />
-                        <output class="hidden" for="help_for_stratum">
+                        <div class="hidden" data-for="help_for_stratum">
                           <?=gettext("(0-16)");?><br />
                           <?=gettext("This may be used to change the PPS Clock stratum");?> (<?=gettext("default");?>: 0). <?=gettext("This may be useful if, for some reason, you want ntpd to prefer a different clock and just monitor this source."); ?></td>
-                        </output>
+                        </div>
                     </tr>
                     <tr>
                       <td><a id="help_for_flags" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Flags') ?></td>
@@ -165,19 +165,19 @@ include("head.inc");
                             </td>
                           </tr>
                         </table>
-                        <output class="hidden" for="help_for_flags">
+                        <div class="hidden" data-for="help_for_flags">
                           <?=gettext("Normally there should be no need to change these options from the defaults."); ?><br />
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_refid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Clock ID') ?></td>
                       <td>
                         <input name="refid" type="text" value="<?=$pconfig['refid'];?>" />
-                        <output class="hidden" for="help_for_refid">
+                        <div class="hidden" data-for="help_for_refid">
                           <?=gettext("(1 to 4 characters)");?><br />
                           <?=gettext("This may be used to change the PPS Clock ID");?> (<?=gettext("default");?>: PPS).
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_opendns.php
+++ b/src/www/services_opendns.php
@@ -142,27 +142,27 @@ include 'head.inc';
                   <td>
                     <input name="enable" type="checkbox" id="enable" value="yes" <?=!empty($pconfig['enable']) ? 'checked="checked"' : "";?> />
                     <strong><?=gettext('Filter DNS requests using OpenDNS'); ?></strong>
-                    <output class="hidden" for="help_for_enable">
+                    <div class="hidden" data-for="help_for_enable">
                       <?= sprintf(gettext(
                         'Enabling the OpenDNS service will overwrite DNS servers configured ' .
                         'via the General Setup page as well as ignore any DNS servers learned ' .
                         'by DHCP/PPP on WAN and use the DNS servers from %s instead.'),
                         '<a href="http://www.opendns.com" target="_blank">OpenDNS.com</a>'
                       ) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_username" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Username'); ?></td>
                   <td>
                     <input name="username" type="text" id="username" size="20" value="<?=$pconfig['username'];?>" />
-                    <output class="hidden" for="help_for_username">
+                    <div class="hidden" data-for="help_for_username">
                       <?=gettext(
                         'Signon Username to log into your OpenDNS dashboard. ' .
                         'It is used to automatically update the IP address of ' .
                         'the registered network.'
                       ); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -175,7 +175,7 @@ include 'head.inc';
                   <td><a id="help_for_host" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Network'); ?></td>
                   <td>
                     <input name="host" type="text" id="host" size="30" value="<?=$pconfig['host'];?>" />
-                    <output class="hidden" for="help_for_host">
+                    <div class="hidden" data-for="help_for_host">
                       <?= sprintf(gettext(
                         'Enter the network name configured on the %sNetworks ' .
                         'Dashboard of OpenDNS%s under \'Manage your networks\'. ' .
@@ -183,7 +183,7 @@ include 'head.inc';
                         'WAN interface changes its IP address.'),
                         '<a href="https://www.opendns.com/dashboard/networks/" target="_blank">', '</a>'
                       ) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -232,12 +232,12 @@ include("head.inc");
                           <?=gettext("Stateless");?>
                         </option>
                       </select>
-                      <output class="hidden" for="help_for_ramode">
+                      <div class="hidden" data-for="help_for_ramode">
                         <?= gettext('Select the Operating Mode for the Router Advertisement (RA) Daemon.') ?></strong>
                         <?= gettext('Use "Router Only" to only advertise this router, "Unmanaged" for Router Advertising with Stateless Autoconfig, ' .
                             '"Managed" for exclusive DHCPv6 Server assignment, "Assisted" for DHCPv6 Server assignment combined with Stateless Autoconfig, ' .
                             'or "Stateless" for Router Advertising with Statless Autoconfig and optional DHCPv6 Server queries.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -254,9 +254,9 @@ include("head.inc");
                           <?=gettext("High");?>
                         </option>
                       </select>
-                      <output class="hidden" for="help_for_rapriority">
+                      <div class="hidden" data-for="help_for_rapriority">
                         <?= sprintf(gettext("Select the Priority for the Router Advertisement (RA) Daemon."))?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -280,9 +280,9 @@ include("head.inc");
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_rainterface">
+                      <div class="hidden" data-for="help_for_rainterface">
                         <?= sprintf(gettext("Select the Interface for the Router Advertisement (RA) Daemon."))?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -350,9 +350,9 @@ include("head.inc");
                         endforeach ?>
                         </tbody>
                       </table>
-                      <output class="hidden" for="help_for_raroutes">
+                      <div class="hidden" data-for="help_for_raroutes">
                         <?= gettext('Routes are specified in CIDR format. The prefix of a route definition should be network prefix; it can be used to advertise more specific routes to the hosts.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -360,9 +360,9 @@ include("head.inc");
                     <td>
                       <input name="radns1" type="text" value="<?=$pconfig['radns1'];?>" /><br />
                       <input name="radns2" type="text" value="<?=$pconfig['radns2'];?>" />
-                      <output class="hidden" for="help_for_radns">
+                      <div class="hidden" data-for="help_for_radns">
                         <?=gettext("NOTE: leave blank to use the system default DNS servers - this interface's IP if DNS forwarder is enabled, otherwise the servers configured on the General page.");?>
-                      </output>
+                      </div>
                       <br />
                       <input id="rasamednsasdhcp6" name="rasamednsasdhcp6" type="checkbox" value="yes" <?=!empty($pconfig['rasamednsasdhcp6']) ? "checked='checked'" : "";?> />
                       <strong><?= gettext("Use the DNS settings of the DHCPv6 server"); ?></strong>
@@ -372,36 +372,36 @@ include("head.inc");
                     <td><a id="help_for_radomainsearchlist" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain search list");?></td>
                     <td>
                       <input name="radomainsearchlist" type="text" id="radomainsearchlist" size="28" value="<?=$pconfig['radomainsearchlist'];?>" />
-                      <output class="hidden" for="help_for_radomainsearchlist">
+                      <div class="hidden" data-for="help_for_radomainsearchlist">
                         <?=gettext("The RA server can optionally provide a domain search list. Use the semicolon character as separator");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_rasend" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('RA Sending') ?></td>
                     <td>
                       <input id="rasend" name="rasend" type="checkbox" value="yes" <?= !empty($pconfig['rasend']) ? 'checked="checked"' : '' ?>/>
-                      <output class="hidden" for="help_for_rasend">
+                      <div class="hidden" data-for="help_for_rasend">
                         <?= gettext('Enable the periodic sending of router advertisements and responding to router solicitations.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_ramininterval" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Minimum Interval') ?></td>
                     <td>
                       <input name="ramininterval" type="text" id="ramininterval" size="28" value="<?=$pconfig['ramininterval'];?>" />
-                      <output class="hidden" for="help_for_ramininterval">
+                      <div class="hidden" data-for="help_for_ramininterval">
                         <?= gettext('The minimum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_ramaxinterval" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Maximum Interval') ?></td>
                     <td>
                       <input name="ramaxinterval" type="text" id="ramaxinterval" size="28" value="<?=$pconfig['ramaxinterval'];?>" />
-                      <output class="hidden" for="help_for_ramaxinterval">
+                      <div class="hidden" data-for="help_for_ramaxinterval">
                         <?= gettext('The maximum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -180,9 +180,9 @@ include_once("head.inc");
                         <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>
                         <td>
                             <input name="port" type="text" id="port" size="6" value="<?=$pconfig['port'];?>" />
-                            <output class="hidden" for="help_for_port">
+                            <div class="hidden" data-for="help_for_port">
                                 <?=gettext("The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.");?>
-                            </output>
+                            </div>
                         </td>
                       </tr>
                       <tr>
@@ -196,9 +196,9 @@ include_once("head.inc");
 <?php
                             endforeach; ?>
                           </select>
-                          <output class="hidden" for="help_for_active_interface">
+                          <div class="hidden" data-for="help_for_active_interface">
                             <?=gettext("Interface IPs used by the DNS Resolver for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -211,9 +211,9 @@ include_once("head.inc");
 <?php
                             endforeach; ?>
                           </select>
-                          <output class="hidden" for="help_for_local_zone_type">
+                          <div class="hidden" data-for="help_for_local_zone_type">
                             <?=sprintf(gettext('The local zone type used for the system domain. Type descriptions are available under "local-zone:" in the %sunbound.conf(5)%s manual page. The default is \'transparent\'.'), '<a target="_blank" href="https://www.unbound.net/documentation/unbound.conf.html">', '</a>');?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -228,9 +228,9 @@ include_once("head.inc");
                         <td>
                           <input name="forwarding" type="checkbox" value="yes" <?=!empty($pconfig['forwarding']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Enable Forwarding Mode");?></strong>
-                          <output class="hidden" for="help_for_forwarding">
+                          <div class="hidden" data-for="help_for_forwarding">
                             <?= gettext('The configured system nameservers will be used to forward queries to.') ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -238,23 +238,23 @@ include_once("head.inc");
                         <td>
                           <input name="regdhcp" type="checkbox" id="regdhcp" value="yes" <?=!empty($pconfig['regdhcp']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Register DHCP leases in the DNS Resolver");?></strong>
-                          <output class="hidden" for="help_for_regdhcp">
+                          <div class="hidden" data-for="help_for_regdhcp">
                             <?= gettext("If this option is set, then machines that specify " .
                             "their hostname when requesting a DHCP lease will be registered " .
                             "in the DNS Resolver, so that their name can be resolved."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_regdhcpdomain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Domain Override");?></td>
                         <td>
                           <input name="regdhcpdomain" type="text" id="regdhcpdomain" value="<?= $pconfig['regdhcpdomain'] ?>"/>
-                          <output class="hidden" for="help_for_regdhcpdomain">
+                          <div class="hidden" data-for="help_for_regdhcpdomain">
                             <?= gettext("The domain name to use for DHCP hostname registration. " .
                               "If empty, the default system domain is used. Note that all DHCP " .
                               "leases will be assigned to the same domain. If this is undesired, " .
                               "static DHCP lease registration is able to provide coherent mappings.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -262,12 +262,12 @@ include_once("head.inc");
                         <td>
                           <input name="regdhcpstatic" type="checkbox" id="regdhcpstatic" value="yes" <?=!empty($pconfig['regdhcpstatic']) ? "checked=\"checked\"" : "";?> />
                           <strong><?=gettext("Register DHCP static mappings in the DNS Resolver");?></strong>
-                          <output class="hidden" for="help_for_regdhcpstatic">
+                          <div class="hidden" data-for="help_for_regdhcpstatic">
                             <?= sprintf(gettext("If this option is set, then DHCP static mappings will ".
                                 "be registered in the DNS Resolver, so that their name can be ".
                                 "resolved. You should also set the domain in %s".
                                 "System: General setup%s to the proper value."),'<a href="system_general.php">','</a>');?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -275,21 +275,21 @@ include_once("head.inc");
                         <td>
                           <input name="reglladdr6" type="checkbox" id="reglladdr6" value="yes" <?= !empty($pconfig['reglladdr6']) ? 'checked="checked"' : '' ?>/>
                           <strong><?= gettext('Register IPv6 link-local addresses in the DNS Resolver') ?></strong>
-                          <output class="hidden" for="help_for_reglladdr6">
+                          <div class="hidden" data-for="help_for_reglladdr6">
                             <?= gettext("If this option is unset, then IPv6 link-local " .
                             "addresses will not be registered in the DNS Resolver, preventing " .
                             "return of unreachable address from the DNS resolver when more " .
                             "than one listen interface is configured."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_txtsupport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("TXT Comment Support");?></td>
                         <td>
                           <input name="txtsupport" type="checkbox" value="yes" <?=!empty($pconfig['txtsupport']) ? "checked=\"checked\"" : "";?> />
-                          <output class="hidden" for="help_for_txtsupport">
+                          <div class="hidden" data-for="help_for_txtsupport">
                             <?=gettext("If this option is set, then any descriptions associated with Host entries and DHCP Static mappings will create a corresponding TXT record.");?><br />
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -302,9 +302,9 @@ include_once("head.inc");
                         <td><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Custom options') ?></td>
                         <td>
                           <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea>
-                          <output class="hidden" for="help_for_custom_options">
+                          <div class="hidden" data-for="help_for_custom_options">
                             <?=gettext("Enter any additional options you would like to add to the DNS Resolver configuration here."); ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr class="showadv" style="display:none">
@@ -321,9 +321,9 @@ include_once("head.inc");
                             endforeach; ?>
 
                           </select>
-                          <output class="hidden" for="help_for_outgoing_interface">
+                          <div class="hidden" data-for="help_for_outgoing_interface">
                             <?=gettext("Utilize different network interface(s) that the DNS Resolver will use to send queries to authoritative servers and receive their replies. By default all interfaces are used. Note that setting explicit outgoing interfaces only works when they are statically configured.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -210,9 +210,9 @@ include("head.inc");
                   <td><a id="help_for_aclname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Access List name");?></td>
                   <td>
                     <input name="aclname" type="text" value="<?=$pconfig['aclname'];?>" />
-                    <output class="hidden" for="help_for_aclname">
+                    <div class="hidden" data-for="help_for_aclname">
                       <?=gettext("Provide an Access List name.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -232,13 +232,13 @@ include("head.inc");
                       <?=gettext("Allow Snoop");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_aclaction">
+                    <div class="hidden" data-for="help_for_aclaction">
                         <?=gettext("Choose what to do with DNS requests that match the criteria specified below.");?> <br />
                         <?=gettext("Deny: This action stops queries from hosts within the netblock defined below.")?> <br />
                         <?=gettext("Refuse: This action also stops queries from hosts within the netblock defined below, but sends a DNS rcode REFUSED error message back to the client.")?> <br />
                         <?=gettext("Allow: This action allows queries from hosts within the netblock defined below.")?> <br />
                         <?=gettext("Allow Snoop: This action allows recursive and nonrecursive access from hosts within the netblock defined below. Used for cache snooping and ideally should only be configured for your administrative host.")?> <br />
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -301,9 +301,9 @@ include("head.inc");
                   <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                   <td>
                     <input name="description" type="text" value="<?=$pconfig['description'];?>" />
-                    <output class="hidden" for="help_for_description">
+                    <div class="hidden" data-for="help_for_description">
                       <?=gettext("You may enter a description here for your reference.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -134,54 +134,54 @@ include_once("head.inc");
                         <td><a id="help_for_hideidentity" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Hide Identity") ?></td>
                         <td>
                           <input name="hideidentity" type="checkbox" id="hideidentity" value="yes" <?= empty($pconfig['hideidentity']) ? '' : 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_hideidentity">
+                          <div class="hidden" data-for="help_for_hideidentity">
                             <?=gettext("If enabled, id.server and hostname.bind queries are refused.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_hideversion" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hide Version");?></td>
                         <td>
                           <input name="hideversion" type="checkbox" id="hideversion" value="yes" <?= empty($pconfig['hideversion']) ? '' : 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_hideversion">
+                          <div class="hidden" data-for="help_for_hideversion">
                             <?= gettext("If enabled, version.server and version.bind queries are refused.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_prefetch" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Prefetch Support") ?></td>
                         <td>
                           <input name="prefetch" type="checkbox" id="prefetch" value="yes" <?= empty($pconfig['prefetch']) ? '': 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_prefetch">
+                          <div class="hidden" data-for="help_for_prefetch">
                             <?= gettext("Message cache elements are prefetched before they expire to help keep the cache up to date. When enabled, this option can cause an increase of around 10% more DNS traffic and load on the server, but frequently requested items will not expire from the cache.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_prefetchkey" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Prefetch DNS Key Support") ?></td>
                         <td>
                           <input name="prefetchkey" type="checkbox" id="prefetchkey" value="yes" <?= empty($pconfig['prefetchkey']) ? '' : 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_prefetchkey">
+                          <div class="hidden" data-for="help_for_prefetchkey">
                             <?= sprintf(gettext("DNSKEY's are fetched earlier in the validation process when a %sDelegation signer%s is encountered. This helps lower the latency of requests but does utilize a little more CPU."), "<a href='http://en.wikipedia.org/wiki/List_of_DNS_record_types'>", "</a>") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_dnssecstripped" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Harden DNSSEC data");?></td>
                         <td>
                           <input name="dnssecstripped" type="checkbox" id="dnssecstripped" value="yes" <?= empty($pconfig['dnssecstripped']) ? '' : 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_dnssecstripped">
+                          <div class="hidden" data-for="help_for_dnssecstripped">
                             <?= gettext("DNSSEC data is required for trust-anchored zones. If such data is absent, the zone becomes bogus. If this is disabled and no DNSSEC data is received, then the zone is made insecure.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_serveexpired" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Serve expired responses') ?></td>
                         <td>
                           <input name="serveexpired" type="checkbox" id="serveexpired" value="yes" <?= empty($pconfig['serveexpired']) ? '' : 'checked="checked"' ?> />
-                          <output class="hidden" for="help_for_serveexpired">
+                          <div class="hidden" data-for="help_for_serveexpired">
                             <?= gettext('Serve expired responses from the cache with a TTL of 0 without waiting for the actual resolution to finish.') ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -196,9 +196,9 @@ include_once("head.inc");
 <?php
                           endforeach;?>
                           </select>
-                          <output class="hidden" for="help_for_msgcachesize">
+                          <div class="hidden" data-for="help_for_msgcachesize">
                             <?= gettext("Size of the message cache. The message cache stores DNS rcodes and validation statuses. The RRSet cache will automatically be set to twice this amount. The RRSet cache contains the actual RR data. The default is 4 megabytes.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -213,9 +213,9 @@ include_once("head.inc");
 <?php
                           endfor;?>
                           </select>
-                          <output class="hidden" for="help_for_outgoing_num_tcp">
+                          <div class="hidden" data-for="help_for_outgoing_num_tcp">
                             <?=gettext("The number of outgoing TCP buffers to allocate per thread. The default value is 10. If 0 is selected then no TCP queries, to authoritative servers, are done.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -230,9 +230,9 @@ include_once("head.inc");
 <?php
                           endfor;?>
                           </select>
-                          <output class="hidden" for="help_for_incoming_num_tcp">
+                          <div class="hidden" data-for="help_for_incoming_num_tcp">
                             <?=gettext("The number of incoming TCP buffers to allocate per thread. The default value is 10. If 0 is selected then no TCP queries, from clients, are accepted.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -247,9 +247,9 @@ include_once("head.inc");
 <?php
                           endforeach;?>
                           </select>
-                          <output class="hidden" for="help_for_num_queries_per_thread">
+                          <div class="hidden" data-for="help_for_num_queries_per_thread">
                             <?=gettext("The number of queries that every thread will service simultaneously. If more queries arrive that need to be serviced, and no queries can be jostled, then these queries are dropped.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -264,27 +264,27 @@ include_once("head.inc");
 <?php
                           endforeach;?>
                           </select>
-                          <output class="hidden" for="help_for_jostle_timeout">
+                          <div class="hidden" data-for="help_for_jostle_timeout">
                             <?= gettext("This timeout is used for when the server is very busy. This protects against denial of service by slow queries or high query rates. The default value is 200 milliseconds.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_cache_max_ttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Maximum TTL for RRsets and messages") ?></td>
                         <td>
                           <input type="text" id="cache_max_ttl" name="cache_max_ttl" size="5" value="<?= $pconfig['cache_max_ttl'] ?>" />
-                          <output class="hidden" for="help_for_cache_max_ttl">
+                          <div class="hidden" data-for="help_for_cache_max_ttl">
                             <?= gettext("Configure a maximum Time to live for RRsets and messages in the cache. The default is 86400 seconds (1 day). When the internal TTL expires the cache item is expired. This can be configured to force the resolver to query for data more often and not trust (very large) TTL values.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_cache_min_ttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Minimum TTL for RRsets and messages") ?></td>
                         <td>
                           <input type="text" id="cache_min_ttl" name="cache_min_ttl" size="5" value="<?= $pconfig['cache_min_ttl'] ?>" />
-                          <output class="hidden" for="help_for_cache_min_ttl">
+                          <div class="hidden" data-for="help_for_cache_min_ttl">
                             <?= gettext("Configure a minimum Time to live for RRsets and messages in the cache. The default is 0 seconds. If the minimum value kicks in, the data is cached for longer than the domain owner intended, and thus less queries are made to look up the data. The 0 value ensures the data in the cache is as the domain owner intended. High values can lead to trouble as the data in the cache might not match up with the actual data anymore.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -297,9 +297,9 @@ include_once("head.inc");
                             <option value="600" <?=$pconfig['infra_host_ttl'] == "600" ? "selected=\"selected\"" : ""; ?>><?=gettext('10 minutes') ?></option>
                             <option value="900" <?=$pconfig['infra_host_ttl'] == "900" ? "selected=\"selected\"" : ""; ?>><?=gettext('15 minutes') ?></option>
                           </select>
-                          <output class="hidden" for="help_for_infra_host_ttl">
+                          <div class="hidden" data-for="help_for_infra_host_ttl">
                             <?=gettext("Time to live for entries in the host cache. The host cache contains roundtrip timing and EDNS support information. The default is 15 minutes.");?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -312,9 +312,9 @@ include_once("head.inc");
                             <option value="20000" <?=$pconfig['infra_cache_numhosts'] == "20000" ? "selected=\"selected\"" : ""; ?>>20000</option>
                             <option value="50000" <?=$pconfig['infra_cache_numhosts'] == "50000" ? "selected=\"selected\"" : ""; ?>>50000</option>
                           </select>
-                          <output class="hidden" for="help_for_infra_cache_numhosts">
+                          <div class="hidden" data-for="help_for_infra_cache_numhosts">
                             <?= gettext("Number of hosts for which information is cached. The default is 10000.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -328,9 +328,9 @@ include_once("head.inc");
                             <option value="40000000" <?=$pconfig['unwanted_reply_threshold'] == "40000000" ? "selected=\"selected\"" : ""; ?>><?=gettext('40 million') ?></option>
                             <option value="50000000" <?=$pconfig['unwanted_reply_threshold'] == "50000000" ? "selected=\"selected\"" : ""; ?>><?=gettext('50 million') ?></option>
                           </select>
-                          <output class="hidden" for="help_for_unwanted_reply_threshold">
+                          <div class="hidden" data-for="help_for_unwanted_reply_threshold">
                             <?= gettext("If enabled, a total number of unwanted replies is kept track of in every thread. When it reaches the threshold, a defensive action is taken and a warning is printed to the log file. This defensive action is to clear the RRSet and message caches, hopefully flushing away any poison. The default is disabled, but if enabled a value of 10 million is suggested.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>
@@ -345,9 +345,9 @@ include_once("head.inc");
 <?php
                           endfor;?>
                           </select>
-                          <output class="hidden" for="help_for_log_verbosity">
+                          <div class="hidden" data-for="help_for_log_verbosity">
                             <?= gettext("Select the log verbosity.") ?>
-                          </output>
+                          </div>
                         </td>
                       </tr>
                       <tr>

--- a/src/www/services_unbound_domainoverride_edit.php
+++ b/src/www/services_unbound_domainoverride_edit.php
@@ -120,30 +120,30 @@ include("head.inc");
                     <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
                     <td>
                       <input name="domain" type="text" id="domain" size="40" value="<?=$pconfig['domain'];?>" />
-                      <output class="hidden" for="help_for_domain">
+                      <div class="hidden" data-for="help_for_domain">
                           <?=gettext("Domain to override (NOTE: this does not have to be a valid TLD!)"); ?><br />
                           <?=gettext("e.g."); ?> <em><?=gettext("test"); ?></em> <?=gettext("or"); ?> <em>mycompany.localdomain</em> <?=gettext("or"); ?> <em>1.168.192.in-addr.arpa</em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP address");?></td>
                     <td>
                         <input name="ip" type="text" id="ip" size="40" value="<?=$pconfig['ip'];?>" />
-                        <output class="hidden" for="help_for_ip">
+                        <div class="hidden" data-for="help_for_ip">
                           <?=gettext("IP address of the authoritative DNS server for this domain"); ?><br />
                           <?=gettext("e.g."); ?> <em>192.168.100.100</em><br />
                           <?=gettext("To use a nondefault port for communication, append an '@' with the port number."); ?><br />
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                     <td>
                       <input name="descr" type="text" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -179,20 +179,20 @@ include("head.inc");
                     <td><a id="help_for_host" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Host");?></td>
                     <td>
                       <input name="host" type="text" value="<?=$pconfig['host'];?>" />
-                      <output class="hidden" for="help_for_host">
+                      <div class="hidden" data-for="help_for_host">
                         <?=gettext("Name of the host, without domain part"); ?>
                         <?=gettext("e.g."); ?> <em><?=gettext("myhost"); ?></em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain");?></td>
                     <td>
                       <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                      <output class="hidden" for="help_for_domain">
+                      <div class="hidden" data-for="help_for_domain">
                         <?=gettext("Domain of the host"); ?><br />
                         <?=gettext("e.g."); ?> <em><?=gettext("example.com"); ?></em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -208,50 +208,50 @@ include("head.inc");
 <?php
                         endforeach; ?>
                       </select>
-                      <output class="hidden" for="help_for_rr">
+                      <div class="hidden" data-for="help_for_rr">
                         <?=gettext("Type of resource record"); ?>
                         <br />
                         <?=gettext("e.g."); ?> <em>A</em> <?=gettext("or"); ?> <em>AAAA</em> <?=gettext("for IPv4 or IPv6 addresses"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="a_aaa_rec">
                     <td><a id="help_for_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP");?></td>
                     <td>
                       <input name="ip" type="text" id="ip" value="<?=$pconfig['ip'];?>" />
-                      <output class="hidden" for="help_for_ip">
+                      <div class="hidden" data-for="help_for_ip">
                         <?=gettext("IP address of the host"); ?><br />
                         <?=gettext("e.g."); ?> <em>192.168.100.100</em> <?=gettext("or"); ?> <em>fd00:abcd::1</em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="mx_rec">
                     <td><a id="help_for_mxprio" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MX Priority");?></td>
                     <td>
                       <input name="mxprio" type="text" id="mxprio" value="<?=$pconfig['mxprio'];?>" />
-                      <output class="hidden" for="help_for_mxprio">
+                      <div class="hidden" data-for="help_for_mxprio">
                         <?=gettext("Priority of MX record"); ?><br />
                         <?=gettext("e.g."); ?> <em>10</em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="mx_rec">
                     <td><a id="help_for_mx" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MX Host");?></td>
                     <td>
                       <input name="mx" type="text" id="mx" size="6" value="<?=$pconfig['mx'];?>" />
-                      <output class="hidden" for="help_for_mx">
+                      <div class="hidden" data-for="help_for_mx">
                         <?=gettext("Host name of MX host"); ?><br />
                         <?=gettext("e.g."); ?> <em>mail.example.com</em>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                     <td>
                       <input name="descr" type="text" id="descr" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here for your reference (not parsed).");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/status_openvpn.php
+++ b/src/www/status_openvpn.php
@@ -187,7 +187,7 @@ $( document ).ready(function() {
                     <button class="btn btn-default act_show_routes" type="button" id="showroutes_<?=$i?>"><i class="fa fa-info"></i>
                       <?=gettext("Show/Hide Routing Table"); ?>
                     </button>
-                    <output  class="hidden"  for="showroutes_<?=$i?>">
+                    <div  class="hidden"  data-for="showroutes_<?=$i?>">
                       <small>
                         <?=$server['name'];?> <?=gettext("Routing Table"); ?>
                       </small>
@@ -218,7 +218,7 @@ $( document ).ready(function() {
                           </tr>
                         </tfoot>
                       </table>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -419,13 +419,13 @@ $(document).ready(function() {
 <?php
                     endforeach;?>
                     </select>
-                    <output class='hidden' for="help_for_sslcertref">
+                    <div class='hidden' data-for="help_for_sslcertref">
                       <?=sprintf(
                         gettext('The %sSSL certificate manager%s can be used to ' .
                         'create or import certificates if required.'),
                         '<a href="/system_certmanager.php">', '</a>'
                       );?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="ssl_opts">
@@ -445,20 +445,20 @@ $(document).ready(function() {
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_sslciphers">
+                      <div class="hidden" data-for="help_for_sslciphers">
                         <?=gettext("Limit SSL cipher selection in case the system defaults are undesired. Note that restrictive use may lead to an inaccessible web GUI.");?>
-                      </output>
+                      </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_webguiport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("TCP port"); ?></td>
                   <td>
                     <input name="webguiport" id="webguiport" type="text" value="<?=$pconfig['webguiport'];?>" placeholder="<?= $pconfig['webguiproto'] == 'https' ? '443' : '80' ?>" />
-                    <output class="hidden" for="help_for_webguiport">
+                    <div class="hidden" data-for="help_for_webguiport">
                       <?=gettext("Enter a custom port number for the web GUI " .
                                             "above if you want to override the default (80 for HTTP, 443 " .
                                             "for HTTPS). Changes will take effect immediately after save."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="ssl_opts">
@@ -466,12 +466,12 @@ $(document).ready(function() {
                   <td style="width:78%">
                     <input name="disablehttpredirect" type="checkbox" value="yes" <?= empty($pconfig['disablehttpredirect']) ? '' : 'checked="checked"';?> />
                     <strong><?= gettext('Disable web GUI redirect rule') ?></strong>
-                    <output class="hidden" for="help_for_disablehttpredirect">
+                    <div class="hidden" data-for="help_for_disablehttpredirect">
                       <?= gettext("When this is unchecked, access to the web GUI " .
                                           "is always permitted even on port 80, regardless of the listening port configured. " .
                                           "Check this box to disable this automatically added redirect rule.");
                                           ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -479,9 +479,9 @@ $(document).ready(function() {
                   <td>
                     <input name="quietlogin" type="checkbox" value="yes" <?= empty($pconfig['quietlogin']) ? '' : 'checked="checked"' ?>/>
                     <strong><?= gettext('Disable logging of web GUI successful logins') ?></strong>
-                    <output class="hidden" for="help_for_quietlogin">
+                    <div class="hidden" data-for="help_for_quietlogin">
                       <?=gettext("When this is checked, successful logins to the web GUI will not be logged.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -489,11 +489,11 @@ $(document).ready(function() {
                   <td>
                     <input name="nodnsrebindcheck" type="checkbox" value="yes" <?= empty($pconfig['nodnsrebindcheck']) ? '' : 'checked="checked"';?>/>
                     <strong><?=gettext("Disable DNS Rebinding Checks"); ?></strong>
-                    <output class="hidden" for="help_for_nodnsrebindcheck">
+                    <div class="hidden" data-for="help_for_nodnsrebindcheck">
                       <?= sprintf(gettext("When this is unchecked, your system is protected against %sDNS Rebinding attacks%s. " .
                                           "This blocks private IP responses from your configured DNS servers. Check this box to disable this protection if it interferes with " .
                                           "web GUI access or name resolution in your environment."),'<a href="http://en.wikipedia.org/wiki/DNS_rebinding">','</a>') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -501,10 +501,10 @@ $(document).ready(function() {
                   <td>
                     <input name="althostnames" type="text" value="<?= $pconfig['althostnames'] ?>"/>
                     <strong><?=gettext("Alternate Hostnames for DNS Rebinding and HTTP_REFERER Checks"); ?></strong>
-                    <output class="hidden" for="help_for_althostnames">
+                    <div class="hidden" data-for="help_for_althostnames">
                       <?= gettext("Here you can specify alternate hostnames by which the router may be queried, to " .
                                           "bypass the DNS Rebinding Attack checks. Separate hostnames with spaces.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -524,10 +524,10 @@ $(document).ready(function() {
                           <?=gettext("High");?>
                         </option>
                     </select>
-                    <output class="hidden" for="help_for_compression">
+                    <div class="hidden" data-for="help_for_compression">
                       <?=gettext("Enable compression of HTTP pages and dynamic content.");?><br/>
                       <?=gettext("Transfer less data to the client for an additional cost in processing power.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -550,9 +550,9 @@ $(document).ready(function() {
 <?php
                     endforeach;?>
                     </select>
-                    <output class="hidden" for="help_for_webguiinterfaces">
+                    <div class="hidden" data-for="help_for_webguiinterfaces">
                       <?= gettext('Only accept connections from the selected interfaces. Leave empty to listen globally. Use with care.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -560,13 +560,13 @@ $(document).ready(function() {
                   <td>
                     <input name="nohttpreferercheck" type="checkbox" value="yes" <?= empty($pconfig['nohttpreferercheck']) ? '' : 'checked="checked"' ?> />
                     <strong><?=gettext("Disable HTTP_REFERER enforcement check"); ?></strong>
-                    <output class="hidden" for="help_for_nohttpreferercheck">
+                    <div class="hidden" data-for="help_for_nohttpreferercheck">
                       <?=sprintf(gettext("When this is unchecked, access to the web GUI " .
                                           "is protected against HTTP_REFERER redirection attempts. " .
                                           "Check this box to disable this protection if you find that it interferes with " .
                                           "web GUI access in certain corner cases such as using external scripts to interact with this system. More information on HTTP_REFERER is available from %sWikipedia%s."),
                                           '<a target="_blank" href="http://en.wikipedia.org/wiki/HTTP_referrer">','</a>') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -590,9 +590,9 @@ $(document).ready(function() {
 <?php
                     endforeach;?>
                     </select>
-                    <output class="hidden" for="help_for_sshlogingroup">
+                    <div class="hidden" data-for="help_for_sshlogingroup">
                       <?= gettext('Select the allowed groups for remote login. The "wheel" group is always set for recovery purposes and an additional local group can be selected at will. Do not yield remote access to non-adminstrators as every user can access system files using SSH or SFTP.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -600,12 +600,12 @@ $(document).ready(function() {
                   <td>
                     <input name="sshdpermitrootlogin" type="checkbox" value="yes" <?= empty($pconfig['sshdpermitrootlogin']) ? '' : 'checked="checked"' ?> />
                     <strong><?=gettext("Permit root user login"); ?></strong>
-                    <output class="hidden" for="help_for_sshdpermitrootlogin">
+                    <div class="hidden" data-for="help_for_sshdpermitrootlogin">
                       <?= gettext(
                         'Root login is generally discouraged. It is advised ' .
                         'to log in via another user and switch to root afterwards.'
                       ) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -613,19 +613,19 @@ $(document).ready(function() {
                   <td>
                     <input name="sshpasswordauth" type="checkbox" value="yes" <?= empty($pconfig['sshpasswordauth']) ? '' : 'checked="checked"' ?> />
                     <strong><?=gettext("Permit password login"); ?></strong>
-                    <output class="hidden" for="help_for_sshpasswordauth">
+                    <div class="hidden" data-for="help_for_sshpasswordauth">
                       <?=sprintf(gettext("When disabled, authorized keys need to be configured for each %sUser%s that has been granted secure shell access."),
                                 '<a href="system_usermanager.php">', '</a>') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_sshport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("SSH port"); ?></td>
                   <td style="width:78%">
                     <input name="sshport" type="text" value="<?=$pconfig['sshport'];?>" placeholder="22" />
-                    <output class="hidden" for="help_for_sshport">
+                    <div class="hidden" data-for="help_for_sshport">
                       <?=gettext("Leave this blank for the default of 22."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -638,9 +638,9 @@ $(document).ready(function() {
 <?php
                     endforeach;?>
                     </select>
-                    <output class="hidden" for="help_for_sshinterfaces">
+                    <div class="hidden" data-for="help_for_sshinterfaces">
                       <?= gettext('Only accept connections from the selected interfaces. Leave empty to listen globally. Use with care.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -661,10 +661,10 @@ $(document).ready(function() {
                       <option value="<?= html_safe($console_key) ?>" <?= $pconfig['primaryconsole'] == $console_key ? 'selected="selected"' : '' ?>><?= $console_type['name'] ?></option>
 <?                  endforeach ?>
                     </select>
-                    <output class="hidden" for="help_for_primaryconsole">
+                    <div class="hidden" data-for="help_for_primaryconsole">
                       <?=gettext("Select the primary console. This preferred console will show boot script output.") ?>
                       <?=gettext("All consoles display OS boot messages, console messages, and the console menu."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -676,10 +676,10 @@ $(document).ready(function() {
                       <option value="<?= html_safe($console_key) ?>" <?= $pconfig['secondaryconsole'] == $console_key ? 'selected="selected"' : '' ?>><?= $console_type['name'] ?></option>
 <?                  endforeach ?>
                     </select>
-                    <output class="hidden" for="help_for_secondaryconsole">
+                    <div class="hidden" data-for="help_for_secondaryconsole">
                       <?=gettext("Select the secondary console if multiple consoles are present."); ?>
                       <?=gettext("All consoles display OS boot messages, console messages, and the console menu."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -693,9 +693,9 @@ $(document).ready(function() {
                       <option value="14400" <?=$pconfig['serialspeed'] == "14400" ? 'selected="selected"' : '' ?>>14400</option>
                       <option value="9600" <?=$pconfig['serialspeed'] == "9600" ? 'selected="selected"' : '' ?>>9600</option>
                     </select>
-                    <output class="hidden" for="help_for_serialspeed">
+                    <div class="hidden" data-for="help_for_serialspeed">
                       <?=gettext("Allows selection of different speeds for the serial console port."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -710,9 +710,9 @@ $(document).ready(function() {
                   <td style="width:78%">
                     <input name="disableintegratedauth" type="checkbox" value="yes" <?= empty($pconfig['disableintegratedauth']) ? '' : 'checked="checked"' ?>  />
                     <strong><?=gettext("Disable integrated authentication"); ?></strong>
-                    <output class="hidden" for="help_for_disableintegratedauth">
+                    <div class="hidden" data-for="help_for_disableintegratedauth">
                         <?=gettext("Disable OPNsense integrated authentication module for console access, falling back to normal unix authentication.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/system_advanced_firewall.php
+++ b/src/www/system_advanced_firewall.php
@@ -263,10 +263,10 @@ include("head.inc");
                   <td>
                     <input name="ipv6allow" type="checkbox" value="yes" <?= !empty($pconfig['ipv6allow']) ? "checked=\"checked\"" :"";?> onclick="enable_change(false)" />
                     <strong><?=gettext("Allow IPv6"); ?></strong>
-                    <output class="hidden" for="help_for_ipv6allow">
+                    <div class="hidden" data-for="help_for_ipv6allow">
                       <?=gettext("All IPv6 traffic will be blocked by the firewall unless this box is checked."); ?><br />
                       <?=gettext("NOTE: This does not disable any IPv6 features on the firewall, it only blocks traffic."); ?><br />
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php           if (count($config['interfaces']) > 1): ?>
@@ -277,29 +277,29 @@ include("head.inc");
                   <td><a id="help_for_natreflection" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reflection for port forwards");?></td>
                   <td>
                     <input name="natreflection" type="checkbox" id="natreflection" value="yes" <?= !empty($pconfig['natreflection']) ? 'checked="checked"' : '' ?>/>
-                    <output class="hidden" for="help_for_natreflection">
+                    <div class="hidden" data-for="help_for_natreflection">
                       <?=gettext("When enabled, this automatically creates additional NAT redirect rules for access to port forwards on your external IP addresses from within your internal networks.");?>
                       <?=gettext("Individual rules may be configured to override this system setting on a per-rule basis.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_enablebinatreflection" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reflection for 1:1");?></td>
                   <td>
                     <input name="enablebinatreflection" type="checkbox" id="enablebinatreflection" value="yes" <?=!empty($pconfig['enablebinatreflection']) ? "checked=\"checked\"" : "";?>/>
-                    <output class="hidden" for="help_for_enablebinatreflection">
+                    <div class="hidden" data-for="help_for_enablebinatreflection">
                       <?=gettext("Enables the automatic creation of additional NAT redirect rules for access to 1:1 mappings of your external IP addresses from within your internal networks.");?>
                       <?=gettext("Individual rules may be configured to override this system setting on a per-rule basis.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_enablenatreflectionhelper" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Automatic outbound NAT for Reflection");?></td>
                   <td>
                     <input name="enablenatreflectionhelper" type="checkbox" id="enablenatreflectionhelper" value="yes" <?=!empty($pconfig['enablenatreflectionhelper']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_enablenatreflectionhelper">
+                    <div class="hidden" data-for="help_for_enablenatreflectionhelper">
                       <?=gettext("Automatically create outbound NAT rules which assist inbound NAT rules that direct traffic back out to the same subnet it originated from.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php           endif; ?>
@@ -320,9 +320,9 @@ include("head.inc");
                       <?=gettext("Daily"); ?>
                     </option>
                     </select>
-                    <output class="hidden" for="help_for_bogonsinterval">
+                    <div class="hidden" data-for="help_for_bogonsinterval">
                       <?=gettext("The frequency of updating the lists of IP addresses that are reserved (but not RFC 1918) or not yet assigned by IANA.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -333,9 +333,9 @@ include("head.inc");
                   <td>
                     <input name="kill_states" type="checkbox" id="kill_states" value="yes" <?= !empty($pconfig['kill_states']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Disable State Killing on Gateway Failure"); ?></strong>
-                    <output class="hidden" for="help_for_kill_states">
+                    <div class="hidden" data-for="help_for_kill_states">
                       <?=gettext("The monitoring process will flush states for a gateway that goes down if this box is not checked. Check this box to disable this behavior."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -343,11 +343,11 @@ include("head.inc");
                   <td>
                     <input name="skip_rules_gw_down" type="checkbox" id="skip_rules_gw_down" value="yes" <?=!empty($pconfig['skip_rules_gw_down']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Skip rules when gateway is down"); ?></strong>
-                    <output class="hidden" for="help_for_skip_rules_gw_down">
+                    <div class="hidden" data-for="help_for_skip_rules_gw_down">
                       <?=gettext("By default, when a rule has a specific gateway set, and this gateway is down, ".
                                           "rule is created and traffic is sent to default gateway.This option overrides that behavior ".
                                           "and the rule is not created when gateway is down"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -355,9 +355,9 @@ include("head.inc");
                   <td>
                     <input name="gw_switch_default" type="checkbox" id="gw_switch_default" value="yes" <?= !empty($pconfig['gw_switch_default']) ? 'checked="checked"' : '' ?> />
                     <strong><?=gettext("Allow default gateway switching"); ?></strong><br />
-                    <output class="hidden" for="help_for_gw_switch_default">
+                    <div class="hidden" data-for="help_for_gw_switch_default">
                       <?= gettext('If the link where the default gateway resides fails switch the default gateway to another available one.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -368,7 +368,7 @@ include("head.inc");
                   <td>
                     <input name="lb_use_sticky" type="checkbox" id="lb_use_sticky" value="yes" <?= !empty($pconfig['lb_use_sticky']) ? 'checked="checked"' : '';?>/>
                     <strong><?=gettext("Use sticky connections"); ?></strong><br />
-                    <output class="hidden" for="help_for_lb_use_sticky">
+                    <div class="hidden" data-for="help_for_lb_use_sticky">
                       <?=gettext("Successive connections will be redirected to the servers " .
                                           "in a round-robin manner with connections from the same " .
                                           "source being sent to the same gateway. This 'sticky " .
@@ -376,13 +376,13 @@ include("head.inc");
                                           "refer to this connection. Once the states expire, so will " .
                                           "the sticky connection. Further connections from that host " .
                                           "will be redirected to the next gateway in the round-robin."); ?>
-                    </output><br/>
+                    </div><br/>
                     <input placeholder="<?=gettext("Source tracking timeout");?>" title="<?=gettext("Source tracking timeout");?>" name="srctrack" id="srctrack" type="text" value="<?= !empty($pconfig['srctrack']) ? $pconfig['srctrack'] : "";?>"/>
-                    <output class="hidden" for="help_for_lb_use_sticky">
+                    <div class="hidden" data-for="help_for_lb_use_sticky">
                       <?=gettext("Set the source tracking timeout for sticky connections in seconds. " .
                                           "By default this is 0, so source tracking is removed as soon as the state expires. " .
                                           "Setting this timeout higher will cause the source/destination relationship to persist for longer periods of time."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -390,12 +390,12 @@ include("head.inc");
                   <td>
                     <input name="pf_share_forward" type="checkbox" id="pf_share_forward" value="yes" <?= !empty($pconfig['pf_share_forward']) ? 'checked="checked"' : '' ?>/>
                     <strong><?=gettext('Use shared forwarding between packet filter, traffic shaper and captive portal'); ?></strong><br />
-                    <output class="hidden" for="help_for_pf_share_forward">
+                    <div class="hidden" data-for="help_for_pf_share_forward">
                       <?= gettext('Using policy routing in the packet filter rules causes packets to skip ' .
                                   'processing for the traffic shaper and captive portal tasks. ' .
                                   'Using this option enables the sharing of such forwarding decisions ' .
                                   'between all components to accomodate complex setups. Use with care.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -403,11 +403,11 @@ include("head.inc");
                   <td>
                     <input name="pf_disable_force_gw" type="checkbox" id="pf_disable_force_gw" value="yes" <?= !empty($pconfig['pf_disable_force_gw']) ? 'checked="checked"' : '' ?>/>
                     <strong><?=gettext('Disable automatic rules which force local services to use the assigned interface gateway.'); ?></strong><br />
-                    <output class="hidden" for="help_pf_disable_force_gw">
+                    <div class="hidden" data-for="help_pf_disable_force_gw">
                       <?= gettext('Outgoing packets from this firewall on an interface which has a gateway ' .
                                   'will normally use the specified gateway for that interface. ' .
                                   'When this option is set, the default routing rules apply (automatic rules will be disabled).') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -417,10 +417,10 @@ include("head.inc");
                   <td><a id="help_for_schedule_states" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Schedule States"); ?></td>
                   <td>
                     <input name="schedule_states" type="checkbox" value="yes" <?=!empty($pconfig['schedule_states']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_schedule_states">
+                    <div class="hidden" data-for="help_for_schedule_states">
                       <?=gettext("By default schedules clear the states of existing connections when the expiration time has come. ".
                                           "This option overrides that behavior by not clearing states for existing connections."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -443,7 +443,7 @@ include("head.inc");
                         <?=gettext("conservative");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_optimization">
+                    <div class="hidden" data-for="help_for_optimization">
                       <?=gettext("Select the type of state table optimization to use");?>
                       <table class="table table-condensed">
                         <tr>
@@ -464,7 +464,7 @@ include("head.inc");
                         </tr>
                       </table>
                       <hr/>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -481,7 +481,7 @@ include("head.inc");
                         <?=gettext("profile");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_rulesetoptimization">
+                    <div class="hidden" data-for="help_for_rulesetoptimization">
                       <?=gettext("Select the type of rules optimization to use");?>
                       <table class="table table-condensed">
                         <tr>
@@ -498,7 +498,7 @@ include("head.inc");
                         </tr>
                       </table>
                       <hr/>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -506,14 +506,14 @@ include("head.inc");
                   <td>
                     <input name="disablefilter" type="checkbox" value="yes" <?= !empty($pconfig['disablefilter']) ? "checked=\"checked\"" : "";?>/>
                     <strong><?=gettext("Disable all packet filtering.");?></strong>
-                    <output class="hidden" for="help_for_disablefilter">
+                    <div class="hidden" data-for="help_for_disablefilter">
                       <?= gettext('Warning: This will convert into a routing-only platform!') ?><br />
                       <?= gettext('Warning: This will also turn off NAT!') ?><br />
                       <?=sprintf(
                         gettext('If you only want to disable NAT, and not firewall rules, visit the %sOutbound NAT%s page.'),
                         '<a href="/firewall_nat_out.php">', '</a>'
                       )?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -537,7 +537,7 @@ include("head.inc");
                         </tr>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_adaptive">
+                    <div class="hidden" data-for="help_for_adaptive">
                       <strong><?=gettext("Timeouts for states can be scaled adaptively as the number of state table entries grows.");?></strong>
                       <br />
                       <strong><?=gettext("start");?></strong></br>
@@ -546,36 +546,36 @@ include("head.inc");
                       <?=gettext("When reaching this number of state entries, all timeout values become zero, effectively purging all state entries immediately. This value is used to define the scale factor, it should not actually be reached (set a lower state limit, see below).");?>
                       <br/>
                       <strong><?=gettext("Note: Leave this blank for the default(0).");?></strong>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_maximumstates" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Firewall Maximum States");?></td>
                   <td>
                     <input name="maximumstates" type="text" id="maximumstates" value="<?=$pconfig['maximumstates'];?>" />
-                    <output class="hidden" for="help_for_maximumstates">
+                    <div class="hidden" data-for="help_for_maximumstates">
                       <strong><?=gettext("Maximum number of connections to hold in the firewall state table.");?></strong>
                       <br />
                       <?=gettext("Note: Leave this blank for the default. On your system the default size is:");?> <?= default_state_size() ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_maximumfrags" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Firewall Maximum Fragments");?></td>
                   <td>
                     <input name="maximumfrags" type="text" id="maximumfrags" value="<?=$pconfig['maximumfrags'];?>" />
-                    <output class="hidden" for="help_for_maximumfrags">
+                    <div class="hidden" data-for="help_for_maximumfrags">
                       <strong><?=gettext("Sets the maximum number of entries in the memory pool used for fragment reassembly.");?></strong>
                       <br />
                       <?=gettext("Note: Leave this blank for the default.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_maximumtableentries" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Firewall Maximum Table Entries");?></td>
                   <td>
                     <input name="maximumtableentries" type="text" id="maximumtableentries" value="<?= html_safe($pconfig['maximumtableentries']) ?>"/>
-                    <output class="hidden" for="help_for_maximumtableentries">
+                    <div class="hidden" data-for="help_for_maximumtableentries">
                       <strong><?=gettext("Maximum number of table entries for systems such as aliases, sshlockout, snort, etc, combined.");?></strong>
                       <br />
                       <?=gettext("Note: Leave this blank for the default.");?>
@@ -584,7 +584,7 @@ include("head.inc");
                         <?= gettext("On your system the default size is:");?> <?= default_table_entries_size(); ?>
 <?php
                       endif;?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -592,11 +592,11 @@ include("head.inc");
                   <td>
                     <input name="bypassstaticroutes" type="checkbox" value="yes" <?=!empty($pconfig['bypassstaticroutes']) ? "checked=\"checked\"" : "";?>/>
                     <strong><?=gettext("Bypass firewall rules for traffic on the same interface");?></strong>
-                    <output class="hidden" for="help_for_bypassstaticroutes">
+                    <div class="hidden" data-for="help_for_bypassstaticroutes">
                       <?=gettext("This option only applies if you have defined one or more static routes. If it is enabled, traffic that enters and " .
                                           "leaves through the same interface will not be checked by the firewall. This may be desirable in some situations where " .
                                           "multiple subnets are connected to the same interface.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -604,10 +604,10 @@ include("head.inc");
                   <td>
                     <input name="disablereplyto" type="checkbox" value="yes" <?=!empty($pconfig['disablereplyto']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Disable reply-to on WAN rules");?></strong>
-                    <output class="hidden" for="help_for_disablereplyto">
+                    <div class="hidden" data-for="help_for_disablereplyto">
                       <?=gettext("With Multi-WAN you generally want to ensure traffic leaves the same interface it arrives on, hence reply-to is added automatically by default. " .
                                           "When using bridging, you must disable this behavior if the WAN gateway IP is different from the gateway IP of the hosts behind the bridged interface.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -615,7 +615,7 @@ include("head.inc");
                   <td>
                     <input name="noantilockout" type="checkbox" value="yes" <?= empty($pconfig['noantilockout']) ? '' : 'checked="checked"' ?>/>
                     <strong><?= gettext('Disable administration anti-lockout rule') ?></strong>
-                    <output class="hidden" for="help_for_noantilockout">
+                    <div class="hidden" data-for="help_for_noantilockout">
                       <?= sprintf(gettext("When this is unchecked, access to the web GUI or SSH " .
                                   "on the %s interface is always permitted, regardless of the user-defined firewall " .
                                   "rule set. Check this box to disable the automatically added rule, so access " .
@@ -623,18 +623,18 @@ include("head.inc");
                                   "in place that allows you in, or you will lock yourself out."),
                                   count($config['interfaces']) == 1 && !empty($config['interfaces']['wan']['if']) ?
                                   gettext('WAN') : gettext('LAN')) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_aliasesresolveinterval" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Aliases Resolve Interval");?></td>
                   <td>
                     <input name="aliasesresolveinterval" type="text" value="<?=$pconfig['aliasesresolveinterval']; ?>" />
-                    <output class="hidden" for="help_for_aliasesresolveinterval">
+                    <div class="hidden" data-for="help_for_aliasesresolveinterval">
                       <strong><?=gettext("Interval, in seconds, that will be used to resolve hostnames configured on aliases.");?></strong>
                       <br />
                       <?=gettext("Note: Leave this blank for the default (300s).");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -642,9 +642,9 @@ include("head.inc");
                   <td>
                     <input name="checkaliasesurlcert" type="checkbox" value="yes" <?=!empty($pconfig['checkaliasesurlcert']) ? "checked=\"checked\"" : "";?> />
                     <strong><?=gettext("Verify HTTPS certificates when downloading alias URLs");?></strong>
-                    <output class="hidden" for="help_for_checkaliasesurlcert">
+                    <div class="hidden" data-for="help_for_checkaliasesurlcert">
                       <?=gettext("Make sure the certificate is valid for all HTTPS addresses on aliases. If it's not valid or is revoked, do not download it.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/system_advanced_misc.php
+++ b/src/www/system_advanced_misc.php
@@ -244,7 +244,7 @@ include("head.inc");
 <?php
                     endforeach; ?>
                   </select>
-                  <output class="hidden" for="help_for_crypto_hardware">
+                  <div class="hidden" data-for="help_for_crypto_hardware">
                     <?=gettext("A cryptographic accelerator module will use hardware support to speed up some " .
                                             "cryptographic functions on systems which have the chip. Do not enable this " .
                                             "option if you have a Hifn cryptographic acceleration card, as this will take " .
@@ -255,7 +255,7 @@ include("head.inc");
                   <br /><br />
                   <?=gettext("If you do not have a crypto chip in your system, this option will have no " .
                                       "effect. To unload the selected module, set this option to 'none' and then reboot."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -263,13 +263,13 @@ include("head.inc");
                 <td>
                   <input name="cryptodev_enable" type="checkbox" id="cryptodev_enable" value="yes" <?= !empty($pconfig['cryptodev_enable']) ? "checked=\"checked\"" : "";?> />
                   <strong><?=gettext("Enable old userland device for cryptographic acceleration"); ?></strong>
-                  <output class="hidden" for="help_for_cryptodev_enable">
+                  <div class="hidden" data-for="help_for_cryptodev_enable">
                     <?=gettext("Old hardware accelerators like 'safe', 'hifn' or 'ubsec' may only provide userland acceleration to e.g. " .
                                             "OpenVPN by means of the /dev/crypto interface, which can be accessed via the OpenSSL " .
                                             "engine framework. Note that LibreSSL does not have support for this device and " .
                                             "instead solely relies on embedded acceleration methods e.g. AES-NI. The default is " .
                                             "to disable this device as it is likely not needed on modern systems."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -288,14 +288,14 @@ include("head.inc");
 <?php
                     endforeach; ?>
                   </select>
-                  <output class="hidden" for="help_for_thermal_hardware">
+                  <div class="hidden" data-for="help_for_thermal_hardware">
                     <?=gettext("If you have a supported CPU, selecting a themal sensor will load the appropriate " .
                                               "driver to read its temperature. Setting this to 'None' will attempt to read the " .
                                               "temperature from an ACPI-compliant motherboard sensor instead, if one is present."); ?>
                     <br /><br />
                     <?=gettext("If you do not have a supported thermal sensor chip in your system, this option will have no " .
                                           "effect. To unload the selected module, set this option to 'none' and then reboot."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -315,9 +315,9 @@ include("head.inc");
                       endfor; ?>
                   </select>
                   <br />
-                  <output class="hidden" for="help_for_rrdbackup">
+                  <div class="hidden" data-for="help_for_rrdbackup">
                     <?=gettext("This will periodically backup the RRD data so it can be restored automatically on the next boot.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -333,9 +333,9 @@ include("head.inc");
 <?php
                     endfor; ?>
                   </select>
-                  <output class="hidden" for="help_for_dhcpbackup">
+                  <div class="hidden" data-for="help_for_dhcpbackup">
                     <?=gettext("This will periodically backup the DHCP leases data so it can be restored automatically on the next boot.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -351,9 +351,9 @@ include("head.inc");
 <?php
                     endfor; ?>
                   </select>
-                  <output class="hidden" for="help_for_netflowbackup">
+                  <div class="hidden" data-for="help_for_netflowbackup">
                     <?=gettext("This will periodically backup the NetFlow data aggregation so it can be restored automatically on the next boot.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -369,9 +369,9 @@ include("head.inc");
 <?php
                     endfor; ?>
                   </select>
-                  <output class="hidden" for="help_for_captiveportalbackup">
+                  <div class="hidden" data-for="help_for_captiveportalbackup">
                     <?=gettext("This will periodically backup the captive portal session data so it can be restored automatically on the next boot.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -381,7 +381,7 @@ include("head.inc");
                 <td><a id="help_for_powerd_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use PowerD"); ?></td>
                 <td>
                   <input name="powerd_enable" type="checkbox" id="powerd_enable" value="yes" <?=!empty($pconfig['powerd_enable']) ? "checked=\"checked\"" : "";?> />
-                  <output class="hidden" for="help_for_powerd_enable">
+                  <div class="hidden" data-for="help_for_powerd_enable">
                     <?=gettext("The powerd utility monitors the system state and sets various power control " .
                                         "options accordingly. It offers four modes (maximum, minimum, adaptive " .
                                         "and hiadaptive) that can be individually selected while on AC power or batteries. " .
@@ -395,7 +395,7 @@ include("head.inc");
                                         "tuned for systems where performance and interactivity are more important " .
                                         "than power consumption. It raises frequency faster, drops slower and " .
                                         "keeps twice lower CPU load."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -452,9 +452,9 @@ include("head.inc");
                       <?=gettext("Maximum");?>
                     </option>
                   </select>
-                  <output class="hidden" for="help_for_powerd_normal_mode">
+                  <div class="hidden" data-for="help_for_powerd_normal_mode">
                     <?=gettext("If the powerd utility can not determine the power state it uses \"normal\" for control."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -472,10 +472,10 @@ include("head.inc");
                 <td>
                   <input name="use_mfs_var" type="checkbox" id="use_mfs_var" value="yes" <?=!empty($pconfig['use_mfs_var']) ? 'checked="checked"' : '';?>/>
                   <strong><?=gettext("Use memory file system for /var"); ?></strong>
-                  <output class="hidden" for="help_for_use_mfs_var">
+                  <div class="hidden" data-for="help_for_use_mfs_var">
                     <?=gettext("Set this if you wish to use /var as a RAM disk (memory file system disks) " .
                       "rather than using the hard disk. Setting this will cause the data /var to be lost on reboot, including log data."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -483,9 +483,9 @@ include("head.inc");
                 <td>
                   <input name="use_mfs_tmp" type="checkbox" id="use_mfs_tmp" value="yes" <?=!empty($pconfig['use_mfs_tmp']) ? 'checked="checked"' : '';?>/>
                   <strong><?=gettext('Use memory file system for /tmp'); ?></strong>
-                  <output class="hidden" for="help_for_use_mfs_tmp">
+                  <div class="hidden" data-for="help_for_use_mfs_tmp">
                     <?= gettext('Set this if you wish to use /tmp as a RAM disk (memory file system disk) rather than using the hard disk.') ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -214,9 +214,9 @@ include("head.inc");
                 <td>
                   <input name="disablechecksumoffloading" type="checkbox" id="disablechecksumoffloading" value="yes" <?= !empty($pconfig['disablechecksumoffloading']) ? "checked=\"checked\"" :"";?> />
                   <strong><?=gettext("Disable hardware checksum offload"); ?></strong>
-                  <output class="hidden" for="help_for_disablechecksumoffloading">
+                  <div class="hidden" data-for="help_for_disablechecksumoffloading">
                     <?=gettext("Checking this option will disable hardware checksum offloading. Checksum offloading is broken in some hardware, particularly some Realtek cards. Rarely, drivers may have problems with checksum offloading and some specific NICs."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -224,9 +224,9 @@ include("head.inc");
                 <td>
                   <input name="disablesegmentationoffloading" type="checkbox" id="disablesegmentationoffloading" value="yes" <?= !empty($pconfig['disablesegmentationoffloading']) ? "checked=\"checked\"" :"";?>/>
                   <strong><?=gettext("Disable hardware TCP segmentation offload"); ?></strong><br />
-                  <output class="hidden" for="help_for_disablesegmentationoffloading">
+                  <div class="hidden" data-for="help_for_disablesegmentationoffloading">
                     <?=gettext("Checking this option will disable hardware TCP segmentation offloading (TSO, TSO4, TSO6). This offloading is broken in some hardware drivers, and may impact performance with some specific NICs."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -234,9 +234,9 @@ include("head.inc");
                 <td>
                   <input name="disablelargereceiveoffloading" type="checkbox" id="disablelargereceiveoffloading" value="yes" <?= !empty($pconfig['disablelargereceiveoffloading']) ? "checked=\"checked\"" :"";?>/>
                   <strong><?=gettext("Disable hardware large receive offload"); ?></strong><br />
-                  <output class="hidden" for="help_for_disablelargereceiveoffloading">
+                  <div class="hidden" data-for="help_for_disablelargereceiveoffloading">
                     <?=gettext("Checking this option will disable hardware large receive offloading (LRO). This offloading is broken in some hardware drivers, and may impact performance with some specific NICs."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -253,9 +253,9 @@ include("head.inc");
                         <?=gettext("Leave default");?>
                       </option>
                   </select>
-                  <output class="hidden" for="help_for_disablevlanhwfilter">
+                  <div class="hidden" data-for="help_for_disablevlanhwfilter">
                     <?= gettext('Set usage of VLAN hardware filtering. This hardware acceleration may be broken in a particular device driver, or may impact performance.') ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -263,19 +263,19 @@ include("head.inc");
                 <td>
                   <input name="sharednet" type="checkbox" id="sharednet" value="yes" <?= !empty($pconfig['sharednet']) ? "checked=\"checked\"" :"";?>/>
                   <strong><?=gettext("Suppress ARP messages"); ?></strong><br />
-                  <output class="hidden" for="help_for_sharednet">
+                  <div class="hidden" data-for="help_for_sharednet">
                     <?=gettext("This option will suppress ARP log messages when multiple interfaces reside on the same broadcast domain"); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_persistent_duid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Unique Identifier"); ?></td>
                 <td>
                   <input name="ipv6duid" type="text" id="ipv6duid" value="<?=htmlspecialchars($pconfig['ipv6duid']);?>" />
-                  <output class="hidden" for="help_for_persistent_duid">
+                  <div class="hidden" data-for="help_for_persistent_duid">
                     <?= gettext('This field can be used to enter an explicit DUID for use by IPv6 DHCP clients.') ?><br />
                     <a onclick="$('#ipv6duid').val('<?= html_safe($duid) ?>');" href="#"><?=gettext("Insert the existing DUID here"); ?></a>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>

--- a/src/www/system_advanced_notifications.php
+++ b/src/www/system_advanced_notifications.php
@@ -165,45 +165,45 @@ include("head.inc");
                 <td><a id="help_for_disable_growl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable Growl Notifications"); ?></td>
                 <td>
                   <input type='checkbox' name='disable_growl' value="yes" <?=!empty($pconfig['disable_growl']) ? "checked=\"checked\"" : "";?>/>
-                  <output class="hidden" for="help_for_disable_growl">
+                  <div class="hidden" data-for="help_for_disable_growl">
                     <?=gettext("Check this option to disable growl notifications but preserve the settings below."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Registration Name"); ?></td>
                 <td>
                   <input name="name" type="text" value="<?=$pconfig['name']; ?>"/>
-                  <output class="hidden" for="help_for_name">
+                  <div class="hidden" data-for="help_for_name">
                     <?=gettext("Enter the name to register with the Growl server (default: PHP-Growl)."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_notification_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Notification Name"); ?></td>
                 <td>
                   <input name='notification_name' type='text' value='<?=$pconfig['notification_name']; ?>' /><br />
-                  <output class="hidden" for="help_for_notification_name">
+                  <div class="hidden" data-for="help_for_notification_name">
                     <?=sprintf(gettext("Enter a name for the Growl notifications (default: %s growl alert)."), $g['product_name']); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_ipaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IP Address"); ?></td>
                 <td>
                   <input name="ipaddress" type="text" value="<?=$pconfig['ipaddress']; ?>" /><br />
-                  <output class="hidden" for="help_for_ipaddress">
+                  <div class="hidden" data-for="help_for_ipaddress">
                     <?=gettext("This is the IP address that you would like to send growl notifications to."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Password"); ?></td>
                 <td>
                   <input name="password" type="password" value="<?=$pconfig['password']; ?>"/><br />
-                  <output class="hidden" for="help_for_password">
+                  <div class="hidden" data-for="help_for_password">
                     <?=gettext("Enter the password of the remote growl notification device."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -213,27 +213,27 @@ include("head.inc");
                 <td><a id="help_for_disable_smtp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable SMTP Notifications"); ?></td>
                 <td>
                   <input type="checkbox" name="disable_smtp" value="yes" <?=!empty($pconfig['disable_smtp']) ? "checked=\"checked\"" : "";?>/>
-                  <output class="hidden" for="help_for_disable_smtp">
+                  <div class="hidden" data-for="help_for_disable_smtp">
                     <?=gettext("Check this option to disable SMTP notifications but preserve the settings below. Some other mechanisms, such as packages, may need these settings in place to function."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_smtpipaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email server"); ?></td>
                 <td>
                   <input name="smtpipaddress" type="text" value="<?=$pconfig['smtpipaddress']; ?>" />
-                  <output class="hidden" for="help_for_smtpipaddress">
+                  <div class="hidden" data-for="help_for_smtpipaddress">
                     <?=gettext("This is the FQDN or IP address of the SMTP Email server to which notifications will be sent."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_smtpport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("SMTP Port of Email server"); ?></td>
                 <td>
                   <input name="smtpport" type="text" value="<?=$pconfig['smtpport']; ?>" />
-                  <output class="hidden" for="help_for_smtpport">
+                  <div class="hidden" data-for="help_for_smtpport">
                     <?=gettext("This is the port of the SMTP Email server, typically 25, 587 (submission) or 465 (smtps)"); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -249,38 +249,38 @@ include("head.inc");
                 <td><a id="help_for_smtpfromaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Sender address"); ?></td>
                 <td>
                   <input name="smtpfromaddress" type="text" value="<?=$pconfig['smtpfromaddress']; ?>" />
-                  <output class="hidden" for="help_for_smtpfromaddress">
+                  <div class="hidden" data-for="help_for_smtpfromaddress">
                     <?=gettext("This is the email address that will appear as the email notification sender."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_smtpnotifyemailaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Recipient address"); ?></td>
                 <td>
                   <input name="smtpnotifyemailaddress" type="text" value="<?=$pconfig['smtpnotifyemailaddress'];?>" />
-                  <output class="hidden" for="help_for_smtpnotifyemailaddress">
+                  <div class="hidden" data-for="help_for_smtpnotifyemailaddress">
                     <?=gettext("Enter the email address that you would like email notifications sent to."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_smtpusername" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email auth username"); ?></td>
                 <td>
                   <input name="smtpusername" type="text" value="<?=$pconfig['smtpusername']; ?>" />
-                  <output class="hidden" for="help_for_smtpusername">
+                  <div class="hidden" data-for="help_for_smtpusername">
                     <small><?=gettext("(optional)");?></small><br/>
                     <?=gettext("Enter the email address username for SMTP authentication."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_smtppassword" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email auth password"); ?></td>
                 <td>
                   <input name='smtppassword' type='password' value='<?=$pconfig['smtppassword']; ?>' /><br />
-                  <output class="hidden" for="help_for_smtppassword">
+                  <div class="hidden" data-for="help_for_smtppassword">
                     <small><?=gettext("(optional)");?></small><br/>
                     <?=gettext("Enter the email address password for SMTP authentication."); ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -296,9 +296,9 @@ include("head.inc");
                   <input name="disablebeep" type="checkbox" id="disablebeep" value="yes" <?=!empty($pconfig['disablebeep']) ? "checked=\"checked\"" : "";?>/>
                   <strong><?=gettext("Disable the startup/shutdown beep"); ?></strong>
                   <br />
-                  <output class="hidden" for="help_for_disablebeep">
+                  <div class="hidden" data-for="help_for_disablebeep">
                     <span class="vexpl"><?=gettext("When this is checked, startup and shutdown sounds will no longer play."); ?></span>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -508,9 +508,9 @@ endif; ?>
                   <td><a id="help_for_ldap_host" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname or IP address");?></td>
                   <td>
                     <input name="ldap_host" type="text" id="ldap_host" size="20" value="<?=$pconfig['ldap_host'];?>"/>
-                    <output class="hidden" for="help_for_ldap_host">
+                    <div class="hidden" data-for="help_for_ldap_host">
                       <?= gettext("NOTE: When using SSL, this hostname MUST match the Common Name (CN) of the LDAP server's SSL Certificate."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="auth_ldap auth_options hidden">
@@ -548,10 +548,10 @@ endif; ?>
 <?php
                     endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_ldap_caref">
+                    <div class="hidden" data-for="help_for_ldap_caref">
                       <span><?=gettext("This option is used if 'SSL Encrypted' option is choosen.");?> <br />
                       <?=gettext("It must match with the CA in the AD otherwise problems will arise.");?></span>
-                    </output>
+                    </div>
 <?php
                     else :?>
                     <b><?=gettext('No Certificate Authorities defined.');?></b> <br /><?=gettext('Create one under');?> <a href="system_camanager.php"><?=gettext('System: Certificates');?></a>.
@@ -575,9 +575,9 @@ endif; ?>
                     <input name="ldap_binddn" type="text" id="ldap_binddn" size="40" value="<?=$pconfig['ldap_binddn'];?>"/>
                     <?=gettext("Password:");?><br/>
                     <input name="ldap_bindpw" type="password" class="formfld pwd" id="ldap_bindpw" size="20" value="<?=$pconfig['ldap_bindpw'];?>"/><br />
-                    <output class="hidden" for="help_for_ldap_binddn">
+                    <div class="hidden" data-for="help_for_ldap_binddn">
                       <?=gettext("Leave empty to use anonymous binds to resolve distinguished names");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="auth_ldap auth_options hidden">
@@ -607,19 +607,19 @@ endif; ?>
                     <li><input type="button" id="act_select" class="btn btn-default" value="<?=gettext("Select");?>" /></li>
                     </ul>
                     <br/>
-                    <output class="hidden" for="help_for_ldapauthcontainers">
+                    <div class="hidden" data-for="help_for_ldapauthcontainers">
                         <br/><?= gettext('Semicolon-separated list of distinguished names optionally containing DC= components.') ?>
                         <br/><?=gettext("Example:");?> OU=Freelancers,O=Company,DC=example,DC=com;CN=Users,OU=Staff,O=Company
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="auth_ldap auth_options hidden">
                   <td><a id="help_for_ldap_extended_query" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Extended Query");?></td>
                   <td>
                     <input name="ldap_extended_query" type="text" id="ldap_extended_query" size="40" value="<?=$pconfig['ldap_extended_query'];?>"/>
-                    <output class="hidden" for="help_for_ldap_extended_query">
+                    <div class="hidden" data-for="help_for_ldap_extended_query">
                       <?=gettext("Example:");?> &amp;(objectClass=inetOrgPerson)(mail=*@example.com)
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php if (!isset($id)) :
@@ -640,9 +640,9 @@ endif; ?>
                   <td><a id="help_for_ldap_attr_user" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("User naming attribute");?></td>
                   <td>
                     <input name="ldap_attr_user" type="text" id="ldap_attr_user" size="20" value="<?=$pconfig['ldap_attr_user'];?>"/>
-                    <output class="hidden" for="help_for_ldap_attr_user">
+                    <div class="hidden" data-for="help_for_ldap_attr_user">
                       <?= gettext('Typically "cn" (OpenLDAP, Novell eDirectory), "sAMAccountName" (Microsoft AD)') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <!-- RADIUS -->
@@ -687,11 +687,11 @@ endif; ?>
                   <td><a id="help_for_radius_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Authentication Timeout");?></td>
                   <td>
                     <input name="radius_timeout" type="text" id="radius_timeout" size="20" value="<?=$pconfig['radius_timeout'];?>"/>
-                    <output class="hidden" for="help_for_radius_timeout">
+                    <div class="hidden" data-for="help_for_radius_timeout">
                       <br /><?= gettext("This value controls how long, in seconds, that the RADIUS server may take to respond to an authentication request.") ?>
                       <br /><?= gettext("If left blank, the default value is 5 seconds.") ?>
                       <br /><br /><?= gettext("NOTE: If you are using an interactive two-factor authentication system, increase this timeout to account for how long it will take the user to receive and enter a token.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <!-- pluggable options -->
@@ -732,9 +732,9 @@ endif; ?>
                         <input name="<?=$fieldname;?>" type="checkbox" value="1" <?=!empty($pconfig[$fieldname]) ? "checked=\"checked\"" : ""; ?>/>
 <?php
                         endif;?>
-                        <output class="hidden" for="help_for_field_<?=$typename;?>_<?=$fieldname;?>">
+                        <div class="hidden" data-for="help_for_field_<?=$typename;?>_<?=$fieldname;?>">
                           <?=$field['help'];?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
 

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -518,9 +518,9 @@ $main_buttons = array(
                 <td style="width:22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
                 <td style="width:78%">
                   <textarea name="cert" cols="65" rows="7" id="cert"><?=isset($pconfig['cert']) ? $pconfig['cert'] : "";?></textarea>
-                  <output class="hidden" for="help_for_cert">
+                  <div class="hidden" data-for="help_for_cert">
                     <?=gettext("Paste a certificate in X.509 PEM format here.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -530,18 +530,18 @@ $main_buttons = array(
                 </td>
                 <td style="width:78%">
                   <textarea name="key" id="key" cols="65" rows="7"><?= isset($pconfig['key']) ? $pconfig['key'] : "";?></textarea>
-                  <output class="hidden" for="help_for_key">
+                  <div class="hidden" data-for="help_for_key">
                     <?=gettext("Paste the private key for the above certificate here. This is optional in most cases, but required if you need to generate a Certificate Revocation List (CRL).");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_serial" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Serial for next certificate");?></td>
                 <td>
                   <input name="serial" type="text" id="serial" size="20" value="<?=$pconfig['serial'];?>"/>
-                  <output class="hidden" for="help_for_serial">
+                  <div class="hidden" data-for="help_for_serial">
                     <?=gettext("Enter a decimal number to be used as the serial number for the next certificate to be created using this CA.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               </tbody>
@@ -591,9 +591,9 @@ $main_buttons = array(
 <?php
                     endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_digest_alg">
+                    <div class="hidden" data-for="help_for_digest_alg">
                       <?= gettext("NOTE: It is recommended to use an algorithm stronger than SHA1 when possible.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -623,55 +623,55 @@ $main_buttons = array(
                   <td><a id="help_for_digest_dn_state" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("State or Province");?> : &nbsp;</td>
                   <td>
                     <input name="dn_state" type="text" size="40" value="<?=$pconfig['dn_state'];?>"/>
-                    <output class="hidden" for="help_for_digest_dn_state">
+                    <div class="hidden" data-for="help_for_digest_dn_state">
                       <em><?=gettext("ex:");?></em>
                       &nbsp;
                       <?=gettext("Sachsen");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_digest_dn_city" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("City");?> : &nbsp;</td>
                   <td>
                     <input name="dn_city" type="text" size="40" value="<?=$pconfig['dn_city'];?>"/>
-                    <output class="hidden" for="help_for_digest_dn_city">
+                    <div class="hidden" data-for="help_for_digest_dn_city">
                       <em><?=gettext("ex:");?></em>
                       &nbsp;
                       <?=gettext("Leipzig");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_digest_dn_organization" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Organization");?> : &nbsp;</td>
                   <td>
                     <input name="dn_organization" type="text" size="40" value="<?=$pconfig['dn_organization'];?>"/>
-                    <output class="hidden" for="help_for_digest_dn_organization">
+                    <div class="hidden" data-for="help_for_digest_dn_organization">
                       <em><?=gettext("ex:");?></em>
                       &nbsp;
                       <?=gettext("My Company Inc");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_digest_dn_email" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email Address");?> : &nbsp;</td>
                   <td>
                     <input name="dn_email" type="text" size="25" value="<?=$pconfig['dn_email'];?>"/>
-                    <output class="hidden" for="help_for_digest_dn_email">
+                    <div class="hidden" data-for="help_for_digest_dn_email">
                       <em><?=gettext("ex:");?></em>
                       &nbsp;
                       <?=gettext("admin@mycompany.com");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_digest_dn_commonname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Common Name");?> : &nbsp;</td>
                   <td>
                     <input name="dn_commonname" type="text" size="25" value="<?=$pconfig['dn_commonname'];?>"/>
-                    <output class="hidden" for="help_for_digest_dn_commonname">
+                    <div class="hidden" data-for="help_for_digest_dn_commonname">
                       <em><?=gettext("ex:");?></em>
                       &nbsp;
                       <?=gettext("internal-ca");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
               </tbody>

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -746,18 +746,18 @@ $( document ).ready(function() {
                   <td style="width:22%"><a id="help_for_cert" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Certificate data");?></td>
                   <td style="width:78%">
                     <textarea name="cert" id="cert" cols="65" rows="7"><?=$pconfig['cert'];?></textarea>
-                    <output class="hidden" for="help_for_cert">
+                    <div class="hidden" data-for="help_for_cert">
                       <?=gettext("Paste a certificate in X.509 PEM format here.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_key" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Private key data");?></td>
                   <td>
                     <textarea name="key" id="key" cols="65" rows="7" class="formfld_cert"><?=$pconfig['key'];?></textarea>
-                    <output class="hidden" for="help_for_key">
+                    <div class="hidden" data-for="help_for_key">
                       <?=gettext("Paste a private key in X.509 PEM format here.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -796,9 +796,9 @@ $( document ).ready(function() {
                         <option value="server_cert" <?=$pconfig['cert_type'] == 'server_cert' ? "selected=\"selected\"" : "";?>> <?=gettext("Server Certificate");?> </option>
                         <option value="v3_ca" <?=$pconfig['cert_type'] == 'v3_ca' ? "selected=\"selected\"" : "";?>> <?=gettext("Certificate Authority");?> </option>
                     </select>
-                    <output class="hidden" for="help_for_digest_cert_type">
+                    <div class="hidden" data-for="help_for_digest_cert_type">
                       <?=gettext("Choose the type of certificate to generate here, the type defines it's constraints");?>
-                    </output>
+                    </div>
                 </td>
               </tr>
               <tr>
@@ -825,9 +825,9 @@ $( document ).ready(function() {
 <?php
                   endforeach; ?>
                   </select>
-                  <output class="hidden" for="help_for_digest_alg">
+                  <div class="hidden" data-for="help_for_digest_alg">
                     <?= gettext("NOTE: It is recommended to use an algorithm stronger than SHA1 when possible.") ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -857,55 +857,55 @@ $( document ).ready(function() {
                 <td><a id="help_for_digest_dn_state" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("State or Province");?> : &nbsp;</td>
                 <td>
                   <input name="dn_state" id="dn_state" type="text" size="40" value="<?=$pconfig['dn_state'];?>"/>
-                  <output class="hidden" for="help_for_digest_dn_state">
+                  <div class="hidden" data-for="help_for_digest_dn_state">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("Sachsen");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_dn_city" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("City");?> : &nbsp;</td>
                 <td>
                   <input name="dn_city" id="dn_city" type="text" size="40" value="<?=$pconfig['dn_city'];?>"/>
-                  <output class="hidden" for="help_for_digest_dn_city">
+                  <div class="hidden" data-for="help_for_digest_dn_city">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("Leipzig");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_dn_organization" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Organization");?> : &nbsp;</td>
                 <td>
                   <input name="dn_organization" id="dn_organization" type="text" size="40" value="<?=$pconfig['dn_organization'];?>"/>
-                  <output class="hidden" for="help_for_digest_dn_organization">
+                  <div class="hidden" data-for="help_for_digest_dn_organization">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("My Company Inc");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_dn_email" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email Address");?> : &nbsp;</td>
                 <td>
                   <input name="dn_email" id="dn_email" type="text" size="25" value="<?=$pconfig['dn_email'];?>"/>
-                  <output class="hidden" for="help_for_digest_dn_email">
+                  <div class="hidden" data-for="help_for_digest_dn_email">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("admin@mycompany.com");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_dn_commonname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Common Name");?> : &nbsp;</td>
                 <td>
                   <input name="dn_commonname" id="dn_commonname" type="text" size="25" value="<?=$pconfig['dn_commonname'];?>"/>
-                  <output class="hidden" for="help_for_digest_dn_commonname">
+                  <div class="hidden" data-for="help_for_digest_dn_commonname">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("internal-ca");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -1009,9 +1009,9 @@ $( document ).ready(function() {
 <?php
                   endforeach; ?>
                   </select>
-                  <output class="hidden" for="help_for_csr_digest_alg">
+                  <div class="hidden" data-for="help_for_csr_digest_alg">
                     <?= gettext("NOTE: It is recommended to use an algorithm stronger than SHA1 when possible.") ?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -1035,66 +1035,66 @@ $( document ).ready(function() {
                 <td><a id="help_for_digest_csr_dn_state" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("State or Province");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_state" type="text" size="40" value="<?=$pconfig['csr_dn_state'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_state">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_state">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("Sachsen");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_csr_dn_city" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("City");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_city" type="text" size="40" value="<?=$pconfig['csr_dn_city'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_city">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_city">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("Leipzig");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_csr_dn_organization" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Organization");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_organization" type="text" size="40" value="<?=$pconfig['csr_dn_organization'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_organization">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_organization">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("My Company Inc");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_csr_dn_organizationalunit" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Organizational Unit");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_organizationalunit" type="text" size="40" value="<?=$pconfig['csr_dn_organizationalunit'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_organizationalunit">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_organizationalunit">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("IT department");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_csr_dn_email" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Email Address");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_email" type="text" size="25" value="<?=$pconfig['csr_dn_email'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_email">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_email">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("admin@mycompany.com");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><a id="help_for_digest_csr_dn_commonname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Common Name");?> : &nbsp;</td>
                 <td>
                   <input name="csr_dn_commonname" type="text" size="25" value="<?=$pconfig['csr_dn_commonname'];?>"/>
-                  <output class="hidden" for="help_for_digest_csr_dn_commonname">
+                  <div class="hidden" data-for="help_for_digest_csr_dn_commonname">
                     <em><?=gettext("ex:");?></em>
                     &nbsp;
                     <?=gettext("internal-ca");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
             </tbody>

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -376,9 +376,9 @@ include("head.inc");
                   <td style="width:22%"><a id="help_for_crltext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("CRL data");?></td>
                   <td style="width:78%">
                     <textarea name="crltext" id="crltext" cols="65" rows="7" class="formfld_crl"><?=$pconfig['crltext'];?></textarea>
-                    <output class="hidden" for="help_for_crltext">
+                    <div class="hidden" data-for="help_for_crltext">
                       <?=gettext("Paste a Certificate Revocation List in X.509 CRL format here.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -395,18 +395,18 @@ include("head.inc");
                   <td style="width:22%"><a id="help_for_lifetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Lifetime");?> (<?=gettext("days");?>)</td>
                   <td style="width:78%">
                     <input name="lifetime" type="text" id="lifetime" size="5" value="<?=$pconfig['lifetime'];?>"/>
-                    <output class="hidden" for="help_for_lifetime">
+                    <div class="hidden" data-for="help_for_lifetime">
                       <?=gettext("Default: 9999");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_serial" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Serial");?></td>
                   <td>
                     <input name="serial" type="text" id="serial" size="5" value="<?=$pconfig['serial'];?>"/>
-                    <output class="hidden" for="help_for_serial">
+                    <div class="hidden" data-for="help_for_serial">
                       <?=gettext("Default: 0");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -443,9 +443,9 @@ include("head.inc");
                 <td><a id="help_for_crltext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("CRL data");?></td>
                 <td>
                   <textarea name="crltext" id="crltext" cols="65" rows="7" class="formfld_crl"><?=$thiscrl['text'];?></textarea>
-                  <output class="hidden" for="help_for_crltext">
+                  <div class="hidden" data-for="help_for_crltext">
                     <?=gettext("Paste a Certificate Revocation List in X.509 CRL format here.");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>

--- a/src/www/system_gateway_groups_edit.php
+++ b/src/www/system_gateway_groups_edit.php
@@ -265,7 +265,7 @@ $( document ).ready(function() {
 <?php
                         endforeach;?>
                       </table>
-                      <output for="help_for_gatewayprio" class="hidden">
+                      <div data-for="help_for_gatewayprio" class="hidden">
                           <br>
                           <strong><?=gettext("Link Priority"); ?></strong> <br />
                           <?=gettext("The priority selected here defines in what order failover and balancing of links will be done. " .
@@ -275,7 +275,7 @@ $( document ).ready(function() {
                           <br />
                           <strong><?=gettext("Virtual IP"); ?></strong> <br />
                           <?=gettext("The virtual IP field selects what (virtual) IP should be used when this group applies to a local Dynamic DNS, IPsec or OpenVPN endpoint") ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -287,18 +287,18 @@ $( document ).ready(function() {
                         <option value="downlatency" <?=$pconfig['trigger'] == "downlatency" ? "selected=\"selected\"" :"";?> ><?=gettext("High Latency");?></option>
                         <option value="downlosslatency" <?=$pconfig['trigger'] == "downlosslatency" ? "selected=\"selected\"" :"";?> ><?=gettext("Packet Loss or High Latency");?></option>
                       </select>
-                      <output for="help_for_triggerlvl" class="hidden">
+                      <div data-for="help_for_triggerlvl" class="hidden">
                         <?=gettext("When to trigger exclusion of a member"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                      <output for="help_for_descr" class="hidden">
+                      <div data-for="help_for_descr" class="hidden">
                         <?=gettext("You may enter a description here for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/system_gateways_edit.php
+++ b/src/www/system_gateways_edit.php
@@ -570,10 +570,10 @@ $( document ).ready(function() {
                   <td><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                   <td>
                     <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : ""; ?> />
-                    <output class="hidden" for="help_for_disabled">
+                    <div class="hidden" data-for="help_for_disabled">
                       <strong><?=gettext("Disable this gateway");?></strong><br />
                       <?=gettext("Set this option to disable this gateway without removing it from the list.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -588,9 +588,9 @@ $( document ).ready(function() {
 <?php
                       endforeach;?>
                     </select>
-                      <output class="hidden" for="help_for_interface">
+                      <div class="hidden" data-for="help_for_interface">
                         <?=gettext("Choose which interface this gateway applies to."); ?>
-                      </output>
+                      </div>
                   </td>
                 </tr>
                 <tr>
@@ -604,76 +604,76 @@ $( document ).ready(function() {
                           <?=gettext("IPv6");?>
                       </option>
                     </select>
-                    <output class="hidden" for="help_for_ipprotocol">
+                    <div class="hidden" data-for="help_for_ipprotocol">
                         <?=gettext("Choose the Internet Protocol this gateway uses."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Name"); ?></td>
                   <td>
                     <input name="name" type="text" size="20" value="<?=$pconfig['name'];?>" />
-                    <output class="hidden" for="help_for_name">
+                    <div class="hidden" data-for="help_for_name">
                       <?=gettext("Gateway name"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_gateway" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Gateway"); ?></td>
                   <td>
                     <input name="gateway" type="text" size="28" value="<?=!empty($pconfig['dynamic']) ? "dynamic" : $pconfig['gateway'];?>"/>
-                    <output class="hidden" for="help_for_gateway">
+                    <div class="hidden" data-for="help_for_gateway">
                       <?=gettext("Gateway IP address"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_defaultgw" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Default Gateway"); ?></td>
                   <td>
                     <input name="defaultgw" type="checkbox" value="yes" <?=!empty($pconfig['defaultgw']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_defaultgw">
+                    <div class="hidden" data-for="help_for_defaultgw">
                       <?=gettext("This will select the above gateway as the default gateway"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_fargw" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Far Gateway"); ?></td>
                   <td>
                     <input name="fargw" type="checkbox" value="yes" <?=!empty($pconfig['fargw']) ? 'checked="checked"' : '';?> />
-                    <output class="hidden" for="help_for_fargw">
+                    <div class="hidden" data-for="help_for_fargw">
                       <?=gettext("This will allow the gateway to exist outside of the interface subnet."); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_monitor_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable Gateway Monitoring"); ?></td>
                   <td>
                     <input name="monitor_disable" type="checkbox" value="yes" <?=!empty($pconfig['monitor_disable']) ? "checked=\"checked\"" : "";?>/>
-                    <output class="hidden" for="help_for_monitor_disable">
+                    <div class="hidden" data-for="help_for_monitor_disable">
                       <?=gettext("This will consider this gateway as always being up"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_monitor" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Monitor IP"); ?></td>
                   <td>
                       <input name="monitor" type="text" value="<?=$pconfig['gateway'] == $pconfig['monitor'] ? "" : $pconfig['monitor'] ;?>" size="28" />
-                      <output class="hidden" for="help_for_monitor">
+                      <div class="hidden" data-for="help_for_monitor">
                         <strong><?=gettext("Alternative monitor IP"); ?></strong> <br />
                         <?=gettext("Enter an alternative address here to be used to monitor the link. This is used for the " .
                                                 "quality RRD graphs as well as the load balancer entries. Use this if the gateway does not respond " .
                                                 "to ICMP echo requests (pings)"); ?>.
-                      </output>
+                      </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_force_down" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Mark Gateway as Down"); ?></td>
                   <td>
                     <input name="force_down" type="checkbox" value="yes" <?=!empty($pconfig['force_down']) ? "checked=\"checked\"" : "";?>/>
-                    <output class="hidden" for="help_for_force_down">
+                    <div class="hidden" data-for="help_for_force_down">
                       <strong><?=gettext("Mark Gateway as Down"); ?></strong><br />
                       <?=gettext("This will force this gateway to be considered Down"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced visible">
@@ -697,9 +697,9 @@ $( document ).ready(function() {
 <?php
                     endfor;?>
                     </select>
-                    <output class="hidden" for="help_for_weight">
+                    <div class="hidden" data-for="help_for_weight">
                       <?=gettext("Weight for this gateway when used in a Gateway Group.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -723,9 +723,9 @@ $( document ).ready(function() {
                             </tr>
                         </tbody>
                     </table>
-                    <output class="hidden" for="help_for_latency">
+                    <div class="hidden" data-for="help_for_latency">
                         <?= sprintf(gettext('Low and high thresholds for latency in milliseconds. Default is %d/%d.'), $apinger_default['latencylow'], $apinger_default['latencyhigh']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -749,28 +749,28 @@ $( document ).ready(function() {
                             </tr>
                         </tbody>
                     </table>
-                    <output class="hidden" for="help_for_loss">
+                    <div class="hidden" data-for="help_for_loss">
                       <?= sprintf(gettext('Low and high thresholds for packet loss in %%. Default is %d/%d.'), $apinger_default['losslow'], $apinger_default['losshigh']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
                   <td><a id="help_for_interval" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Probe Interval");?></td>
                   <td>
                     <input name="interval" id="interval" type="text" value="<?=$pconfig['interval'];?>" onclick="calculated_change()" />
-                    <output class="hidden" for="help_for_interval">
+                    <div class="hidden" data-for="help_for_interval">
                       <?= sprintf(gettext('How often that an ICMP probe will be sent in seconds. Default is %d.'), $apinger_default['interval']) ?><br /><br />
                       <?=gettext("NOTE: The quality graph is averaged over seconds, not intervals, so as the probe interval is increased the accuracy of the quality graph is decreased.");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
                   <td><a id="help_for_down" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Down");?></td>
                   <td>
                     <input name="down" type="text" value="<?=$pconfig['down'];?>" />
-                    <output class="hidden" for="help_for_down">
+                    <div class="hidden" data-for="help_for_down">
                       <?= sprintf(gettext('The number of seconds of failed probes before the alarm will fire. Default is %d.'), $apinger_default['down']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -779,9 +779,9 @@ $( document ).ready(function() {
                     <input name="avg_delay_samples" id="avg_delay_samples" type="text" value="<?=$pconfig['avg_delay_samples'];?>" onchange="calculated_change()"  />
                     <input name="avg_delay_samples_calculated" type="checkbox" id="avg_delay_samples_calculated" value="yes" <?=!empty($pconfig['avg_delay_samples_calculated']) ? "checked=\"checked\"" : "";?> onclick="calculated_change()" />
                     <?=gettext("Use calculated value."); ?>
-                    <output class="hidden" for="help_for_avg_delay_samples">
+                    <div class="hidden" data-for="help_for_avg_delay_samples">
                       <?= sprintf(gettext('How many replies should be used to compute average delay for controlling "delay" alarms? Default is %d.'), $apinger_default['avg_delay_samples']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -791,9 +791,9 @@ $( document ).ready(function() {
                     <input name="avg_loss_samples_calculated" type="checkbox" id="avg_loss_samples_calculated" value="yes" <?= !empty($pconfig['avg_loss_samples_calculated']) ? "checked=\"checked\"" : "";?> onclick="calculated_change()" />
                     <?=gettext("Use calculated value."); ?>
 
-                    <output class="hidden" for="help_for_avg_loss_samples">
+                    <div class="hidden" data-for="help_for_avg_loss_samples">
                       <?= sprintf(gettext('How many probes should be used to compute average packet loss? Default is %d.'), $apinger_default['avg_loss_samples']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -803,9 +803,9 @@ $( document ).ready(function() {
                     <input name="avg_loss_delay_samples_calculated" type="checkbox" id="avg_loss_delay_samples_calculated" value="yes" <?= !empty($pconfig['avg_loss_delay_samples_calculated']) ? "checked=\"checked\"" : "";?> onclick="calculated_change()" />
                     <?=gettext("Use calculated value."); ?>
 
-                    <output class="hidden" for="help_for_avg_loss_delay_samples">
+                    <div class="hidden" data-for="help_for_avg_loss_delay_samples">
                       <?= sprintf(gettext('The delay (in qty of probe samples) after which loss is computed. Without this, delays longer than the probe interval would be treated as packet loss. Default is %d.'), $apinger_default['avg_loss_delay_samples']) ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="advanced hidden">
@@ -821,9 +821,9 @@ $( document ).ready(function() {
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                       <?=gettext("You may enter a description here for your reference (not parsed)"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -252,22 +252,22 @@ include("head.inc");
               <td><a id="help_for_hostname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Hostname"); ?></td>
               <td>
                 <input name="hostname" type="text" size="40" value="<?=$pconfig['hostname'];?>" />
-                <output class="hidden" for="help_for_hostname">
+                <div class="hidden" data-for="help_for_hostname">
                   <?=gettext("Name of the firewall host, without domain part"); ?>
                   <br />
                   <?=gettext("e.g."); ?> <em><?=gettext("firewall");?></em>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
               <td><a id="help_for_domain" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Domain"); ?></td>
               <td>
                 <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
-                <output class="hidden" for="help_for_domain">
+                <div class="hidden" data-for="help_for_domain">
                   <?=gettext("Do not use 'local' as a domain name. It will cause local hosts running mDNS (avahi, bonjour, etc.) to be unable to resolve local hosts not running mDNS."); ?>
                   <br />
                   <?=sprintf(gettext("e.g. %smycorp.com, home, office, private, etc.%s"),'<em>','</em>') ?>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -282,9 +282,9 @@ include("head.inc");
 <?php
                   endforeach; ?>
                 </select>
-                <output class="hidden" for="help_for_timezone">
+                <div class="hidden" data-for="help_for_timezone">
                   <?=gettext("Select the location closest to you"); ?>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -299,11 +299,11 @@ include("head.inc");
 <?php
                   endforeach;?>
                 </select>
-                <output class="hidden" for="help_for_language">
+                <div class="hidden" data-for="help_for_language">
                   <strong>
                     <?= gettext('Choose a language for the web GUI.') ?>
                   </strong>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -319,11 +319,11 @@ include("head.inc");
 <?php
                 endforeach; ?>
                 </select>
-                <output class="hidden" for="help_for_theme">
+                <div class="hidden" data-for="help_for_theme">
                   <strong>
                     <?= gettext('This will change the look and feel of the GUI.') ?>
                   </strong>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -334,11 +334,11 @@ include("head.inc");
               <td>
                 <input name="prefer_ipv4" type="checkbox" id="prefer_ipv4" value="yes" <?= !empty($pconfig['prefer_ipv4']) ? "checked=\"checked\"" : "";?> />
                 <strong><?=gettext("Prefer to use IPv4 even if IPv6 is available"); ?></strong>
-                <output class="hidden" for="help_for_prefer_ipv4">
+                <div class="hidden" data-for="help_for_prefer_ipv4">
                   <?=gettext("By default, if a hostname resolves IPv6 and IPv4 addresses ".
                                       "IPv6 will be used, if you check this option, IPv4 will be " .
                                       "used instead of IPv6."); ?>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -388,14 +388,14 @@ include("head.inc");
                     endfor; ?>
                   </tbody>
                 </table>
-                <output class="hidden" for="help_for_dnsservers">
+                <div class="hidden" data-for="help_for_dnsservers">
                   <?=gettext("Enter IP addresses to be used by the system for DNS resolution. " .
                   "These are also used for the DHCP service, DNS forwarder and for PPTP VPN clients."); ?>
                   <br />
                   <br />
                   <?=gettext("In addition, optionally select the gateway for each DNS server. " .
                   "When using multiple WAN connections there should be at least one unique DNS server per gateway."); ?>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -405,22 +405,22 @@ include("head.inc");
                 <strong>
                   <?=gettext("Allow DNS server list to be overridden by DHCP/PPP on WAN"); ?>
                 </strong>
-                <output class="hidden" for="help_for_dnsservers_opt">
+                <div class="hidden" data-for="help_for_dnsservers_opt">
                   <?= gettext("If this option is set, DNS servers " .
                   "assigned by a DHCP/PPP server on WAN will be used " .
                   "for its own purposes (including the DNS forwarder). " .
                   "However, they will not be assigned to DHCP and PPTP " .
                   "VPN clients.") ?>
-                </output>
+                </div>
                 <br/>
                 <input name="dnslocalhost" type="checkbox" value="yes" <?=$pconfig['dnslocalhost'] ? "checked=\"checked\"" : ""; ?> />
                 <strong>
                   <?=gettext("Do not use the DNS Forwarder/Resolver as a DNS server for the firewall"); ?>
                 </strong>
-                <output class="hidden" for="help_for_dnsservers_opt">
+                <div class="hidden" data-for="help_for_dnsservers_opt">
                   <?=gettext("By default localhost (127.0.0.1) will be used as the first DNS server where the DNS Forwarder or DNS Resolver is enabled and set to listen on Localhost, so system can use the local DNS service to perform lookups. ".
                   "Checking this box omits localhost from the list of DNS servers."); ?>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -241,9 +241,9 @@ $( document ).ready(function() {
                 <td><a id="help_for_desc" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description");?></td>
                 <td>
                   <input name="description" type="text" value="<?=$pconfig['description'];?>" />
-                  <output class="hidden" for="help_for_desc">
+                  <div class="hidden" data-for="help_for_desc">
                     <?=gettext("Group description, for your own information only");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -302,9 +302,9 @@ $( document ).ready(function() {
                       </td>
                     </tr>
                   </table>
-                  <output class="hidden" for="help_for_groups">
+                  <div class="hidden" data-for="help_for_groups">
                       <?=gettext("Hold down CTRL (pc)/COMMAND (mac) key to select multiple items");?>
-                  </output>
+                  </div>
                 </td>
               </tr>
 <?php

--- a/src/www/system_hasync.php
+++ b/src/www/system_hasync.php
@@ -115,12 +115,12 @@ include("head.inc");
                   <td><a id="help_for_pfsyncenabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Synchronize States') ?></td>
                   <td>
                     <input type="checkbox" name="pfsyncenabled" value="on" <?= !empty($pconfig['pfsyncenabled']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_pfsyncenabled">
+                    <div class="hidden" data-for="help_for_pfsyncenabled">
                       <?= sprintf(gettext('pfsync transfers state insertion, update, and deletion messages between firewalls.%s' .
                         'Each firewall sends these messages out via multicast on a specified interface, using the PFSYNC protocol (%sIP Protocol 240%s).%s' .
                         'It also listens on that interface for similar messages from other firewalls, and imports them into the local state table.%s' .
                         'This setting should be enabled on all members of a failover group.'), '<br/>','<a href="http://www.openbsd.org/faq/pf/carp.html" target="_blank">','</a>','<br/>','<br/>') ?>
-                      <div class="well well-sm" ><b><?=gettext('Clicking save will force a configuration sync if it is enabled! (see Configuration Synchronization Settings below)') ?></b></output>
+                      <div class="well well-sm" ><b><?=gettext('Clicking save will force a configuration sync if it is enabled! (see Configuration Synchronization Settings below)') ?></b></div>
                     </div>
                   </td>
                 </tr>
@@ -128,9 +128,9 @@ include("head.inc");
                   <td><a id="help_for_disablepreempt" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Disable preempt') ?></td>
                   <td>
                     <input type="checkbox" name="disablepreempt" value="on" <?= !empty($pconfig['disablepreempt']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_disablepreempt">
+                    <div class="hidden" data-for="help_for_disablepreempt">
                       <?=gettext("When this device is configured as CARP master it will try to switch to master when powering up, this option will keep this one slave if there already is a master on the network");?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -148,7 +148,7 @@ include("head.inc");
 <?php
                     endforeach; ?>
                     </select>
-                    <output class="hidden" for="help_for_pfsyncinterface">
+                    <div class="hidden" data-for="help_for_pfsyncinterface">
                       <?=gettext('If Synchronize States is enabled, it will utilize this interface for communication.') ?><br/><br/>
                       <div class="well">
                         <lu>
@@ -156,7 +156,7 @@ include("head.inc");
                         <li><?=gettext('You must define a IP on each machine participating in this failover group.') ?></li>
                         <li><?=gettext('You must have an IP assigned to the interface on any participating sync nodes.') ?></li>
                         </lu>
-                      </output>
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -164,9 +164,9 @@ include("head.inc");
                   <td><a id="help_for_pfsyncpeerip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Synchronize Peer IP') ?></td>
                   <td>
                     <input name="pfsyncpeerip" type="text" value="<?=$pconfig['pfsyncpeerip']; ?>" />
-                    <output class="hidden" for="help_for_pfsyncpeerip">
+                    <div class="hidden" data-for="help_for_pfsyncpeerip">
                       <?=gettext('Setting this option will force pfsync to synchronize its state table to this IP address. The default is directed multicast.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
               </table>
@@ -182,14 +182,14 @@ include("head.inc");
                   <td style="width:22%"><a id="help_for_synchronizetoip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Synchronize Config to IP') ?></td>
                   <td>
                     <input name="synchronizetoip" type="text" value="<?=$pconfig['synchronizetoip']; ?>" />
-                    <output class="hidden" for="help_for_synchronizetoip">
+                    <div class="hidden" data-for="help_for_synchronizetoip">
                       <?=gettext('Enter the IP address of the firewall to which the selected configuration sections should be synchronized.') ?><br />
                       <div class="well">
                         <lu>
                           <li><?=sprintf(gettext('When using XMLRPC sync to a backup machine running on another port/protocol please input the full url (example: %s)'), 'https://192.168.1.1:444/') ?></li>
                           <li><?=gettext('For setting up the backup machine leave this field empty, and do not forget to allow incoming connections on the specified interface for synchronization.') ?></li>
                         </lu>
-                      </output>
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -197,11 +197,11 @@ include("head.inc");
                   <td><a id="help_for_username" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Remote System Username') ?></td>
                   <td>
                     <input  name="username" type="text" value="<?=$pconfig['username'];?>" />
-                    <output class="hidden" for="help_for_username">
+                    <div class="hidden" data-for="help_for_username">
                       <?=gettext('Enter the web GUI username of the system entered above for synchronizing your configuration.') ?><br />
                       <div class="well well-sm">
                         <b><?=gettext('Do not use the Synchronize Config to IP and username option on backup cluster members!') ?></b>
-                      </output>
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -209,11 +209,11 @@ include("head.inc");
                   <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Remote System Password') ?></td>
                   <td>
                     <input  type="password" name="password" value="<?=$pconfig['password']; ?>" />
-                    <output class="hidden" for="help_for_password">
+                    <div class="hidden" data-for="help_for_password">
                       <?=gettext('Enter the web GUI password of the system entered above for synchronizing your configuration.') ?><br />
                       <div class="well well-sm">
                         <b><?=gettext('Do not use the Synchronize Config to IP and password option on backup cluster members!') ?></b>
-                      </output>
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -221,90 +221,90 @@ include("head.inc");
                   <td><a id="help_for_synchronizeusers" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Users and Groups') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizeusers" value="on" <?=!empty($pconfig['synchronizeusers']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizeusers">
+                    <div class="hidden" data-for="help_for_synchronizeusers">
                       <?=gettext('Automatically sync the users and groups over to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizeauthservers" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Auth Servers') ?></td>
                   <td>
                     <input type="checkbox" name='synchronizeauthservers' value="on" <?=!empty($pconfig['synchronizeauthservers']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizeauthservers">
+                    <div class="hidden" data-for="help_for_synchronizeauthservers">
                       <?=gettext('Automatically sync the authentication servers (e.g. LDAP, RADIUS) over to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizecerts" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Certificates') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizecerts" value="on" <?=!empty($pconfig['synchronizecerts']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizecerts">
+                    <div class="hidden" data-for="help_for_synchronizecerts">
                       <?=gettext('Automatically sync the Certificate Authorities, Certificates, and Certificate Revocation Lists over to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizerules" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Firewall Rules') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizerules" value="on" <?=!empty($pconfig['synchronizerules']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizerules">
+                    <div class="hidden" data-for="help_for_synchronizerules">
                       <?=gettext('Automatically sync the firewall rules to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizeschedules" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Firewall Schedules') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizeschedules" value="on" <?=!empty($pconfig['synchronizeschedules']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_synchronizeschedules">
+                    <div class="hidden" data-for="help_for_synchronizeschedules">
                       <?=gettext('Automatically sync the firewall schedules to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizealiases" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Aliases') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizealiases" value="on" <?=!empty($pconfig['synchronizealiases']) ? "checked=\"checked\"" : "";?>/>
-                    <output class="hidden" for="help_for_synchronizealiases">
+                    <div class="hidden" data-for="help_for_synchronizealiases">
                       <?=gettext('Automatically sync the aliases over to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizenat" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('NAT') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizenat" value="on" <?=!empty($pconfig['synchronizenat']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_synchronizenat">
+                    <div class="hidden" data-for="help_for_synchronizenat">
                       <?=gettext('Automatically sync the NAT rules over to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizedhcpd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('DHCPD') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizedhcpd" value="on" <?=!empty($pconfig['synchronizedhcpd']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizedhcpd">
+                    <div class="hidden" data-for="help_for_synchronizedhcpd">
                       <?=gettext('Automatically sync the DHCP Server settings over to the other HA host when changes are made. This only applies to DHCP for IPv4.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizestaticroutes" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Static Routes') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizestaticroutes" value="on" <?=!empty($pconfig['synchronizestaticroutes']) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_synchronizestaticroutes">
+                    <div class="hidden" data-for="help_for_synchronizestaticroutes">
                       <?=gettext('Automatically sync the Static Route configuration to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <td><a id="help_for_synchronizevirtualip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Virtual IPs') ?></td>
                   <td>
                     <input type="checkbox" name="synchronizevirtualip" value="on" <?=!empty($pconfig['synchronizevirtualip']) ? "checked=\"checked\"" : "";?> />
-                    <output class="hidden" for="help_for_synchronizevirtualip">
+                    <div class="hidden" data-for="help_for_synchronizevirtualip">
                       <?=gettext('Automatically sync the CARP Virtual IPs to the other HA host when changes are made.') ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <!-- Hook xmlrpc sync plugins -->
@@ -314,9 +314,9 @@ include("head.inc");
                   <td><a id="help_for_synchronize<?=$syncid?>" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=$synccnf['description'];?></td>
                   <td>
                     <input type="checkbox" name="synchronize<?=$syncid?>" value="on" <?=!empty($pconfig['synchronize'.$syncid]) ? "checked=\"checked\"" :"";?> />
-                    <output class="hidden" for="help_for_synchronize<?=$syncid?>">
+                    <div class="hidden" data-for="help_for_synchronize<?=$syncid?>">
                       <?=$synccnf['help'];?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -620,27 +620,27 @@ $( document ).ready(function() {
                     <td><a id="help_for_fullname" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Full name");?></td>
                     <td>
                       <input name="descr" type="text" value="<?=$pconfig['descr'];?>" <?= $pconfig['scope'] == "system" || !empty($pconfig['user_dn']) ? "readonly=\"readonly\"" : "";?> />
-                      <output class="hidden" for="help_for_fullname">
+                      <div class="hidden" data-for="help_for_fullname">
                         <?=gettext("User's full name, for your own information only");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_email" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("E-Mail");?></td>
                     <td>
                       <input name="email" type="text" value="<?= $pconfig['email'] ?>" />
-                      <output class="hidden" for="help_for_email">
+                      <div class="hidden" data-for="help_for_email">
                         <?= gettext('User\'s e-mail address, for your own information only') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_comment" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Comment");?></td>
                     <td>
                       <textarea name="comment" id="comment" class="form-control" cols="65" rows="3"><?= $pconfig['comment'] ?></textarea>
-                      <output class="hidden" for="help_for_comment">
+                      <div class="hidden" data-for="help_for_comment">
                         <?= gettext('User comment, for your own information only') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -666,9 +666,9 @@ $( document ).ready(function() {
                     <td><a id="help_for_expires" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Expiration date"); ?></td>
                     <td>
                       <input name="expires" type="text" id="expires" class="datepicker" data-date-format="mm/dd/yyyy" value="<?=$pconfig['expires'];?>" />
-                      <output class="hidden" for="help_for_expires">
+                      <div class="hidden" data-for="help_for_expires">
                           <?=gettext("Leave blank if the account shouldn't expire, otherwise enter the expiration date in the following format: mm/dd/yyyy"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -729,9 +729,9 @@ $( document ).ready(function() {
                           </td>
                         </tr>
                       </table>
-                      <output class="hidden" for="help_for_groups">
+                      <div class="hidden" data-for="help_for_groups">
                           <?=gettext("Hold down CTRL (pc)/COMMAND (mac) key to select multiple items");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -879,10 +879,10 @@ $( document ).ready(function() {
                                   </tr>
                               </tfoot>
                           </table>
-                          <output class="hidden" for="help_for_apikeys">
+                          <div class="hidden" data-for="help_for_apikeys">
                               <hr/>
                               <?=gettext('Manage API keys here for machine to machine interaction using this user\'s credentials.');?>
-                          </output>
+                          </div>
                       </td>
                   </tr>
 <?php
@@ -900,9 +900,9 @@ $( document ).ready(function() {
                     <td>
                       <input name="otp_seed" type="text" value="<?=$pconfig['otp_seed'];?>"/>
                       <input type="checkbox" name="gen_otp_seed"/>&nbsp;<small><?= gettext('Generate new secret (160 bit)') ?></small>
-                      <output class="hidden" for="help_for_otp_seed">
+                      <div class="hidden" data-for="help_for_otp_seed">
                         <?=gettext("OTP (base32) seed to use when a one time password authenticator is used");?><br/>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -921,9 +921,9 @@ $( document ).ready(function() {
                         $('#otp_qrcode').qrcode('<?= $otp_url ?>');
                       </script>
                       </div>
-                      <output class="hidden" for="help_for_otp_code">
+                      <div class="hidden" data-for="help_for_otp_code">
                         <?= gettext('Scan this QR code for easy setup with external apps.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -159,11 +159,11 @@ include("head.inc");
 <?php
                         endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_language">
+                      <div class="hidden" data-for="help_for_language">
                         <strong>
                           <?= gettext('Choose a language for the web GUI.') ?>
                         </strong>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/system_usermanager_settings.php
+++ b/src/www/system_usermanager_settings.php
@@ -127,10 +127,10 @@ endif;?>
                   <td style="width:22%"><a id="help_for_session_timeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Session Timeout"); ?></td>
                   <td style="width:78%">
                     <input class="form-control" name="session_timeout" id="session_timeout" type="text" size="8" value="<?=$pconfig['session_timeout'];?>" />
-                    <output class="hidden" for="help_for_session_timeout">
+                    <div class="hidden" data-for="help_for_session_timeout">
                       <?=gettext("Time in minutes to expire idle management sessions. The default is 4 hours (240 minutes).");?><br />
                       <?=gettext("Enter 0 to never expire sessions. NOTE: This is a security risk!");?><br />
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/vpn_ipsec_keys_edit.php
+++ b/src/www/vpn_ipsec_keys_edit.php
@@ -138,9 +138,9 @@ include("head.inc");
                     <td><a id="help_for_ident" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Identifier"); ?></td>
                     <td>
                       <input name="ident" type="text" class="formfld unknown" id="ident" size="30" value="<?=$pconfig['ident'];?>" />
-                      <output class="hidden" for="help_for_ident">
+                      <div class="hidden" data-for="help_for_ident">
                         <?=gettext("This can be either an IP address, fully qualified domain name or an email address."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/vpn_ipsec_mobile.php
+++ b/src/www/vpn_ipsec_mobile.php
@@ -360,9 +360,9 @@ if (isset($input_errors) && count($input_errors) > 0) {
                       <td><a id="help_for_enabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Enable")?></td>
                     <td>
                         <input name="enable" type="checkbox" id="enable" value="yes" <?= !empty($pconfig['enable']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_enabled">
+                        <div class="hidden" data-for="help_for_enabled">
                             <?=gettext("Enable IPsec Mobile Client Support"); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                     <tr>
@@ -395,10 +395,10 @@ foreach ($auth_servers as $auth_key => $auth_server) : ?>
 <?php
                       endforeach ?>
                       </select>
-                      <output class="hidden" for="help_for_local_group">
+                      <div class="hidden" data-for="help_for_local_group">
                         <?= gettext('Restrict access to users in the selected local group. Please be aware ' .
                           'that other authentication backends will refuse to authenticate when using this option.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                     <tr>
@@ -428,19 +428,19 @@ endfor; ?>
                     <td><a id="help_for_net_list" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Network List"); ?></td>
                     <td>
                         <input name="net_list" type="checkbox" id="net_list_enable" value="yes" <?= !empty($pconfig['net_list']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_net_list">
+                        <div class="hidden" data-for="help_for_net_list">
                             <?=gettext("Provide a list of accessible networks to clients"); ?><br />
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_save_passwd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Save Xauth Password"); ?></td>
                     <td>
                         <input name="save_passwd" type="checkbox" id="save_passwd_enable" value="yes" <?= !empty($pconfig['save_passwd']) ? "checked=\"checked\"" : "";?> />
-                        <output class="hidden" for="help_for_save_passwd">
+                        <div class="hidden" data-for="help_for_save_passwd">
                             <?=gettext("Allow clients to save Xauth passwords (Cisco VPN client only)."); ?><br />
                             <?=gettext("NOTE: With iPhone clients, this does not work when deployed via the iPhone configuration utility, only by manual entry."); ?><br />
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -448,9 +448,9 @@ endfor; ?>
                     <td>
                         <input name="dns_domain_enable" type="checkbox" id="dns_domain_enable" value="yes"  <?= !empty($pconfig['dns_domain']) ? "checked=\"checked\"" : "";?> onclick="dns_domain_change()" />
                         <input name="dns_domain" type="text" id="dns_domain" size="30" value="<?=$pconfig['dns_domain'];?>" />
-                        <output class="hidden" for="help_for_dns_domain_enable">
+                        <div class="hidden" data-for="help_for_dns_domain_enable">
                             <?=gettext("Provide a default domain name to clients"); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -458,10 +458,10 @@ endfor; ?>
                     <td>
                         <input name="dns_split_enable" type="checkbox" id="dns_split_enable" value="yes" <?= !empty($pconfig['dns_split']) ? "checked=\"checked\"" : "";?> onclick="dns_split_change()" />
                         <input name="dns_split" type="text" class="form-control unknown" id="dns_split" size="30" value="<?=$pconfig['dns_split'];?>" />
-                        <output class="hidden" for="help_for_dns_split_enable">
+                        <div class="hidden" data-for="help_for_dns_split_enable">
                             <?=gettext("Provide a list of split DNS domain names to clients. Enter a comma separated list."); ?><br />
                             <?=gettext("NOTE: If left blank, and a default domain is set, it will be used for this value."); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -478,9 +478,9 @@ endfor; ?>
                             <?=gettext("Server"); ?> #4:
                           <input name="dns_server4" type="text" class="form-control unknown" id="dns_server4" size="20" value="<?=$pconfig['dns_server4'];?>" />
                         </div>
-                        <output class="hidden" for="help_for_dns_server_enable">
+                        <div class="hidden" data-for="help_for_dns_server_enable">
                             <?=gettext("Provide a DNS server list to clients"); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -493,9 +493,9 @@ endfor; ?>
                             <?=gettext("Server"); ?> #2:
                           <input name="wins_server2" type="text" class="form-control unknown" id="wins_server2" size="20" value="<?=$pconfig['wins_server2'];?>" />
                         </div>
-                        <output class="hidden" for="help_for_wins_server_enable">
+                        <div class="hidden" data-for="help_for_wins_server_enable">
                             <?=gettext("Provide a WINS server list to clients"); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -514,9 +514,9 @@ endfor; ?>
 endforeach;
 ?>
                         </select>
-                        <output class="hidden" for="help_for_pfs_group_enable">
+                        <div class="hidden" data-for="help_for_pfs_group_enable">
                             <?=gettext("Provide the Phase2 PFS group to clients ( overrides all mobile phase2 settings )"); ?>
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>
@@ -524,9 +524,9 @@ endforeach;
                     <td>
                         <input name="login_banner_enable" type="checkbox" id="login_banner_enable" value="yes" <?= !empty($pconfig['login_banner']) ? "checked=\"checked\"" : "";?> onclick="login_banner_change()" />
                         <textarea name="login_banner" cols="65" rows="7" id="login_banner" class="formpre"><?=$pconfig['login_banner'];?></textarea>
-                        <output class="hidden" for="help_for_login_banner_enable">
+                        <div class="hidden" data-for="help_for_login_banner_enable">
                             <?=gettext("Provide a login banner to clients"); ?><br />
-                        </output>
+                        </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -564,9 +564,9 @@ include("head.inc");
                     <td><a id="help_for_clone_phase2" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Clone phase2"); ?></td>
                     <td>
                       <input name="clone_phase2" type="checkbox" id="clone_phase2" value="yes" <?=!empty($pconfig['clone_phase2'])?"checked=\"checked\"":"";?> />
-                      <output class="hidden" for="help_for_clone_phase2">
+                      <div class="hidden" data-for="help_for_clone_phase2">
                         <?=gettext("Clone related phase 2 entries as well, remember to change the networks. All phase 2 entries will be added in disabled state"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php
@@ -575,11 +575,11 @@ include("head.inc");
                     <td style="width:22%; vertical-align:top"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td>
                       <input name="disabled" type="checkbox" id="disabled" value="yes" <?=!empty($pconfig['disabled'])?"checked=\"checked\"":"";?> />
-                      <output class="hidden" for="help_for_disabled">
+                      <div class="hidden" data-for="help_for_disabled">
                         <strong><?=gettext("Disable this phase1 entry"); ?></strong><br />
                         <?=gettext("Set this option to disable this phase1 without " .
                                                 "removing it from the list."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -592,9 +592,9 @@ include("head.inc");
                         <option value="route" <?=$pconfig['auto'] == "route" ?  "selected=\"selected\"" : ""; ?>><?=gettext("Start on traffic");?></option>
                         <option value="start" <?=$pconfig['auto'] == "start" ?  "selected=\"selected\"" : ""; ?>><?=gettext("Start immediate");?></option>
                       </select>
-                      <output class="hidden" for="help_for_auto">
+                      <div class="hidden" data-for="help_for_auto">
                         <?=gettext("Choose the connect behaviour here, when using CARP you might want to consider the 'Respond only' option here (wait for the other side to connect)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -612,9 +612,9 @@ include("head.inc");
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_iketype">
+                      <div class="hidden" data-for="help_for_iketype">
                         <?=gettext("Select the KeyExchange Protocol version to be used. Usually known as IKEv1 or IKEv2."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -631,9 +631,9 @@ include("head.inc");
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_protocol">
+                      <div class="hidden" data-for="help_for_protocol">
                         <?=gettext("Select the Internet Protocol family from this dropdown."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -674,9 +674,9 @@ include("head.inc");
                             <?=gettext("Any");?>
                         </option>
                       </select>
-                      <output class="hidden" for="help_for_interface">
+                      <div class="hidden" data-for="help_for_interface">
                         <?=gettext("Select the interface for the local endpoint of this phase1 entry."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <?php if (empty($pconfig['mobile'])) :
@@ -686,9 +686,9 @@ include("head.inc");
                     <td><a id="help_for_remotegw" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Remote gateway"); ?></td>
                     <td>
                       <input name="remote-gateway" type="text" class="formfld unknown" id="remotegw" size="28" value="<?=$pconfig['remote-gateway'];?>" />
-                      <output class="hidden" for="help_for_remotegw">
+                      <div class="hidden" data-for="help_for_remotegw">
                         <?=gettext("Enter the public IP address or host name of the remote gateway"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
 <?php            endif;
@@ -697,10 +697,10 @@ include("head.inc");
                     <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="descr" type="text" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                      <output class="hidden" for="help_for_descr">
+                      <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here " .
                                                 "for your reference (not parsed)."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -725,10 +725,10 @@ include("head.inc");
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_authmethod">
+                      <div class="hidden" data-for="help_for_authmethod">
                         <?=gettext("Must match the setting chosen on the remote side."); ?><br />
                         <?=sprintf(gettext("If you select EAP-RADIUS, you must define your RADIUS servers on the %sServers%s page."), '<a href="/system_authservers.php">', '</a>'); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="mode_tr">
@@ -745,9 +745,9 @@ include("head.inc");
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_mode">
+                      <div class="hidden" data-for="help_for_mode">
                         <?=gettext("Aggressive is more flexible, but less secure."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -818,9 +818,9 @@ endforeach; ?>
                     <td>
                       <input name="pre-shared-key" type="text" class="formfld unknown" id="pskey" size="40"
                              value="<?= $pconfig['authentication_method'] == "pre_shared_key" || $pconfig['authentication_method'] == "xauth_psk_server" ? $pconfig['pre-shared-key'] : "";?>" />
-                      <output class="hidden" for="help_for_psk">
+                      <div class="hidden" data-for="help_for_psk">
                         <?=gettext("Input your Pre-Shared Key string."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="auth_opt auth_eap_tls">
@@ -838,9 +838,9 @@ endforeach; ?>
                       endif;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_certref">
+                      <div class="hidden" data-for="help_for_certref">
                         <?=gettext("Select a certificate previously configured in the Certificate Manager."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="auth_opt auth_eap_tls_caref">
@@ -861,9 +861,9 @@ endforeach; ?>
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_caref">
+                      <div class="hidden" data-for="help_for_caref">
                         <?=gettext("Select a certificate authority previously configured in the Certificate Manager."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr class="auth_opt auth_eap_radius">
@@ -880,9 +880,9 @@ endforeach; ?>
                         endif;
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_authservers">
+                      <div class="hidden" data-for="help_for_authservers">
                         <?=gettext("Select authentication servers to use."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -932,9 +932,9 @@ endforeach; ?>
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_halgo">
+                      <div class="hidden" data-for="help_for_halgo">
                         <?=gettext("Must match the setting chosen on the remote side."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -966,18 +966,18 @@ endforeach; ?>
 <?php                endforeach;
 ?>
                       </select>
-                      <output class="hidden" for="help_for_dhgroup">
+                      <div class="hidden" data-for="help_for_dhgroup">
                         <?=gettext("Must match the setting chosen on the remote side."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_lifetime" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Lifetime"); ?></td>
                     <td>
                       <input name="lifetime" type="text" id="lifetime" size="20" value="<?=$pconfig['lifetime'];?>" />
-                      <output class="hidden" for="help_for_lifetime">
+                      <div class="hidden" data-for="help_for_lifetime">
                         <?=gettext("seconds"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -987,27 +987,27 @@ endforeach; ?>
                     <td><a id="help_for_rekey_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Disable Rekey");?></td>
                     <td>
                       <input name="rekey_enable" type="checkbox" id="rekey_enable" value="yes" <?= !empty($pconfig['rekey_enable']) ? "checked=\"checked\"" : ""; ?> />
-                      <output class="hidden" for="help_for_rekey_enable">
+                      <div class="hidden" data-for="help_for_rekey_enable">
                         <?=gettext("Whether a connection should be renegotiated when it is about to expire."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_reauth_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Disable Reauth");?></td>
                     <td>
                       <input name="reauth_enable" type="checkbox" id="reauth_enable" value="yes" <?= !empty($pconfig['reauth_enable']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_reauth_enable">
+                      <div class="hidden" data-for="help_for_reauth_enable">
                         <?=gettext("Whether rekeying of an IKE_SA should also reauthenticate the peer. In IKEv1, reauthentication is always done."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tunnel_isolation" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Tunnel Isolation') ?></td>
                     <td>
                       <input name="tunnel_isolation" type="checkbox" id="tunnel_isolation" value="yes" <?= !empty($pconfig['tunnel_isolation']) ? 'checked="checked"' : '' ?>/>
-                      <output class="hidden" for="help_for_tunnel_isolation">
+                      <div class="hidden" data-for="help_for_tunnel_isolation">
                         <?= gettext('This option will create a tunnel for each phase 2 entry for IKEv2 interoperability with e.g. FortiGate devices.') ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -1024,41 +1024,41 @@ endforeach; ?>
                           <?=gettext("Force"); ?>
                         </option>
                       </select>
-                      <output class="hidden" for="help_for_nat_traversal">
+                      <div class="hidden" data-for="help_for_nat_traversal">
                           <?=gettext("Set this option to enable the use of NAT-T (i.e. the encapsulation of ESP in UDP packets) if needed, " .
                                                   "which can help with clients that are behind restrictive firewalls."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_mobike" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Disable MOBIKE"); ?></td>
                     <td>
                       <input name="mobike" type="checkbox" id="mobike"  <?=!empty($pconfig['mobike']) ? "checked=\"checked\"":"";?> />
-                      <output class="hidden" for="help_for_mobike">
+                      <div class="hidden" data-for="help_for_mobike">
                           <?=gettext("Disables the IKEv2 MOBIKE protocol defined by RFC 4555");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_dpd_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Dead Peer Detection"); ?></td>
                     <td>
                       <input name="dpd_enable" type="checkbox" id="dpd_enable" value="yes" <?=!empty($pconfig['dpd_delay']) && !empty($pconfig['dpd_maxfail'])?"checked=\"checked\"":"";?> />
-                      <output class="hidden" for="help_for_dpd_enable">
+                      <div class="hidden" data-for="help_for_dpd_enable">
                         <?=gettext("Enable DPD"); ?>
-                      </output>
+                      </div>
                       <div id="opt_dpd">
                         <br />
                         <input name="dpd_delay" type="text" class="formfld unknown" id="dpd_delay" size="5" value="<?=$pconfig['dpd_delay'];?>" />
                         <?=gettext("seconds"); ?>
-                        <output class="hidden" for="help_for_dpd_enable">
+                        <div class="hidden" data-for="help_for_dpd_enable">
                           <?=gettext("Delay between requesting peer acknowledgement."); ?>
-                        </output>
+                        </div>
                         <br />
                         <input name="dpd_maxfail" type="text" class="formfld unknown" id="dpd_maxfail" size="5" value="<?=$pconfig['dpd_maxfail'];?>" />
                         <?=gettext("retries"); ?>
-                        <output class="hidden" for="help_for_dpd_enable">
+                        <div class="hidden" data-for="help_for_dpd_enable">
                           <?=gettext("Number of consecutive failures allowed before disconnect."); ?>
-                        </output>
+                        </div>
                       </div>
                     </td>
                   </tr>

--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -486,11 +486,11 @@ if (isset($input_errors) && count($input_errors) > 0) {
                   <td style="width:22%"><a id="help_for_disabled" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                   <td style="width:78%" class="vtable">
                     <input name="disabled" type="checkbox" id="disabled" value="yes" <?= !empty($pconfig['disabled']) ? "checked=\"checked\"" : "" ;?> />
-                    <output class="hidden" for="help_for_disabled">
+                    <div class="hidden" data-for="help_for_disabled">
                         <?=gettext("Disable this phase2 entry"); ?><br/>
                         <?=gettext("Set this option to disable this phase2 entry without " .
                                                   "removing it from the list"); ?>.
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>
@@ -517,10 +517,10 @@ if (isset($input_errors) && count($input_errors) > 0) {
                   <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                   <td>
                     <input name="descr" type="text" id="descr" size="40" value="<?=$pconfig['descr'];?>" />
-                    <output class="hidden" for="help_for_descr">
+                    <div class="hidden" data-for="help_for_descr">
                         <?=gettext("You may enter a description here " .
                                                     "for your reference (not parsed)"); ?>.
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr class="opt_localid">
@@ -614,9 +614,9 @@ endif; ?>
                     endforeach; ?>
                     </select>
                     <br />
-                    <output class="hidden" for="help_for_proto">
+                    <div class="hidden" data-for="help_for_proto">
                         <?=gettext("ESP is encryption, AH is authentication only"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr id="opt_enc">
@@ -647,11 +647,11 @@ endif; ?>
 <?php
                       endforeach; ?>
 
-                      <output class="hidden" for="help_for_encalg">
+                      <div class="hidden" data-for="help_for_encalg">
                           <?=gettext("Hint: use 3DES for best compatibility or if you have a hardware " .
                                                   "crypto accelerator card. Blowfish is usually the fastest in " .
                                                   "software encryption"); ?>.
-                      </output>
+                      </div>
                   </td>
                 </tr>
                 <tr>
@@ -708,9 +708,9 @@ endif; ?>
                   <td><a id="help_for_pinghost" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Automatically ping host"); ?></td>
                   <td>
                     <input name="pinghost" type="text" class="formfld unknown" id="pinghost" size="28" value="<?=$pconfig['pinghost'];?>" />
-                    <output class="hidden" for="help_for_pinghost">
+                    <div class="hidden" data-for="help_for_pinghost">
                         <?=gettext("IP address"); ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php
@@ -719,13 +719,13 @@ endif; ?>
                   <td><a id="help_for_spd" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Manual SPD entries"); ?></td>
                   <td>
                     <input name="spd" type="text" id="spd" value="<?= $pconfig['spd'];?>" />
-                    <output class="hidden" for="help_for_spd">
+                    <div class="hidden" data-for="help_for_spd">
                         <strong><?=gettext("Register additional Security Policy Database entries"); ?></strong><br/>
                         <?=gettext("Strongswan automatically creates SPD policies for the networks defined in this phase2. ".
                                    "If you need to allow other networks to use this ipsec tunnel, you can add them here as a comma seperated list.".
                                    "When configured, you can use network address translation to push packets through this tunnel from these networks."); ?><br/>
                         <small><?=gettext("e.g. 192.168.1.0/24, 192.168.2.0/24"); ?></small>
-                    </output>
+                    </div>
                   </td>
                 </tr>
 <?php

--- a/src/www/vpn_ipsec_settings.php
+++ b/src/www/vpn_ipsec_settings.php
@@ -165,11 +165,11 @@ if (isset($input_errors) && count($input_errors) > 0) {
                       <td style="width:78%" class="vtable">
                         <input name="preferoldsa_enable" type="checkbox" id="preferoldsa_enable" value="yes" <?= !empty($pconfig['preferoldsa_enable']) ? "checked=\"checked\"" : "";?> />
                         <strong><?=gettext("Prefer older IPsec SAs"); ?></strong>
-                        <output class="hidden" for="help_for_preferoldsa_enable">
+                        <div class="hidden" data-for="help_for_preferoldsa_enable">
                             <?=gettext("By default, if several SAs match, the newest one is " .
                                                   "preferred if it's at least 30 seconds old. Select this " .
                                                   "option to always prefer old SAs over new ones."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -181,10 +181,10 @@ if (isset($input_errors) && count($input_errors) > 0) {
                           <option value="<?=$ptnet;?>" selected="selected"><?=$ptnet;?></option>
 <?php                   endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_passthrough_networks">
+                        <div class="hidden" data-for="help_for_passthrough_networks">
                             <?=gettext("This exempts traffic for one or more subnets from getting processed by the IPsec stack in the kernel. ".
                                         "When sending all traffic to the remote location, you probably want to add your lan network(s) here"); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -192,19 +192,19 @@ if (isset($input_errors) && count($input_errors) > 0) {
                       <td style="width:78%" class="vtable">
                         <input name="auto_routes_disable" type="checkbox" id="auto_routes_disable" value="yes" <?= !empty($pconfig['auto_routes_disable']) ? "checked=\"checked\"" : "";?> />
                         <strong><?=gettext("Do not automatically install routes"); ?></strong>
-                        <output class="hidden" for="help_for_auto_routes_disable">
+                        <div class="hidden" data-for="help_for_auto_routes_disable">
                             <?=gettext("By default, IPsec installs routes when a tunnel becomes active. " .
                                                   "Select this option to prevent automatically adding routes" .
                                                   " to the system routing table. See charon.install_routes"); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td><a id="help_for_ipsec_debug" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPsec Debug"); ?></td>
                       <td>
-                        <output class="hidden" for="help_for_ipsec_debug">
+                        <div class="hidden" data-for="help_for_ipsec_debug">
                                       <strong><?=gettext("Start IPsec in debug mode based on sections selected"); ?></strong> <br/>
-                        </output>
+                        </div>
 <?php                   foreach ($ipsec_loglevels as $lkey => $ldescr) :
 ?>
                         <?=$ldescr?>
@@ -220,9 +220,9 @@ endforeach; ?>
                         </select>
 <?php
 endforeach; ?>
-                        <output class="hidden" for="help_for_ipsec_debug">
+                        <div class="hidden" data-for="help_for_ipsec_debug">
                         <?=gettext("Launch IPsec in debug mode so that more verbose logs will be generated to aid in troubleshooting."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -555,18 +555,18 @@ $( document ).ready(function() {
               <td><a id="help_for_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
               <td>
                 <input name="disable" type="checkbox" value="yes" <?= !empty($pconfig['disable']) ? "checked=\"checked\"" : "";?> />
-                <output class="hidden" for="help_for_disable">
+                <div class="hidden" data-for="help_for_disable">
                   <small><?=gettext("Set this option to disable this client without removing it from the list"); ?>.</small>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
               <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
               <td>
                 <input name="description" type="text" class="form-control unknown" size="30" value="<?=$pconfig['description'];?>" />
-                <output class="hidden" for="help_for_description">
+                <div class="hidden" data-for="help_for_description">
                   <small><?=gettext("You may enter a description here for your reference (not parsed)"); ?>.</small>
-                </output>
+                </div>
               </td>
             </tr>
             <tr>
@@ -716,9 +716,9 @@ $( document ).ready(function() {
             <td>
               <input name="resolve_retry" type="checkbox" value="yes" <?= !empty($pconfig['resolve_retry']) ? 'checked="checked"' : '' ?>/>
               <strong><?= gettext('Infinitely resolve remote server') ?></strong>
-              <output class="hidden" for="help_for_resolve_retry">
+              <div class="hidden" data-for="help_for_resolve_retry">
                 <div><small><?=gettext("Continuously attempt to resolve the server host name. Useful when communicating with a server that is not permanently connected to the Internet"); ?></small></div>
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
@@ -754,9 +754,9 @@ $( document ).ready(function() {
             <td><a id="help_for_local_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local port");?></td>
             <td>
               <input name="local_port" type="text" class="form-control unknown" size="5" value="<?=$pconfig['local_port'];?>" />
-              <output class="hidden" for="help_for_local_port">
+              <div class="hidden" data-for="help_for_local_port">
                 <em><small><?=gettext("Set this option if you would like to bind to a specific port. Leave this blank or enter 0 for a random dynamic port."); ?></small></em>
-              </output>
+              </div>
             </td>
           </tr>
          </table>
@@ -777,9 +777,9 @@ $( document ).ready(function() {
               <div><input name="auth_user" id="auth_user" class="form-control unknown" type="text" size="20" value="<?=$pconfig['auth_user'];?>" /></div>
               <div><?=gettext("Password"); ?></div>
               <div><input name="auth_pass" id="auth_pass" type="password" class="form-control pwd" size="20" value="<?=$pconfig['auth_pass'];?>" /></div>
-              <output class="hidden" for="help_for_auth_user_pass">
+              <div class="hidden" data-for="help_for_auth_user_pass">
                 <?=gettext("Leave empty when no user name and password are needed."); ?>
-              </output>
+              </div>
               <br/>
             </td>
           </tr>
@@ -787,9 +787,9 @@ $( document ).ready(function() {
             <td><a id="help_for_reneg-sec" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Renegotiate time"); ?></td>
             <td>
               <input type="text" name="reneg-sec" value="<?=$pconfig['reneg-sec'];?>">
-              <output class="hidden" for="help_for_reneg-sec">
+              <div class="hidden" data-for="help_for_reneg-sec">
                 <?= gettext('Renegotiate data channel key after n seconds (default=3600). Set to 0 to disable.') ?>
-              </output>
+              </div>
             </td>
            </tr>
           </table>
@@ -934,9 +934,9 @@ $( document ).ready(function() {
 <?php
               endforeach; ?>
               </select>
-              <output class="hidden" for="help_for_digest">
+              <div class="hidden" data-for="help_for_digest">
                 <?=gettext("NOTE: Leave this set to SHA1 unless the server is set to match. SHA1 is the default for OpenVPN."); ?>
-              </output>
+              </div>
             </td>
           </tr>
           <tr id="engine">
@@ -971,7 +971,7 @@ $( document ).ready(function() {
             <td style="width:22%"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
             <td style="width:78%">
               <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
-              <output class="hidden" for="help_for_tunnel_network">
+              <div class="hidden" data-for="help_for_tunnel_network">
                 <?=gettext("This is the IPv4 virtual network used for private " .
                                 "communications between this client and the " .
                                 "server expressed using CIDR (eg. 10.0.8.0/24). " .
@@ -979,14 +979,14 @@ $( document ).ready(function() {
                                 "server address and the second network address " .
                                 "will be assigned to the client virtual " .
                                 "interface"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
             <td><a id="help_for_tunnel_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Tunnel Network"); ?></td>
             <td>
               <input name="tunnel_networkv6" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_networkv6'];?>" />
-              <output class="hidden" for="help_for_tunnel_networkv6">
+              <div class="hidden" data-for="help_for_tunnel_networkv6">
                 <?=gettext("This is the IPv6 virtual network used for private " .
                                 "communications between this client and the " .
                                 "server expressed using CIDR (eg. fe80::/64). " .
@@ -994,14 +994,14 @@ $( document ).ready(function() {
                                 "server address and the second network address " .
                                 "will be assigned to the client virtual " .
                                 "interface"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
             <td><a id="help_for_remote_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Remote Network"); ?></td>
             <td>
               <input name="remote_network" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_network'];?>" />
-              <output class="hidden" for="help_for_remote_network">
+              <div class="hidden" data-for="help_for_remote_network">
                 <?=gettext("These are the IPv4 networks that will be routed through " .
                                 "the tunnel, so that a site-to-site VPN can be " .
                                 "established without manually changing the routing tables. " .
@@ -1009,14 +1009,14 @@ $( document ).ready(function() {
                                 "If this is a site-to-site VPN, enter the " .
                                 "remote LAN/s here. You may leave this blank to " .
                                 "only communicate with other clients"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
             <td><a id="help_for_remote_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Remote Network"); ?></td>
             <td>
               <input name="remote_networkv6" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_networkv6'];?>" />
-              <output class="hidden" for="help_for_remote_networkv6">
+              <div class="hidden" data-for="help_for_remote_networkv6">
                 <?=gettext("These are the IPv6 networks that will be routed through " .
                                 "the tunnel, so that a site-to-site VPN can be " .
                                 "established without manually changing the routing tables. " .
@@ -1024,19 +1024,19 @@ $( document ).ready(function() {
                                 "If this is a site-to-site VPN, enter the " .
                                 "remote LAN/s here. You may leave this blank to " .
                                 "only communicate with other clients"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
             <td><a id="help_for_use_shaper" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Limit outgoing bandwidth");?></td>
             <td>
               <input name="use_shaper" type="text" class="form-control unknown" size="5" value="<?=$pconfig['use_shaper'];?>" />
-              <output class="hidden" for="help_for_use_shaper">
+              <div class="hidden" data-for="help_for_use_shaper">
                 <?=gettext("Maximum outgoing bandwidth for this tunnel. " .
                                 "Leave empty for no limit. The input value has " .
                                 "to be something between 100 bytes/sec and 100 " .
                                 "Mbytes/sec (entered as bytes per second)"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
@@ -1054,45 +1054,45 @@ $( document ).ready(function() {
                 <?php
                                 endforeach; ?>
               </select>
-              <output class="hidden" for="help_for_compression">
+              <div class="hidden" data-for="help_for_compression">
                 <?=gettext("Compress tunnel packets using the LZO algorithm. Adaptive compression will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
-              </output>
+              </div>
             </td>
           </tr>
           <tr>
             <td><a id="help_for_passtos" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Type-of-Service"); ?></td>
             <td>
               <input name="passtos" type="checkbox" value="yes" <?=!empty($pconfig['passtos']) ? "checked=\"checked\"" : "" ;?>  />
-              <output class="hidden" for="help_for_passtos">
+              <div class="hidden" data-for="help_for_passtos">
                 <?=gettext("Set the TOS IP header value of tunnel packets to match the encapsulated packet value"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr class="chkboxNoTunIPv6">
             <td><a id="help_for_no_tun_ipv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable IPv6"); ?></td>
             <td>
               <input name="no_tun_ipv6" type="checkbox" value="yes" <?=!empty($pconfig['no_tun_ipv6']) ? "checked=\"checked\"" : "" ;?> />
-              <output class="hidden" for="help_for_no_tun_ipv6">
+              <div class="hidden" data-for="help_for_no_tun_ipv6">
                 <?=gettext("Don't forward IPv6 traffic"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr id="chkboxRouteNoPull">
             <td><a id="help_for_route_no_pull" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Don't pull routes"); ?></td>
             <td>
               <input name="route_no_pull" type="checkbox" value="yes" <?=!empty($pconfig['route_no_pull']) ? "checked=\"checked\"" : "" ;?> />
-              <output class="hidden" for="help_for_route_no_pull">
+              <div class="hidden" data-for="help_for_route_no_pull">
                 <?=sprintf(gettext("Don't add or remove routes automatically. Instead pass routes to %s--route-up%s script using environmental variables"),'<strong>','</strong>') ?>.
-              </output>
+              </div>
             </td>
           </tr>
           <tr id="chkboxRouteNoExec">
             <td><a id="help_for_route_no_exec" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Don't add/remove routes"); ?></td>
             <td>
               <input name="route_no_exec" type="checkbox" value="yes" <?=!empty($pconfig['route_no_exec']) ? "checked=\"checked\"" : "" ;?> />
-              <output class="hidden" for="help_for_route_no_exec">
+              <div class="hidden" data-for="help_for_route_no_exec">
                 <?=gettext("This option effectively bars the server from adding routes to the client's routing table, however note that this option still allows the server to set the TCP/IP properties of the client's TUN/TAP interface"); ?>.
-              </output>
+              </div>
             </td>
           </tr>
          </table>
@@ -1110,9 +1110,9 @@ $( document ).ready(function() {
             <td style="width:22%"><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
             <td style="width:78%">
               <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea><br />
-              <output class="hidden" for="help_for_custom_options">
+              <div class="hidden" data-for="help_for_custom_options">
                 <?=gettext("Enter any additional options you would like to add to the configuration file here."); ?>
-              </output>
+              </div>
             </td>
           </tr>
           <tr id="comboboxVerbosityLevel">
@@ -1129,13 +1129,13 @@ $( document ).ready(function() {
                             <option value="<?=$verb_value; ?>" <?=$selected; ?>><?=$verb_desc;?></option>
               <?php endforeach; ?>
               </select>
-              <output class="hidden" for="help_for_verbosity_level">
+              <div class="hidden" data-for="help_for_verbosity_level">
                 <?=gettext("Each level shows all info from the previous levels. Level 3 is recommended if you want a good summary of what's happening without being swamped by output.") ?> <br /> <br />
                 <?=sprintf(gettext("%snone%s -- No output except fatal errors."),'<strong>','</strong>') ?> <br />
                 <?=sprintf(gettext("%sdefault%s-%s4%s -- Normal usage range."),'<strong>','</strong>','<strong>','</strong>'); ?> <br />
                 <?=sprintf(gettext("%s5%s -- Output R and W characters to the console for each packet read and write, uppercase is used for TCP/UDP packets and lowercase is used for TUN/TAP packets."),'<strong>','</strong>') ?> <br />
                 <?=sprintf(gettext("%s6%s-%s11%s -- Debug info range."),'<strong>','</strong>','<strong>','</strong>') ?>
-              </output>
+              </div>
               </td>
           </tr>
         </table>

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -390,9 +390,9 @@ if ($act!="new" && $act!="edit") {
                     <td style="width:22%"><a id="help_for_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disabled"); ?></td>
                     <td style="width:78%">
                       <input name="disable" type="checkbox" value="yes" <?= !empty($pconfig['disable']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_disable">
+                      <div class="hidden" data-for="help_for_disable">
                         <?=gettext("Set this option to disable this client-specific override without removing it from the list"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -407,39 +407,39 @@ if ($act!="new" && $act!="edit") {
 <?php
                       endforeach;?>
                       </select>
-                      <output class="hidden" for="help_for_servers">
+                      <div class="hidden" data-for="help_for_servers">
                         <?=gettext("Select the OpenVPN servers where this override applies to, leave empty for all"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_common_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Common name"); ?></td>
                     <td>
                       <input name="common_name" type="text" value="<?=$pconfig['common_name'];?>" />
-                      <output class="hidden" for="help_for_common_name">
+                      <div class="hidden" data-for="help_for_common_name">
                         <?=gettext("Enter the client's X.509 common name here"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                     <td>
                       <input name="description" type="text" value="<?=$pconfig['description'];?>" />
-                      <output class="hidden" for="help_for_description">
+                      <div class="hidden" data-for="help_for_description">
                         <?=gettext("You may enter a description here for your reference (not parsed)"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_block" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Connection blocking"); ?></td>
                     <td>
                       <input name="block" type="checkbox" value="yes" <?= !empty($pconfig['block']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_block">
+                      <div class="hidden" data-for="help_for_block">
                           <?=gettext("Block this client connection based on its common name"); ?>.<br/>
                           <?=gettext("Don't use this option to permanently disable a " .
                                                      "client due to a compromised key or password. " .
                                                      "Use a CRL (certificate revocation list) instead"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -452,7 +452,7 @@ if ($act!="new" && $act!="edit") {
                     <td><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
                     <td>
                       <input name="tunnel_network" type="text" size="20" value="<?=$pconfig['tunnel_network'];?>" />
-                      <output class="hidden" for="help_for_tunnel_network">
+                      <div class="hidden" data-for="help_for_tunnel_network">
                         <?=gettext("This is the IPv4 virtual network used for private " .
                                                 "communications between this client and the " .
                                                 "server expressed using CIDR (eg. 10.0.8.0/24). " .
@@ -460,14 +460,14 @@ if ($act!="new" && $act!="edit") {
                                                 "server address and the second network address " .
                                                 "will be assigned to the client virtual " .
                                                 "interface"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_tunnel_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Tunnel Network"); ?></td>
                     <td>
                       <input name="tunnel_networkv6" type="text" value="<?=$pconfig['tunnel_networkv6'];?>" />
-                      <output class="hidden" for="help_for_tunnel_networkv6">
+                      <div class="hidden" data-for="help_for_tunnel_networkv6">
                           <?=gettext("This is the IPv6 virtual network used for private " .
                                                 "communications between this server and client " .
                                                 "hosts expressed using CIDR (eg. fe80::/64). " .
@@ -475,38 +475,38 @@ if ($act!="new" && $act!="edit") {
                                                 "the server virtual interface. The remaining " .
                                                 "network addresses can optionally be assigned " .
                                                 "to connecting clients. (see Address Pool)"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="local_optsv4">
                     <td><a id="help_for_local_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Local Network"); ?></td>
                     <td>
                       <input name="local_network" type="text" size="40" value="<?=$pconfig['local_network'];?>" />
-                      <output class="hidden" for="help_for_local_network">
+                      <div class="hidden" data-for="help_for_local_network">
                         <?=gettext("These are the IPv4 networks that will be accessible " .
                                                 "from this particular client. Expressed as a comma-separated list of one or more CIDR ranges."); ?>
                       <br /><?=gettext("NOTE: You do not need to specify networks here if they have " .
                                             "already been defined on the main server configuration.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="local_optsv6">
                     <td><a id="help_for_local_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Local Network"); ?></td>
                     <td>
                       <input name="local_networkv6" type="text" size="40" value="<?=$pconfig['local_networkv6'];?>" />
-                      <output class="hidden" for="help_for_local_networkv6">
+                      <div class="hidden" data-for="help_for_local_networkv6">
                                                     <?=gettext("These are the IPv6 networks that will be accessible " .
                                                     "from this particular client. Expressed as a comma-separated list of one or more IP/PREFIX networks."); ?><br />
                                                     <?=gettext("NOTE: You do not need to specify networks here if they have " .
                                                     "already been defined on the main server configuration.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="remote_optsv4">
                     <td><a id="help_for_remote_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Remote Network"); ?></td>
                     <td>
                       <input name="remote_network" type="text" size="40" value="<?=$pconfig['remote_network'];?>" />
-                      <output class="hidden" for="help_for_remote_network">
+                      <div class="hidden" data-for="help_for_remote_network">
                         <?=gettext("These are the IPv4 networks that will be routed " .
                                                 "to this client specifically using iroute, so that a site-to-site " .
                                                 "VPN can be established. " .
@@ -515,14 +515,14 @@ if ($act!="new" && $act!="edit") {
                                                 "be routed"); ?>.<br />
                         <?=gettext("NOTE: Remember to add these subnets to the " .
                                                 "IPv4 Remote Networks list on the corresponding OpenVPN server settings.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr id="remote_optsv6">
                     <td><a id="help_for_remote_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Remote Network"); ?></td>
                     <td>
                       <input name="remote_networkv6" type="text" size="40" value="<?=$pconfig['remote_networkv6'];?>" />
-                      <output class="hidden" for="help_for_remote_networkv6">
+                      <div class="hidden" data-for="help_for_remote_networkv6">
                         <?=gettext("These are the IPv6 networks that will be routed " .
                                                 "to this client specifically using iroute, so that a site-to-site " .
                                                 "VPN can be established. " .
@@ -531,16 +531,16 @@ if ($act!="new" && $act!="edit") {
                                                 "be routed."); ?><br />
                         <?=gettext("NOTE: Remember to add these subnets to the " .
                                                 "IPv6 Remote Networks list on the corresponding OpenVPN server settings.");?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_gwredir" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Redirect Gateway"); ?></td>
                     <td>
                       <input name="gwredir" type="checkbox" value="yes" <?= !empty($pconfig['gwredir']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_gwredir">
+                      <div class="hidden" data-for="help_for_gwredir">
                         <?=gettext("Force all client generated traffic through the tunnel"); ?>.
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -553,9 +553,9 @@ if ($act!="new" && $act!="edit") {
                     <td><a id="help_for_push_reset" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Server Definitions"); ?></td>
                     <td>
                       <input name="push_reset" type="checkbox" value="yes" <?= !empty($pconfig['push_reset']) ? "checked=\"checked\"" : "";?> />
-                      <output class="hidden" for="help_for_push_reset">
+                      <div class="hidden" data-for="help_for_push_reset">
                           <?=gettext("Prevent this client from receiving any server-defined client settings."); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -565,9 +565,9 @@ if ($act!="new" && $act!="edit") {
                       <div id="dns_domain_data" style="display:none">
                         <input name="dns_domain" type="text" id="dns_domain" value="<?=$pconfig['dns_domain'];?>" />
                       </div>
-                      <output class="hidden" for="help_for_dns_domain">
+                      <div class="hidden" data-for="help_for_dns_domain">
                         <?=gettext("Provide a default domain name to clients"); ?><br />
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -584,9 +584,9 @@ if ($act!="new" && $act!="edit") {
                         <?=gettext("Server #4:"); ?>&nbsp;
                         <input name="dns_server4" type="text" id="dns_server4" size="20" value="<?=htmlspecialchars($pconfig['dns_server4']);?>" />
                       </div>
-                      <output class="hidden" for="help_for_dns_server">
+                      <div class="hidden" data-for="help_for_dns_server">
                         <?=gettext("Provide a DNS server list to clients"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
@@ -599,19 +599,19 @@ if ($act!="new" && $act!="edit") {
                         <?=gettext("Server #2:"); ?>&nbsp;
                         <input name="ntp_server2" type="text" id="ntp_server2" size="20" value="<?=$pconfig['ntp_server2'];?>" />
                       </div>
-                      <output class="hidden" for="help_for_ntp_server">
+                      <div class="hidden" data-for="help_for_ntp_server">
                         <?=gettext("Provide a NTP server list to clients"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_netbios_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NetBIOS Options"); ?></td>
                     <td>
                       <input name="netbios_enable" type="checkbox" id="netbios_enable" value="yes" <?=!empty($pconfig['netbios_enable']) ? "checked=\"checked\"" : "" ;?> />
-                      <output class="hidden" for="help_for_netbios_enable">
+                      <div class="hidden" data-for="help_for_netbios_enable">
                         <?=gettext("Enable NetBIOS over TCP/IP");?><br/>
                         <?=gettext("If this option is not set, all NetBIOS-over-TCP/IP options (including WINS) will be disabled"); ?>.
-                      </output>
+                      </div>
 
                       <div id="netbios_data">
                         <?=gettext("Node Type"); ?>:&nbsp;
@@ -626,21 +626,21 @@ if ($act!="new" && $act!="edit") {
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_netbios_enable">
+                        <div class="hidden" data-for="help_for_netbios_enable">
                           <?=gettext("Possible options: b-node (broadcasts), p-node " .
                                                     "(point-to-point name queries to a WINS server), " .
                                                     "m-node (broadcast then query name server), and " .
                                                     "h-node (query name server, then broadcast)."); ?>
-                        </output>
+                        </div>
                         Scope ID:&nbsp;
                         <input name="netbios_scope" type="text" id="netbios_scope" value="<?=$pconfig['netbios_scope'];?>" />
-                        <output class="hidden" for="help_for_netbios_enable">
+                        <div class="hidden" data-for="help_for_netbios_enable">
                           <?=gettext("A NetBIOS Scope ID provides an extended naming " .
                                                     "service for NetBIOS over TCP/IP. The NetBIOS " .
                                                     "Scope ID isolates NetBIOS traffic on a single " .
                                                     "network to only those nodes with the same " .
                                                     "NetBIOS Scope ID."); ?>
-                        </output>
+                        </div>
                       </div>
                     </td>
                   </tr>
@@ -654,19 +654,19 @@ if ($act!="new" && $act!="edit") {
                         <?=gettext("Server #2:"); ?>
                         <input name="wins_server2" type="text" id="wins_server2" size="20" value="<?=$pconfig['wins_server2'];?>" />
                       </div>
-                      <output class="hidden" for="help_for_wins_server">
+                      <div class="hidden" data-for="help_for_wins_server">
                         <?=gettext("Provide a WINS server list to clients"); ?>
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>
                     <td><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
                     <td>
                       <textarea rows="6" cols="70" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea>
-                      <output class="hidden" for="help_for_custom_options">
+                      <div class="hidden" data-for="help_for_custom_options">
                         <?=gettext("Enter any additional options you would like to add for this client specific override, separated by a semicolon"); ?><br />
                         <?=gettext("EXAMPLE: push \"route 10.0.0.0 255.255.255.0\""); ?>;
-                      </output>
+                      </div>
                     </td>
                   </tr>
                   <tr>

--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -1334,22 +1334,22 @@ if (isset($savemsg)) {
                         <option value="tls-remote-quote"><?=gettext("Use tls-remote and quote the server CN");?></option>
                         <option value="none"><?=gettext("Do not verify the server CN");?></option>
                       </select>
-                      <output class="hidden" for="help_for_verify_server_cn">
+                      <div class="hidden" data-for="help_for_verify_server_cn">
                         <?=gettext("Optionally verify the server certificate Common Name (CN) when the client connects. Current clients, including the most recent versions of Windows, Viscosity, Tunnelblick, OpenVPN on iOS and Android and so on should all work at the default automatic setting.");?><br/><br/>
                         <?=gettext("Only use tls-remote if you must use an older client that you cannot control. The option has been deprecated by OpenVPN and will be removed in the next major version.");?><br/><br/>
                         <?=gettext("With tls-remote the server CN may optionally be enclosed in quotes. This can help if the server CN contains spaces and certain clients cannot parse the server CN. Some clients have problems parsing the CN with quotes. Use only as needed.");?>
-                      </output>
+                      </div>
                 </td>
               </tr>
               <tr class="mode_server">
                 <td style="vertical-align:top"><a id="help_for_random_local_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Random Local Port");?></td>
                 <td>
                       <input name="randomlocalport" id="randomlocalport" type="checkbox" value="yes" checked="CHECKED" />
-                      <output class="hidden" for="help_for_random_local_port">
+                      <div class="hidden" data-for="help_for_random_local_port">
                         <?=gettext("Use a random local source port (lport) for traffic from the client. Without this set, two clients may not run concurrently.");?>
                         <br/>
                         <?=gettext("NOTE: Not supported on older clients. Automatically disabled for Yealink and Snom configurations."); ?>
-                      </output>
+                      </div>
               </tr>
               <tr class="mode_server">
                 <td style="vertical-align:top"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Certificate Export Options");?></td>
@@ -1374,9 +1374,9 @@ if (isset($savemsg)) {
                 <td style="vertical-align:top"><a id="help_for_http_proxy" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use Proxy");?></td>
                 <td>
                       <input name="useproxy" id="useproxy" type="checkbox" value="yes" />
-                      <output class="hidden" for="help_for_http_proxy">
+                      <div class="hidden" data-for="help_for_http_proxy">
                         <?=gettext("Use a proxy to communicate with the server.");?>
-                      </output>
+                      </div>
                       <div id="useproxy_opts" style="display:none" >
                         <label for="useproxytype"><?=gettext("Type");?></label>
                         <select name="useproxytype" id="useproxytype">
@@ -1410,21 +1410,21 @@ if (isset($savemsg)) {
                 <td style="vertical-align:top"><a id="help_for_openvpnmanager" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Management Interface OpenVPN Manager");?></td>
                 <td>
                       <input name="openvpnmanager" id="openvpnmanager" type="checkbox" value="yes" />
-                      <output class="hidden" for="help_for_openvpnmanager">
+                      <div class="hidden" data-for="help_for_openvpnmanager">
                         <?=gettext('This will change the generated .ovpn configuration to allow for usage of the management interface. '.
                         'With this OpenVPN can be used also by non-administrator users. '.
                         'This is also useful for Windows systems where elevated permissions are needed to add routes to the system.');?>
-                      </output>
+                      </div>
                 </td>
               </tr>
               <tr class="mode_server">
                 <td style="vertical-align:top"><a id="help_for_advancedoptions" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Additional configuration options");?></td>
                 <td>
                       <textarea rows="6" cols="68" name="advancedoptions" id="advancedoptions"></textarea><br/>
-                      <output class="hidden" for="help_for_advancedoptions">
+                      <div class="hidden" data-for="help_for_advancedoptions">
                         <?=gettext("Enter any additional options you would like to add to the OpenVPN client export configuration here, separated by a line break or semicolon"); ?><br/>
                         <?=gettext("EXAMPLE: remote-random"); ?>;
-                      </output>
+                      </div>
                 </td>
               </tr>
               <tr>
@@ -1554,10 +1554,10 @@ if (isset($savemsg)) {
                     endforeach;?>
                       </tbody>
                     </table>
-                    <output class="hidden" for="help_for_clientpkg">
+                    <div class="hidden" data-for="help_for_clientpkg">
                       <br/><br/>
                       <?= gettext("If you expect to see a certain client in the list but it is not there, it is usually due to a CA mismatch between the OpenVPN server instance and the client certificates found in the User Manager.") ?>
-                    </output>
+                    </div>
                   </td>
                 </tr>
                 <tr>

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -610,18 +610,18 @@ $( document ).ready(function() {
                         <div>
                           <input name="disable" type="checkbox" value="yes" <?= !empty($pconfig['disable']) ? "checked=\"checked\"" : "";?> />
                         </div>
-                        <output class="hidden" for="help_for_disable">
+                        <div class="hidden" data-for="help_for_disable">
                         <?=gettext("Set this option to disable this server without removing it from the list"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_description" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Description"); ?></td>
                       <td>
                         <input name="description" type="text" class="form-control unknown" size="30" value="<?=htmlspecialchars($pconfig['description']);?>" />
-                        <output class="hidden" for="help_for_description">
+                        <div class="hidden" data-for="help_for_description">
                             <?=gettext("You may enter a description here for your reference (not parsed)"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -680,10 +680,10 @@ $( document ).ready(function() {
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_local_group">
+                        <div class="hidden" data-for="help_for_local_group">
                           <?= gettext('Restrict access to users in the selected local group. Please be aware ' .
                             'that other authentication backends will refuse to authenticate when using this option.') ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -974,9 +974,9 @@ endif; ?>
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_digest">
+                        <div class="hidden" data-for="help_for_digest">
                             <?= gettext('Leave this set to SHA1 unless all clients are set to match. SHA1 is the default for OpenVPN.') ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr id="engine">
@@ -1028,11 +1028,11 @@ endif; ?>
                     </tr>
                     <tr>
                       <td>
-                        <output class="hidden" for="help_for_cert_depth">
+                        <div class="hidden" data-for="help_for_cert_depth">
                           <span>
                             <?=gettext("When a certificate-based client logs in, do not accept certificates below this depth. Useful for denying certificates made with intermediate CAs generated from the same CA as the server."); ?>
                           </span>
-                        </output>
+                        </div>
                         </td></tr>
                         </table>
                       </td>
@@ -1041,11 +1041,11 @@ endif; ?>
                       <td style="width:22%"><a id="help_for_strictusercn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Strict User/CN Matching"); ?></td>
                       <td>
                         <input name="strictusercn" type="checkbox" value="yes" <?=!empty($pconfig['strictusercn']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_strictusercn">
+                        <div class="hidden" data-for="help_for_strictusercn">
                           <span>
                               <?=gettext("When authenticating users, enforce a match between the Common Name of the client certificate and the username given at login."); ?>
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                 </table>
@@ -1063,7 +1063,7 @@ endif; ?>
                       <td style="width:22%" id="ipv4_tunnel_network"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
                       <td witdh="78%">
                         <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
-                        <output class="hidden" for="help_for_tunnel_network">
+                        <div class="hidden" data-for="help_for_tunnel_network">
                             <?=gettext("This is the IPv4 virtual network used for private " .
                                                   "communications between this server and client " .
                                                   "hosts expressed using CIDR (eg. 10.0.8.0/24). " .
@@ -1071,14 +1071,14 @@ endif; ?>
                                                   "the server virtual interface. The remaining " .
                                                   "network addresses can optionally be assigned " .
                                                   "to connecting clients. (see Address Pool)"); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_tunnel_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Tunnel Network"); ?></td>
                       <td>
                         <input name="tunnel_networkv6" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_networkv6'];?>" />
-                        <output class="hidden" for="help_for_tunnel_networkv6">
+                        <div class="hidden" data-for="help_for_tunnel_networkv6">
                             <?=gettext("This is the IPv6 virtual network used for private " .
                                                   "communications between this server and client " .
                                                   "hosts expressed using CIDR (eg. fe80::/64). " .
@@ -1086,18 +1086,18 @@ endif; ?>
                                                   "the server virtual interface. The remaining " .
                                                   "network addresses can optionally be assigned " .
                                                   "to connecting clients. (see Address Pool)"); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
                       <td style="width:22%"><a id="help_for_serverbridge_dhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Bridge DHCP"); ?></td>
                       <td>
                               <input id="serverbridge_dhcp" name="serverbridge_dhcp" type="checkbox" value="yes" <?=!empty($pconfig['serverbridge_dhcp']) ? "checked=\"checked\"" : "" ;?>/>
-                              <output class="hidden" for="help_for_serverbridge_dhcp">
+                              <div class="hidden" data-for="help_for_serverbridge_dhcp">
                                 <span>
                                     <?=gettext("Allow clients on the bridge to obtain DHCP."); ?><br />
                                 </span>
-                              </output>
+                              </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
@@ -1127,28 +1127,28 @@ endif; ?>
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_serverbridge_interface">
+                        <div class="hidden" data-for="help_for_serverbridge_interface">
                             <?=gettext("The interface to which this tap instance will be " .
                                                   "bridged. This is not done automatically. You must assign this " .
                                                   "interface and create the bridge separately. " .
                                                   "This setting controls which existing IP address and subnet " .
                                                   "mask are used by OpenVPN for the bridge. Setting this to " .
                                                   "'none' will cause the Server Bridge DHCP settings below to be ignored."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
                       <td style="width:22%"><a id="help_for_serverbridge_dhcp_start" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Server Bridge DHCP Start"); ?></td>
                       <td>
                         <input  id="serverbridge_dhcp_start" name="serverbridge_dhcp_start" type="text" class="form-control unknown" size="20" value="<?=$pconfig['serverbridge_dhcp_start'];?>" />
-                        <output class="hidden" for="help_for_serverbridge_dhcp_start">
+                        <div class="hidden" data-for="help_for_serverbridge_dhcp_start">
                             <?=gettext("When using tap mode as a multi-point server, " .
                                                   "you may optionally supply a DHCP range to use on the " .
                                                   "interface to which this tap instance is bridged. " .
                                                   "If these settings are left blank, DHCP will be passed " .
                                                   "through to the LAN, and the interface setting above " .
                                                   "will be ignored."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tap">
@@ -1161,46 +1161,46 @@ endif; ?>
                       <td style="width:22%"><a id="help_for_gwredir" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Redirect Gateway"); ?></td>
                       <td>
                         <input name="gwredir" id="gwredir" type="checkbox" value="yes" <?=!empty($pconfig['gwredir']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_gwredir">
+                        <div class="hidden" data-for="help_for_gwredir">
                             <span>
                                 <?=gettext("Force all client generated traffic through the tunnel"); ?>.
                             </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user opt_gwredir">
                       <td style="width:22%"><a id="help_local_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Local Network"); ?></td>
                       <td>
                         <input name="local_network" type="text" class="form-control unknown" size="40" value="<?=$pconfig['local_network'];?>" />
-                        <output class="hidden" for="help_local_network">
+                        <div class="hidden" data-for="help_local_network">
                             <?=gettext("These are the IPv4 networks that will be accessible " .
                                                   "from the remote endpoint. Expressed as a comma-separated list of one or more CIDR ranges. " .
                                                   "You may leave this blank if you don't " .
                                                   "want to add a route to the local network " .
                                                   "through this tunnel on the remote machine. " .
                                                   "This is generally set to your LAN network"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user opt_gwredir">
                       <td style="width:22%"><a id="help_for_local_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Local Network"); ?></td>
                       <td>
                         <input name="local_networkv6" type="text" class="form-control unknown" size="40" value="<?=$pconfig['local_networkv6'];?>" />
-                        <output class="hidden" for="help_for_local_networkv6">
+                        <div class="hidden" data-for="help_for_local_networkv6">
                             <?=gettext("These are the IPv6 networks that will be accessible " .
                                                   "from the remote endpoint. Expressed as a comma-separated list of one or more IP/PREFIX. " .
                                                   "You may leave this blank if you don't " .
                                                   "want to add a route to the local network " .
                                                   "through this tunnel on the remote machine. " .
                                                   "This is generally set to your LAN network"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
                       <td style="width:22%"><a id="help_for_remote_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Remote Network"); ?></td>
                       <td>
                         <input name="remote_network" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_network'];?>" />
-                        <output class="hidden" for="help_for_remote_network">
+                        <div class="hidden" data-for="help_for_remote_network">
                             <?=gettext("These are the IPv4 networks that will be routed through " .
                                                   "the tunnel, so that a site-to-site VPN can be " .
                                                   "established without manually changing the routing tables. " .
@@ -1208,14 +1208,14 @@ endif; ?>
                                                   "If this is a site-to-site VPN, enter the " .
                                                   "remote LAN/s here. You may leave this blank if " .
                                                   "you don't want a site-to-site VPN"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_p2p_tls opt_mode_p2p_shared_key opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
                       <td style="width:22%"><a id="help_for_remote_networkv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv6 Remote Network"); ?></td>
                       <td>
                         <input name="remote_networkv6" type="text" class="form-control unknown" size="40" value="<?=$pconfig['remote_networkv6'];?>" />
-                        <output class="hidden" for="help_for_remote_networkv6">
+                        <div class="hidden" data-for="help_for_remote_networkv6">
                             <?=gettext("These are the IPv6 networks that will be routed through " .
                                                   "the tunnel, so that a site-to-site VPN can be " .
                                                   "established without manually changing the routing tables. " .
@@ -1223,16 +1223,16 @@ endif; ?>
                                                   "If this is a site-to-site VPN, enter the " .
                                                   "remote LAN/s here. You may leave this blank if " .
                                                   "you don't want a site-to-site VPN"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_maxclients" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Concurrent connections");?></td>
                       <td>
                         <input name="maxclients" type="text" class="form-control unknown" size="5" value="<?=$pconfig['maxclients'];?>" />
-                        <output class="hidden" for="help_for_maxclients">
+                        <div class="hidden" data-for="help_for_maxclients">
                             <?=gettext("Specify the maximum number of clients allowed to concurrently connect to this server"); ?>.
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -1250,53 +1250,53 @@ endif; ?>
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_compression">
+                        <div class="hidden" data-for="help_for_compression">
                             <?=gettext("Compress tunnel packets using the LZO algorithm. Adaptive compression will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_passtos" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Type-of-Service"); ?></td>
                       <td>
                         <input name="passtos" type="checkbox" value="yes" <?=!empty($pconfig['passtos']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_passtos">
+                        <div class="hidden" data-for="help_for_passtos">
                           <span>
                             <?=gettext("Set the TOS IP header value of tunnel packets to match the encapsulated packet value"); ?>.
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls opt_mode_server_user opt_mode_server_tls_user">
                       <td style="width:22%"><a id="help_for_client2client" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Inter-client communication"); ?></td>
                       <td>
                           <input name="client2client" type="checkbox" value="yes"  <?=!empty($pconfig['client2client']) ? "checked=\"checked\"" : "" ;?> />
-                          <output class="hidden" for="help_for_client2client">
+                          <div class="hidden" data-for="help_for_client2client">
                             <span>
                                 <?=gettext("Allow communication between clients connected to this server"); ?>
                             </span>
-                          </output>
+                          </div>
                       </td>
                     </tr>
                     <tr id="duplicate_cn">
                       <td style="width:22%"><a id="help_for_duplicate_cn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Duplicate Connections"); ?></td>
                       <td>
                             <input name="duplicate_cn" type="checkbox" value="yes" <?=!empty($pconfig['duplicate_cn']) ? "checked=\"checked\"" : "" ;?> />
-                            <output class="hidden" for="help_for_duplicate_cn">
+                            <div class="hidden" data-for="help_for_duplicate_cn">
                               <span>
                                 <?=gettext("Allow multiple concurrent connections from clients using the same Common Name.<br />NOTE: This is not generally recommended, but may be needed for some scenarios."); ?>
                               </span>
-                            </output>
+                            </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tun">
                       <td style="width:22%"><a id="help_for_no_tun_ipv6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable IPv6"); ?></td>
                       <td>
                         <input name="no_tun_ipv6" type="checkbox" value="yes" <?=!empty($pconfig['no_tun_ipv6']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_no_tun_ipv6">
+                        <div class="hidden" data-for="help_for_no_tun_ipv6">
                           <span>
                             <?=gettext("Don't forward IPv6 traffic"); ?>.
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                   </table>
@@ -1314,35 +1314,35 @@ endif; ?>
                       <td style="width:22%"><a id="help_for_dynamic_ip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Dynamic IP"); ?></td>
                       <td style="width:78%">
                         <input name="dynamic_ip" type="checkbox" id="dynamic_ip" value="yes" <?=!empty($pconfig['dynamic_ip']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_dynamic_ip">
+                        <div class="hidden" data-for="help_for_dynamic_ip">
                           <span>
                             <?=gettext("Allow connected clients to retain their connections if their IP address changes"); ?>.<br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_pool_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Address Pool"); ?></td>
                       <td>
                         <input name="pool_enable" type="checkbox" id="pool_enable" value="yes" <?=!empty($pconfig['pool_enable']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_pool_enable">
+                        <div class="hidden" data-for="help_for_pool_enable">
                           <span>
                             <?=gettext("Provide a virtual adapter IP address to clients (see Tunnel Network)"); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="dev_mode dev_mode_tun" id="topology_subnet_opt">
                       <td style="width:22%"><a id="help_for_topology_subnet" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Topology"); ?></td>
                       <td>
                         <input name="topology_subnet" type="checkbox" id="topology_subnet" value="yes"  <?=!empty($pconfig['topology_subnet']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_topology_subnet">
+                        <div class="hidden" data-for="help_for_topology_subnet">
                           <span>
                             <?=gettext("Allocate only one IP per client (topology subnet), rather than an isolated subnet per client (topology net30)."); ?><br />
                             <?=gettext("Relevant when supplying a virtual adapter IP address to clients when using tun mode on IPv4."); ?><br />
                             <?=gettext("Some clients may require this even for IPv6, such as OpenVPN Connect (iOS/Android). Others may break if it is present, such as older versions of OpenVPN or clients such as Yealink phones."); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -1352,11 +1352,11 @@ endif; ?>
                         <div id="dns_domain_data">
                               <input name="dns_domain" type="text" class="form-control unknown" id="dns_domain" size="30" value="<?=htmlspecialchars($pconfig['dns_domain']);?>" />
                         </div>
-                        <output class="hidden" for="help_for_dns_domain">
+                        <div class="hidden" data-for="help_for_dns_domain">
                           <span>
                               <?=gettext("Provide a default domain name to clients"); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -1381,22 +1381,22 @@ endif; ?>
                               </span>
                               <input name="dns_server4" type="text" class="form-control unknown" id="dns_server4" size="20" value="<?=$pconfig['dns_server4'];?>" />
                         </div>
-                        <output class="hidden" for="help_for_dns_server">
+                        <div class="hidden" data-for="help_for_dns_server">
                           <span>
                             <?=gettext("Provide a DNS server list to clients"); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr id="chkboxPushRegisterDNS">
                       <td style="width:22%"><a id="help_for_push_register_dns" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Force DNS cache update"); ?></td>
                       <td>
                         <input name="push_register_dns" type="checkbox" value="yes" <?=!empty($pconfig['push_register_dns']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_push_register_dns">
+                        <div class="hidden" data-for="help_for_push_register_dns">
                           <span>
                             <?=gettext("Run ''net stop dnscache'', ''net start dnscache'', ''ipconfig /flushdns'' and ''ipconfig /registerdns'' on connection initiation. This is known to kick Windows into recognizing pushed DNS servers."); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
@@ -1413,23 +1413,23 @@ endif; ?>
                           </span>
                           <input name="ntp_server2" type="text" class="form-control unknown" id="ntp_server2" size="20" value="<?=$pconfig['ntp_server2'];?>" />
                         </div>
-                        <output class="hidden" for="help_for_ntp_server_enable">
+                        <div class="hidden" data-for="help_for_ntp_server_enable">
                           <span>
                             <?=gettext("Provide a NTP server list to clients"); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>
                       <td style="width:22%"><a id="help_for_netbios_enable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NetBIOS Options"); ?></td>
                       <td>
                         <input name="netbios_enable" type="checkbox" id="netbios_enable" value="yes" <?=!empty($pconfig['netbios_enable']) ? "checked=\"checked\"" : "" ;?>  />
-                        <output class="hidden" for="help_for_netbios_enable">
+                        <div class="hidden" data-for="help_for_netbios_enable">
                           <span>
                             <?=gettext("Enable NetBIOS over TCP/IP"); ?><br />
                             <?=gettext("If this option is not set, all NetBIOS-over-TCP/IP options (including WINS) will be disabled"); ?>.
                           </span>
-                        </output>
+                        </div>
                         <div id="netbios_data">
                           <span>
                             <?=gettext("Node Type"); ?>:&nbsp;
@@ -1446,23 +1446,23 @@ endif; ?>
 <?php
                           endforeach; ?>
                           </select>
-                          <output class="hidden" for="help_for_netbios_enable">
+                          <div class="hidden" data-for="help_for_netbios_enable">
                             <?=gettext("Possible options: b-node (broadcasts), p-node " .
                                                         "(point-to-point name queries to a WINS server), " .
                                                         "m-node (broadcast then query name server), and " .
                                                         "h-node (query name server, then broadcast)."); ?>
-                          </output>
+                          </div>
                           <span>
                             <?=gettext("Scope ID"); ?>:&nbsp;
                           </span>
                           <input name="netbios_scope" type="text" class="form-control unknown" id="netbios_scope" size="30" value="<?=$pconfig['netbios_scope'];?>" />
-                          <output class="hidden" for="help_for_netbios_enable">
+                          <div class="hidden" data-for="help_for_netbios_enable">
                             <?=gettext("A NetBIOS Scope ID provides an extended naming " .
                                                         "service for NetBIOS over TCP/IP. The NetBIOS " .
                                                         "Scope ID isolates NetBIOS traffic on a single " .
                                                         "network to only those nodes with the same " .
                                                         "NetBIOS Scope ID."); ?>
-                          </output>
+                          </div>
                         </div>
                       </td>
                     </tr>
@@ -1470,11 +1470,11 @@ endif; ?>
                       <td style="width:22%"><a id="help_for_wins_server" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("WINS Servers"); ?></td>
                       <td>
                         <input name="wins_server_enable" type="checkbox" id="wins_server_enable" value="yes" <?=!empty($pconfig['wins_server1']) || !empty($pconfig['wins_server2']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_wins_server">
+                        <div class="hidden" data-for="help_for_wins_server">
                           <span>
                             <?=gettext("Provide a WINS server list to clients"); ?><br />
                           </span>
-                        </output>
+                        </div>
                         <div id="wins_server_data">
                           <span>
                             <?=gettext("Server #1:"); ?>&nbsp;
@@ -1494,22 +1494,22 @@ endif; ?>
                         <div id="client_mgmt_port_data">
                               <input name="client_mgmt_port" type="text" class="form-control unknown" id="client_mgmt_port" size="30" value="<?=htmlspecialchars($pconfig['client_mgmt_port']);?>" />
                         </div>
-                        <output class="hidden" for="help_for_client_mgmt_port">
+                        <div class="hidden" data-for="help_for_client_mgmt_port">
                           <span>
                             <?=gettext("Use a different management port on clients. The default port is 166. Specify a different port if the client machines need to select from multiple OpenVPN links."); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls_user">
                       <td style="width:22%"><a id="help_for_use-common-name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Use common name"); ?></td>
                       <td>
                         <input name="use-common-name" type="checkbox" value="1" <?=!empty($pconfig['use-common-name']) ? "checked=\"checked\"" : "" ;?> />
-                        <output class="hidden" for="help_for_use-common-name">
+                        <div class="hidden" data-for="help_for_use-common-name">
                           <span>
                             <?=gettext("When using a client certificate, use certificate common name for indexing purposes instead of username"); ?><br />
                           </span>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                   </table>
@@ -1527,9 +1527,9 @@ endif; ?>
                       <td style="width:22%"><a id="help_for_custom_options" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Advanced"); ?></td>
                       <td>
                         <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea><br />
-                        <output class="hidden" for="help_for_custom_options">
+                        <div class="hidden" data-for="help_for_custom_options">
                           <?=gettext("Enter any additional options you would like to add to the configuration file here."); ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr id="comboboxVerbosityLevel">
@@ -1547,7 +1547,7 @@ endif; ?>
 <?php
                         endforeach; ?>
                         </select>
-                        <output class="hidden" for="help_for_verbosity_level">
+                        <div class="hidden" data-for="help_for_verbosity_level">
                           <?=gettext("Each level shows all info from the previous levels. Level 3 is recommended if you want a good summary of what's happening without being swamped by output."); ?><br /> <br />
                           <?=sprintf(gettext("%s0%s -- No output except fatal errors."),'<strong>','</strong>') ?> <br />
                           <?=sprintf(gettext("%s1%s -- startup info + connection initiated messages + non-fatal encryption & net errors."),'<strong>','</strong>') ?> <br />
@@ -1555,19 +1555,19 @@ endif; ?>
                           <?=sprintf(gettext("%s4%s -- Normal usage range."),'<strong>','</strong>') ?> <br />
                           <?=sprintf(gettext("%s5%s -- Output R and W characters to the console for each packet read and write, uppercase is used for TCP/UDP packets and lowercase is used for TUN/TAP packets."),'<strong>','</strong>') ?> <br />
                           <?=sprintf(gettext("%s6%s-%s11%s -- Debug info range."),'<strong>','</strong>','<strong>','</strong>') ?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr class="opt_mode opt_mode_server_tls_user opt_mode_server_user">
                       <td><a id="help_for_reneg-sec" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Renegotiate time"); ?></td>
                       <td>
                         <input type="text" name="reneg-sec" value="<?=$pconfig['reneg-sec'];?>">
-                        <output class="hidden" for="help_for_reneg-sec">
+                        <div class="hidden" data-for="help_for_reneg-sec">
                           <?=sprintf(
                               gettext('Renegotiate data channel key after n seconds (default=3600).%s' .
                                      'When using a one time password, be advised that your connection will automatically drop because your password is not valid anymore.%sSet to 0 to disable, remember to change your client as well.'),
                                      '<br/>','<br/>');?>
-                        </output>
+                        </div>
                       </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Help For - Data For Attribute

Use original element (&lt;div&gt;/&lt;small&gt;) with "data-for" attribute.

The old jquery "for" attribute selectors can be removed once conversion to "data-for" attribute is complete (including plugins).

The old jquery selectors to remove once conversion is complete.
  opnsense_ui.js & head.inc
  $("*[for='" + $(this).attr('id') + "']")....
  $('[for*="help_for"]')....

If you'd like to go this route (with or without the css padding) let me know and I'll make a plugins commit for the same.  If you're wanting to do something else that's fine too.  Just close this PR.  I probably should have gone the data-for attribute route to being with rather than changing to the output element.  A good little learning exercise.