### PR TITLE
Link-local-Dpinger-fix

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -423,8 +423,14 @@ EOD;
         /* identifier */
         $params .= exec_safe('-i %s ', $name);
 
-        /* bind src address */
+        /* bind src address and watch out for a % char in the string! */
+
+        if(strpos($gwifip,'%')) {
+        $params .= exec_safe('-B \045%s ', $gwifip);
+        } else {
         $params .= exec_safe('-B %s ', $gwifip);
+        }
+        
 
         /* PID filename */
         $params .= exec_safe('-p %s ', "/var/run/dpinger_{$name}.pid");


### PR DESCRIPTION
When using link-local gateways for monitoring - something Apinger could not do, the %sign in the interface IP causes issues when passed through exec_safe(). In order not to affect any other calls to the function I have put a check in the gwlib.inc file where the interface IP ( $gwifip ) is added to the params.

All it does is to use "\045" as a prefix to the '%' if found. Adding a '%' char as a prefix did not work.