### PR TITLE
proxy: Fix typo in description message.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -184,13 +184,13 @@
                 <id>proxy.general.traffic.maxDownloadSize</id>
                 <label>Maximum download size (kB)</label>
                 <type>text</type>
-                <help><![CDATA[Enter the maxium size for downloads in kilobytes (leave empty to disable).]]></help>
+                <help><![CDATA[Enter the maximum size for downloads in kilobytes (leave empty to disable).]]></help>
             </field>
             <field>
                 <id>proxy.general.traffic.maxUploadSize</id>
                 <label>Maximum upload size (kB)</label>
                 <type>text</type>
-                <help><![CDATA[Enter the maxium size for uploads in kilobytes (leave empty to disable).]]></help>
+                <help><![CDATA[Enter the maximum size for uploads in kilobytes (leave empty to disable).]]></help>
             </field>
             <field>
                 <id>proxy.general.traffic.OverallBandwidthTrotteling</id>


### PR DESCRIPTION
There was a typo in src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml.
The correct text is "maximum".