### PR TITLE
Track6_Allow_DHCPD6

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4669,3 +4669,28 @@ function get_carp_interface_status($carpinterface)
     }
     return;
 }
+
+function make_ipv6_64_address($prefix,$suffix)
+{
+    $prefix_array = array();
+    $prefix_array = explode(":", $prefix);
+    $prefix_array[4] = '0';        
+    $prefix_array[5] = '0';
+    $prefix_array[6] = '0';
+    $prefix_array[7] = '0';
+
+    $suffix_array = array();
+    $suffix_array = explode(":",$suffix);
+    $suffix_size = sizeof($suffix_array);
+
+    $loop = 7;
+    for($count = $suffix_size-1; $count > 0; $count--) {
+        if(!empty($suffix_array[$count])) {
+            $prefix_array[$loop] = $suffix_array[$count];
+            --$loop;
+        }
+    }
+    $address = implode(":", $prefix_array);
+
+    return $address;
+}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -113,7 +113,7 @@ function services_radvd_configure($blacklist = array())
 
     /* handle manually configured DHCP6 server settings first */
     foreach ($config['dhcpdv6'] as $dhcpv6if => $dhcpv6ifconf) {
-        if (isset($config['interfaces'][$dhcpv6if]['track6-interface'])) {
+        if (isset($config['interfaces'][$dhcpv6if]['track6-interface']) && !isset($config['interfaces'][$dhcpv6if]['dhcpd6track6allowoverride'])) {
             continue;
         } elseif (!isset($config['interfaces'][$dhcpv6if]['enable'])) {
             continue;
@@ -134,7 +134,7 @@ function services_radvd_configure($blacklist = array())
         }
 
         $ifcfgipv6 = get_interface_ipv6($dhcpv6if);
-        if (!is_ipaddrv6($ifcfgipv6)) {
+        if (!is_ipaddrv6($ifcfgipv6) && !isset($config['interfaces'][$dhcpv6if]['dhcpd6track6allowoverride'])) {
             continue;
         }
 
@@ -1087,16 +1087,23 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
             $ifcfgipv6 = Net_IPv6::getNetmask($ifcfgipv6, 64);
             $trackifname = $config['interfaces'][$ifname]['track6-interface'];
             $trackcfg = $config['interfaces'][$trackifname];
+            $ifcfgipv6arr = array();
             $pdlen = calculate_ipv6_delegation_length($trackifname);
             $ifcfgipv6arr =explode(":", $ifcfgipv6);
             $dhcpdv6cfg[$ifname] = array();
             $dhcpdv6cfg[$ifname]['enable'] = true;
             /* range */
-            $ifcfgipv6arr[7] = "1000";
-            $dhcpdv6cfg[$ifname]['range'] = array();
-            $dhcpdv6cfg[$ifname]['range']['from'] = Net_IPv6::compress(implode(":", $ifcfgipv6arr));
-            $ifcfgipv6arr[7] = "2000";
-            $dhcpdv6cfg[$ifname]['range']['to'] = Net_IPv6::compress(implode(":", $ifcfgipv6arr));
+            if(!isset($config['interfaces'][$ifname]['dhcpd6track6allowoverride']) || (isset($config['interfaces'][$ifname]['dhcpd6track6allowoverride']) && !isset($config['dhcpdv6'][$ifname]['enable']))) {
+                $ifcfgipv6arr[7] = "1000";
+                $dhcpdv6cfg[$ifname]['range'] = array();
+                $dhcpdv6cfg[$ifname]['range']['from'] = Net_IPv6::compress(implode(":", $ifcfgipv6arr));
+                $ifcfgipv6arr[7] = "2000";
+                $dhcpdv6cfg[$ifname]['range']['to'] = Net_IPv6::compress(implode(":", $ifcfgipv6arr));
+            } else {
+               // Get config entry and marry it to the live prefix          
+               $dhcpdv6cfg[$ifname]['range']['to'] = make_ipv6_64_address($ifcfgipv6,$config['dhcpdv6'][$ifname]['range']['to']);
+               $dhcpdv6cfg[$ifname]['range']['from'] = make_ipv6_64_address($ifcfgipv6,$config['dhcpdv6'][$ifname]['range']['from']);
+            }
             /* prefix length > 0? We can add dhcp6 prefix delegation server */
             if ($pdlen > 2) {
                 $pdlenmax = $pdlen;
@@ -1198,7 +1205,7 @@ EOD;
         if (is_ipaddrv6($ifcfgipv6)) {
             $dhcpdv6conf .= "\nsubnet6 {$subnetv6}/{$ifcfgsnv6}";
         } elseif (!empty($dhcpv6ifconf['range']['from'])) {
-            $subnet6 = gen_subnetv6($dhcpv6ifconf['range']['from'], "64");
+            $subnet6 = gen_subnetv6($dhcpv6ifconf['range']['from'], "64", !isset($dhcpdv6cfg[$ifname]['dhcpd6track6allowoverride']));
             $dhcpdv6conf .= "\nsubnet6 {$subnet6}/64";
         }
         $dhcpdv6conf .= " {\n";

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -150,9 +150,9 @@ function gen_subnet($ipaddr, $bits)
 }
 
 /* return the subnet address given a host address and a subnet bit count */
-function gen_subnetv6($ipaddr, $bits)
+function gen_subnetv6($ipaddr, $bits, $validate = true)
 {
-    if (!is_ipaddrv6($ipaddr) || !is_numeric($bits)) {
+    if ($validate && (!is_ipaddrv6($ipaddr) || !is_numeric($bits))) {
         return "";
     }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -216,7 +216,7 @@ class MenuSystem
                     if (!empty(filter_var($node->ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))) {
                         $iftargets['dhcp4'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                     }
-                    if (!empty(filter_var($node->ipaddrv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))) {
+                    if (!empty(filter_var($node->ipaddrv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) || isset($node->dhcpd6track6allowoverride)) {
                         $iftargets['dhcp6'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                     }
                 }

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -355,6 +355,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     foreach ($std_copy_fieldnames as $fieldname) {
         $pconfig[$fieldname] = isset($a_interfaces[$if][$fieldname]) ? $a_interfaces[$if][$fieldname] : null;
     }
+    $pconfig['dhcpd6track6allowoverride'] = ($a_interfaces[$if]['dhcpd6track6allowoverride']);
     $pconfig['enable'] = isset($a_interfaces[$if]['enable']);
     $pconfig['lock'] = isset($a_interfaces[$if]['lock']);
     $pconfig['blockpriv'] = isset($a_interfaces[$if]['blockpriv']);
@@ -598,7 +599,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (isset($config['dhcpd']) && isset($config['dhcpd'][$if]['enable']) && (! preg_match("/^staticv4/", $pconfig['type']))) {
             $input_errors[] = gettext("The DHCP Server is active on this interface and it can be used only with a static IP configuration. Please disable the DHCP Server service on this interface first, then change the interface configuration.");
         }
-        if (isset($config['dhcpdv6']) && isset($config['dhcpdv6'][$if]['enable']) && (! preg_match("/^staticv6/", $pconfig['type6']))) {
+        if (isset($config['dhcpdv6']) && isset($config['dhcpdv6'][$if]['enable']) && (! preg_match("/^staticv6/", $pconfig['type6'])) && !isset($pconfig['dhcpd6track6allowoverride'])) {
             $input_errors[] = gettext("The DHCPv6 Server is active on this interface and it can be used only with a static IPv6 configuration. Please disable the DHCPv6 Server service on this interface first, then change the interface configuration.");
         }
 
@@ -1139,6 +1140,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (ctype_xdigit($pconfig['track6-prefix-id--hex'])) {
                         $new_config['track6-prefix-id'] = intval($pconfig['track6-prefix-id--hex'], 16);
                     }
+                    $new_config['dhcpd6track6allowoverride'] = !empty($pconfig['dhcpd6track6allowoverride']);
                     break;
             }
 
@@ -2818,6 +2820,20 @@ include("head.inc");
                               <?= gettext("The value in this field is the (Delegated) IPv6 prefix id. This determines the configurable network ID based on the dynamic IPv6 connection"); ?>
                               <br />
                               <?= sprintf(gettext("Enter a hexadecimal value between %x and %x here, default value is 0."), 0, pow(2, calculate_ipv6_delegation_length($pconfig['track6-interface'])) - 1); ?>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td><a id="help_for_dhcpd6_opt" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Manual IPv6 DHCPD and RA"); ?></td>
+                          <td>
+                            <input name="dhcpd6track6allowoverride" type="checkbox" value="yes" <?= $pconfig['dhcpd6track6allowoverride'] ? 'checked="checked"' : '' ?>/>
+                            <?=gettext("Allow manual adjustment of DHCPD6 and RA when using Track6"); ?>
+                            <div class="hidden" data-for="help_for_dhcpd6_opt">
+                              <?= gettext("If this option is set,  you will be " .
+                              "able to manually set dhcpd server Router Advertisent  " .
+                              "options even though your LAN IPv6 is tracking.\n" .
+                              "Great care must be taken when using this option and if " .
+                              "not absolutely needed do not use.") ?>
                             </div>
                           </td>
                         </tr>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -190,13 +190,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             /* make sure the range lies within the current subnet */
             $ifcfgip = get_interface_ipv6($if);
             $ifcfgsn = get_interface_subnetv6($if);
+            
             $subnet_start = gen_subnetv6($ifcfgip, $ifcfgsn);
             $subnet_end = gen_subnetv6_max($ifcfgip, $ifcfgsn);
+            
+            if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {                
+                $wifcfgip = get_interface_ipv6($if);
+                $wifcfgsn = get_interface_subnetv6($if);
+                $range_from = make_ipv6_64_address(get_interface_ipv6($if),$pconfig['range_from']);
+                $range_to = make_ipv6_64_address( get_interface_ipv6($if),$pconfig['range_to']);
+               
+                           
+            } else {    
+                $range_from = $pconfig['range_from'];
+                $range_to = $pconfig['range_to'];
+            }
 
             if (!empty($pconfig['range_from']) && !empty($pconfig['range_to'])) {
+                
+                // Need to add the subnet prefix to the subnet start and end if the system is using dhcp6d on a tracked interface
                 if (is_ipaddrv6($ifcfgip) && !empty($pconfig['range_from']) && !empty($pconfig['range_to'])) {
-                    if ((!is_inrange_v6($pconfig['range_from'], $subnet_start, $subnet_end)) ||
-                        (!is_inrange_v6($pconfig['range_to'], $subnet_start, $subnet_end))) {
+                    if ((!is_inrange_v6($range_from, $subnet_start, $subnet_end)) ||
+                        (!is_inrange_v6($range_to, $subnet_start, $subnet_end))) {
                         $input_errors[] = gettext("The specified range lies outside of the current subnet.");
                     }
                 }
@@ -321,6 +336,28 @@ legacy_html_escape_form_data($pconfig);
 
 include("head.inc");
 
+if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
+	$trackifname = $config['interfaces'][$if]['track6-interface'];
+	$trackcfg = $config['interfaces'][$trackifname];
+    if(!isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
+	$wifcfgsn = "64";
+	$wifcfgip = '::';
+    } else {
+        $wifcfgip = get_interface_ipv6($if);
+        $wifcfgsn = get_interface_subnetv6($if);
+        $prefix_array = array();
+        $prefix_array = explode(":", $wifcfgip);
+        $prefix_array[4] = '0';        
+        $prefix_array[5] = '0';
+        $prefix_array[6] = '0';
+        $prefix_array[7] = '0';
+        $wifprefix = Net_IPv6::compress(implode(":",$prefix_array));
+    }
+
+} else {
+	$wifcfgip = get_interface_ipv6($if);
+	$wifcfgsn = get_interface_subnetv6($if);
+}
 ?>
 
 <body>
@@ -431,24 +468,48 @@ include("head.inc");
                     </tr>
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet");?></td>
+<?php                if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
+                        <td>
+                           <?=gettext("Prefix Delegation");?>
+                        </td>
+                      <?php else: ?>  
                       <td>
-                        <?=gen_subnetv6($config['interfaces'][$if]['ipaddrv6'], $config['interfaces'][$if]['subnetv6']);?>
+                        <?=gen_subnetv6($wifcfgip, $wifcfgsn);?>
                       </td>
+<?php
+                       endif; ?>
+                       
                     </tr>
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet mask");?></td>
                       <td>
-                        <?=htmlspecialchars($config['interfaces'][$if]['subnetv6']);?> <?=gettext("bits");?>
+                        <?=htmlspecialchars($wifcfgsn);?> <?=gettext("bits");?>
                       </td>
                     </tr>
+<?php
+                    if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>           
+                     <tr>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Current LAN IPv6 prefix");?></td>
+                      <td>
+                        <?=htmlspecialchars( $wifprefix);?>
+                      </td>
+                    </tr>          
+<?php
+                    endif; ?>      
+                    
                       <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Available range");?></td>
                       <td>
 <?php
-                        $range_from = gen_subnetv6($config['interfaces'][$if]['ipaddrv6'], $config['interfaces'][$if]['subnetv6']);
+                        //$range_from = gen_subnetv6($config['interfaces'][$if]['ipaddrv6'], $config['interfaces'][$if]['subnetv6']);
+                        $range_from = gen_subnetv6($wifcfgip, $wifcfgsn);
                         $range_from++;
-                        $range_to = gen_subnetv6_max($config['interfaces'][$if]['ipaddrv6'], $config['interfaces'][$if]['subnetv6']);?>
+                        $range_to = gen_subnetv6_max($wifcfgip, $wifcfgsn);?>
                         <?=$range_from;?> - <?=$range_to;?>
+<?php                   if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
+                            <?=gettext("Prefix Delegation subnet will be prefixed to the available range.");?>
+<?php
+                       endif; ?>                   
                       </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
This is the initial commit. There is much more work to do, dhcpd6.conf will need to be re-writen on a prefix change is the major omission at this point, but this commit will allow the user to manually set dhcpd6 range and RADVD options. To enable, go to the System->Settings->General Page and enable Manual IPv6 DHCPD and RA,