### PR TITLE
fix for dhcpd6 not being configured.

### DIFF
--- a/src/etc/rc.newwanipv6
+++ b/src/etc/rc.newwanipv6
@@ -113,15 +113,14 @@ if (!empty($grouptmp)) {
     array_walk($grouptmp, 'interface_group_add_member');
 }
 
-$manual_dhcpv6 = false;
+$track6_dhcpv6 = false;
 
 foreach (link_interface_to_track6($interface, true) as $lanif => $lancfg) {
-    if (isset($lancfg['dhcpd6track6allowoverride'])) {
-        $manual_dhcpv6 = true;
+    if ($lancfg['ipaddrv6'] == "track6") {
+        $track6_dhcpv6 = true;
     }
 }
-
-if ($manual_dhcpv6) {
+if ($track6_dhcpv6) {
     services_dhcpd_configure('inet6');
 }
 


### PR DESCRIPTION
dhcpd6 needs configuring whether it's manual override or not. This patch checks to see if track6 is set and uses that as the conditional.