### PR TITLE
Make IPSec Phase1 defaults more secure

### DIFF
--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -126,9 +126,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $pconfig['myid_type'] = "myaddress";
         $pconfig['peerid_type'] = "peeraddress";
         $pconfig['authentication_method'] = "pre_shared_key";
-        $pconfig['encryption-algorithm'] = array("name" => "3des") ;
-        $pconfig['hash-algorithm'] = "sha1";
-        $pconfig['dhgroup'] = "24";
+        $pconfig['encryption-algorithm'] = array("name" => "aes", "keylen" => "128");
+        $pconfig['hash-algorithm'] = "sha256";
+        $pconfig['dhgroup'] = "14";
         $pconfig['lifetime'] = "28800";
         $pconfig['nat_traversal'] = "on";
         $pconfig['iketype'] = "ikev1";


### PR DESCRIPTION
3DES shouldn't be used anymore, same to SHA1. Also, DH, the higher the number doesn't mean it's more secure. DH22-24 should be avoided in a new draft of RFC:

https://tools.ietf.org/html/draft-ietf-ipsecme-rfc4307bis-18#section-2.4

The new values are marked as MUST or SHOULD+ values from the RFC.