### PR TITLE
Help debugging of Traffic Shaping by generating ipfw comments in rules

### DIFF
--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -185,7 +185,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif
     %} xmit {{physical_interface(rule.interface2)
-    }}
+    }} // {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
 {%                         if rule.direction == 'out' or not rule.direction %}
 add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
@@ -196,7 +196,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif
     %} recv {{physical_interface(rule.interface2)
-    }}
+    }} // {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
 {%                       else %}
 {#  normal, single interface situation  #}
@@ -207,7 +207,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} {{rule.direction}} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} via {{
     physical_interface(rule.interface)
-    }}
+    }} // {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                       endif %}
 {%                   endif %}
 {%            endif %}


### PR DESCRIPTION
`ipfw show`:

```
60004  50573  69792852 queue 10000 ip from not 192.168.23.0/24 to any xmit lagg0_vlan2342 recv em0 // wan -> lan: down,75 weight
60005  29657   3088201 queue 10003 ip from any to not 192.168.23.0/24 recv lagg0_vlan2342 xmit em0 // lan -> wan: up,75 weight
```