### PR TITLE
Unset rcvar first to ensure any previous assignment of rcvar is unset…

### DIFF
--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -41,6 +41,7 @@ rc_enabled()
 {
 	rc_filename=${1}
 	name=${2}
+	unset rcvar
 
 	# check if service has a name
 	if [ -z "${name}" ]; then


### PR DESCRIPTION
… since it is being used in a global context not locally scoped within the rc_enabled() function