### PR TITLE
Add runlevel 'boot' for syshook (from Smart-Soft)

### DIFF
--- a/src/etc/rc
+++ b/src/etc/rc
@@ -42,6 +42,8 @@ export HOME PATH
 
 echo "Mounting filesystems..."
 
+/usr/local/etc/rc.syshook boot
+
 # tunefs may refuse otherwise
 mount -fr / 2> /dev/null
 


### PR DESCRIPTION
To implement as described in opnsense/core#2114
This runlevel for running tasks before filesystems are mounted and checked.
