### PR TITLE
Cause data through saveFormToEndpoint callback_ok to be passed through

### DIFF
--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -90,7 +90,7 @@ function saveFormToEndpoint(url,formid,callback_ok, disable_dialog) {
                 }
             } else if ( callback_ok != undefined ) {
                 // execute callback function
-                callback_ok();
+                callback_ok(data);
             }
         }
     });


### PR DESCRIPTION
When calling saveFormToEndpoint I'd like to be able to reference data in the front end that was returned through the ajax call - as in the example below

```javascript
$("#someAction").click(function(){
    saveFormToEndpoint(url="/api/plugin/feature",formid='frm_Form',callback_ok=function(data){
        $("#someElement").html(data['message']);
    });
});
```

The PR allows this data to be passed through as required.

I'd highlight however that I do not know the codebase well enough to know if this has other side effects or could be leveraged in ways to cause unwanted behaviors - while it seems probably okay I'd ask project maintainer(s) to provide guidance if required.