### PR TITLE
Confirm KU/EKU for server certs

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -417,6 +417,7 @@ function cert_get_purpose($str_crt, $decode = true)
     if (
         isset($crt_details['extensions']['extendedKeyUsage'])
         && strstr($crt_details['extensions']['extendedKeyUsage'], "TLS Web Server Authentication") !== false
+        && isset($crt_details['extensions']['keyUsage'])
         && strpos($crt_details['extensions']['keyUsage'], "Digital Signature") !== false
         && strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false
     )

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -414,7 +414,12 @@ function cert_get_purpose($str_crt, $decode = true)
     $crt_details = openssl_x509_parse($str_crt);
     $purpose = array();
     $purpose['ca'] = (stristr($crt_details['extensions']['basicConstraints'], 'CA:TRUE') === false) ? 'No': 'Yes';
-    if (isset($crt_details['extensions']['extendedKeyUsage']) && strstr($crt_details['extensions']['extendedKeyUsage'], "TLS Web Server Authentication") !== false) {
+    if (
+        isset($crt_details['extensions']['extendedKeyUsage'])
+        && strstr($crt_details['extensions']['extendedKeyUsage'], "TLS Web Server Authentication") !== false
+        && strpos($crt_details['extensions']['keyUsage'], "Digital Signature") !== false
+        && strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false
+    )
         $purpose['server'] = 'Yes';
     } else {
         $purpose['server'] = 'No';


### PR DESCRIPTION
Addresses https://github.com/opnsense/core/issues/2459.

Server certificates should have KU set to include "Digital Signature" and "Key Encipherment," and EKU set to "TLS Web Server Authentication."

OpenVPN requires both KU and EKU set correctly to successfully validate if client is using remote-cert-tls server configuration parameter.