### PR TITLE
After install, give basic tip that GUI IP can be set in console

### DIFF
--- a/src/sbin/opnsense-installer
+++ b/src/sbin/opnsense-installer
@@ -83,11 +83,13 @@ echo
 echo "The installation finished successfully."
 echo
 echo "After reboot, open a web browser and navigate to"
-echo "https://192.168.1.1 (or the LAN IP address)."
+echo "https://192.168.1.1 (or the LAN IP address). The console"
+echo "can also be used to set a different LAN IP."
 echo
-echo "You might need to acknowledge the HTTPS certificate if "
-echo "your browser reports it as untrusted.  This is normal"
-echo "as a self-signed certificate is used by default."
+echo "Your browser may report the HTTPS certificate as untrusted"
+echo "and ask you to accept it. This is normal, as the default"
+echo "certificate will be self-signed and cannot be validated by"
+echo "an external root authority."
 echo
 echo -n "Rebooting in 5 seconds.  CTRL-C to abort"
 for n in 5 4 3 2 1; do


### PR DESCRIPTION
If the user's existing subnet isn't 192.168.1.1/xx, then telling the user to use this IP will fail. So tell the user how to set a different IP after reboot, rather than just telling them to use an IP that won't work for them.

Kept short this time - 1 line only :)

Also edited wording re certificate, to be clearer about this as well, by starting with what they will actually see (*"Your browser may..."* rather than *"You might need to..."*). Added just 1 line there as well.  

The wording *"and cannot be validated by an external root authority"* is so people don't worry about "WHY ISN'T IT TRUSTED, IS IT INSECURE!" - makes clear there isn't **external** validation. Also better understanding is good. Possible reword: "This is normal, as the initial certificate will be self-signed, and not signed by an external root authority."

Hopefully not overdoing it. (Life should be easy for newcomers, and install is where newcomers first see if a thing works for them!) Perhaps they can be squashed down to save text space.  If so please do.