### PR TITLE
monit: UI improvements; phpunit tests

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
@@ -43,9 +43,33 @@ class SettingsController extends ApiControllerBase
 {
 
     /**
-     * list with valid model node types
+     * @var null|object the monit model object
+     */
+    private $mdlMonit = null;
+
+    /**
+     * @var array list with valid model node types
      */
     private $nodeTypes = array('general', 'alert', 'service', 'test');
+
+    /**
+     * initialize object properties
+     */
+    public function onConstruct()
+    {
+        $this->mdlMonit = new Monit();
+    }
+
+    /**
+     * check if changes to the monit settings were made
+     * @return result array
+     */
+    public function dirtyAction()
+    {
+        $result = array('status' => 'ok');
+        $result['monit']['dirty'] = $this->mdlMonit->configChanged();
+        return $result;
+    }
 
     /**
      * query monit settings
@@ -58,14 +82,13 @@ class SettingsController extends ApiControllerBase
         $result = array("result" => "failed");
         if ($this->request->isGet() && $nodeType != null) {
             $this->validateNodeType($nodeType);
-            $mdlMonit = new Monit();
             if ($nodeType == 'general') {
-                $node = $mdlMonit->getNodeByReference($nodeType);
+                $node = $this->mdlMonit->getNodeByReference($nodeType);
             } else {
                 if ($uuid != null) {
-                    $node = $mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
+                    $node = $this->mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
                 } else {
-                    $node = $mdlMonit->$nodeType->Add();
+                    $node = $this->mdlMonit->$nodeType->Add();
                 }
             }
             if ($node != null) {
@@ -87,14 +110,13 @@ class SettingsController extends ApiControllerBase
         $result = array("result" => "failed", "validations" => array());
         if ($this->request->isPost() && $this->request->hasPost("monit") && $nodeType != null) {
             $this->validateNodeType($nodeType);
-            $mdlMonit = new Monit();
             if ($nodeType == 'general') {
-                $node = $mdlMonit->getNodeByReference($nodeType);
+                $node = $this->mdlMonit->getNodeByReference($nodeType);
             } else {
                 if ($uuid != null) {
-                    $node = $mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
+                    $node = $this->mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
                 } else {
-                    $node = $mdlMonit->$nodeType->Add();
+                    $node = $this->mdlMonit->$nodeType->Add();
                 }
             }
             if ($node != null) {
@@ -130,7 +152,7 @@ class SettingsController extends ApiControllerBase
                 }
 
                 $node->setNodes($monitInfo[$nodeType]);
-                $valMsgs = $mdlMonit->performValidation();
+                $valMsgs = $this->mdlMonit->performValidation();
                 foreach ($valMsgs as $field => $msg) {
                     $fieldnm = str_replace($node->__reference, "monit." . $nodeType, $msg->getField());
                     $result["validations"][$fieldnm] = $msg->getMessage();
@@ -138,11 +160,10 @@ class SettingsController extends ApiControllerBase
                 if (empty($result["validations"])) {
                     unset($result["validations"]);
                     $result['result'] = 'ok';
-                    $mdlMonit->serializeToConfig();
+                    $this->mdlMonit->serializeToConfig();
                     Config::getInstance()->save();
-                    if ($nodeType == 'general' && $monitInfo['general']['enabled'] == '0') {
-                        $svcMonit = new ServiceController();
-                        $result = $svcMonit->stopAction();
+                    if ($this->mdlMonit->configDirty()) {
+                        $result['status'] = 'ok';
                     }
                 }
             }
@@ -162,21 +183,22 @@ class SettingsController extends ApiControllerBase
         if ($nodeType != null) {
             $this->validateNodeType($nodeType);
             if ($uuid != null) {
-                $mdlMonit = new Monit();
-                $node = $mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
+                $node = $this->mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
                 if ($node != null) {
-                    if ($mdlMonit->$nodeType->del($uuid) == true) {
+                    if ($this->mdlMonit->$nodeType->del($uuid) == true) {
                         // delete relations
                         if ($nodeType == 'test') {
-                            $nodeName = $mdlMonit->getNodeByReference($nodeType . '.' . $uuid . '.name');
+                            $nodeName = $this->mdlMonit->getNodeByReference($nodeType . '.' . $uuid . '.name');
                             if ($nodeName != null) {
                                 $nodeName = $nodeName->__toString();
-                                $this->deleteRelations('service', 'tests', $uuid, 'test', $nodeName, $mdlMonit);
+                                $this->deleteRelations('service', 'tests', $uuid, 'test', $nodeName, $this->mdlMonit);
                             }
                         }
-                        $mdlMonit->serializeToConfig();
+                        $this->mdlMonit->serializeToConfig();
                         Config::getInstance()->save();
-                        $result["result"] = "ok";
+                        if ($this->mdlMonit->configDirty()) {
+                            $result['status'] = 'ok';
+                        }
                     }
                 }
             }
@@ -194,19 +216,18 @@ class SettingsController extends ApiControllerBase
     {
         $result = array("result" => "failed");
         if ($this->request->isPost() && $nodeType != null) {
-            $mdlMonit = new Monit();
             if ($uuid != null) {
-                $node = $mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
+                $node = $this->mdlMonit->getNodeByReference($nodeType . '.' . $uuid);
                 if ($node != null) {
                     if ($node->enabled->__toString() == "1") {
                         $node->enabled = "0";
                     } else {
                         $node->enabled = "1";
                     }
-                    $mdlMonit->serializeToConfig();
+                    $this->mdlMonit->serializeToConfig();
                     Config::getInstance()->save();
                     $svcMonit = new ServiceController();
-                    $result= $svcMonit->reloadAction();
+                    $result= $svcMonit->reconfigureAction();
                 } else {
                     $result['result'] = "not found";
                 }
@@ -227,8 +248,7 @@ class SettingsController extends ApiControllerBase
         $this->sessionClose();
         if ($this->request->isPost() && $nodeType != null) {
             $this->validateNodeType($nodeType);
-            $mdlMonit = new Monit();
-            $grid = new UIModelGrid($mdlMonit->$nodeType);
+            $grid = new UIModelGrid($this->mdlMonit->$nodeType);
             $fields = array();
             switch ($nodeType) {
                 case 'alert':
@@ -257,8 +277,7 @@ class SettingsController extends ApiControllerBase
 
             $cfg = Config::getInstance();
             $cfgObj = $cfg->object();
-            $mdlMonit = new Monit();
-            $node = $mdlMonit->getNodeByReference('general');
+            $node = $this->mdlMonit->getNodeByReference('general');
             $generalSettings = array();
 
             // inherit SMTP settings from System->Settings->Notifications
@@ -279,16 +298,18 @@ class SettingsController extends ApiControllerBase
 
             // apply them
             $node->setNodes($generalSettings);
-            $valMsgs = $mdlMonit->performValidation();
+            $valMsgs = $this->mdlMonit->performValidation();
             foreach ($valMsgs as $field => $msg) {
                 $fieldnm = str_replace($node->__reference, "monit.general.", $msg->getField());
                 $result["validations"][$fieldnm] = $msg->getMessage();
             }
             if (empty($result["validations"])) {
                 unset($result["validations"]);
-                $result['result'] = 'ok';
-                $mdlMonit->serializeToConfig();
+                $this->mdlMonit->serializeToConfig();
                 Config::getInstance()->save();
+                if ($this->mdlMonit->configDirty()) {
+                    $result['status'] = 'ok';
+                }
             }
         }
         return $result;
@@ -311,12 +332,16 @@ class SettingsController extends ApiControllerBase
      * @param $nodeType
      * @param $uuid
      * @param $relNodeType
-     * @param &$mdlMonit
      * @throws \Exception
      */
-    private function deleteRelations($nodeType = null, $nodeField = null, $relUuid = null, $relNodeType = null, $relNodeName = null, &$mdlMonit = null)
-    {
-        $nodes = $mdlMonit->$nodeType->getNodes();
+    private function deleteRelations(
+        $nodeType = null,
+        $nodeField = null,
+        $relUuid = null,
+        $relNodeType = null,
+        $relNodeName = null
+    ) {
+        $nodes = $this->mdlMonit->$nodeType->getNodes();
         // get nodes with relations
         foreach ($nodes as $nodeUuid => $node) {
             // get relation uuids
@@ -324,14 +349,14 @@ class SettingsController extends ApiControllerBase
                 // remove uuid from field
                 if ($fieldUuid == $relUuid) {
                     $refField = $nodeType . '.' . $nodeUuid . '.' . $nodeField;
-                    $relNode = $mdlMonit->getNodeByReference($refField);
+                    $relNode = $this->mdlMonit->getNodeByReference($refField);
                     $nodeRels = str_replace($relUuid, '', $relNode->__toString());
                     $nodeRels = str_replace(',,', ',', $nodeRels);
                     $nodeRels = rtrim($nodeRels, ',');
                     $nodeRels = ltrim($nodeRels, ',');
-                    $mdlMonit->setNodeByReference($refField, $nodeRels);
+                    $this->mdlMonit->setNodeByReference($refField, $nodeRels);
                     if ($relNode->isEmptyAndRequired()) {
-                        $nodeName = $mdlMonit->getNodeByReference($nodeType . '.' . $nodeUuid . '.name')->__toString();
+                        $nodeName = $this->mdlMonit->getNodeByReference($nodeType . '.' . $nodeUuid . '.name')->__toString();
                         throw new \Exception("Cannot delete $relNodeType '$relNodeName' from $nodeType '$nodeName'");
                     }
                 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
@@ -45,7 +45,7 @@ class SettingsController extends ApiControllerBase
     /**
      * @var null|object the monit model object
      */
-    private $mdlMonit = null;
+    public $mdlMonit = null;
 
     /**
      * @var array list with valid model node types
@@ -226,8 +226,9 @@ class SettingsController extends ApiControllerBase
                     }
                     $this->mdlMonit->serializeToConfig();
                     Config::getInstance()->save();
-                    $svcMonit = new ServiceController();
-                    $result= $svcMonit->reconfigureAction();
+                    if ($this->mdlMonit->configDirty()) {
+                        $result['status'] = 'ok';
+                    }
                 } else {
                     $result['result'] = "not found";
                 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/StatusController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/StatusController.php
@@ -61,7 +61,7 @@ class StatusController extends ApiControllerBase
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
             // get credentials if configured
-            $mdlMonit = new Monit();
+            $mdlMonit = new Monit(false);
             if ($mdlMonit->general->httpdUsername->__toString() != null && trim($mdlMonit->general->httpdUsername->__toString()) !== "" &&
                 $mdlMonit->general->httpdPassword->__toString() != null && trim($mdlMonit->general->httpdPassword->__toString()) !== "") {
                     curl_setopt($ch, CURLOPT_USERPWD, $mdlMonit->general->httpdUsername->__toString() . ":" . $mdlMonit->general->httpdPassword->__toString());

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
@@ -31,7 +31,6 @@
 namespace OPNsense\Monit;
 
 use OPNsense\Base\BaseModel;
-use Phalcon\Logger\Adapter\Syslog;
 
 /**
  * Class Monit

--- a/src/opnsense/mvc/tests/app/compound/OPNsense/Monit/MonitTest.php
+++ b/src/opnsense/mvc/tests/app/compound/OPNsense/Monit/MonitTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * Copyright (C) 2018 EURO-LOG AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Monit\Api;
+
+use \OPNsense\Core\Config;
+
+class MonitTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * list with model node types
+     */
+    private $nodeTypes = array('alert', 'service', 'test');
+
+    // holds the SettingsController object
+    protected static $setMonit;
+
+    public static function setUpBeforeClass()
+    {
+        self::$setMonit = new \OPNsense\Monit\Api\SettingsController;
+    }
+
+    private function cleanupNodes($nodeType = null)
+    {
+        $nodes = self::$setMonit->mdlMonit->$nodeType->getNodes();
+        foreach ($nodes as $nodeUuid => $node) {
+            self::$setMonit->mdlMonit->$nodeType->del($nodeUuid);
+        }
+    }
+
+    /**
+     * test getAction
+     */
+    public function testGet()
+    {
+        $this->assertInstanceOf('\OPNsense\Monit\Api\SettingsController', self::$setMonit);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('unknown nodeType');
+        $response = self::$setMonit->getAction('wrong_node_type');
+        $testConfig = [];
+        $response = self::$setMonit->getAction('general');
+        $testConfig['general'] = $response['monit']['general'];
+        
+        $this->assertEquals($response['status'], 'ok');
+        $this->assertArrayHasKey('enabled', $response['monit']['general']);
+        
+        return $testConfig;
+    }
+
+    /**
+     * test searchAction
+     * @depends testGet
+     */
+    public function testSearch($testConfig)
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = array('current' => '1', 'rowCount' => '7');
+        
+        foreach ($this->nodeTypes as $nodeType) {
+            $response = self::$setMonit->searchAction($nodeType);
+            $this->assertArrayHasKey('total', $response);
+            $testConfig[$nodeType] = $response['rows'];
+        }
+        
+        return $testConfig;
+    }
+
+    /**
+     * test delAction
+     * not really a test if the config is empty, but we will delete something later
+     * @depends testSearch
+     */
+    public function testReset($testConfig)
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        foreach (array_reverse($this->nodeTypes) as $nodeType) {
+            foreach ($testConfig[$nodeType] as $node) {
+                $response = self::$setMonit->delAction($nodeType, $node['uuid']);
+                $this->assertEquals($response['status'], 'ok');
+            }
+        }
+        // need an assertion here to succeed this test on empty config
+        $this->assertTrue(true);
+    }
+
+    /**
+     * test setAction general
+     * @depends testReset
+     */
+    public function testSetGeneral()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // interval too high
+        $_POST = array('monit' => ['general' => ['interval' => '864000']]);
+        $response = self::$setMonit->setAction('general');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertNotEmpty($response['validations']['monit.general.interval']);
+        
+        // set correct interval
+        $_POST = array('monit' => ['general' => ['interval' => '120', 'enabled' => '0']]);
+        $response = self::$setMonit->setAction('general');
+        $this->assertEquals($response['status'], 'ok');
+    }
+
+    /**
+     * test dirtyAction
+     * @depends testSetGeneral
+     */
+    public function testDirtyAction()
+    {
+        $this->assertInstanceOf('\OPNsense\Monit\Api\SettingsController', self::$setMonit);
+        $response = self::$setMonit->dirtyAction();
+        $this->assertEquals($response['status'], 'ok');
+        $this->assertEquals($response['monit']['dirty'], true);
+        
+    }
+
+    /**
+     * test setAction alert
+     * @depends testReset
+     */
+    public function testSetAlert()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // malformed email address
+        $_POST = array('monit' => ['alert' => ['recipient' => '123456789']]);
+        $response = self::$setMonit->setAction('alert');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertNotEmpty($response['validations']['monit.alert.recipient']);
+        $this->cleanupNodes('alert');
+        
+        // create alert for ServiceControllerTest
+        $_POST = array('monit' => ['alert' => ['recipient' => 'root@localhost.local', 'enabled' => '1']]);
+        $response = self::$setMonit->setAction('alert');
+        $this->assertEquals($response['status'], 'ok');
+    }
+
+}


### PR DESCRIPTION
This PR removes the 'Test-/Reload Configuration' buttons.
Changes goes immediately after clicking 'Save Changes' to the config.xml and
a message appears to 'Apply' the configuration. After applying the configuration it is tested
and the Monit daemon is reloaded. In principle, the same as the Relayd.

The model has a locking mechanism now to prevent failures from concurrent access.
E.g. delete multiple items from the 'Service' tab leaves some configured.
The __constructor of the model locks per default the model object.
It is used by Service- and SettingsController with lock. The StatusController access it
without lock only for reading.

Last but not least, I added some PHPunit tests.