### PR TITLE
IDS: add uncategorized category to classification and rule download

### DIFF
--- a/src/opnsense/scripts/suricata/metadata/rules/opnsense.xml
+++ b/src/opnsense/scripts/suricata/metadata/rules/opnsense.xml
@@ -8,5 +8,6 @@
         <file description="media-streaming">opnsense.media_streaming.rules</file>
         <file description="messaging">opnsense.messaging.rules</file>
         <file description="social-networking">opnsense.social_media.rules</file>
+        <file description="uncategorized">opnsense.uncategorized.rules</file>
     </files>
 </ruleset>

--- a/src/opnsense/service/templates/OPNsense/IDS/classification.config
+++ b/src/opnsense/service/templates/OPNsense/IDS/classification.config
@@ -44,3 +44,4 @@ config classification: messaging,Messenger app detection by OPNsense,2
 config classification: media-streaming,Media-Streaming app detection by OPNsense,2
 config classification: mail,Mailprovider app detection by OPNsense,2
 config classification: test,OPNsense Test Rules,3
+config classification: uncategorized,Uncategorized app detection by OPNsense,2


### PR DESCRIPTION
First https://github.com/opnsense/rules/pull/9 has to be merged to master/stable and the ruleset synced by daily cron to final webserver.