### PR TITLE
Copy pfsync0 MTU from real interface

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1525,6 +1525,8 @@ function interfaces_carp_setup($verbose = false)
 {
     global $config;
 
+    $intf_stats = legacy_interfaces_details();
+
     if ($verbose) {
         echo 'Configuring CARP settings...';
         flush();
@@ -1542,6 +1544,7 @@ function interfaces_carp_setup($verbose = false)
         }
 
         mwexec("/sbin/ifconfig pfsync0 syncdev {$carp_sync_int} {$syncpeer} up", false);
+        mwexec("/sbin/ifconfig pfsync0 mtu {$intf_stats[$carp_sync_int]['mtu']}", false);
     } else {
         mwexec("/sbin/ifconfig pfsync0 -syncdev -syncpeer down", false);
     }


### PR DESCRIPTION
in some situation, like OpenStack, mtu is less then default (1500) and
it cause replication issue
we have noticed on a low used firewall with 2/3k State table size more
then 100k State table size on the backup server

copy mtu from real interface fix this issue