### PR TITLE
Move selected ... to end

### DIFF
--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -312,7 +312,7 @@ $main_buttons = array(
                       <?=$natent['descr'];?> &nbsp;
                     </td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
                         <span class="fa fa-arrow-left fa-fw"></span>
                       </a>
                       <a href="firewall_nat_1to1_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>">
@@ -334,7 +334,7 @@ $main_buttons = array(
                   <tr>
                     <td colspan="7"></td>
                     <td>
-                      <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('move selected rules to end')) ?>" class="act_move btn btn-default btn-xs">
+                      <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('Move selected rules to end')) ?>" class="act_move btn btn-default btn-xs">
                         <i class="fa fa-arrow-left fa-fw"></i>
                       </button>
                       <button id="del_x" title="<?= html_safe(gettext('Delete selected')) ?>" data-toggle="tooltip" class="act_delete btn btn-default btn-xs">

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -234,7 +234,7 @@ $main_buttons = array(
                           <?=$natent['descr'];?>
                       </td>
                       <td>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('move selected rules before this rule')) ?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('Move selected rules before this rule')) ?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
                         </a>
                         <a href="firewall_nat_npt_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
@@ -253,7 +253,7 @@ $main_buttons = array(
                     <tr>
                         <td colspan="7"> </td>
                         <td>
-                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('move selected rules to end')) ?>" class="act_move btn btn-default btn-xs">
+                        <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('Move selected rules to end')) ?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
                         </a>
                         <a id="del_x" title="<?= html_safe(gettext('Delete selected')) ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -483,7 +483,7 @@ include("head.inc");
                       <?=htmlspecialchars($natent['descr']);?>&nbsp;
                     </td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('move selected rules before this rule')) ?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext('Move selected rules before this rule')) ?>" class="act_move btn btn-default btn-xs">
                         <i class="fa fa-arrow-left fa-fw"></i>
                       </a>
                       <a href="firewall_nat_out_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
@@ -506,7 +506,7 @@ include("head.inc");
                   <td colspan="6" class="hidden-xs hidden-sm"></td>
                   <td colspan="5"></td>
                   <td>
