### PR TITLE
WIP: Add ignore_hotplug_events interface option

### DIFF
--- a/src/etc/rc.linkup
+++ b/src/etc/rc.linkup
@@ -40,6 +40,12 @@ function handle_argument_group($iface, $argument2)
     global $config;
 
     if (isset($config['interfaces'][$iface])) {
+        if (isset($config['interfaces'][$iface]['ignore_hotplug_events'])) {
+            $friendly = convert_friendly_interface_to_friendly_descr($iface);
+            log_error("Hotplug event {$argument2} detected for {$friendly}({$iface}) but ignoring as ignore_hotplug_events is set");
+            return;
+        }
+
         // set defaults
         $ipaddr = '0.0.0.0';
         $ip6addr = '::';

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -359,6 +359,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['lock'] = isset($a_interfaces[$if]['lock']);
     $pconfig['blockpriv'] = isset($a_interfaces[$if]['blockpriv']);
     $pconfig['blockbogons'] = isset($a_interfaces[$if]['blockbogons']);
+    $pconfig['ignore_hotplug_events'] = isset($a_interfaces[$if]['ignore_hotplug_events']);
     $pconfig['dhcp6-ia-pd-send-hint'] = isset($a_interfaces[$if]['dhcp6-ia-pd-send-hint']);
     $pconfig['dhcp6sendsolicit'] = isset($a_interfaces[$if]['dhcp6sendsolicit']);
     $pconfig['dhcp6prefixonly'] = isset($a_interfaces[$if]['dhcp6prefixonly']);
@@ -950,6 +951,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             $new_config['blockpriv'] = !empty($pconfig['blockpriv']);
             $new_config['blockbogons'] = !empty($pconfig['blockbogons']);
+            $new_config['ignore_hotplug_events'] = !empty($pconfig['ignore_hotplug_events']);
             if (!empty($pconfig['mtu'])) {
                 $new_config['mtu'] = $pconfig['mtu'];
             }
@@ -1729,6 +1731,15 @@ include("head.inc");
                               "(but not RFC 1918) or not yet assigned by IANA."); ?>
                               <?=gettext("Bogons are prefixes that should never appear in the Internet routing table, " .
                               "and obviously should not appear as the source address in any packets you receive."); ?>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td><a id="help_for_ignore_hotplug_events" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Ignore hotplug events"); ?></td>
+                          <td>
+                            <input name="ignore_hotplug_events" type="checkbox" id="ignore_hotplug_events" value="yes" <?=!empty($pconfig['ignore_hotplug_events']) ? "checked=\"checked\"" : ""; ?> />
+                            <div class="hidden" data-for="help_for_ignore_hotplug_events">
+                              <?=gettext("When set, this option ignores hotplug events. This should be used if faulty hardware generates unwanted hotplug events"); ?>
                             </div>
                           </td>
                         </tr>


### PR DESCRIPTION
Adds an option to ignore hotplug events for an interface. Currently we also always ignore hotplug events for interfaces with both static v4 and v6 addresses set, this option does not change that behaviour.

OpenWRT has a similar setting called "force link" which ignores hotplug events as well as doing some other things.

![iOpenWRT settings screenshot showing force link](https://user-images.githubusercontent.com/782440/44299578-0e90f880-a2f1-11e8-9bb4-163efb5e3b53.png)

Currently adding it under the block bogons option.

![image](https://user-images.githubusercontent.com/782440/44299593-59ab0b80-a2f1-11e8-995e-2d966b112b3f.png)
