### PR TITLE
Further KU/EKU fixes.

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -418,8 +418,8 @@ function cert_get_purpose($str_crt, $decode = true)
         strstr($crt_details['extensions']['extendedKeyUsage'], "TLS Web Server Authentication") !== false &&
         isset($crt_details['extensions']['keyUsage']) &&
         strpos($crt_details['extensions']['keyUsage'], "Digital Signature") !== false &&
-	( strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false ||
-	  strpos($crt_details['extensions']['keyUsage'], "Key Agreement") !== false ) ) {
+        ( strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false ||
+          strpos($crt_details['extensions']['keyUsage'], "Key Agreement") !== false ) ) {
         $purpose['server'] = 'Yes';
     } else {
         $purpose['server'] = 'No';

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -418,7 +418,8 @@ function cert_get_purpose($str_crt, $decode = true)
         strstr($crt_details['extensions']['extendedKeyUsage'], "TLS Web Server Authentication") !== false &&
         isset($crt_details['extensions']['keyUsage']) &&
         strpos($crt_details['extensions']['keyUsage'], "Digital Signature") !== false &&
-        strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false) {
+	( strpos($crt_details['extensions']['keyUsage'], "Key Encipherment") !== false ||
+	  strpos($crt_details['extensions']['keyUsage'], "Key Agreement") !== false ) ) {
         $purpose['server'] = 'Yes';
     } else {
         $purpose['server'] = 'No';

--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -189,7 +189,7 @@ basicConstraints=CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+# nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -299,7 +299,7 @@ basicConstraints=CA:FALSE
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+# nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -360,7 +360,7 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 # Make a cert with nsCertType=server
 basicConstraints=CA:FALSE
 nsCertType			= server
-nsComment			= "OpenSSL Generated Server Certificate"
+#nsComment			= "OpenSSL Generated Server Certificate"
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth,1.3.6.1.5.5.8.2.2

--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -189,7 +189,7 @@ basicConstraints=CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-# nsComment			= "OpenSSL Generated Certificate"
+nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -299,7 +299,7 @@ basicConstraints=CA:FALSE
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-# nsComment			= "OpenSSL Generated Certificate"
+nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -360,7 +360,7 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 # Make a cert with nsCertType=server
 basicConstraints=CA:FALSE
 nsCertType			= server
-#nsComment			= "OpenSSL Generated Server Certificate"
+nsComment			= "OpenSSL Generated Server Certificate"
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth,1.3.6.1.5.5.8.2.2


### PR DESCRIPTION
Related to #2459. 

The matching KUs for EKU "TLS Web Server Authentication" are Digital Signature AND (Key Encipherment OR Key Agreement). Added for compatibility with externally-generated certificates.

Removed the nsComment extension from all cert profiles. It's deprecated like nsCertType is, though nsCertType was retained in the server profile for backwards compatibility with ancient OpenVPN clients using the ns-cert-type configuration parameter.

Tested by porting modified code to a running OPNsense firewall and generating a bunch of certificates, all of which function properly.