### PR TITLE
Add "Show host fingerprints" shell option: SSH host keys, X.509 cert

### DIFF
--- a/src/opnsense/scripts/shell/fingerprints.php
+++ b/src/opnsense/scripts/shell/fingerprints.php
@@ -1,0 +1,41 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2018 Robin Schneider <ypid@riseup.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+echo "\nFingerprints of this host follow. Please compare them when connecting to this host to prevent MITM attacks.\n";
+
+echo "\nFingerprints of SSH host keys:\n";
+
+foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
+    passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path));
+}
+
+echo "\nFingerprints of HTTPS X.509 certificate:\n";
+
+passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
+passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha1");

--- a/src/opnsense/scripts/shell/fingerprints.php
+++ b/src/opnsense/scripts/shell/fingerprints.php
@@ -27,15 +27,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-echo "\nFingerprints of this host follow. Please compare them when connecting to this host to prevent MITM attacks.\n";
+require_once("config.inc");
 
-echo "\nFingerprints of SSH host keys:\n";
-
-foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
-    passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path));
+if (isset($config['system']['ssh']['enabled']) or $config['system']['webgui']['protocol'] == "https") {
+    echo "\nFingerprints of this host follow. Please compare them when connecting to this host to prevent MITM attacks.\n";
+} else {
+    echo "\nNo fingerprints to show because neither HTTPS nor SSH are enabled.\n";
 }
 
-echo "\nFingerprints of HTTPS X.509 certificate:\n";
+if (isset($config['system']['ssh']['enabled'])) {
+    echo "\nFingerprints of SSH host keys:\n";
 
-passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
-passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha1");
+    foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
+        passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path));
+    }
+}
+
+if ($config['system']['webgui']['protocol'] == "https") {
+    echo "\nFingerprints of HTTPS X.509 certificate:\n";
+
+    passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
+    passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha1");
+}

--- a/src/sbin/opnsense-shell
+++ b/src/sbin/opnsense-shell
@@ -17,6 +17,7 @@ CMD_PASSWORD="/usr/local/opnsense/scripts/shell/password.php"
 CMD_PFLOG="/usr/sbin/tcpdump -s 256 -v -S -l -n -e -ttt -i pflog0"
 CMD_PFTOP="/usr/local/sbin/pftop"
 CMD_PING="/usr/local/opnsense/scripts/shell/ping.php"
+CMD_FINGERPRINTS="/usr/local/opnsense/scripts/shell/fingerprints.php"
 CMD_REBOOT="/usr/local/opnsense/scripts/shell/reboot.php"
 CMD_RELOAD="/usr/local/etc/rc.reload_all"
 CMD_RESTORE="/usr/local/opnsense/scripts/shell/restore.sh"
@@ -116,13 +117,14 @@ while : ; do
 set -e
 
 echo
-echo "  0) Logout                              7) Ping host"
-echo "  1) Assign interfaces                   8) Shell"
-echo "  2) Set interface IP address            9) pfTop"
-echo "  3) Reset the root password            10) Firewall log"
-echo "  4) Reset to factory defaults          11) Reload all services"
-echo "  5) Power off system                   12) Update from console"
-echo "  6) Reboot system                      13) Restore a backup"
+echo "  0) Logout                              8) Shell""
+echo "  1) Assign interfaces                   9) pfTop"
+echo "  2) Set interface IP address           10) Firewall log"
+echo "  3) Reset the root password            11) Reload all services"
+echo "  4) Reset to factory defaults          12) Update from console"
+echo "  5) Power off system                   13) Restore a backup"
+echo "  6) Reboot system                      14) Show host fingerprints"
+echo "  7) Ping host"
 echo
 read -p "Enter an option: " OPCODE
 echo
@@ -173,6 +175,9 @@ case ${OPCODE} in
 	;;
 13)
 	${CMD_RESTORE}
+	;;
+14)
+	${CMD_FINGERPRINTS}
 	;;
 *)
 	;;


### PR DESCRIPTION
Example output:

```
Enter an option: 14


Fingerprints of this host follow. Please compare them when connecting to this host to prevent MITM attacks.

Fingerprints of SSH host keys:
256 SHA256:fcMIAgT/vZR/TWP0j8AFROTNnudkU1tP9sRhbsIa8vM root@OPNsense.localdomain (ECDSA)
256 SHA256:lDenOc5wy2WU0e6sSz2hR9nEFnMqx5c3u1F/pHxgJlY root@OPNsense.localdomain (ED25519)
2048 SHA256:dsw9srlQHL0hPJlEdR9rL769N30BTZgXG9gXbdZGOkU root@OPNsense.localdomain (RSA)

Fingerprints of HTTPS X.509 certificate:
SHA256 Fingerprint=F0:E6:EB:31:E8:87:AF:52:16:4E:84:05:3B:6C:03:2C:C1:DF:5A:E7:36:F4:32:44:3B:B5:57:63:97:45:C3:77
SHA1 Fingerprint=2A:DE:8C:09:90:9E:76:6B:01:4D:05:7B:81:22:7E:B6:B6:0F:1A:86
```

Previously (#2427) I suggested to extract the X.509 certificate from the xml config but the difficult part for me who is not so familiar with the implementation of OPNsense is to find the certificate which is actually used by the local web server. I found that `/var/etc/cert.pem` is used in the configuration of the local web server and assume that this is the easier way to implement this in the expectation that the file name does not change without being also changed in this script and that the file exists. If it does not exist, OpenSSL would complain with a useful error message.

This commit is one piece to make fully trusted bootstrapping easier.
Related to: https://github.com/opnsense/core/issues/2427
Tested on: OPNsense 18.1.10-amd64 (and forward ported it to master)
Alternative implementation to: https://github.com/opnsense/core/issues/2427