### PR TITLE
Use openssh_enabled() in src/opnsense/scripts/shell/banner.php

### DIFF
--- a/src/opnsense/scripts/shell/banner.php
+++ b/src/opnsense/scripts/shell/banner.php
@@ -126,7 +126,7 @@ foreach ($iflist as $ifname => $friendly) {
 
 echo PHP_EOL;
 
-if (isset($config['system']['ssh']['enabled']) || $config['system']['webgui']['protocol'] == 'https') {
+if (openssh_enabled() || $config['system']['webgui']['protocol'] == 'https') {
     echo PHP_EOL;
 }
 


### PR DESCRIPTION
This is only an improvement and unification of `src/opnsense/scripts/shell/banner.php`.

Using `openssh_enabled()` both times in this file is preferred over one time using `isset($config['system']['ssh']['enabled'])` and the other time using `openssh_enabled()`.

Updates: 00f9b21
Updates: 81e50ab
Updates: https://github.com/opnsense/core/pull/2481