### PR TITLE
border between <a>´s are missing

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -386,7 +386,7 @@ main.page-content.col-lg-12 {
         padding-left: 0px;
         padding-right: 0px;
         padding-top: 12px;
-        border-bottom: 2px solid #lightergrey;
+        border-bottom: 2px solid #EAEAEA;
         border-right: 1px solid #D9D9D9;
         > span {
           &.fa, &.glyphicon {

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7127,7 +7127,7 @@ main.page-content.col-lg-12 {
   padding-left: 0px;
   padding-right: 0px;
   padding-top: 12px;
-  border-bottom: 2px solid #lightergrey;
+  border-bottom: 2px solid #EAEAEA;
   border-right: 1px solid #D9D9D9;
 }
 #navigation.col-sidebar-left > div > nav > #mainmenu > div > a.list-group-item > span.fa,


### PR DESCRIPTION
I noticed that the separation of the individual <a> links is missing. Now it is up to you to say if we should install it again or not. if you do not want it please just delete this pr. have added two screenshots as a comparison. Thank you, best regards, René

new would be:
![grafik](https://user-images.githubusercontent.com/34602360/46902520-2c30a780-cec7-11e8-8921-5450193deaab.png)

old was:
![grafik](https://user-images.githubusercontent.com/34602360/46902523-38b50000-cec7-11e8-9e13-0a8c6bd7d759.png)

