### PR TITLE
Make optional cert fields optional.

### DIFF
--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -127,17 +127,17 @@ string_mask = utf8only
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
-countryName_default		= AU
+#countryName_default		= AU
 countryName_min			= 2
 countryName_max			= 2
 
 stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= Some-State
+#stateOrProvinceName_default	= Some-State
 
 localityName			= Locality Name (eg, city)
 
 0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Internet Widgits Pty Ltd
+#0.organizationName_default	= Internet Widgits Pty Ltd
 
 # we can do this but it is not needed normally :-)
 #1.organizationName		= Second Organization Name (eg, company)

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -263,35 +263,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         } elseif ($pconfig['camethod'] == "internal") {
             $reqdfields = explode(
                 " ",
-                "descr keylen lifetime dn_country dn_state dn_city ".
-                "dn_organization dn_email dn_commonname"
-            );
+                "descr keylen lifetime dn_country dn_commonname");
             $reqdfieldsn = array(
                     gettext("Descriptive name"),
                     gettext("Key length"),
                     gettext("Lifetime"),
                     gettext("Distinguished name Country Code"),
-                    gettext("Distinguished name State or Province"),
-                    gettext("Distinguished name City"),
-                    gettext("Distinguished name Organization"),
-                    gettext("Distinguished name Email Address"),
                     gettext("Distinguished name Common Name"));
         } elseif ($pconfig['camethod'] == "intermediate") {
             $reqdfields = explode(
                 " ",
-                "descr caref keylen lifetime dn_country dn_state dn_city ".
-                "dn_organization dn_email dn_commonname"
-            );
+                "descr caref keylen lifetime dn_country dn_commonname");
             $reqdfieldsn = array(
                     gettext("Descriptive name"),
                     gettext("Signing Certificate Authority"),
                     gettext("Key length"),
                     gettext("Lifetime"),
                     gettext("Distinguished name Country Code"),
-                    gettext("Distinguished name State or Province"),
-                    gettext("Distinguished name City"),
-                    gettext("Distinguished name Organization"),
-                    gettext("Distinguished name Email Address"),
                     gettext("Distinguished name Common Name"));
         }
 
