### PR TITLE
Wrap the IP address

### DIFF
--- a/src/www/widgets/widgets/interface_list.widget.php
+++ b/src/www/widgets/widgets/interface_list.widget.php
@@ -126,7 +126,7 @@ require_once("interfaces.inc");
         <td style="width:35%;">
           <?=empty($ifinfo['media']) ? htmlspecialchars($ifinfo['cell_mode']) : htmlspecialchars($ifinfo['media']);?>
         </td>
-        <td style="width:45%;">
+        <td style="width:45%; word-break: break-word;">
           <?=htmlspecialchars($ifinfo['ipaddr']);?>
           <?=!empty($ifinfo['ipaddr']) ? "<br/>" : "";?>
           <?=htmlspecialchars($ifinfo['ipaddrv6']);?>


### PR DESCRIPTION
On lobby with more than two columns, in the interface_list.widget the IPv6 address can be longer than the box. This wraps it.