### PR TITLE
If SLAAC, don't fix the subnet based on the current address

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -301,7 +301,7 @@ function services_radvd_configure($blacklist = array())
 
         $ifcfgipv6 = get_interface_ipv6($if);
 
-        if (is_ipaddrv6($ifcfgipv6)) {
+        if ($autotype != 'slaac' && is_ipaddrv6($ifcfgipv6)) {
             $ifcfgsnv6 = get_interface_subnetv6($if);
             $subnetv6 = gen_subnetv6($ifcfgipv6, $ifcfgsnv6);
         }


### PR DESCRIPTION
Additional fix for issue #2394 to prevent an incorrect prefix in case radvd.conf is created after the interface already has an IP address.