### PR TITLE
IDS, add whitelists

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
@@ -6,6 +6,18 @@
         <help>Enable this fingerprint rule.</help>
     </field>
     <field>
+        <id>rule.source</id>
+        <label>Source IP</label>
+        <type>text</type>
+        <help>Set the source IP or network to match. Leave this field empty for using "any".</help>
+    </field>
+    <field>
+        <id>rule.destination</id>
+        <label>Destination IP</label>
+        <type>text</type>
+        <help>Set the destination IP or network to match. Leave this field empty for using "any".</help>
+    </field>
+    <field>
         <id>rule.fingerprint</id>
         <label>SSL/Fingerprint</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -32,6 +32,12 @@
                     <default>1</default>
                     <Required>Y</Required>
                 </enabled>
+                <source type="NetworkField">
+                    <Required>N</Required>
+                </source>
+                <destination type="NetworkField">
+                    <Required>N</Required>
+                </destination>
                 <fingerprint type="TextField">
                     <Required>N</Required>
                     <mask>/^([0-9a-fA-F:]){59,59}$/u</mask>
@@ -62,6 +68,7 @@
                     <OptionValues>
                         <alert>Alert</alert>
                         <drop>Drop</drop>
+                        <pass>Pass</pass>
                     </OptionValues>
                 </action>
             </rule>

--- a/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
+++ b/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
@@ -9,7 +9,7 @@
 {%      for rule in helpers.toList('OPNsense.IDS.userDefinedRules.rule') %}
 {%          if rule.enabled|default('0') == '1' %}
 {{rule.action}}{% if rule.fingerprint|default('') != ""
-      %} tls {% else %} ip {% endif %} {% if rule.source|default('any') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('any') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
+      %} tls {% else %} ip {% endif %} {% if rule.source|default('') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
       if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif
       %}{%
       if rule.geoip|default('') != ""%} geoip:{% if rule.geoip_direction|default('') != '' %}{{rule.geoip_direction}},{% endif %}{{rule.geoip}} ;{% endif

--- a/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
+++ b/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
@@ -9,7 +9,7 @@
 {%      for rule in helpers.toList('OPNsense.IDS.userDefinedRules.rule') %}
 {%          if rule.enabled|default('0') == '1' %}
 {{rule.action}}{% if rule.fingerprint|default('') != ""
-      %} tls {% else %} ip {% endif %} {% if rule.source|default('any') != "" %} {{ rule.source }} {{% else %} any {% endif %} any -> {% if rule.destination|default('any') != "" %} {{ rule.destination }} {{% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
+      %} tls {% else %} ip {% endif %} {% if rule.source|default('any') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('any') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
       if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif
       %}{%
       if rule.geoip|default('') != ""%} geoip:{% if rule.geoip_direction|default('') != '' %}{{rule.geoip_direction}},{% endif %}{{rule.geoip}} ;{% endif

--- a/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
+++ b/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
@@ -9,7 +9,7 @@
 {%      for rule in helpers.toList('OPNsense.IDS.userDefinedRules.rule') %}
 {%          if rule.enabled|default('0') == '1' %}
 {{rule.action}}{% if rule.fingerprint|default('') != ""
-      %} tls {% else %} ip {% endif %} any any -> any any (msg:"{{rule.description.replace('"','\"')}}"; {%
+      %} tls {% else %} ip {% endif %} {% if rule.source|default('any') != "" %} {{ rule.source }} {{% else %} any {% endif %} any -> {% if rule.destination|default('any') != "" %} {{ rule.destination }} {{% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
       if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif
       %}{%
       if rule.geoip|default('') != ""%} geoip:{% if rule.geoip_direction|default('') != '' %}{{rule.geoip_direction}},{% endif %}{{rule.geoip}} ;{% endif


### PR DESCRIPTION
As discussed in #2110 with @AdSchellevis here are whitelists.

I didn't realized it's that simple. Two new fields for source/destination. When empty it's any, so existing rules won't be changed. In dropdown there's now a "Pass" to add a whitelist.

Since we have in suricata.yaml:

```
action-order:
  - pass
  - drop
  - reject
  - alert
```

.. we don't run into problems when the SID is higher than the match. 


Here's my test rule:

`pass ip   10.10.10.1  any ->  192.168.55.5  any (msg:"test pass";  sid:4294967294; rev:1;)
`

If I have a FP on let's say some SIP attacks from a real phone, normally you'd just disable the rule to get it running. But it would also allow this kind of attack. Now you can just create a whitelist from your phone to your PBX and that's it.

So, what do you think?