### PR TITLE
Speedup reloading interfaces.

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -955,7 +955,7 @@ function interfaces_configure($verbose = false)
     interfaces_group_setup();
 
     if ($reload == INTERFACE_RELOAD_ALL) {
-        system_routing_configure('', $verbose);
+        system_routing_configure($verbose);
         ipsec_configure_do($verbose);
         plugins_configure('dns', $verbose);
         services_dhcpd_configure('all', array(), $verbose);

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -29,6 +29,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+const INTERFACE_BOOTING = 1;
+const INTERFACE_RELOAD_SINGLE = 2;
+const INTERFACE_RELOAD_ALL = 3;
+
 require_once("interfaces.lib.inc");
 require_once("gwlb.inc");
 
@@ -905,7 +909,7 @@ function interfaces_configure($verbose = false)
     $track6_list = array();
 
     /* This is needed to speedup interfaces on bootup. */
-    $reload = !file_exists('/var/run/booting');
+    $reload = file_exists('/var/run/booting') ? INTERFACE_BOOTING : INTERFACE_RELOAD_ALL;
 
     foreach ($iflist as $if => $ifname) {
         $realif = $config['interfaces'][$if]['if'];
@@ -950,8 +954,8 @@ function interfaces_configure($verbose = false)
 
     interfaces_group_setup();
 
-    if ($reload) {
-        system_routing_configure($verbose);
+    if ($reload == INTERFACE_RELOAD_ALL) {
+        system_routing_configure('', $verbose);
         ipsec_configure_do($verbose);
         plugins_configure('dns', $verbose);
         services_dhcpd_configure('all', array(), $verbose);
@@ -2374,7 +2378,7 @@ function interface_virtual_create($interface)
 }
 
 
-function interface_configure($interface = 'wan', $reloadall = false, $linkupevent = false, $verbose = false)
+function interface_configure($interface = 'wan', $reload = INTERFACE_BOOTING, $linkupevent = false, $verbose = false)
 {
     global $config;
 
@@ -2588,11 +2592,17 @@ function interface_configure($interface = 'wan', $reloadall = false, $linkupeven
             system_hosts_generate();
         }
 
-        if ($reloadall == true) {
+        if (in_array($reload, [INTERFACE_RELOAD_SINGLE, INTERFACE_RELOAD_ALL])) {
             system_routing_configure(false, $interface);
+        }
+
+        if ($reload == INTERFACE_RELOAD_SINGLE) {
             ipsec_configure_do();
             plugins_configure('dns');
             services_dhcpd_configure();
+        }
+
+        if (in_array($reload, [INTERFACE_RELOAD_SINGLE, INTERFACE_RELOAD_ALL])) {
             configd_run("dyndns reload {$interface}");
             configd_run("rfc2136 reload {$interface}");
         }

--- a/src/etc/rc.initial.setlanip
+++ b/src/etc/rc.initial.setlanip
@@ -558,7 +558,7 @@ echo "done.\n";
 system_hosts_generate(true);
 system_resolvconf_generate(true);
 interface_bring_down($interface);
-interface_configure($interface, true, false, true);
+interface_configure($interface, INTERFACE_RELOAD_SINGLE, false, true);
 setup_gateways_monitor(true);
 filter_configure_sync(true);
 

--- a/src/etc/rc.linkup
+++ b/src/etc/rc.linkup
@@ -70,7 +70,7 @@ function handle_argument_group($iface, $argument2)
                     log_error("DEVD Ethernet attached event for {$iface}");
                     log_error("HOTPLUG: Configuring interface {$iface}");
                     // Do not try to readd to bridge otherwise em(4) has problems
-                    interface_configure($iface, true, true);
+                    interface_configure($iface, INTERFACE_RELOAD_SINGLE, true);
                     break;
             }
         }

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -513,7 +513,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 foreach ($toapplylist as $ifapply => $ifcfgo) {
                     interface_bring_down($ifapply, $ifcfgo);
                     if (isset($config['interfaces'][$ifapply]['enable'])) {
-                        interface_configure($ifapply, true);
+                        interface_configure($ifapply, INTERFACE_RELOAD_SINGLE);
                     }
                 }
             }

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -309,7 +309,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                           interface_sync_wireless_clones($config['interfaces'][$ifname], false);
                       }
                       /* Reload all for the interface. */
-                      interface_configure($ifname, true);
+                      interface_configure($ifname, INTERFACE_RELOAD_SINGLE);
                       // count changes
                       $changes++;
                   }


### PR DESCRIPTION
If WAN-interface has no connection then restart of all services is very slow. The IP address is received by DHCP for a long time and the DNS server is restarted for a long time. Moreover, the DNS server is rebooted three times: once per initialization of each interface and once again on the general reboot of interfaces. I removed the unnecessary reset of the DNS servers on each interface. Restart all services accelerated in half.