### PR TITLE
Print SSH and X.509 fingerprints in console banner without need to login

### DIFF
--- a/src/opnsense/scripts/shell/banner.php
+++ b/src/opnsense/scripts/shell/banner.php
@@ -122,20 +122,27 @@ foreach ($iflist as $ifname => $friendly) {
         );
     }
 }
-printf("\n\n");
 
-foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
-    printf(" SSH: ");
-    /* `| cut -d ' ' -f 1-2,4-` is used to filter out the comment (hostname) from the host key.
-     * With the hostname included, one fingerprint would normally not fit on the console screen.
-     */
-    passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path) . " | cut -d ' ' -f 1-2,4-");
+if (isset($config['system']['ssh']['enabled']) or $config['system']['webgui']['protocol'] == "https") {
+    printf("\n\n");
 }
 
-printf(" HTTPS X.509 cert: ");
-/* This output will need two lines in console output.
- * Not much we can do about this.
- */
-passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
+if (isset($config['system']['ssh']['enabled'])) {
+    foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
+        printf(" SSH: ");
+        /* `| cut -d ' ' -f 1-2,4-` is used to filter out the comment (hostname) from the host key.
+         * With the hostname included, one fingerprint would normally not fit on the console screen.
+         */
+        passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path) . " | cut -d ' ' -f 1-2,4-");
+    }
+}
+
+if ($config['system']['webgui']['protocol'] == "https") {
+    printf(" HTTPS X.509 cert: ");
+    /* This output will need two lines in console output.
+     * Not much we can do about this.
+     */
+    passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
+}
 
 printf("\n");

--- a/src/opnsense/scripts/shell/banner.php
+++ b/src/opnsense/scripts/shell/banner.php
@@ -122,5 +122,20 @@ foreach ($iflist as $ifname => $friendly) {
         );
     }
 }
+printf("\n\n");
+
+foreach (glob("/conf/sshd/ssh_host_*_key.pub") as $ssh_host_pub_key_file_path) {
+    printf(" SSH: ");
+    /* `| cut -d ' ' -f 1-2,4-` is used to filter out the comment (hostname) from the host key.
+     * With the hostname included, one fingerprint would normally not fit on the console screen.
+     */
+    passthru("ssh-keygen -l -f " . escapeshellarg($ssh_host_pub_key_file_path) . " | cut -d ' ' -f 1-2,4-");
+}
+
+printf(" HTTPS X.509 cert: ");
+/* This output will need two lines in console output.
+ * Not much we can do about this.
+ */
+passthru("openssl x509 -in /var/etc/cert.pem -noout -fingerprint -sha256");
 
 printf("\n");


### PR DESCRIPTION
Example output:

```
$ /usr/local/etc/rc.initial.banner

*** test-fw.localdomain: OPNsense 18.1.10 (amd64/OpenSSL) ***

 WAN (vtnet0)    -> v4/DHCP4: 172.30.23.2/24

 SSH: 256 SHA256:fcMIAgT/vZR/TWP0j8AFROTNnudkU1tP9sRhbsIa8vM (ECDSA)
 SSH: 256 SHA256:lDenOc5wy2WU0e6sSz2hR9nEFnMqx5c3u1F/pHxgJlY (ED25519)
 SSH: 2048 SHA256:dsw9srlQHL0hPJlEdR9rL769N30BTZgXG9gXbdZGOkU (RSA)
 HTTPS X.509 cert: SHA256 Fingerprint=F0:E6:EB:31:E8:87:AF:52:16:4E:84:05:3B:6C:03:2C:C1:DF:5A:E7:36:F4:32:44:3B:B5:57:63:97:45:C3:77
```

The list of fingerprints is appended after the interface list because the interface list might be pretty long and thus would move the fingerprints out of the screen which we don’t want.

Previously (#2427) I suggested to extract the X.509 certificate from the xml config but the difficult part for me who is not so familiar with the implementation of OPNsense is to find the certificate which is actually used by the local web server. I found that `/var/etc/cert.pem` is used in the configuration of the local web server and assume that this is the easier way to implement this in the expectation that the file name does not change without being also changed in this script and that the file exists. If it does not exist, OpenSSL would complain with a useful error message.

This commit is one piece to make fully trusted bootstrapping easier.
Related to: https://github.com/opnsense/core/issues/2427
Tested on: OPNsense 18.1.10-amd64
Alternative implementation to: https://github.com/opnsense/core/pull/2476