@@ -357,11 +345,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 } elseif ($pconfig['camethod'] == "internal") {
                     $dn = array(
                         'countryName' => $pconfig['dn_country'],
-                        'stateOrProvinceName' => $pconfig['dn_state'],
-                        'localityName' => $pconfig['dn_city'],
-                        'organizationName' => $pconfig['dn_organization'],
-                        'emailAddress' => $pconfig['dn_email'],
-                        'commonName' => $pconfig['dn_commonname']);
+			'commonName' => $pconfig['dn_commonname']);
+
+		    if (!empty($pconfig['dn_state'])) {
+                        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
+                    }
+
+                    if (!empty($pconfig['dn_city'])) {
+                        $dn['localityName'] = $pconfig['dn_city'];
+                    }
+
+                    if (!empty($pconfig['dn_organization'])) {
+                        $dn['organizationName'] = $pconfig['dn_organization'];
+                    }
+
+                    if (!empty($pconfig['dn_email'])) {
+                        $dn['emailAddress'] = $pconfig['dn_email'];
+                    }
+
                     if (!ca_create($ca, $pconfig['keylen'], $pconfig['lifetime'], $dn, $pconfig['digest_alg'])) {
                         $input_errors = array();
                         while ($ssl_err = openssl_error_string()) {
@@ -371,11 +372,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 } elseif ($pconfig['camethod'] == "intermediate") {
                     $dn = array(
                         'countryName' => $pconfig['dn_country'],
-                        'stateOrProvinceName' => $pconfig['dn_state'],
-                        'localityName' => $pconfig['dn_city'],
-                        'organizationName' => $pconfig['dn_organization'],
-                        'emailAddress' => $pconfig['dn_email'],
                         'commonName' => $pconfig['dn_commonname']);
+		    
+		    if (!empty($pconfig['dn_state'])) {
+                        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
+                    }
+
+                    if (!empty($pconfig['dn_city'])) {
+                        $dn['localityName'] = $pconfig['dn_city'];
+                    }
+
+                    if (!empty($pconfig['dn_organization'])) {
+                        $dn['organizationName'] = $pconfig['dn_organization'];
+                    }
+
+                    if (!empty($pconfig['dn_email'])) {
+                        $dn['emailAddress'] = $pconfig['dn_email'];
+                    }
+
                     if (!ca_inter_create($ca, $pconfig['keylen'], $pconfig['lifetime'], $dn, $pconfig['caref'], $pconfig['digest_alg'])) {
                         $input_errors = array();
                         while ($ssl_err = openssl_error_string()) {

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -343,11 +343,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 if ($pconfig['camethod'] == "existing") {
                     ca_import($ca, $pconfig['cert'], $pconfig['key'], $pconfig['serial']);
                 } elseif ($pconfig['camethod'] == "internal") {
-                    $dn = array(
-                        'countryName' => $pconfig['dn_country'],
-			'commonName' => $pconfig['dn_commonname']);
+                    $dn = array('countryName' => $pconfig['dn_country'],
+			                    'commonName' => $pconfig['dn_commonname']);
 
-		    if (!empty($pconfig['dn_state'])) {
+                    if (!empty($pconfig['dn_state'])) {
                         $dn['stateOrProvinceName'] = $pconfig['dn_state'];
                     }
 
@@ -370,11 +369,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                         }
                     }
                 } elseif ($pconfig['camethod'] == "intermediate") {
-                    $dn = array(
-                        'countryName' => $pconfig['dn_country'],
-                        'commonName' => $pconfig['dn_commonname']);
+                    $dn = array('countryName' => $pconfig['dn_country'],
+                                'commonName' => $pconfig['dn_commonname']);
 		    
-		    if (!empty($pconfig['dn_state'])) {
+                    if (!empty($pconfig['dn_state'])) {
                         $dn['stateOrProvinceName'] = $pconfig['dn_state'];
                     }
 

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -294,32 +294,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 $input_errors[] = gettext("This certificate does not appear to be valid.");
             }
         } elseif ($pconfig['certmethod'] == "internal") {
-            $reqdfields = explode(" ", "descr caref keylen lifetime dn_country dn_state dn_city ".
-                "dn_organization dn_email dn_commonname"
-            );
+            $reqdfields = explode(" ", "descr caref keylen lifetime dn_country dn_commonname");
             $reqdfieldsn = array(
                     gettext("Descriptive name"),
                     gettext("Certificate authority"),
                     gettext("Key length"),
                     gettext("Lifetime"),
                     gettext("Distinguished name Country Code"),
-                    gettext("Distinguished name State or Province"),
-                    gettext("Distinguished name City"),
-                    gettext("Distinguished name Organization"),
-                    gettext("Distinguished name Email Address"),
                     gettext("Distinguished name Common Name"));
         } elseif ($pconfig['certmethod'] == "external") {
-            $reqdfields = explode(" ", "descr csr_keylen csr_dn_country csr_dn_state csr_dn_city ".
-                "csr_dn_organization csr_dn_email csr_dn_commonname"
-            );
+            $reqdfields = explode(" ", "descr csr_keylen csr_dn_country csr_dn_commonname");
             $reqdfieldsn = array(
                     gettext("Descriptive name"),
                     gettext("Key length"),
                     gettext("Distinguished name Country Code"),
-                    gettext("Distinguished name State or Province"),
-                    gettext("Distinguished name City"),
-                    gettext("Distinguished name Organization"),
-                    gettext("Distinguished name Email Address"),
                     gettext("Distinguished name Common Name"));
         } elseif ($pconfig['certmethod'] == "existing") {
             $reqdfields = array("certref");
@@ -456,14 +444,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 if ($pconfig['certmethod'] == "external") {
                     $dn = array(
                         'countryName' => $pconfig['csr_dn_country'],
-                        'stateOrProvinceName' => $pconfig['csr_dn_state'],
-                        'localityName' => $pconfig['csr_dn_city'],
-                        'organizationName' => $pconfig['csr_dn_organization'],
-                        'emailAddress' => $pconfig['csr_dn_email'],
                         'commonName' => $pconfig['csr_dn_commonname']);
                     if (!empty($pconfig['csr_dn_organizationalunit'])) {
                         $dn['organizationalUnitName'] = $pconfig['csr_dn_organizationalunit'];
+		    }
+
+                    if (!empty($pconfig['dn_state'])) {
+                        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
                     }
+
+                    if (!empty($pconfig['dn_city'])) {
+                        $dn['localityName'] = $pconfig['dn_city'];
+                    }
+
+                    if (!empty($pconfig['dn_organization'])) {
+                        $dn['organizationName'] = $pconfig['dn_organization'];
+                    }
+
+                    if (!empty($pconfig['dn_email'])) {
+                        $dn['emailAddress'] = $pconfig['dn_email'];
+                    }
+
                     if (count($altnames)) {
                         $altnames_tmp = array();
                         foreach ($altnames as $altname) {

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -410,21 +410,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 }
 
                 if ($pconfig['certmethod'] == "internal") {
-                    $dn = array(
-                        'countryName' => $pconfig['dn_country'],
-			'commonName' => $pconfig['dn_commonname']);
+                    $dn = array('countryName' => $pconfig['dn_country'],
+                                'commonName' => $pconfig['dn_commonname']);
 
-		    if (!empty($pconfig['dn_state'])) {
-		        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
-		    }
-		    
-		    if (!empty($pconfig['dn_city'])) {
-			$dn['localityName'] = $pconfig['dn_city'];
-		    }
-		    
-		    if (!empty($pconfig['dn_organization'])) {
-			$dn['organizationName'] = $pconfig['dn_organization'];
-		    }
+                    if (!empty($pconfig['dn_state'])) {
+                        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
+                    }
+
+                    if (!empty($pconfig['dn_city'])) {
+                        $dn['localityName'] = $pconfig['dn_city'];
+                    }
+
+                    if (!empty($pconfig['dn_organization'])) {
+                        $dn['organizationName'] = $pconfig['dn_organization'];
+                    }
 
                     if (!empty($pconfig['dn_email'])) {
                         $dn['emailAddress'] = $pconfig['dn_email'];
@@ -455,12 +454,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 }
 
                 if ($pconfig['certmethod'] == "external") {
-                    $dn = array(
-                        'countryName' => $pconfig['csr_dn_country'],
-                        'commonName' => $pconfig['csr_dn_commonname']);
+                    $dn = array('countryName' => $pconfig['csr_dn_country'],
+                                'commonName' => $pconfig['csr_dn_commonname']);
+                    
                     if (!empty($pconfig['csr_dn_organizationalunit'])) {
                         $dn['organizationalUnitName'] = $pconfig['csr_dn_organizationalunit'];
-		    }
+                    }
 
                     if (!empty($pconfig['dn_state'])) {
                         $dn['stateOrProvinceName'] = $pconfig['dn_state'];

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -412,11 +412,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 if ($pconfig['certmethod'] == "internal") {
                     $dn = array(
                         'countryName' => $pconfig['dn_country'],
-                        'stateOrProvinceName' => $pconfig['dn_state'],
-                        'localityName' => $pconfig['dn_city'],
-                        'organizationName' => $pconfig['dn_organization'],
-                        'emailAddress' => $pconfig['dn_email'],
-                        'commonName' => $pconfig['dn_commonname']);
+			'commonName' => $pconfig['dn_commonname']);
+
+		    if (!empty($pconfig['dn_state'])) {
+		        $dn['stateOrProvinceName'] = $pconfig['dn_state'];
+		    }
+		    
+		    if (!empty($pconfig['dn_city'])) {
+			$dn['localityName'] = $pconfig['dn_city'];
+		    }
+		    
+		    if (!empty($pconfig['dn_organization'])) {
+			$dn['organizationName'] = $pconfig['dn_organization'];
+		    }
+
+                    if (!empty($pconfig['dn_email'])) {
+                        $dn['emailAddress'] = $pconfig['dn_email'];
+                    }
+
                     if (count($altnames)) {
                         $altnames_tmp = array();
                         foreach ($altnames as $altname) {


### PR DESCRIPTION
Fixes #2317. Makes cert fields other than common name and country code optional.

Tested by generating internal CAs, intermediate CAs, client certs, server certs. Omitted fields are not included as part of the distinguishedName.