### PR TITLE
Add Destination IP to Alert Search

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/ServiceController.php
@@ -181,7 +181,7 @@ class ServiceController extends ApiMutableServiceControllerBase
 
             if ($this->request->getPost('searchPhrase', 'string', '') != "") {
                 $filterTag = $filter->sanitize($this->request->getPost('searchPhrase'), "query");
-                $searchPhrase = 'alert,alert_action,src_ip/"*'.$filterTag .'*"';
+                $searchPhrase = 'alert,alert_action,src_ip,dest_ip/"*'.$filterTag .'*"';
             } else {
                 $searchPhrase = '';
             }

--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -835,7 +835,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <div class="row">
                 <div class="col-sm-12 actionBar">
                     <select id="alert-logfile" class="selectpicker" data-width="200px"></select>
-                    <span id="actDeleteLog" class="btn btn-lg fa fa-trash" style="cursor: pointer;" title="Delete Log File"></span>
+                    <span id="actDeleteLog" class="btn btn-lg fa fa-trash" style="cursor: pointer;" title="Delete Alert Log"></span>
                     <select id="alert-logfile-max" class="selectpicker" data-width="80px">
                         <option value="7">7</option>
                         <option value="50">50</option>

--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -835,7 +835,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <div class="row">
                 <div class="col-sm-12 actionBar">
                     <select id="alert-logfile" class="selectpicker" data-width="200px"></select>
-                    <span id="actDeleteLog" class="btn btn-lg fa fa-trash" style="cursor: pointer;"></span>
+                    <span id="actDeleteLog" class="btn btn-lg fa fa-trash" style="cursor: pointer;" title="Delete Log File"></span>
                     <select id="alert-logfile-max" class="selectpicker" data-width="80px">
                         <option value="7">7</option>
                         <option value="50">50</option>


### PR DESCRIPTION
This adds Destination IP as a search filter for the IDS Alerts.  It also adds a tooltip to the trash can.