### PR TITLE
feature: Top level menu item link pivots + security improvements

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
@@ -1,53 +1,74 @@
 <aside id="navigation" class="page-side col-xs-12 col-sm-3 col-lg-2 hidden-xs">
     <div class="row">
         <nav class="page-side-nav">
-            <div id="mainmenu" class="panel" style="border:0px" >
+            <div id="mainmenu" class="panel" style="border:0px">
                 <div class="panel list-group" style="border:0px">
-                {% for topMenuItem in menuSystem %}
-                    <a href="#{{ topMenuItem.Id }}" class="list-group-item {% if topMenuItem.Selected %}  active-menu-title {% endif  %}" data-toggle="collapse" data-parent="#mainmenu"><span class="{{ topMenuItem.CssClass }} __iconspacer"></span>{{ lang._(topMenuItem.VisibleName) }} </a>
-                    <div class="collapse  {% if topMenuItem.Selected %} active-menu in {% endif  %}" id="{{ topMenuItem.Id }}">
-                        {% for subMenuItem in topMenuItem.Children %}
-                            {% if subMenuItem.Url == '' %}
-                                {# next level items, submenu is a container #}
-                                <a href="#{{ topMenuItem.Id }}_{{ subMenuItem.Id }}" class="list-group-item {% if subMenuItem.Selected %}  active-menu-title {% endif  %}" data-toggle="collapse" data-parent="#{{ topMenuItem.Id }}">
-                                  <div style="display: table;width: 100%;">
-                                    <div style="display: table-row">
-                                      <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
-                                        <div style="display: table-cell; text-align:right; vertical-align:middle;"><span class="{{ subMenuItem.CssClass }}"></span></div>
-                                      </div>
-                                  </div>
-                                </a>
-                                <div class="collapse {% if subMenuItem.Selected %} active-menu in {% endif  %}" id="{{ topMenuItem.Id }}_{{ subMenuItem.Id }}" >
-                                    {% for subsubMenuItem in subMenuItem.Children %}
-                                        {% if subsubMenuItem.IsExternal == "Y" %}
-                                            <a href="{{ subsubMenuItem.Url }}" target="_blank" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ lang._(subsubMenuItem.VisibleName) }}</a>
-                                        {% elseif acl.isPageAccessible(session.get('Username'),subsubMenuItem.Url)  %}
+                    {% for topMenuItem in menuSystem %}
+                        {% if topMenuItem.Children|length >= 1 %}
+                            <a href="#{{ topMenuItem.Id }}" class="list-group-item {% if topMenuItem.Selected %}  active-menu-title {% endif  %}" data-toggle="collapse" data-parent="#mainmenu">
+                                <span class="{{ topMenuItem.CssClass }} __iconspacer"></span>{{ lang._(topMenuItem.VisibleName) }}
+                            </a>
+                            <div class="collapse  {% if topMenuItem.Selected %} active-menu in {% endif  %}" id="{{ topMenuItem.Id }}">
+                                {% for subMenuItem in topMenuItem.Children %}
+                                    {% if subMenuItem.Url == '' %}
+                                    {# next level items, submenu is a container #}
+                                        <a href="#{{ topMenuItem.Id }}_{{ subMenuItem.Id }}" class="list-group-item {% if subMenuItem.Selected %}  active-menu-title {% endif  %}"
+                                            data-toggle="collapse" data-parent="#{{ topMenuItem.Id }}">
+                                            <div style="display: table;width: 100%;">
+                                                <div style="display: table-row">
+                                                    <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
+                                                    <div style="display: table-cell; text-align:right; vertical-align:middle;">
+                                                        <span class="{{ subMenuItem.CssClass }}"></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <div class="collapse {% if subMenuItem.Selected %} active-menu in {% endif  %}" id="{{ topMenuItem.Id }}_{{ subMenuItem.Id }}">
+                                            {% for subsubMenuItem in subMenuItem.Children %} {% if subsubMenuItem.IsExternal == "Y" %}
+                                            <a href="{{ subsubMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ lang._(subsubMenuItem.VisibleName) }}</a>
+                                            {% elseif acl.isPageAccessible(session.get('Username'),subsubMenuItem.Url) %}
                                             <a href="{{ subsubMenuItem.Url }}" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ lang._(subsubMenuItem.VisibleName) }}</a>
