### PR TITLE
Add a special case for /31 tunnel networks to the OpenVPN config generator (fixes #2529).

### DIFF
--- a/src/www/vpn_openvpn_export.php
+++ b/src/www/vpn_openvpn_export.php
@@ -701,11 +701,18 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $zipco
         $conf .= openvpn_gen_routes($settings['local_networkv6'], 'ipv6');
     }
     if (!empty($settings['tunnel_network'])) {
-        list($ip, $mask) = explode('/', $settings['tunnel_network']);
-        $mask = gen_subnet_mask($mask);
+        list($ip, $prefix_length) = explode('/', $settings['tunnel_network']);
+        $mask = gen_subnet_mask($prefix_length);
         $baselong = ip2long32($ip) & ip2long($mask);
-        $ip1 = long2ip32($baselong + 1);
-        $ip2 = long2ip32($baselong + 2);
+
+        if ($prefix_length == "31") {
+            // As per RFC3021, in a /31 network, first address is the first host address
+            $ip1 = long2ip32($baselong);
+            $ip2 = long2ip32($baselong + 1);
+        } else {
+            $ip1 = long2ip32($baselong + 1);
+            $ip2 = long2ip32($baselong + 2);
+        }
         $conf .= "ifconfig $ip2 $ip1\n";
     }
     $conf .= "keepalive 10 60\n";


### PR DESCRIPTION
A fix for #2529 

I believe this should do the trick, though I have to admit I couldn't test it because I haven't figured out the procedure for testing it on a live system yet (editing the file in /usr/local/www and restarting services seems to have no effect) and I don't have a FreeBSD machine handy. If someone points me to a correct procedure for testing changes on a live system, I'll be grateful (if there's no such thing I can make a build setup of course).

Since I haven't contributed to OPNSense before, if I broke any process or coding conventions, just let me know and I'll fix it.