### PR TITLE
Auto Prefix Delegation tracking.

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2973,11 +2973,13 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg)
 
     $dhcp6cscript = "#!/bin/sh\n";
     $dhcp6cscript .= "if [ -n '" . (!empty($wancfg['adv_dhcp6_debug']) ? 'debug' : '') . "' ]; then\n";
-    $dhcp6cscript .= "\t/usr/bin/logger -t dhcp6c \"dhcp6c \$REASON on {$wanif}\"\n";
+    $dhcp6cscript .= "\t/usr/bin/logger -t dhcpd \"dhcp6c \$REASON on {$wanif}\"\n";
+    $dhcp6cscript .= "\t/usr/bin/logger -t dhcpd \"dhcp6c PD_INFO \$PD_INFO on {$wanif}\"\n";
     $dhcp6cscript .= "fi\n";
     $dhcp6cscript .= "case \$REASON in\n";
     $dhcp6cscript .= "REQUEST|" . (!empty($wancfg['dhcp6norelease']) ? 'EXIT' : 'RELEASE') . ")\n";
-    $dhcp6cscript .= "\t/usr/bin/logger -t dhcp6c \"dhcp6c \$REASON on {$wanif} - running newipv6\"\n";
+    $dhcp6cscript .= "\t/usr/bin/logger -t dhcpd \"dhcp6c \$REASON on {$wanif} - running newipv6\"\n";
+    $dhcp6cscript .= "\techo \${PD_INFO} > /tmp/{$wanif}_dhcp6cpd\n";
     $dhcp6cscript .= "\t/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
     $dhcp6cscript .= "\t;;\n";
     $dhcp6cscript .= "*)\n";

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1091,6 +1091,15 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
         if (isset($blacklist[$ifname])) {
             continue;
         }