-                    <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=html_safe(gettext('move selected rules to end'))?>" class="act_move btn btn-default btn-xs">
+                    <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?=html_safe(gettext('Move selected rules to end'))?>" class="act_move btn btn-default btn-xs">
                       <i class="fa fa-arrow-left fa-fw"></i>
                     </button>
                     <button id="del_x" title="<?= html_safe(gettext('Delete selected')) ?>" data-toggle="tooltip" class="act_delete btn btn-default btn-xs">

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -681,7 +681,7 @@ $( document ).ready(function() {
                       </div>
                     </td>
                     <td>
-                      <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
+                      <button id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
                         <i class="fa fa-arrow-left fa-fw"></i>
                       </button>
 <?php

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -709,6 +709,7 @@ $( document ).ready(function() {
 <?php
                   endif;
                   endforeach;
+                  $i++;
                   if (!$interface_has_rules):
 ?>
                   <tr>

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -363,7 +363,7 @@ $( document ).ready(function() {
                         <a href="firewall_scrub_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
                           <span class="fa fa-pencil fa-fw"></span>
                         </a>
-                        <a data-id="<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
+                        <a data-id="<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
                         </a>
                         <a data-id="<?=$i;?>" title="<?= html_safe(gettext('Delete')) ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
@@ -385,7 +385,7 @@ $( document ).ready(function() {
                         <a><i class="fa fa-list fa-fw"></i></a> <?=gettext("Alias (click to view/edit)");?>
                       </td>
                       <td>
-                        <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected rules to end")) ?>" class="act_move btn btn-default btn-xs">
+                        <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected rules to end")) ?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
                         </a>
                         <a data-id="x" title="<?= html_safe(gettext("delete selected rules")) ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -360,11 +360,11 @@ $( document ).ready(function() {
                         <?=$scrubEntry['descr'];?>
                     </td>
                     <td>
-                        <a href="firewall_scrub_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
-                          <span class="fa fa-pencil fa-fw"></span>
-                        </a>
                         <a data-id="<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected rules before this rule")) ?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
+                        </a>
+                        <a href="firewall_scrub_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
+                          <span class="fa fa-pencil fa-fw"></span>
                         </a>
                         <a data-id="<?=$i;?>" title="<?= html_safe(gettext('Delete')) ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">
                           <span class="fa fa-trash fa-fw"></span>

--- a/src/www/firewall_virtual_ip.php
+++ b/src/www/firewall_virtual_ip.php
@@ -294,7 +294,7 @@ $main_buttons = array(
                       <?=htmlspecialchars($vipent['descr']);?>
                     </td>
                     <td>
-                      <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected virtual IPs before this entry")) ?>" class="act_move btn btn-default btn-xs">
+                      <a id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected virtual IPs before this entry")) ?>" class="act_move btn btn-default btn-xs">
                         <span class="fa fa-arrow-left fa-fw"></span>
                       </a>
                       <a href="firewall_virtual_ip_edit.php?id=<?=$i;?>" data-toggle="tooltip" title="<?= html_safe(gettext('Edit')) ?>" class="btn btn-default btn-xs">
@@ -317,7 +317,7 @@ $main_buttons = array(
                   <tr>
                     <td colspan="5"></td>
                     <td>
-                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("move selected virtual IPs to end")) ?>" class="act_move btn btn-default btn-xs">
+                      <a type="submit" id="move_<?=$i;?>" name="move_<?=$i;?>_x" data-toggle="tooltip" title="<?= html_safe(gettext("Move selected virtual IPs to end")) ?>" class="act_move btn btn-default btn-xs">
                         <span class="fa fa-arrow-left fa-fw"></span>
                       </a>
                       <a id="del_x" title="<?= html_safe(gettext('delete selected virtual IPs')) ?>" data-toggle="tooltip"  class="btn btn-default btn-xs">

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -432,7 +432,7 @@ $( document ).ready(function() {
                       </td>
                       <td class="text-nowrap">
                         <button data-id="<?=$i; ?>" data-act="movep1" type="submit" class="act_move btn btn-default btn-xs"
-                          title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip">
+                          title="<?=gettext("Move selected entries before this");?>" data-toggle="tooltip">
                           <i class="fa fa-arrow-left fa-fw"></i>
                         </button>
                         <a href="vpn_ipsec_phase1.php?p1index=<?=$i; ?>" class="btn btn-default btn-xs"
@@ -558,7 +558,7 @@ $( document ).ready(function() {
                                 endif; ?>
                                 <td class="text-nowrap">
                                   <button data-id="<?=$j; ?>" data-act="movep2" type="submit" class="act_move btn btn-default btn-xs"
-                                    title="<?=gettext("move selected entries before this");?>" data-toggle="tooltip">
+                                    title="<?=gettext("Move selected entries before this");?>" data-toggle="tooltip">
                                     <i class="fa fa-arrow-left fa-fw"></i>
                                   </button>
                                   <a href="vpn_ipsec_phase2.php?p2index=<?=$ph2ent['uniqid']; ?>"
@@ -587,7 +587,7 @@ $( document ).ready(function() {
                                 if ($j > 0) :?>
 
                                   <button data-id="<?=$j+1; ?>" data-act="movep2" type="submit" class="act_move btn btn-default btn-xs"
-                                    title="<?=gettext("move selected phase 2 entries to end");?>" data-toggle="tooltip">
+                                    title="<?=gettext("Move selected phase 2 entries to end");?>" data-toggle="tooltip">
                                     <i class="fa fa-arrow-down fa-fw"></i>
                                   </button>
                                   <button data-id="x" type="submit" title="<?=gettext("delete selected phase 2 entries");?>" data-toggle="tooltip"
@@ -618,7 +618,7 @@ $( document ).ready(function() {
                           type="submit"
                           data-id="<?=$i;?>"
                           data-act="movep1"
-                          title="<?=gettext("move selected phase 1 entries to end");?>"
+                          title="<?=gettext("Move selected phase 1 entries to end");?>"
                           data-toggle="tooltip"
                           class="act_move btn btn-default btn-xs">
                           <i class="fa fa-arrow-down fa-fw"></i>

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -1205,7 +1205,7 @@ $( document ).ready(function() {
                 <td><?= htmlspecialchars(implode(', ', $server)) ?></td>
                 <td><?= htmlspecialchars($client['description']) ?></td>
                 <td class="text-nowrap">
-                    <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("move selected before this item");?>" class="act_move btn btn-default btn-xs">
+                    <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("Move selected before this item");?>" class="act_move btn btn-default btn-xs">
                       <span class="fa fa-arrow-left fa-fw"></span>
                     </a>
                     <a href="vpn_openvpn_client.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs">
@@ -1225,7 +1225,7 @@ $( document ).ready(function() {
               <tr>
                 <td colspan="4"></td>
                 <td class="text-nowrap">
-                  <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("move selected items to end");?>" class="act_move btn btn-default btn-xs">
+                  <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("Move selected items to end");?>" class="act_move btn btn-default btn-xs">
                     <span class="fa fa-arrow-down fa-fw"></span>
                   </a>
                   <a data-id="x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">

--- a/src/www/vpn_openvpn_csc.php
+++ b/src/www/vpn_openvpn_csc.php
@@ -710,7 +710,7 @@ if ($act!="new" && $act!="edit") {
                           <?=htmlspecialchars($csc['description']);?>
                       </td>
                       <td class="text-nowrap">
-                        <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("move selected before this item");?>" class="act_move btn btn-default btn-xs">
+                        <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("Move selected before this item");?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-left fa-fw"></span>
                         </a>
                         <a href="vpn_openvpn_csc.php?act=edit&amp;id=<?=$i;?>" class="btn btn-default btn-xs"><span class="fa fa-pencil fa-fw"></span></a>
@@ -728,7 +728,7 @@ if ($act!="new" && $act!="edit") {
                         <?=gettext("Additional OpenVPN client specific overrides can be added here.");?>
                       </td>
                       <td class="text-nowrap">
-                        <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("move selected items to end");?>" class="act_move btn btn-default btn-xs">
+                        <a data-id="<?=$i;?>" data-toggle="tooltip" title="<?=gettext("Move selected items to end");?>" class="act_move btn btn-default btn-xs">
                           <span class="fa fa-arrow-down fa-fw"></span>
                         </a>
                         <a data-id="x" title="<?=gettext("delete selected rules"); ?>" data-toggle="tooltip"  class="act_delete btn btn-default btn-xs">


### PR DESCRIPTION
What I did:

- Some upper and lower case corrections on the tooltips.
- Rearranged the buttons order in "Firewall: Settings: Normalization"
- Correction for the "move to end" function for "Firewall: Rules: xxx"