### PR TITLE
focus fix

### DIFF
--- a/src/opnsense/www/js/opnsense_theme.js
+++ b/src/opnsense/www/js/opnsense_theme.js
@@ -118,6 +118,9 @@ $(document).ready(function () {
                     mousedown: function() {
                         $(this).trigger("click");
                     }
+					mouseup: function() {
+						$(this).blur();
+					}
                 }
                 layer1_a.on(events);
                 layer2_a.on(events);


### PR DESCRIPTION
@fichtner
if you click on a link and then leave it, the focus remains on this link.
With this fix, this is now also fixed.

I'm sorry I found another mistake, but the sidebar should be perfect.
Now I'm dedicated to the last problem!

regards rené