### PR TITLE
Add a special case for /31 networks to openvpn_get_interface_ip() (another instance of #2529)

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -1479,9 +1479,21 @@ function openvpn_create_dirs()
 
 function openvpn_get_interface_ip($ip, $mask)
 {
-    $baselong = ip2long32($ip) & ip2long($mask);
-    $ip1 = long2ip32($baselong + 1);
-    $ip2 = long2ip32($baselong + 2);
+    $masklong = ip2long($mask);
+    $baselong = ip2long32($ip) & $masklong;
+
+    // Special case for /31 networks which lack network and broadcast addresses.
+    // As per RFC3021, both addresses should be treated as host addresses.
+    if ($masklong == 0xfffffffe)
+    {
+        $ip1 = long2ip32($baselong);
+        $ip2 = long2ip32($baselong + 1);
+    }
+    else
+    {
+        $ip1 = long2ip32($baselong + 1);
+        $ip2 = long2ip32($baselong + 2);
+    }
     return array($ip1, $ip2);
 }
 


### PR DESCRIPTION
Finally, I've fixed it in the place where I originally intended to fix it (#2529).

This time I've verified that it works, thanks to people on the IRC who explained me how to restart the web GUI properly.