### PR TITLE
Enable charon.install_routes from GUI

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -880,6 +880,9 @@ function ipsec_configure_do($verbose = false, $interface = '')
 
         $cnf_add_to_charon_section = "";
         $cnf_add_to_charon_section .= $aggressive_psk ? "\ti_dont_care_about_security_and_use_aggressive_mode_psk=yes\n":"";
+		if(isset($config['ipsec']['auto_routes_disable'])) {
+		    $cnf_add_to_charon_section .= "\tinstall_routes = no\n";
+		}
         if (isset($a_client['enable']) && isset($a_client['net_list'])) {
             $cnf_add_to_charon_section .= "\tcisco_unity = yes\n";
         }

--- a/src/www/vpn_ipsec_settings.php
+++ b/src/www/vpn_ipsec_settings.php
@@ -40,6 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig  = array();
     $pconfig['disablevpnrules'] = isset($config['system']['disablevpnrules']);
     $pconfig['preferoldsa_enable'] = isset($config['ipsec']['preferoldsa']);
+	$pconfig['auto_routes_disable'] = isset($config['ipsec']['auto_routes_disable']);
     if (!empty($config['ipsec']['passthrough_networks'])) {
         $pconfig['passthrough_networks'] = explode(',', $config['ipsec']['passthrough_networks']);
     } else {
@@ -94,6 +95,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $config['ipsec']['passthrough_networks'] = implode(',', $pconfig['passthrough_networks']);
         } elseif (isset($config['ipsec']['passthrough_networks'])) {
             unset($config['ipsec']['passthrough_networks']);
+        }
+        if (isset($pconfig['auto_routes_disable']) && $pconfig['auto_routes_disable'] == "yes") {
+            $config['ipsec']['auto_routes_disable'] = true;
+        } elseif (isset($config['ipsec']['auto_routes_disable'])) {
+            unset($config['ipsec']['auto_routes_disable']);
         }
 
         write_config();
@@ -178,6 +184,18 @@ if (isset($input_errors) && count($input_errors) > 0) {
                         <output class="hidden" for="help_for_passthrough_networks">
                             <?=gettext("This exempts traffic for one or more subnets from getting processed by the IPsec stack in the kernel. ".
                                         "When sending all traffic to the remote location, you probably want to add your lan network(s) here"); ?>
+                        </output>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><a id="help_for_auto_routes_disable" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Do not install routes"); ?></td>
+                      <td style="width:78%" class="vtable">
+                        <input name="auto_routes_disable" type="checkbox" id="auto_routes_disable" value="yes" <?= !empty($pconfig['auto_routes_disable']) ? "checked=\"checked\" : """;?> />
+                        <strong><?=gettext("Do not automatically install routes"); ?></strong>
+                        <output class="hidden" for="help_for_auto_routes_disable">
+                            <?=gettext("By default, IPsec installs routes when a tunnel becomes active. " .
+                                                  "Select this option to prevent automatically adding routes" .
+                                                  " to the system routing table. See charon.install_routes"); ?>
                         </output>
                       </td>
                     </tr>


### PR DESCRIPTION
When routing the default route over IPSec, installing 0.0.0.0/1 and 128.0.0.0/1 routes effectively overrides the default gateway, making it impossible for the firewall itself to use the route, because this hack (https://doc.pfsense.org/index.php/Why_can%27t_I_query_SNMP,_use_syslog,_NTP,_or_other_services_initiated_by_the_firewall_itself_over_IPsec_VPN) no longer works.

This is alleviated by adding the option to not automatically install routes via the charon.install_routes directive (https://wiki.strongswan.org/projects/strongswan/wiki/Strongswanconf).

The rationale behind providing this via GUI is that "Passthrough Networks" also is provided for that exact reason; providing the new switch rounds off this experience.