### PR TITLE
Add traffic data and IP address to Radius Accounting messages

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -201,7 +201,7 @@ class Radius extends Base implements IAuthConnector
      * @param $sessionid    session id
      * @param $session_time total time spend on this session
      */
-    public function stopAccounting($username, $sessionid, $session_time)
+    public function stopAccounting($username, $sessionid, $session_time, $bytes_in, $bytes_out, $ip_address)
     {
         // only send messages if target port specified
         if ($this->acctPort != null) {
@@ -240,6 +240,12 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_SESSION_TIME, $session_time)) {
                 $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, RADIUS_ACCT_INPUT_OCTETS, $bytes_in)) {
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, RADIUS_ACCT_OUTPUT_OCTETS, $bytes_out)) {
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
+                $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_TERMINATE_CAUSE, RADIUS_TERM_USER_REQUEST)) {
                 $error = radius_strerror($radius);
             }
@@ -269,7 +275,7 @@ class Radius extends Base implements IAuthConnector
      * @param $sessionid    session id
      * @param $session_time total time spend on this session
      */
-    public function updateAccounting($username, $sessionid, $session_time)
+    public function updateAccounting($username, $sessionid, $session_time, $bytes_in, $bytes_out, $ip_address)
     {
         // only send messages if target port specified
         if ($this->acctPort != null) {
@@ -310,6 +316,12 @@ class Radius extends Base implements IAuthConnector
             } elseif (!radius_put_int($radius, RADIUS_ACCT_AUTHENTIC, RADIUS_AUTH_LOCAL)) {
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_SESSION_TIME, $session_time)) {
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, RADIUS_ACCT_INPUT_OCTETS, $bytes_in)) {
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, RADIUS_ACCT_OUTPUT_OCTETS, $bytes_out)) {
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
                 $error = radius_strerror($radius);
             }
 

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
@@ -41,9 +41,12 @@ $result = $db->query('
     select      c.zoneid
     ,           c.sessionid
     ,           c.username
+	,           c.ip_address
     ,           c.authenticated_via
     ,           c.deleted
     ,           c.created
+	,           si.bytes_in
+	,           si.bytes_out
     ,           accs.state
     from        cp_clients c
     inner join  session_restrictions sr on sr.zoneid = c.zoneid and sr.sessionid = c.sessionid
@@ -80,14 +83,14 @@ if ($result !== false) {
                 $stmt->execute();
                 if (method_exists($authenticator, 'startAccounting')) {
                     $time_spend = time() - $row['created'];
-                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spend);
+                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
                 }
             } elseif ($row['state'] != 'STOPPED') {
                 // send interim updates (if applicable)
                 if (method_exists($authenticator, 'updateAccounting')) {
                     // send interim update event
                     $time_spend = time() - $row['created'];
-                    $authenticator->updateAccounting($row['username'], $row['sessionid'], $time_spend);
+                    $authenticator->updateAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
                 }
             }
         }

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
@@ -41,12 +41,12 @@ $result = $db->query('
     select      c.zoneid
     ,           c.sessionid
     ,           c.username
-	,           c.ip_address
+    ,           c.ip_address
     ,           c.authenticated_via
     ,           c.deleted
     ,           c.created
-	,           si.bytes_in
-	,           si.bytes_out
+    ,           si.bytes_in
+    ,           si.bytes_out
     ,           accs.state
     from        cp_clients c
     inner join  session_restrictions sr on sr.zoneid = c.zoneid and sr.sessionid = c.sessionid


### PR DESCRIPTION
In reference to #2363 this pull request adds support for traffic data (bytes_in/out) in IP address fields in the Radius Accounting messages.