### PR TITLE
monit: create template before stopping Monit for ServiceController test

### DIFF
--- a/src/opnsense/mvc/tests/app/compound/OPNsense/Monit/MonitTest.php
+++ b/src/opnsense/mvc/tests/app/compound/OPNsense/Monit/MonitTest.php
@@ -286,6 +286,10 @@ class MonitTest extends \PHPUnit\Framework\TestCase
         $svcMonit = new \OPNsense\Monit\Api\ServiceController;
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
+        // configtest
+        $response = $svcMonit->configtestAction();
+        $this->assertEquals($response['result'], 'Control file syntax OK');
+
         // status
         $response = $svcMonit->statusAction();
         $this->assertRegExp('/running|stopped/', $response['status']);


### PR DESCRIPTION
This will fix (https://github.com/opnsense/core/pull/2505#issuecomment-402021083)
MonitTest.php tries to stop the Monit daemon before ServiceController test.
But for an unconfigured Monit `configctl monit stop` returns `Error (1)` caused by a missing monit_enable rc.conf setting.