### PR TITLE
blank problem advanced button

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -75,7 +75,7 @@ label           :   dialog label
                         <tbody>
                         {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
                         <tr>
-                            <td>{% if base_dialog_advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i> </a><small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
+                            <td>{% if base_dialog_advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a>&nbsp;<small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
                             <td colspan="2" style="text-align:right;">
                                 {% if base_dialog_help|default(false) %}<small>{{ lang._('full help') }} </small><a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_formDialog{{base_dialog_id}}"></i></a>{% endif %}
                             </td>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -62,7 +62,7 @@ data_title      :   data-title to set on form
         <tbody>
 {% if advanced|default(false) or help|default(false) %}
         <tr>
-            <td style="text-align:left">{% if advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}"></i> </a><small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
+            <td style="text-align:left">{% if advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}"></i></a>&nbsp;<small>{{ lang._('advanced mode') }} </small>{% endif %}</td>
             <td colspan="2" style="text-align:right">
                 {% if help|default(false) %}<small>{{ lang._('full help') }} </small><a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
             </td>


### PR DESCRIPTION
since i used opnsense i noticed that the advanced slider button has an ugly blank on hover and focus. this problem occurs in every theme. has to do with a wrong placed blank.  Its also visible in the original theme of opnsense. I've fixed this with a standard html syntax. its visible on every page which uses an advanced button. like monitor, proxy and so on...see the screenshot

![grafik](https://user-images.githubusercontent.com/34602360/43683972-2ce40ea8-9897-11e8-9f96-8b4401986767.png)

![grafik](https://user-images.githubusercontent.com/34602360/43684034-af5bad7c-9898-11e8-9f8b-dbb5a709bccc.png)

![grafik](https://user-images.githubusercontent.com/34602360/43684043-dc61aff6-9898-11e8-9f33-d58911406f35.png)
