### PR TITLE
Fix hostname sanitizing to allow asterisk for wildcards

### DIFF
--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -67,7 +67,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
 
-    if (!empty($pconfig['host']) && !is_hostname($pconfig['host'])) {
+   // either allow to be a valid, sanatized hostname, or be a special case * for wildcards
+   if (!empty($pconfig['host']) && (!is_hostname($pconfig['host']) || $pconfig['host'] == "*")) {
         $input_errors[] = gettext("The hostname can only contain the characters A-Z, 0-9 and '-'.");
     }
 


### PR DESCRIPTION
Follow up for https://github.com/opnsense/core/pull/2313 , fixing form validation not allowing an asterisk ( i was testing with REST before, sorry )