+        if(!empty($config['dhcpdv6'][$ifname]['dnsserver'][0])){
+            // user specified DNS servers
+            $dns_arrv6 = array(); //reset
+            foreach($config['dhcpdv6'][$ifname]['dnsserver'] as $dnsserver) {
+                if (is_ipaddrv6($dnsserver)) {
+                    $dns_arrv6[] = $dnsserver;
+                }
+            }            
+        }        
         if (!empty($config['interfaces'][$ifname]['track6-interface'])) {
             $realif = get_real_interface($ifname, "inet6");
             $ifcfgipv6 = get_interface_ipv6($ifname);
@@ -1101,11 +1110,22 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
             $trackifname = $config['interfaces'][$ifname]['track6-interface'];
             $trackcfg = $config['interfaces'][$trackifname];
             $pdlen = calculate_ipv6_delegation_length($trackifname);
-            $dhcpdv6cfg[$ifname] = array();
-            $dhcpdv6cfg[$ifname]['enable'] = true;
+
+            // The real length obtained by dhcp6c
+            $assigned_pd = array();
+            $assigned_pd = get_ipv6_PD(get_real_interface($trackifname, "inet6"));
+            
+            $assigned_pd_prefix = $assigned_pd[0];
+            $assigned_pd_length = $assigned_pd[1];
+            
+            $assigned_pd_array = array();
+            $assigned_pd_array = explode(":",$assigned_pd_prefix);
+
+            $ifcfgipv6arr = $ifcfgipv6arr = explode(':', $ifcfgipv6);
             if (!isset($config['interfaces'][$ifname]['dhcpd6track6allowoverride']) || !isset($config['dhcpdv6'][$ifname]['enable'])) {
-                /* fixed range */
-                $ifcfgipv6arr = $ifcfgipv6arr = explode(':', $ifcfgipv6);
+                $dhcpdv6cfg[$ifname] = array();
+                $dhcpdv6cfg[$ifname]['enable'] = true;
+                /* fixed range */                
                 $ifcfgipv6arr[7] = '1000';
                 $dhcpdv6cfg[$ifname]['range'] = array();
                 $dhcpdv6cfg[$ifname]['range']['from'] = Net_IPv6::compress(implode(':', $ifcfgipv6arr));
@@ -1137,10 +1157,79 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
                 $dhcpdv6cfg[$ifname]['range']['from'] = make_ipv6_64_address($ifcfgipv6, $config['dhcpdv6'][$ifname]['range']['from']);
                 $dhcpdv6cfg[$ifname]['range']['to'] = make_ipv6_64_address($ifcfgipv6, $config['dhcpdv6'][$ifname]['range']['to']);
 
+                $pd_prefix_from_array = array();
+                $pd_prefix_to_array = array();
+                
+                $pd_prefix_from_array = explode(":",$config['dhcpdv6'][$ifname]['prefixrange']['from']);
+                $pd_prefix_to_array = explode(":",$config['dhcpdv6'][$ifname]['prefixrange']['to']);
+                
+                $pd_prefix_from_array[2] = sprintf("%02s",$pd_prefix_from_array[2]);
+                $pd_prefix_to_array[2] = sprintf("%02s",$pd_prefix_to_array[2]);
+
+                $pd_prefix_from_array_out = array();
+                $pd_prefix_to_array_out = array();
+                
+                for($x=0;$x<4;$x++) // make the prefx long format
+                {
+                    $assigned_pd_array[$x] = sprintf("%04s",$assigned_pd_array[$x]);
+                }
+                
+                $pd_prefix_from_array_out = $assigned_pd_array;
+                $pd_prefix_to_array_out = $assigned_pd_array;
+                
+                $pdval = intval($config['dhcpdv6'][$ifname]['prefixrange']['prefixlength']);
+                
+                switch($pdval) {
+                
+                // For PD sizes of /60 through /64, the user must do the math!
+                case 60:
+                case 62:
+                case 63:
+                case 64: // 3&4th bytes on 4th array
+                    $pd_prefix_from_array_out[3] =  sprintf("%04s",$assigned_pd_array[3]); // make it 4 bytes   
+                    $pd_prefix_from_array_out[3] = substr($pd_prefix_from_array_out[3],0,2).$pd_prefix_from_array[2];
+                    $pd_prefix_to_array_out[3] =  sprintf("%04s",$assigned_pd_array[3]); // make it 4 bytes   
+                    $pd_prefix_to_array_out[3] = substr($pd_prefix_to_array_out[3],0,2).$pd_prefix_to_array[2];
+                break;
+                
+                case 56: // 1st&2nd bytes on 4th array
+                    $pd_prefix_from_array[2] = str_pad($pd_prefix_from_array[2],4,"0");
+                    $pd_prefix_from_array_out[3] =  sprintf("%s",$pd_prefix_from_array[2]); // make it 4 bytes                       
+                    $pd_prefix_to_array[2] = str_pad($pd_prefix_to_array[2],4,"0");
+                    $pd_prefix_to_array_out[3] =  sprintf("%s",$pd_prefix_to_array[2]); // make it 4 bytes                                     
+                break;
+                case 52: // 1st byte on 4th array only, 0 to f, we only want one byte, but lookout for the user entering more
+                    $len = strlen($pd_prefix_from_array[2]);                    
+                    $pd_prefix_from_array[2] = substr($pd_prefix_from_array[2],$len-1,1);
+                    $pd_prefix_from_array_out[3] =  sprintf("%s000",substr($pd_prefix_from_array[2],0,1)); // first byte from entered value                      
+                    $len = strlen($pd_prefix_to_array[2]);                    
+                    $pd_prefix_to_array[2] = substr($pd_prefix_to_array[2],$len-1,1);
+                    $pd_prefix_to_array_out[3] =   sprintf("%s000",substr($pd_prefix_to_array[2],0,1));                                    
+                break;
+                case 48: // 4th byte on 2nd array,                    
+                    $pd_prefix_from_array[2] = substr($pd_prefix_from_array[2],0,1);
+                    $pd_prefix_from_array_out[1] =  substr(sprintf("%03s",$assigned_pd_array[1]),0,3).$pd_prefix_from_array[2]; // get 1st 3 byte + nibble
+                    
+                    $pd_prefix_to_array[2] = substr($pd_prefix_to_array[2],0,1);
+                    $pd_prefix_to_array_out[1] =  substr(sprintf("%03s",$assigned_pd_array[1]),0,3).$pd_prefix_to_array[2]; // get 1st 3 byte + nibble   
+                    $numcount = count(pd_prefix_to_array_out[2]);
+                    // clear junk ( this is for testing as I only get a /48 to start with
+                    for($x=4;$x>1;$x--) {
+                        unset($pd_prefix_from_array_out[$x]);
+                        unset($pd_prefix_to_array_out[$x]);
+                    }
+                    array_push($pd_prefix_from_array_out,"");
+                    array_push($pd_prefix_to_array_out,"");
+                        
+                break;                    
+                }
+                
+                $ipv6_from_pd_from = implode(":",$pd_prefix_from_array_out);
+                $ipv6_from_pd_to = implode(":",$pd_prefix_to_array_out);
                 $dhcpdv6cfg[$ifname]['prefixrange'] = array();
                 $dhcpdv6cfg[$ifname]['prefixrange']['prefixlength'] = $config['dhcpdv6'][$ifname]['prefixrange']['prefixlength'];
-                $dhcpdv6cfg[$ifname]['prefixrange']['from'] = $config['dhcpdv6'][$ifname]['prefixrange']['from'];
-                $dhcpdv6cfg[$ifname]['prefixrange']['to'] = $config['dhcpdv6'][$ifname]['prefixrange']['to'];
+                $dhcpdv6cfg[$ifname]['prefixrange']['from'] = $ipv6_from_pd_from;
+                $dhcpdv6cfg[$ifname]['prefixrange']['to'] = $ipv6_from_pd_to;
             }
         }
     }
@@ -1954,4 +2043,26 @@ function service_control_restart($name, $extras)
     }
 
     return sprintf(gettext("%s has been restarted."), htmlspecialchars($name));
