### PR TITLE
do not start lighttpd when nginx is installed

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -143,9 +143,6 @@ function webgui_configure_do($verbose = false, $interface = '')
         return;
     }
 
-    /* only stop the frontend when the generation was successful */
-    killbypid('/var/run/lighty-webConfigurator.pid', 'TERM', true);
-
     /* flush Phalcon volt templates */
     foreach (glob('/usr/local/opnsense/mvc/app/cache/*.php') as $filename) {
         unlink($filename);
@@ -153,6 +150,20 @@ function webgui_configure_do($verbose = false, $interface = '')
 
     /* regenerate the php.ini files in case the setup has changed */
     configd_run('template reload OPNsense/WebGui');
+
+    if (trim(configd_run('firmware plugin nginx')) == '1' || trim(configd_run('firmware plugin nginx-devel')) == '1')
+    {
+        // in case the nginx plugin is installed, it will handle the request instead of the default server.
+        configd_run('template reload OPNsense/Nginx');
+        configd_run('nginx restart');
+        if ($verbose) {
+            echo "done.\n";
+        }
+        return;
+    }
+
+    /* only stop the frontend when the generation was successful */
+    killbypid('/var/run/lighty-webConfigurator.pid', 'TERM', true);
 
     /*
      * Force reloading all php-cgi children to

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -151,6 +151,15 @@ function webgui_configure_do($verbose = false, $interface = '')
     /* regenerate the php.ini files in case the setup has changed */
     configd_run('template reload OPNsense/WebGui');
 
+    /* only stop the frontend when the generation was successful */
+    killbypid('/var/run/lighty-webConfigurator.pid', 'TERM', true);
+
+    /*
+     * Force reloading all php-cgi children to
+     * avoid hiccups with moved include files.
+     */
+    killbyname('php-cgi', 'HUP');
+
     if (trim(configd_run('firmware plugin nginx')) == '1' || trim(configd_run('firmware plugin nginx-devel')) == '1')
     {
         // in case the nginx plugin is installed, it will handle the request instead of the default server.
@@ -161,15 +170,6 @@ function webgui_configure_do($verbose = false, $interface = '')
         }
         return;
     }
-
-    /* only stop the frontend when the generation was successful */
-    killbypid('/var/run/lighty-webConfigurator.pid', 'TERM', true);
-
-    /*
-     * Force reloading all php-cgi children to
-     * avoid hiccups with moved include files.
-     */
-    killbyname('php-cgi', 'HUP');
 
     /* start lighthttpd */
     if (!count($listeners) || mwexec('/usr/local/sbin/lighttpd -f /var/etc/lighty-webConfigurator.conf')) {


### PR DESCRIPTION
the nginx plugin takes over and handles those requests so the port can be reused for other things like a reverse proxy or serving local files.