### PR TITLE
ZFS support in rc and opnsense-importer (from Smart-Soft)

### DIFF
--- a/src/etc/rc
+++ b/src/etc/rc
@@ -47,6 +47,7 @@ mount -fr / 2> /dev/null
 
 GROWFS_MARKER=/.probe.for.growfs.nano
 ROOT_IS_UFS=
+ZFS_DEV=
 
 while read FS_PART FS_MNT FS_TYPE FS_MORE; do
 	# only tune our own file systems
@@ -96,6 +97,28 @@ while read FS_PART FS_MNT FS_TYPE FS_MORE; do
 	fi
 done < /etc/fstab
 
+if [ -z "${ROOT_IS_UFS}" ]; then
+    ###Check root on ZFS
+    ORIGINAL_IFS="${IFS}"
+    IFS=$'\n'
+    ZFSCHK=$(mount -t zfs)
+
+    for rmnt in $ZFSCHK; do
+        ZFS_DEV=$(echo ${rmnt} | awk '{ print $1 }')
+        ZFS_MNT=$(echo ${rmnt} | awk '{ print $3 }')
+        if [ "${ZFS_MNT}" = "/" ]; then
+            break;
+        fi
+        ZFS_DEV=
+    done
+    IFS="${ORIGINAL_IFS}"
+fi
+
+if [ -z "${ROOT_IS_UFS}" ] && [ -n "${ZFS_DEV}" ]; then
+    ###Remount ZFS root read-write
+    mount -t zfs -o rw,remount ${ZFS_DEV} /
+fi
+
 attempts=0
 while [ ${attempts} -lt 3 ]; do
 	if [ -n "${ROOT_IS_UFS}" ]; then
@@ -108,14 +131,6 @@ while [ ${attempts} -lt 3 ]; do
 	fi
 	attempts=$((attempts+1))
 done
-
-if kldstat -qm zfs; then
-	mount -uw /
-	zfs mount -va
-	# maybe there is a mountpoint in fstab
-	# that requires ZFS to be fully set up
-	mount -a
-fi
 
 # clear growfs marker now that we are read/write
 rm -f ${GROWFS_MARKER}

--- a/src/sbin/opnsense-importer
+++ b/src/sbin/opnsense-importer
@@ -52,15 +52,13 @@ bootstrap_and_exit()
 
 	# clean up after a finished import
 	if [ -d ${MNT} ]; then
-		if [ -n "${PART}" ]; then
-			umount ${MNT} && rm -rf ${MNT}
-		elif [ -n "${POOL}" ]; then
-			zpool export ${POOL} && rm -rf ${MNT}
+		umount ${MNT} 2> /dev/null
+		rm -rf ${MNT}
+		if [ -n "${ZFSPOOL}" ]; then
+		    echo -n "Exporting ${ZFSPOOL}... "
+		    zpool export ${ZFSPOOL}
+		    echo "done. "
 		fi
-	fi
-
-	if [ -z "${ZFS}" ]; then
-		kldunload zfs
 	fi
 
 	# error code given or assumed ok (trap)
@@ -110,16 +108,6 @@ timeout_prompt()
 	return ${RETURN}
 }
 
-zfs_load()
-{
-	# we need to load ZFS to list pools
-	if kldstat -qm zfs; then
-		export ZFS="yes"
-	else
-		kldload zfs
-	fi
-}
-
 probe_for_part()
 {
 	DEV=${1}
@@ -132,11 +120,6 @@ probe_for_part()
 		# GPT layout found
 		export PART="/dev/${DEV}p3"
 		return 0
-	elif [ "${DEV}" = "zroot" ]; then
-		if zpool import | awk '{ print $1 " " $2 }' | grep -q "${DEV} ONLINE"; then
-			export POOL="${DEV}"
-			return 0
-		fi
 	fi
 
 	return 1
@@ -146,8 +129,6 @@ DEVS=
 PART=
 
 if [ -n "${1}" ]; then
-	zfs_load
-
 	if ! probe_for_part ${1}; then
 		echo "No previous configuration was found on this device."
 		bootstrap_and_exit 1
@@ -165,12 +146,10 @@ else
 		fi
 	fi
 
-	zfs_load
-
 	DEVS=$(camcontrol devlist; gmirror status -s; graid status -s)
 fi
 
-while [ -z "${PART}" -a -z "${POOL}" ]; do
+while [ -z "${PART}" ]; do
 	echo
 	echo "${DEVS}"
 	echo
@@ -187,29 +166,48 @@ while [ -z "${PART}" -a -z "${POOL}" ]; do
 	fi
 done
 
+echo "Starting import for partition '${PART}'."
+echo
+
 mkdir -p ${MNT}
 
-if [ -n "${PART}" ]; then
-	echo "Starting import for partition '${PART}'."
-	echo
+###Check ZFS on source
+zpool import -af
 
-	echo -n "Running fsck..."
-	fsck -t ufs -y ${PART} > /dev/null
-	echo "done."
+ZPCHK=$(zpool get -H cachefile)
+ZFSPOOL=
+ORIGINAL_IFS="${IFS}"
 
-	if ! mount ${PART} ${MNT}; then
-		echo "The device could not be mounted."
-		bootstrap_and_exit 1
-	fi
-elif [ -n "${POOL}" ]; then
-	echo "Starting import for ZFS pool '${POOL}'."
-	echo
+IFS=$'\n'
+PART_NAME=$(echo ${PART} | sed -e "s/.*\///")
 
-	zpool import -f -R ${MNT} ${POOL}
-	if ! zfs mount ${POOL}/ROOT/default; then
-		echo "The device could not be mounted."
-	fi
+for zplist in ${ZPCHK}; do
+    CPOOL=$(echo ${zplist} | awk '{ print $1  }')
+    zt=$(zpool status ${CPOOL} | grep -c ${PART_NAME})
+    if [ ${zt} -ne "0" ]; then
+	ZFSPOOL=${CPOOL}
+    else
+	zpool export ${CPOOL} >/dev/null 2>/dev/null
+    fi
+done
+
+if [ -z "${ZFSPOOL}" ]; then
+    echo -n "Running fsck..."
+    fsck -t ufs -y ${PART} > /dev/null
+    echo "done."
+
+    if ! mount ${PART} ${MNT} 2> /dev/null; then
+	    echo "The device could not be mounted."
+	    bootstrap_and_exit 1
+    fi
+else
+    if ! mount -t zfs ${ZFSPOOL}/root ${MNT} 2>/dev/null; then
+	echo "ZFS pool ${ZFSPOOL} could not be mounted."
+	bootstrap_and_exit 1
+    fi
 fi
+
+IFS="${ORIGINAL_IFS}"
 
 if [ -f "${MNT}/conf/config.xml" ]; then
 	rm -rf /conf/*


### PR DESCRIPTION
Implementation of ZFS support in Opensense
It is assumed that Opensense root is mounted on a ZFS pool with a random name in
the “root” volume (i.e. "<some_name>"/root). Later any other ZFS filesystems can be mounted in the usual way.

It is assumed that ZFS root does not have fstab entry, same as in FreeBSD system.

Scanning all pools present in the running system is performed in the importer. If ZFS pool
uses the corresponding partition (i.e. - /dev/ada0s1a or /dev/ada0p3 for example) and contains “root” volume – this volume is mounted and then the importer works as usual. Pool is exported before exiting.