-                                        {% endif %}
-                                    {% endfor %}
-                                </div>
-                        {% elseif subMenuItem.IsExternal == "Y" %}
-                                <a href="{{ subMenuItem.Url }}" target="_blank" class="list-group-item {% if subMenuItem.Selected %} active {% endif  %}"  aria-expanded="{% if subMenuItem.Selected %}true{%else%}false{% endif  %}">
-                                  <div style="display: table;width: 100%;">
-                                    <div style="display: table-row">
-                                      <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
-                                        <div style="display: table-cell; text-align:right; vertical-align:middle;"><span class="{{ subMenuItem.CssClass }}"></span></div>
-                                      </div>
-                                  </div>
+                                            {% endif %} {% endfor %}
+                                        </div>
+                                    {% elseif subMenuItem.IsExternal == "Y" %}
+                                        <a href="{{ subMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item {% if subMenuItem.Selected %} active {% endif  %}"
+                                            aria-expanded="{% if subMenuItem.Selected %}true{%else%}false{% endif  %}">
+                                            <div style="display: table;width: 100%;">
+                                                <div style="display: table-row">
+                                                    <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
+                                                    <div style="display: table-cell; text-align:right; vertical-align:middle;">
+                                                        <span class="{{ subMenuItem.CssClass }}"></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </a>
+                                    {% elseif acl.isPageAccessible(session.get('Username'),subMenuItem.Url) %}
+                                        <a href="{{ subMenuItem.Url }}" class="list-group-item {% if subMenuItem.Selected %} active {% endif  %}">
+                                            <div style="display: table;width: 100%;">
+                                                <div style="display: table-row">
+                                                    <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
+                                                    <div style="display: table-cell; text-align:right; vertical-align:middle;">
+                                                        <span class="{{ subMenuItem.CssClass }}"></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </a>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% else %}
+                            {# parent level link menu items that pivot #}
+                            {% if topMenuItem.IsExternal == "Y" %}
+                                <a href="{{ topMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item {% if topMenuItem.Selected %}  active-menu-title {% endif  %}" data-parent="#mainmenu">
+                                    <span class="{{ topMenuItem.CssClass }} __iconspacer"></span>{{ lang._(topMenuItem.VisibleName) }}
                                 </a>
-                            {% elseif acl.isPageAccessible(session.get('Username'),subMenuItem.Url)  %}
-                                <a href="{{ subMenuItem.Url }}" class="list-group-item {% if subMenuItem.Selected %} active {% endif  %}">
-                                  <div style="display: table;width: 100%;">
-                                    <div style="display: table-row">
-                                      <div style="display: table-cell">{{ lang._(subMenuItem.VisibleName) }}</div>
-                                        <div style="display: table-cell; text-align:right; vertical-align:middle;"><span class="{{ subMenuItem.CssClass }}"></span></div>
-                                      </div>
-                                  </div>
+                            {% elseif acl.isPageAccessible(session.get('Username'),topMenuItem.Url) %}
+                                <a href="{{ topMenuItem.Url }}" class="list-group-item {% if topMenuItem.Selected %}  active-menu-title {% endif  %}" data-parent="#mainmenu">
+                                    <span class="{{ topMenuItem.CssClass }} __iconspacer"></span>{{ lang._(topMenuItem.VisibleName) }}
                                 </a>
                             {% endif %}
-                        {% endfor %}
-                    </div>
-                {% endfor %}
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </nav>

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -87,6 +87,8 @@ if($need_alert_display == true) {
                     <div class="panel list-group" style="border:0px">
 <?php
                           foreach($menuSystem as $topMenuItem): ?>
+<?php
+                          if (count($topMenuItem->Children) >= 1): ?>
                             <a href="#<?=$topMenuItem->Id;?>" class="list-group-item <?= $topMenuItem->Selected ? 'active-menu-title' : ""; ?>" data-toggle="collapse" data-parent="#mainmenu"><span class="<?=$topMenuItem->CssClass;?> __iconspacer"></span><?=gettext($topMenuItem->VisibleName);?>  </a>
                             <div class="collapse <?=$topMenuItem->Selected ? 'active-menu in' :"";?>" id="<?=$topMenuItem->Id;?>">
 <?php
@@ -134,11 +136,29 @@ if($need_alert_display == true) {
                                     </div>
                                   </div>
                                 </a>
+
 <?php
                               endif;?>
 <?php
                             endforeach; ?>
                             </div>
+<?php
+                          else: ?>
+<?php
+                              if ($topMenuItem->IsExternal == "Y" ):?>
+                                <a href="<?=$topMenuItem->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item <?=$topMenuItem->Selected ? "active-menu-title" : "";?>" data-parent="#mainmenu">
+                                    <span class="<?=$topMenuItem->CssClass;?> __iconspacer"></span><?=gettext($topMenuItem->VisibleName);?>
+                                </a>
+<?php
+                              elseif ($aclObj->isPageAccessible($_SESSION['Username'],$topMenuItem->Url)):?>
+                                <a href="<?=$topMenuItem->Url;?>" class="list-group-item <?=$topMenuItem->Selected ? "active-menu-title" : "";?>" data-parent="#mainmenu">
+                                    <span class="<?=$topMenuItem->CssClass;?> __iconspacer"></span><?=gettext($topMenuItem->VisibleName);?>
+                                </a>
+
+<?php
+                              endif;?>
+<?php
+                        endif;?>                      
 <?php
                         endforeach; ?>
                     </div>

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -106,7 +106,7 @@ if($need_alert_display == true) {
                                   foreach ($subMenuItem->Children as $subsubMenuItem):?>
 <?php
                                     if ($subsubMenuItem->IsExternal == "Y"):?>
-                                            <a href="<?=$subsubMenuItem->Url;?>" target="_blank" class="list-group-item menu-level-3-item <?=$subsubMenuItem->Selected ? "active" :"";?>"><?=gettext($subsubMenuItem->VisibleName);?></a>
+                                            <a href="<?=$subsubMenuItem->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item menu-level-3-item <?=$subsubMenuItem->Selected ? "active" :"";?>"><?=gettext($subsubMenuItem->VisibleName);?></a>
 <?php
                                     elseif ($aclObj->isPageAccessible($_SESSION['Username'],$subsubMenuItem->Url)):?>
                                             <a href="<?=$subsubMenuItem->Url;?>" class="list-group-item menu-level-3-item <?=$subsubMenuItem->Selected ? "active" :"";?>"><?=gettext($subsubMenuItem->VisibleName);?></a>
@@ -116,7 +116,7 @@ if($need_alert_display == true) {
                                 </div>
 <?php
                               elseif ($subMenuItem->IsExternal == "Y" ):?>
-                                <a href="<?=$subMenuItem->Url;?>" target="_blank" class="list-group-item <?=$subMenuItem->Selected ? "active" : "";?>" aria-expanded="<?=$subMenuItem->Selected ? "true" : "false";?>">
+                                <a href="<?=$subMenuItem->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item <?=$subMenuItem->Selected ? "active" : "";?>" aria-expanded="<?=$subMenuItem->Selected ? "true" : "false";?>">
                                   <div style="display: table;width: 100%;">
                                     <div style="display: table-row">
                                       <div style="display: table-cell"><?=gettext($subMenuItem->VisibleName);?></div>


### PR DESCRIPTION
This feature adds the ability to have parent level menu items that are clickable and that can pivot to an internal link as well as a external link.

I made some improvements on the security stand point for external links due to the fact we are using `target="_blank"`. You can read more about the potential security risks here:

* [Target="_blank" - the most underestimated vulnerability ever](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/)

I've added `rel="noopener noreferrer"` to legacy code as well as additional feature code.