### PR TITLE
Fix IPsec RADIUS secret

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -987,7 +987,7 @@ EOD;
                             if (in_array($auth_server['name'], explode(',', $ph1ent['authservers']))) {
                                 $radius_servers .= "\t\t\t\tserver" . $radius_server_num . " {\n";
                                 $radius_servers .= "\t\t\t\t\taddress = " . $auth_server['host'] . "\n";
-                                $radius_servers .= "\t\t\t\t\tsecret = " . $auth_server['radius_secret'] . "\n";
+                                $radius_servers .= "\t\t\t\t\tsecret = \"" . $auth_server['radius_secret'] . "\"\n";
                                 $radius_servers .= "\t\t\t\t\tauth_port = " . $auth_server['radius_auth_port'] . "\n";
 
                                 if (!empty($auth_server['radius_acct_port'])) {


### PR DESCRIPTION
Add double quotes around the RADIUS secret to prevent some corner cases where the secret was not fully read.