### PR TITLE
Fix use of undefined constant where string was intended

### DIFF
--- a/src/www/diag_logs_template.inc
+++ b/src/www/diag_logs_template.inc
@@ -52,7 +52,7 @@ if (!empty($_POST['clear'])) {
     } else {
         system_clear_log($logfile);
     }
-    if (function_exists(clear_hook)) {
+    if (function_exists('clear_hook')) {
         clear_hook();
     }
 }


### PR DESCRIPTION
function_exists() takes a string, but an undefined constant was passed. If a constant is undefined, PHP will convert it to a string, but this is very dirty behaviour.