### PR TITLE
monit: change mail format field for alerts to textbox

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/alerts.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/alerts.xml
@@ -27,7 +27,7 @@
    <field>
       <id>monit.alert.format</id>
       <label>Mail format</label>
-      <type>text</type>
+      <type>textbox</type>
       <help><![CDATA[The email format for alerts.<br><i>Subject: $SERVICE on $HOST failed</i>]]></help>
    </field>
    <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -148,8 +148,6 @@
          </events>
          <format type="TextField">
             <Required>N</Required>
-            <mask>/^.{1,255}$/u</mask>
-            <ValidationMessage>Message format should be a string between 1 and 255 characters.</ValidationMessage>
          </format>
          <reminder type="IntegerField">
             <default>10</default>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -1,6 +1,6 @@
 <model>
    <mount>//OPNsense/monit</mount>
-   <version>1.0.3</version>
+   <version>1.0.4</version>
    <description>Monit settings</description>
    <items>
       <general>


### PR DESCRIPTION
Change the Mail Format field for Alerts to textbox to configure it multi-line.
The problem came up with opnsense/plugins#820