### PR TITLE
Enhancement: URLs load correctly regardless of trailing slash

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/Routing.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Routing.php
@@ -128,16 +128,16 @@ class Routing
         // where module is mapped to the corresponding namespace
         foreach ($registered_modules as $module_name => $module_configs) {
             $namespace = array_shift($module_configs)['namespace'];
-            $this->router->add("/".$module_name."/", array(
-                "namespace" => $namespace
+            $this->router->add("/" . $module_name, array(
+                "namespace" => $namespace,
             ));
 
-            $this->router->add("/".$module_name."/:controller/", array(
+            $this->router->add("/" . $module_name . "/:controller", array(
                 "namespace" => $namespace,
                 "controller" => 1
             ));
 
-            $this->router->add("/".$module_name."/:controller/:action/", array(
+            $this->router->add("/" . $module_name . "/:controller/:action", array(
                 "namespace" => $namespace,
                 "controller" => 1,
                 "action" => 2
@@ -158,7 +158,7 @@ class Routing
                     foreach (glob($module_config['path']."/*.php") as $filename) {
                         // extract controller name and bind static in routing table
                         $controller = strtolower(str_replace('Controller.php', '', basename($filename)));
-                        $this->router->add("/{$module_name}/{$controller}/:action/", array(
+                        $this->router->add("/{$module_name}/{$controller}/:action", array(
                             "namespace" => $module_config['namespace'],
                             "controller" => $controller,
                             "action" => 1
@@ -172,6 +172,7 @@ class Routing
                     }
                 }
             }
+            $this->router->removeExtraSlashes(true);
         }
     }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/Menu.xml
@@ -60,7 +60,7 @@
             <Status order="200" url="/status_habackup.php"/>
         </HighAvailability>
         <Routes cssClass="fa fa-map-signs fa-fw">
-            <Configuration order="10" url="/ui/routes/" />
+            <Configuration order="10" url="/ui/routes" />
             <Log order="100" VisibleName="Log File" url="/diag_logs_routing.php"/>
         </Routes>
         <Settings cssClass="fa fa-cogs fa-fw">


### PR DESCRIPTION
In the current OPNsense, URLs that don't end in an extension (`php`) have to end with a trailing slash. If you navigate to the same URL without the trailing slash, the page is not found and you get a "Page not found" page. I went ahead and fixed the routing so that URLs are now dynamic in the aspect of whether you go to `/ui/plugin-page` or `/ui/plugin-page/` the content for that page loads.

The functionality is standard Phalcon stuff, and you can read more about the change I made at the following location:

link: [Dealing with extra/trailing slashes](https://olddocs.phalconphp.com/en/3.0.0/reference/routing.html#dealing-with-extra-trailing-slashes)

I also went ahead and fixed the one menu item that was using a trailing `/` to not use it.