+}
+
+function get_ipv6_PD($realif)
+{
+    if(file_exists("/tmp/{$realif}_dhcp6cpd")) {
+        $pd = trim(file_get_contents("/tmp/{$realif}_dhcp6cpd"));
+        $pd_array = array();
+        $pd_array = explode("/",$pd);
+        if(strlen($pd_array[1]) > 0) {
+            return($pd_array);
+        } else {
+            return null;
+        }        
+    }    
+}
+
+function get_ipv6_PD_string($realif)
+{
+    $pd_array = array();
+    $pd_array = get_ipv6_PD($realif);
+    
+    return($pd_array[0]."/".$pd_array[1]);
 }

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -54,9 +54,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         header(url_safe('Location: /index.php'));
         exit;
     }
-
+  
+    $trackrealifname = get_real_interface($config['interfaces'][$if]['track6-interface']);
+  
     $pconfig = array();
 
+    
+    
     if (!empty($config['dhcpdv6'][$if]['range'])) {
         $pconfig['range_from'] = $config['dhcpdv6'][$if]['range']['from'];
         $pconfig['range_to'] = $config['dhcpdv6'][$if]['range']['to'];
@@ -341,7 +345,11 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
     $prefix_array[7] = '0';
     $wifprefix = Net_IPv6::compress(implode(':', $prefix_array));
 }
-
+if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
+        $maxlength = 4;
+} else {
+        $maxlength = 32;
+}
 ?>
 <body>
 <script>
@@ -450,25 +458,21 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                       </td>
                     </tr>
                     <tr>
-                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet");?></td>
-<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                      <td><?= gettext('Prefix Delegation') ?></td>
-<?php else: ?>
-                      <td><?= gen_subnetv6($wifcfgip, $wifcfgsn) ?></td>
-<?php endif ?>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet");?></td>                      
+                      <td><?= gen_subnetv6($wifcfgip, $wifcfgsn) ?></td>  
                     </tr>
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet mask");?></td>
-<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                      <td><?= gettext('Prefix Delegation') ?></td>
-<?php else: ?>
                       <td><?= htmlspecialchars($wifcfgsn) ?> <?= gettext('bits') ?></td>
-<?php endif ?>
                     </tr>
 <?php if(isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
                      <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Current LAN IPv6 prefix");?></td>
                       <td><?= htmlspecialchars($wifprefix) ?></td>
+                    </tr>
+                     <tr>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Current assigned IPv6 PD/Mask");?></td>
+                      <td><?= htmlspecialchars(get_ipv6_PD_string($trackrealifname)) ?></td>
                     </tr>
 <?php endif ?>
                     <tr>
@@ -480,7 +484,7 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                         $range_to = gen_subnetv6_max($wifcfgip, $wifcfgsn);?>
                         <?=$range_from;?> - <?=$range_to;?>
 <?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                        <?= gettext('Prefix delegation subnet will be prefixed to the available range.') ?>
+                        <?= gettext('<br>Prefix delegation subnet will be prefixed to the available range.') ?>
 <?php endif ?>
                       </td>
                     </tr>
@@ -518,8 +522,8 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                           </thead>
                           <tbody>
                             <tr>
-                              <td><input name="prefixrange_from" type="text" id="range_from" value="<?=$pconfig['prefixrange_from'];?>" /></td>
-                              <td><input name="prefixrange_to" type="text" id="range_to" value="<?=$pconfig['prefixrange_to'];?>" /> </td>
+                              <td><input name="prefixrange_from" maxlength=<?=$maxlength;?> type="text" id="range_from" value="<?=$pconfig['prefixrange_from'];?>" /></td>
+                              <td><input name="prefixrange_to" maxlength=<?=$maxlength;?> type="text" id="range_to" value="<?=$pconfig['prefixrange_to'];?>" /> </td>
                             </tr>
                             <tr>
                               <td>
@@ -540,6 +544,11 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                         <div class="hidden" data-for="help_for_prefixrange">
                           <?= gettext("You can define a Prefix range here for DHCP Prefix Delegation. This allows for assigning networks to subrouters. " .
                           "The start and end of the range must end on boundaries of the prefix delegation size."); ?>
+                          <?= gettext('<br>The system does not check the validity of your emtry against the selected mask - please refer to an online net calculator
+                        to ensure you have entered a correct range if the dhcpd6 server fails to start.') ?>
+<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
+                        <?= gettext('<br>When using a tracked interface then please only enter the range itself. i.e. ::xx. For example, for a /60 subnet from ::20 to ::40.') ?>                        
+<?php endif ?>                          
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
This adds the ability of prefix delegation to follow the change of the tracked interface.

Also added some changes to services_shcpv6.php in terms of help info and to limit the number of chars a user can enter when entering a value for PD ranges when tracking overide is in place. These changes reqiure a modified dhcp6c client that now gives out the prefix range and mask as an env var. This is picked up in interfaces.inc  and echoed to a file in /tmp.

Added correction for override ignoring additional options apart from range, such as dns servers etc as PR #2633 

