### PR TITLE
dhcpd6 PD Auto tracking additons

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1123,6 +1123,7 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
             }
 
             $ifcfgipv6 = Net_IPv6::getNetmask($ifcfgipv6, 64);
+            $ifcfgipv6arr = explode(':', $ifcfgipv6);
 
             if (!isset($config['interfaces'][$ifname]['dhcpd6track6allowoverride'])) {
                 /* mock a real server */
@@ -1130,7 +1131,6 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
                 $dhcpdv6cfg[$ifname]['enable'] = true;
 
                 /* fixed range */
-                $ifcfgipv6arr = $ifcfgipv6arr = explode(':', $ifcfgipv6);
                 $ifcfgipv6arr[7] = '1000';
                 $dhcpdv6cfg[$ifname]['range'] = array();
                 $dhcpdv6cfg[$ifname]['range']['from'] = Net_IPv6::compress(implode(':', $ifcfgipv6arr));
@@ -1163,6 +1163,71 @@ function services_dhcpdv6_configure($blacklist = array(), $verbose = false)
                     'from' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['from']),
                     'to' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['to']),
                 );
+
+                $pd_prefix_from_array = array();
+                $pd_prefix_to_array = array();
+
+                $pd_prefix_from_array = explode(":",$config['dhcpdv6'][$ifname]['prefixrange']['from']);
+                $pd_prefix_to_array = explode(":",$config['dhcpdv6'][$ifname]['prefixrange']['to']);
+                
+                $pd_prefix_from_array[2] = sprintf("%02s",$pd_prefix_from_array[2]);
+                $pd_prefix_to_array[2] = sprintf("%02s",$pd_prefix_to_array[2]);
+
+                $pd_prefix_from_array_out = array();
+                $pd_prefix_to_array_out = array();
+
+                for($x=0;$x<4;$x++) // make the prefx long format otherwise dhcpd complains
+                {
+                    $ifcfgipv6arr[$x] = sprintf("%04s",$ifcfgipv6arr[$x]);
+                }
+
+                $pd_prefix_from_array_out = $ifcfgipv6arr;
+                $pd_prefix_to_array_out = $ifcfgipv6arr;
+                
+                $pdval = intval($config['dhcpdv6'][$ifname]['prefixrange']['prefixlength']);
+                                                
+                switch($pdval) {
+                    // For PD sizes of /60 through /64, the user must do the math!
+                    case 60:
+                    case 62:
+                    case 63:
+                    case 64: // 3&4th bytes on 4th array
+                        $pd_prefix_from_array_out[3] =  sprintf("%04s",$ifcfgipv6arr[3]); // make it 4 bytes   
+                        $pd_prefix_from_array_out[3] = substr($pd_prefix_from_array_out[3],0,2).$pd_prefix_from_array[2];
+                        $pd_prefix_to_array_out[3] =  sprintf("%04s",$ifcfgipv6arr[3]); // make it 4 bytes   
+                        $pd_prefix_to_array_out[3] = substr($pd_prefix_to_array_out[3],0,2).$pd_prefix_to_array[2];
+                    break;
+                    
+                    case 56: // 1st&2nd bytes on 4th array
+                        $pd_prefix_from_array[2] = str_pad($pd_prefix_from_array[2],4,"0");
+                        $pd_prefix_from_array_out[3] =  sprintf("%s",$pd_prefix_from_array[2]); // make it 4 bytes                       
+                        $pd_prefix_to_array[2] = str_pad($pd_prefix_to_array[2],4,"0");
+                        $pd_prefix_to_array_out[3] =  sprintf("%s",$pd_prefix_to_array[2]); // make it 4 bytes                                     
+                    break;
+                    case 52: // 1st byte on 4th array only, 0 to f, we only want one byte, but lookout for the user entering more
+                        $len = strlen($pd_prefix_from_array[2]);                    
+                        $pd_prefix_from_array[2] = substr($pd_prefix_from_array[2],$len-1,1);
+                        $pd_prefix_from_array_out[3] =  sprintf("%s000",substr($pd_prefix_from_array[2],0,1)); // first byte from entered value                      
+                        $len = strlen($pd_prefix_to_array[2]);                    
+                        $pd_prefix_to_array[2] = substr($pd_prefix_to_array[2],$len-1,1);
+                        $pd_prefix_to_array_out[3] =   sprintf("%s000",substr($pd_prefix_to_array[2],0,1));                                    
+                    break;
+                    case 48: // 4th byte on 2nd array,                    
+                        $pd_prefix_from_array[2] = substr($pd_prefix_from_array[2],0,1);
+                        $pd_prefix_from_array_out[1] =  substr(sprintf("%03s",$ifcfgipv6arr[1]),0,3).$pd_prefix_from_array[2]; // get 1st 3 byte + nibble
+                        
+                        $pd_prefix_to_array[2] = substr($pd_prefix_to_array[2],0,1);
+                        $pd_prefix_to_array_out[1] =  substr(sprintf("%03s",$ifcfgipv6arr[1]),0,3).$pd_prefix_to_array[2]; // get 1st 3 byte + nibble   
+                    break;                    
+                }
+                
+                $ipv6_from_pd_from = implode(":",$pd_prefix_from_array_out);
+                $ipv6_from_pd_to = implode(":",$pd_prefix_to_array_out);
+                log_error("pd out = {$ipv6_from_pd_from}");
+                $dhcpdv6cfg[$ifname]['prefixrange'] = array();
+                $dhcpdv6cfg[$ifname]['prefixrange']['prefixlength'] = $config['dhcpdv6'][$ifname]['prefixrange']['prefixlength'];
+                $dhcpdv6cfg[$ifname]['prefixrange']['from'] =  Net_IPv6::compress($ipv6_from_pd_from);
+                $dhcpdv6cfg[$ifname]['prefixrange']['to'] =  Net_IPv6::compress($ipv6_from_pd_to);
             }
         }
     }

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -331,6 +331,13 @@ include("head.inc");
 
 $wifcfgip = get_interface_ipv6($if);
 $wifcfgsn = get_interface_subnetv6($if);
