### PR TITLE
monit: add quotes and timeout to custom program path

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
@@ -36,6 +36,13 @@
       <help><![CDATA[According to the service type path can be a file or a directory.]]></help>
    </field>
    <field>
+      <id>monit.service.timeout</id>
+      <label>Program Timeout</label>
+      <type>text</type>
+      <advanced>true</advanced>
+      <help><![CDATA[The timeout for custom program checks.]]></help>
+   </field>
+   <field>
       <id>monit.service.address</id>
       <label>Address</label>
       <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -1,6 +1,6 @@
 <model>
    <mount>//OPNsense/monit</mount>
-   <version>1.0.4</version>
+   <version>1.0.5</version>
    <description>Monit settings</description>
    <items>
       <general>
@@ -199,6 +199,13 @@
             <mask>/^(\/[^\/ ]*)+\/?.*$/</mask>
             <ValidationMessage>Should be a valid absolute file or folder path.</ValidationMessage>
          </path>
+         <timeout type="IntegerField">
+            <default>300</default>
+            <Required>N</Required>
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>86400</MaximumValue>
+            <ValidationMessage>Program Timeout needs to be an integer value between 1 and 86400</ValidationMessage>>
+         </timeout>
          <address type="TextField">
             <Required>N</Required>
             <mask>/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-4]|2[0-5][0-9]|[01]?[0-9][0-9]?)$/</mask>

--- a/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
@@ -185,6 +185,7 @@ POSSIBILITY OF SUCH DAMAGE.
          $('tr[id="row_monit.service.pidfile"]').addClass('hidden');
          $('tr[id="row_monit.service.match"]').addClass('hidden');
          $('tr[id="row_monit.service.path"]').addClass('hidden');
+         $('tr[id="row_monit.service.timeout"]').addClass('hidden');
          $('tr[id="row_monit.service.address"]').addClass('hidden');
          $('tr[id="row_monit.service.interface"]').addClass('hidden');
          $('tr[id="row_monit.service.start"]').removeClass('hidden');
@@ -227,6 +228,7 @@ POSSIBILITY OF SUCH DAMAGE.
                break;
             default:
                $('tr[id="row_monit.service.path"]').removeClass('hidden');
+               $('tr[id="row_monit.service.timeout"]').removeClass('hidden');
          }
       };
       $('#DialogEditService').on('shown.bs.modal', function() {ShowHideFields();});
@@ -234,6 +236,7 @@ POSSIBILITY OF SUCH DAMAGE.
       $('#monit\\.service\\.pidfile').on('input', function() {ShowHideFields();});
       $('#monit\\.service\\.match').on('input', function() {ShowHideFields();});
       $('#monit\\.service\\.path').on('input', function() {ShowHideFields();});
+      $('#monit\\.service\\.timeout').on('input', function() {ShowHideFields();});
       $('#monit\\.service\\.address').on('input', function() {ShowHideFields();});
       $('#monit\\.service\\.interface').on('changed.bs.select', function(e) {ShowHideFields();});
 

--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -101,9 +101,13 @@ check {{ service.type }} {{ service.name }} {{ address }} {{ interface }}
 {%     elif service.type == 'system' %}
 check {{ service.type }} {{ service.name }}
 {%     else %}
-{%      set path = "with path " ~ service.path %}
+{%      set path = "with path \"" ~ service.path ~ "\"" %}
 {%      if service.type == 'custom' %}
-check program {{ service.name }} {{ path }}
+{%       set timeout = '' %}
+{%       if service.timeout|default('0') != 0 %}
+{%         set timeout = "timeout " ~ service.timeout ~ " seconds" %}
+{%       endif %}
+check program {{ service.name }} {{ path }} {{ timeout }}
 {%      else %}
 check {{ service.type }} {{ service.name }} {{ path }}
 {%      endif %}


### PR DESCRIPTION
Add quotation marks to custom program path and the timeout parameter.
See #2811 and [Monit Service Checks](https://mmonit.com/monit/documentation/monit.html#Program)