### PR TITLE
Add `openssl x509 -fingerprint -sha256` to "Show certificate info"

### DIFF
--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -209,7 +209,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     } elseif ($act == "info") {
       if (isset($id)) {
           // use openssl to dump cert in readable format
-          $process = proc_open('/usr/local/bin/openssl x509 -text', array(array("pipe", "r"), array("pipe", "w")), $pipes);
+          $process = proc_open('/usr/local/bin/openssl x509 -fingerprint -sha256 -text', array(array("pipe", "r"), array("pipe", "w")), $pipes);
           if (is_resource($process)) {
              fwrite($pipes[0], base64_decode($a_cert[$id]['crt']));
              fclose($pipes[0]);


### PR DESCRIPTION
Nice thing is that `openssl x509` respects the order of supplied arguments. It was chosen to print the one line of fingerprint above of the X509 text dump. `-sha256` is needed because OpenSSL 1.0.2k-freebsd 26 Jan 2017 seems to default to SHA1 currently.


Example of the first line:

```
SHA256 Fingerprint=F0:E6:EB:31:E8:87:AF:52:16:4E:84:05:3B:6C:03:2C:C1:DF:5A:E7:36:F4:32:44:3B:B5:57:63:97:45:C3:77
```

This commit is one piece to make fully trusted bootstrapping easier.
Related to: https://github.com/opnsense/core/issues/2427
URL path of the GUI page involved: /system_certmanager.php