### PR TITLE
Fix old-style constructor in PEAR.inc

### DIFF
--- a/src/etc/inc/PEAR.inc
+++ b/src/etc/inc/PEAR.inc
@@ -146,7 +146,7 @@ class PEAR
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -863,8 +863,8 @@ class PEAR_Error
      * @access public
      *
      */
-    function PEAR_Error($message = 'unknown error', $code = null,
-                        $mode = null, $options = null, $userinfo = null)
+    function __construct($message = 'unknown error', $code = null,
+                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {
             $mode = PEAR_ERROR_RETURN;


### PR DESCRIPTION
Since PHP5, __construct() is preferred. As of PHP7, the old PHP4 style constructor is deprecated.

There are also a dozen occurrences in contrib, but I assume those are supposed to be fixed upstream.