### PR TITLE
Fix gateway creation for GRE/GIF tunnels

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -498,6 +498,7 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
                 $ctype = $ifcfg['ipaddr'];
                 break;
             default:
+                $tunnelif = substr($ifcfg['if'], 0, 3);
                 if (substr($ifcfg['if'], 0, 4) ==  "ovpn") {
                     // if current iface is an ovpn server endpoint then skip it
                     if (substr($ifcfg['if'], 4, 1) == 's') {
@@ -505,6 +506,10 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
                     }
 
                     $ctype = "VPNv4";
+                } elseif ($tunnelif == "gif" || $tunnelif == "gre") {
+                    if (is_ipaddrv4(interfaces_tun_get_configured_address($ifcfg['if']))) {
+                        $ctype = "TUNNELv4";
+                    }
                 }
                 break;
         }
@@ -582,7 +587,9 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 
                     $ctype = "VPNv6";
                 } elseif ($tunnelif == "gif" || $tunnelif == "gre") {
-                    $ctype = "TUNNELv6";
+                    if (is_ipaddrv6(interfaces_tun_get_configured_address($ifcfg['if']))) {
+                        $ctype = "TUNNELv6";
+                    }
                 }
                 break;
         }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -648,6 +648,57 @@ function interface_lagg_configure(&$lagg)
     return $laggif;
 }
 
+function interfaces_tun_get_configured_address($realif, $local = true)
+{
+    if (empty($realif)) {
+    	return;
+    }
+    
+    global $config;    
+    switch (substr($realif, 0, strlen($realif)-1)) {
+    	case "gre":
+	    // Travers thru configured GRE tunnels
+	    if (isset($config['gres']['gre'])) {
+		    foreach ($config['gres']['gre'] as $i => $gre) {
+		        if (empty($gre['greif'])) {
+		            $gre['greif'] = "gre{$i}";
+		        }
+		        
+		        if ($realif == $gre['greif']) {
+		            if ($local) {
+		               return $gre['tunnel-local-addr'];
+		            } else {
+		               return $gre['tunnel-remote-addr'];
+		            }
+		        }
+		    }          
+	    }	    	
+	    break;
+	    
+    	case "gif":
+	    // Travers thru configured GIF tunnels
+	    if (isset($config['gifs']['gif'])) {
+		    foreach ($config['gifs']['gif'] as $i => $gif) {
+		        if (empty($gif['gifif'])) {
+		            $gif['gifif'] = "gif{$i}";
+		        }
+		        
+		        if ($realif == $gif['gifif']) {
+		            if ($local) {
+		               return $gif['tunnel-local-addr'];
+		            } else {
+		               return $gif['tunnel-remote-addr'];
+		            }
+		        }
+		    }          
+	    }	    
+	    break;	
+	    
+	default:
+		return;
+    }
+}
+
 function interfaces_gre_configure($checkparent = 0, $verbose = false, $realif = '')
 {
     global $config;

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -657,7 +657,7 @@ function interfaces_tun_get_configured_address($realif, $local = true)
     global $config;    
     switch (substr($realif, 0, strlen($realif)-1)) {
     	case "gre":
-	    // Travers thru configured GRE tunnels
+	    // Lookup thru configured GRE tunnels
 	    if (isset($config['gres']['gre'])) {
 		    foreach ($config['gres']['gre'] as $i => $gre) {
 		        if (empty($gre['greif'])) {
@@ -676,7 +676,7 @@ function interfaces_tun_get_configured_address($realif, $local = true)
 	    break;
 	    
     	case "gif":
-	    // Travers thru configured GIF tunnels
+	    // Lookup thru configured GIF tunnels
 	    if (isset($config['gifs']['gif'])) {
 		    foreach ($config['gifs']['gif'] as $i => $gif) {
 		        if (empty($gif['gifif'])) {


### PR DESCRIPTION
I've noticed that there is no GWv4 created for GIF tunnel with configured IPv4 address, but obviously useless GWv6 is successfully created. Current base code does not have any logic for GWv4 creation at all which made me very devastatingly upset so even sun stopped rising every morning upon my house.

This fix allows gateway creation accordingly to the currently configured address space on given iface.

I hope this piece of nano fix will do good.