### PR TITLE
Fix error with domain "."

### DIFF
--- a/src/opnsense/service/modules/template.py
+++ b/src/opnsense/service/modules/template.py
@@ -61,8 +61,8 @@ class Template(object):
                                           extensions=["jinja2.ext.do", "jinja2.ext.loopcontrols"])
 
         # register additional filters
-        self._j2_env.filters['decode_idna'] = lambda x:x.decode('idna')
-        self._j2_env.filters['encode_idna'] = lambda x:x.encode('idna')
+        self._j2_env.filters['decode_idna'] = lambda x:x.decode('idna') if x != "." else "."
+        self._j2_env.filters['encode_idna'] = lambda x:x.encode('idna') if x != "." else "."
 
     def list_module(self, module_name):
         """ list single module content


### PR DESCRIPTION
If I enter a dot in the "Blacklist" field, the template is not generated.

![screenshot](https://user-images.githubusercontent.com/9945787/41913220-fc75aed2-7958-11e8-965b-eb3ac4d5ca06.png)

> configd.py: [2827e8c5-d25e-4dd0-929e-5a499c33e498] Inline action failed with OPNsense/Proxy OPNsense/Proxy/squid.conf label empty or too long at Traceback (most recent call last): File "/usr/local/opnsense/service/modules/processhandler.py", line 507, in execute return ph_inline_actions.execute(self, inline_act_parameters) File "/usr/local/opnsense/service/modules/ph_inline_actions.py", line 51, in execute filenames = tmpl.generate(parameters) File "/usr/local/opnsense/service/modules/template.py", line 326, in generate raise render_exception Exception: OPNsense/Proxy OPNsense/Proxy/squid.conf label empty or too long