### PR TITLE
fix table headers: tr elements cannot have a colspan, th elements can

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -106,8 +106,8 @@ label           :   dialog label
             <col class="col-md-{{ msgzone_width|default(5) }}"/>
         </colgroup>
         <thead>
-          <tr colspan="3">
-            <th><h2>{{field['label']}}</h2></th>
+          <tr>
+            <th colspan="3"><h2>{{field['label']}}</h2></th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
fix for an UI bug found while developing the nginx 1.1 plugin. Due to the really long headings, they would break in the first column because the colspan is set incorrectly.