+$pdlen = calculate_ipv6_delegation_length($config['interfaces'][$if]['track6-interface'])-1;
+
+if($pdlen<0) {
+    $pdlen_disp = "N/A";
+} else {
+      $pdlen_disp = 64-$pdlen;
+}
 
 if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
     $prefix_array = array();
@@ -451,24 +458,21 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                     </tr>
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet");?></td>
-<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                      <td><?= gettext('Prefix Delegation') ?></td>
-<?php else: ?>
                       <td><?= gen_subnetv6($wifcfgip, $wifcfgsn) ?></td>
-<?php endif ?>
-                    </tr>
                     <tr>
-                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet mask");?></td>
-<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                      <td><?= gettext('Prefix Delegation') ?></td>
-<?php else: ?>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Subnet mask");?></td>                      
                       <td><?= htmlspecialchars($wifcfgsn) ?> <?= gettext('bits') ?></td>
-<?php endif ?>
                     </tr>
 <?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
                      <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Current LAN IPv6 prefix");?></td>
                       <td><?= htmlspecialchars($wifprefix) ?></td>
+                    </tr>
+<?php endif ?>
+<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride']) && $pdlen > 0): ?>
+                     <tr>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Prefix delegation max available size");?></td>
+                      <td><?= htmlspecialchars($pdlen_disp)?></td>
                     </tr>
 <?php endif ?>
                     <tr>
@@ -480,7 +484,7 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                         $range_to = gen_subnetv6_max($wifcfgip, $wifcfgsn);?>
                         <?=$range_from;?> - <?=$range_to;?>
 <?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
-                        <?= gettext('Prefix delegation subnet will be prefixed to the available range.') ?>
+                        <?= gettext('<br>Prefix subnet will be prefixed to the available range.') ?>
 <?php endif ?>
                       </td>
                     </tr>
@@ -540,6 +544,12 @@ if ($config['interfaces'][$if]['ipaddrv6'] == 'track6') {
                         <div class="hidden" data-for="help_for_prefixrange">
                           <?= gettext("You can define a Prefix range here for DHCP Prefix Delegation. This allows for assigning networks to subrouters. " .
                           "The start and end of the range must end on boundaries of the prefix delegation size."); ?>
+                           <?= gettext("Ensure that any prefix delegation range does not overlap the LAN prefix range."); ?>
+                          <?= gettext('<br>The system does not check the validity of your emtry against the selected mask - please refer to an online net calculator
+                        to ensure you have entered a correct range if the dhcpd6 server fails to start.') ?>
+<?php if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])): ?>
+                        <?= gettext('<br>When using a tracked interface then please only enter the range itself. i.e. ::xx. For example, for a /60 subnet from ::20 to ::40.') ?>                        
+<?php endif ?>
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
Does not use dhcp6c mods. uses existing functions to determine the PD length available.