### PR TITLE
Update helptext in dialogRule.xml

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
@@ -38,7 +38,7 @@
         <id>rule.src_port</id>
         <label>src-port</label>
         <type>text</type>
-        <help>source port number or well known name (imap,imaps,http,https,...), for ranges use a dash</help>
+        <help>source port number or well known name (imap, imaps, http, https, ...), for ranges use a dash</help>
     </field>
     <field>
         <id>rule.destination</id>
@@ -56,7 +56,7 @@
         <id>rule.dst_port</id>
         <label>dst-port</label>
         <type>text</type>
-        <help>destination port number or well known name (imap,imaps,http,https,...), for ranges use a dash</help>
+        <help>destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash</help>
     </field>
     <field>
         <id>rule.direction</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
@@ -38,7 +38,7 @@
         <id>rule.src_port</id>
         <label>src-port</label>
         <type>text</type>
-        <help>source port number or well known name (imap,imaps, http,https,...)</help>
+        <help>source port number or well known name (imap,imaps,http,https,...), for ranges use a dash</help>
     </field>
     <field>
         <id>rule.destination</id>
@@ -56,7 +56,7 @@
         <id>rule.dst_port</id>
         <label>dst-port</label>
         <type>text</type>
-        <help>destination port number or well known name (imap,imaps, http,https,...)</help>
+        <help>destination port number or well known name (imap,imaps,http,https,...), for ranges use a dash</help>
     </field>
     <field>
         <id>rule.direction</id>


### PR DESCRIPTION
We really should define some standards here. In plugins labels start always (or 90%) with upper case and helptext also starts upper case and ends with a dot (if not an IP address or something like that)