### PR TITLE
Clarify install media login message/options

### DIFF
--- a/src/etc/rc.subr.d/livemode
+++ b/src/etc/rc.subr.d/livemode
@@ -58,11 +58,9 @@ if (is_install_media()) {
 
         echo "\n";
 
-        $greeting  = "Welcome!  You may now start OPNsense. There are two options:\n" .
-                     "Log in as 'root' to run OPNsense \"live\" from its current media " .
-                     "(without modifying the system), or for quick access to the shell.\n" .
-                     "Log in as 'installer' to start the OPNsense installer.\n" .
-                     "Use the default root password for both accounts.";
+        $greeting  = "Welcome!  OPNsense is running in \"live\" mode from install media.\n" .
+                     "Please login as 'root' to continue in live mode, or as 'installer' to install OPNsense.\n" .
+                     "Use the default or previously-imported root password for both accounts.";
 
         if (!isset($config['system']['ssh']['noauto']) && is_process_running('sshd')) {
             $greeting .= "  Remote login via SSH is also enabled.";

--- a/src/etc/rc.subr.d/livemode
+++ b/src/etc/rc.subr.d/livemode
@@ -58,12 +58,14 @@ if (is_install_media()) {
 
         echo "\n";
 
-        $greeting  = "Welcome!  Both `root' and `installer' users are available for system\n";
-        $greeting .= "setup or invoking the installer, respectively.  The predefined root\n";
-        $greeting .= "password works for both accounts.";
+        $greeting  = "Welcome!  You may now select the mode to run OPNsense.\n" .
+                     "Log in as 'root' to run OPNsense \"live\" from its current media " .
+                     "(without modifying the system), or for quick access to the shell.\n" .
+                     "Log in as 'installer' to start the OPNsense installer.\n" .
+                     "Use the default root password for both accounts.";
 
         if (!isset($config['system']['ssh']['noauto']) && is_process_running('sshd')) {
-            $greeting .= "  Remote login via SSH is possible.";
+            $greeting .= "  Remote login via SSH is also enabled.";
         }
 
         echo $greeting . "\n";

--- a/src/etc/rc.subr.d/livemode
+++ b/src/etc/rc.subr.d/livemode
@@ -58,7 +58,7 @@ if (is_install_media()) {
 
         echo "\n";
 
-        $greeting  = "Welcome!  OPNsense is running in \"live\" mode from install media.\n" .
+        $greeting  = "Welcome!  OPNsense is running in live mode from install media.\n" .
                      "Please login as 'root' to continue in live mode, or as 'installer' to install OPNsense.\n" .
                      "Use the default or previously-imported root password for both accounts.";
 

--- a/src/etc/rc.subr.d/livemode
+++ b/src/etc/rc.subr.d/livemode
@@ -58,7 +58,7 @@ if (is_install_media()) {
 
         echo "\n";
 
-        $greeting  = "Welcome!  You may now select the mode to run OPNsense.\n" .
+        $greeting  = "Welcome!  You may now start OPNsense. There are two options:\n" .
                      "Log in as 'root' to run OPNsense \"live\" from its current media " .
                      "(without modifying the system), or for quick access to the shell.\n" .
                      "Log in as 'installer' to start the OPNsense installer.\n" .


### PR DESCRIPTION
Just saying _"Both root and installer are available"_ is not very intuitive to a new user trying out OPNsense for the first time - which is the point where it needs to be most clear what's going on. (They may well enter root, thinking that "system setup" _means" installing, which isn't unreasonable.)

This PR clarifies the message.