### PR TITLE
GUI Issue when changing WAN PPPoE to DHCP

### DIFF
--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -289,7 +289,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                   $config['interfaces'][$ifname]['if'] = $ifport;
                   if ($interfaces[$ifport]['section'] == 'ppps.ppp') {
                       $config['interfaces'][$ifname]['ipaddr'] = $interfaces[$ifport]['type'];
-                  }
+                  } else {
+					  $config['interfaces'][$ifname]['ipaddr'] = 'dhcp';
 
                   if (substr($ifport, 0, 3) == 'gre' || substr($ifport, 0, 3) == 'gif') {
                       unset($config['interfaces'][$ifname]['ipaddr']);


### PR DESCRIPTION
Issue #2206 Can't switch WAN from PPPoE to DHCP directly

When changing from PPPoE to DHCP on the WAN interface, re-assigning the interface will still not allow you to select dhcp, static is OK.

This simply forces it to DHCP and allows the user to continue.