### PR TITLE
dhcpv6 static leases with tracked interface: apply prefix to fixed IPv6 address

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1386,6 +1386,10 @@ host s_{$dhcpv6if}_{$i} {
 
 EOD;
                 if (!empty($sm['ipaddrv6'])) {
+                    if (isset($config['interfaces'][$dhcpv6if]['track6-interface'])
+                        && isset($config['interfaces'][$dhcpv6if]['dhcpd6track6allowoverride'])) {
+                        $sm['ipaddrv6'] = make_ipv6_64_address($ifcfgipv6, $sm['ipaddrv6']);
+                    }
                     $dhcpdv6conf .= "  fixed-address6 {$sm['ipaddrv6']};\n";
                 }
 

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -180,6 +180,9 @@ include("head.inc");
                         <?=gettext("If an IPv6 address is entered, the address must be outside of the pool.");?>
                         <br />
                         <?=gettext("If no IPv6 address is given, one will be dynamically allocated from the pool.");?>
+                        <br />
+                        <?= gettext("When using a static WAN address, this should be entered using the full IPv6 address. " .
+                        "When using a dynamic WAN address, only enter the suffix part (i.e. ::1:2:3:4)."); ?>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
When operating a dhcpv6 server on an interface with IPv6 configuration mode "Track Interface" with "Allow manual adjustment of DHCPv6 and Router Advertisements", static leases with fixed IP don't work as expected. One is required to enter a full IPv6 address, the static lease will break whenever the dynamic prefix changes. The same problem is already solved for the configuration field "Range": when using a dynamic prefix it is possible to enter only the suffix part, the configuration file is automatically generated with the current prefix.
This patch uses the same technique to generate a fixed IPv6 address for static leases. The help message advises to use only the suffix when a dynamic prefix is used, and in the generated configuration file the prefix will be added.