### PR TITLE
[#2898] proxy: fix custom whitelist in group-acl

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -28,36 +28,6 @@ adaptation_access request_mod allow whiteList
 http_access allow whiteList
 {% endif %}
 
-{% if helpers.exists('OPNsense.proxy.forward.acl.blackList') %}
-
-#
-# ACL list (Deny) blacklist
-{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
-adaptation_access response_mod deny blackList
-{%   endif %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
-adaptation_access request_mod deny blackList
-{%   endif %}
-{% endif %}
-http_access deny blackList
-{% endif %}
-
-{% if helpers.exists('OPNsense.proxy.forward.acl.remoteACLs.blacklists') %}
-{%   for blacklist in helpers.toList('OPNsense.proxy.forward.acl.remoteACLs.blacklists.blacklist') if blacklist.enabled=='1' %}
-# ACL list (Deny) remoteblacklist_{{blacklist.filename}}
-{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
-adaptation_access response_mod deny remoteblacklist_{{blacklist.filename}}
-{%   endif %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
-adaptation_access request_mod deny remoteblacklist_{{blacklist.filename}}
-{%   endif %}
-{% endif %}
-http_access deny remoteblacklist_{{blacklist.filename}}
-{%   endfor %}
-{% endif %}
-
 {% if helpers.exists('OPNsense.proxy.forward.acl.browser') %}
 
 # ACL list (Deny) blockuseragent
@@ -187,6 +157,36 @@ adaptation_access request_mod deny exclude_icap
 
 # Auth plugins
 include /usr/local/etc/squid/auth/*.conf
+
+{% if helpers.exists('OPNsense.proxy.forward.acl.blackList') %}
+
+#
+# ACL list (Deny) blacklist
+{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
+adaptation_access response_mod deny blackList
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
+adaptation_access request_mod deny blackList
+{%   endif %}
+{% endif %}
+http_access deny blackList
+{% endif %}
+
+{% if helpers.exists('OPNsense.proxy.forward.acl.remoteACLs.blacklists') %}
+{%   for blacklist in helpers.toList('OPNsense.proxy.forward.acl.remoteACLs.blacklists.blacklist') if blacklist.enabled=='1' %}
+# ACL list (Deny) remoteblacklist_{{blacklist.filename}}
+{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
+adaptation_access response_mod deny remoteblacklist_{{blacklist.filename}}
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
+adaptation_access request_mod deny remoteblacklist_{{blacklist.filename}}
+{%   endif %}
+{% endif %}
+http_access deny remoteblacklist_{{blacklist.filename}}
+{%   endfor %}
+{% endif %}
 
 #
 # Access Permission configuration:


### PR DESCRIPTION
This PR resolves the issue found in https://github.com/opnsense/core/issues/2898


## Issue
Currently, the plugin os-web-proxy-useracl do not work if a local and/or remote blacklist is used. (This is an issue with opnsense core webproxy config).