### PR TITLE
Restore area - line break is missing! - fix

### DIFF
--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -384,14 +384,14 @@ $( document ).ready(function() {
                 <tr>
                   <td>
                     <?=gettext("Restore area:"); ?>
-                    <select name="restorearea" id="restorearea" class="selectpicker">
+                    <p><select name="restorearea" id="restorearea" class="selectpicker">
                       <option value=""><?=gettext("ALL");?></option>
 <?php
                     foreach($areas as $area => $areaname):?>
                       <option value="<?=$area;?>"><?=$areaname;?></option>
 <?php
                     endforeach;?>
-                    </select><br/>
+                    </select></p>
                     <input name="conffile" type="file" id="conffile" /><br/>
                     <input name="rebootafterrestore" type="checkbox" id="rebootafterrestore" checked="checked" />
                     <?=gettext("Reboot after a successful restore."); ?><br/>


### PR DESCRIPTION
Restore area - line break is missing! - fix
i changed it using <p> </p>

see my screenshots for comparison

old:
![grafik](https://user-images.githubusercontent.com/34602360/46913367-dffb6b00-cf8b-11e8-927c-e4e86cbef1fe.png)

new:
![grafik](https://user-images.githubusercontent.com/34602360/46913369-e7227900-cf8b-11e8-9ff6-10547199873b.png)
