### PR TITLE
add support for wildcard entries in unbound

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -590,8 +590,15 @@ function unbound_add_host_entries()
             switch ($host['rr']) {
                 case 'A':
                 case 'AAAA':
-                    $unbound_entries .= "local-data-ptr: \"{$host['ip']} {$host['host']}{$host['domain']}\"\n";
-                    $unbound_entries .= "local-data: \"{$host['host']}{$host['domain']} IN {$host['rr']} {$host['ip']}\"\n";
+                    // handle wildcard entries which have * as a hostname. Since we added a . above, we match on *.
+                    if( trim($host['host']) == "*." ) {
+                      $unbound_entries .= "local-zone: \"{$host['domain']}\" redirect\n";
+                      $unbound_entries .= "local-data: \"{$host['domain']} IN {$host['rr']} {$host['ip']}\"\n";
+                    }
+                    else {
+                      $unbound_entries .= "local-data-ptr: \"{$host['ip']} {$host['host']}{$host['domain']}\"\n";
+                      $unbound_entries .= "local-data: \"{$host['host']}{$host['domain']} IN {$host['rr']} {$host['ip']}\"\n";
+                    }
                     break;
                 case 'MX':
                     $unbound_entries .= "local-data: \"{$host['host']}{$host['domain']} IN MX {$host['mxprio']} {$host['mx']}\"\n";

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -180,8 +180,8 @@ include("head.inc");
                     <td>
                       <input name="host" type="text" value="<?=$pconfig['host'];?>" />
                       <div class="hidden" data-for="help_for_host">
-                        <?=gettext("Name of the host, without domain part"); ?>
-                        <?=gettext("e.g."); ?> <em><?=gettext("myhost"); ?></em>
+                        <?=gettext("Name of the host, without domain part. Use '*' to create a wildcard-entry"); ?>
+                        <?=gettext("e.g."); ?> <em><?=gettext("myhost"); ?></em> or <em>*</em>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
Using * as a hostname, one now create wildcard domains in unbound.
```
redirect
                 The query is answered from the local data for the zone  name.
                 There  may  be  no  local  data  beneath the zone name.  This
                 answers queries for the zone, and all subdomains of the  zone
                 with the local data for the zone.  It can be used to redirect
                 a domain to return a different  address  record  to  the  end
                 user,    with   local-zone:   "example.com."   redirect   and
                 local-data: "example.com. A 127.0.0.1" queries for  www.exam-
                 ple.com and www.foo.example.com are redirected, so that users
                 with web browsers  cannot  access  sites  with  suffix  exam-
                 ple.com.
```