### PR TITLE
make Schedule icon reflect current schedule state

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -652,6 +652,7 @@ $( document ).ready(function() {
                                 if ($schedule['name'] == $filterent['sched'])
                                 {
                                     $schedule_descr = (isset($schedule['descr'])) ? $schedule['descr'] : "";
+                                    break;
                                 }
                             }
                         }
@@ -661,7 +662,14 @@ $( document ).ready(function() {
                         </span>
                         <a href="/firewall_schedule_edit.php?name=<?=htmlspecialchars($filterent['sched']);?>"
                             title="<?= html_safe(gettext('Edit')) ?>" data-toggle="tooltip">
-                          <i class="fa fa-calendar"></i>
+<?php
+                        if (filter_get_time_based_rule_status($schedule)):?>
+                          <i class="fa fa-calendar text-success"></i>
+<?php
+                        else:?>
+                          <i class="fa fa-calendar text-muted"></i>
+<?php
+                        endif;?>
                         </a>
 <?php
                        endif;?>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -763,6 +763,8 @@ $( document ).ready(function() {
                           <td style="width:100px"><?=gettext("log");?></td>
                           <td style="width:16px"><span class="fa fa-long-arrow-right text-info"></span></td>
                           <td style="width:100px"><?=gettext("in");?></td>
+                          <td style="width:16px"><span class="fa fa-calendar text-success"></span></td>
+                          <td style="width:100px"><?=gettext("schedule (active)");?></td>
 <?php                     if ($selected_if == 'FloatingRules'): ?>
                           <td style="width:16px"><span class="fa fa-flash text-warning"></span></td>
                           <td style="width:100px"><?=gettext("first match");?></td>
@@ -782,6 +784,8 @@ $( document ).ready(function() {
                           <td class="nowrap"><?=gettext("log (disabled)");?></td>
                           <td style="width:16px"><span class="fa fa-long-arrow-left"></span></td>
                           <td style="width:100px"><?=gettext("out");?></td>
+                          <td style="width:16px"><span class="fa fa-calendar text-muted"></span></td>
+                          <td style="width:100px"><?=gettext("schedule (inactive)");?></td>
 <?php                     if ($selected_if == 'FloatingRules'): ?>
                           <td style="width:16px"><span class="fa fa-flash text-muted"></span></td>
                           <td style="width:100px"><?=gettext("last match");?></td>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -799,8 +799,8 @@ $( document ).ready(function() {
                     <td colspan="10"><?=gettext("Alias (click to view/edit)");?></td>
                   </tr>
                   <tr class="hidden-xs hidden-sm">
-                    <td><a><i><span class="fa fa-calendar"></i></a></td>
-                    <td colspan="10"><?=gettext("Schedule (click to view/edit)");?></td>
+                    <td><a><i><span class="fa fa-calendar text-success"></i> / <i><span class="fa fa-calendar text-muted"></i></a></td>
+                    <td colspan="10"><?=gettext("Active/Inactive Schedule (click to view/edit)");?></td>
                   </tr>
                   <tr class="hidden-xs hidden-sm">
                     <td colspan="11">


### PR DESCRIPTION

![2018-09-28 13_06_55-lan _ rules _ firewall](https://user-images.githubusercontent.com/2997504/46232189-35e0d980-c323-11e8-9158-86f48a317bd6.png)
On firewall_rules.php, there is no indication whether a schedule-based
rule is active. This change to the schedule icon applies the same styles
that are applied to a disabled/enabled Pass rule icon (text-muted and
text-success).

The break added to the foreach loop is needed to retain reference to the
attached schedule for the filter_get_time_based_rule_status() call