### PR TITLE
Fix for static IPv6 when using PPPoE IPv4 on WAN

### DIFF
--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -129,6 +129,13 @@ if (isset($config['interfaces'][$interface]['ipaddrv6'])) {
                 interface_dhcpv6_configure($interface, $config['interfaces'][$interface]);
             }
             break;
+       default:
+                if (!in_array($tunnelif, array("gif", "gre", "ovp"))) {
+                    if (is_ipaddrv6($config['interfaces'][$interface]['ipaddrv6']) && $config['interfaces'][$interface]['subnetv6'] <> "") {
+                        mwexec("/sbin/ifconfig " . escapeshellarg($interface_real) . " inet6 {$config['interfaces'][$interface]['ipaddrv6']} prefixlen " . escapeshellarg($config['interfaces'][$interface]['subnetv6']));
+                    }
+                }
+            break;
     }
 }
 


### PR DESCRIPTION
When using a static WAN IPv6 address and using PPPoE for v4,  if you save and apply the interface - this is when the interface is already up, the IPv6 address does not get applied, an error from ifconfig is generated. It appears as though the interface is not ready to accept the v6 address. This fix adds a slight delay in calling ifconfig if both the IPv6 address is static and the v4 is pppoe.

This is a fix for issue 2726 [https://github.com/opnsense/core/issues/2726](url)