### PR TITLE
monit: add SSL options to mail server connection

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/general.xml
@@ -50,6 +50,20 @@
       <help><![CDATA[Enable encryption.]]></help>
    </field>
    <field>
+      <id>monit.general.sslversion</id>
+      <label>SSL Version</label>
+      <type>dropdown</type>
+      <help><![CDATA[Set the SSL version to use. In AUTO mode, only TLS is used.]]></help>
+      <advanced>true</advanced>
+   </field>
+   <field>
+      <id>monit.general.sslverify</id>
+      <label>Verify SSL certificates</label>
+      <type>checkbox</type>
+      <help><![CDATA[Enable or disable SSL server certificate verification.]]></help>
+      <advanced>true</advanced>
+   </field>
+   <field>
       <id>monit.general.logfile</id>
       <label>Log File</label>
       <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -1,6 +1,6 @@
 <model>
    <mount>//OPNsense/monit</mount>
-   <version>1.0.4</version>
+   <version>1.0.5</version>
    <description>Monit settings</description>
    <items>
       <general>
@@ -47,6 +47,23 @@
             <default>0</default>
             <Required>Y</Required>
          </ssl>
+         <sslversion type="OptionField">
+            <default>auto</default>
+            <Required>Y</Required>
+            <OptionValues>
+               <auto>AUTO</auto>
+               <sslv2>SSLV2</sslv2>
+               <sslv3>SSLV3</sslv3>
+               <tlsv1>TLSV1</tlsv1>
+               <tlsv11>TLSV11</tlsv11>
+               <tlsv12>TLSV12</tlsv12>
+               <tlsv13>TLSV13</tlsv13>
+            </OptionValues>
+         </sslversion>
+         <sslverify type="BooleanField">
+            <Required>N</Required>
+            <default>0</default>
+         </sslverify>
          <logfile type="TextField">
             <Required>N</Required>
             <default>syslog facility log_daemon</default>

--- a/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
@@ -111,6 +111,7 @@ POSSIBILITY OF SUCH DAMAGE.
          $('.selectpicker').selectpicker('refresh');
          isSubsystemDirty();
          updateServiceControlUI('monit');
+         ShowHideGeneralFields();
       });
 
       // show/hide httpd/mmonit options
@@ -128,8 +129,18 @@ POSSIBILITY OF SUCH DAMAGE.
             $('tr[id="row_monit.general.mmonitTimeout"]').addClass('hidden');
             $('tr[id="row_monit.general.mmonitRegisterCredentials"]').addClass('hidden');
          }
+         if ($('#monit\\.general\\.ssl')[0].checked) {
+            $('tr[id="row_monit.general.sslversion"]').removeClass('hidden');
+            $('tr[id="row_monit.general.sslverify"]').removeClass('hidden');
+         } else {
+            $('tr[id="row_monit.general.sslversion"]').addClass('hidden');
+            $('tr[id="row_monit.general.sslverify"]').addClass('hidden');
+         }
       };
       $('#monit\\.general\\.httpdEnabled').unbind('click').click(function(){
+         ShowHideGeneralFields();
+      });
+      $('#monit\\.general\\.ssl').unbind('click').click(function(){
          ShowHideGeneralFields();
       });
       $('#show_advanced_frm_GeneralSettings').click(function(){
@@ -137,7 +148,7 @@ POSSIBILITY OF SUCH DAMAGE.
       });
 
       $('#btnSaveGeneral').unbind('click').click(function(){
-	   $("#btnSaveGeneralProgress").addClass("fa fa-spinner fa-pulse");
+         $("#btnSaveGeneralProgress").addClass("fa fa-spinner fa-pulse");
          var frm_id = 'frm_GeneralSettings';
          saveFormToEndpoint(url = "/api/monit/settings/set/general/",formid=frm_id,callback_ok=function(){
             isSubsystemDirty();

--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -57,7 +57,23 @@ set eventqueue basedir {{ OPNsense.monit.general.eventqueuePath }} {{ slots }}
 {%      set username = "username " ~ OPNsense.monit.general.username %}
 {%      set password = "password " ~ '"' ~ OPNsense.monit.general.password ~ '"' %}
 {%    endif %}
-{%    set ssl = 'using ssl' if OPNsense.monit.general.ssl|default('0') == '1' %}
+{%    if OPNsense.monit.general.ssl|default('0') == '1' %}
+{%      set ssl = 'using ssl' %}
+{%      set ssloptions = '' %}
+{%      if helpers.exists('OPNsense.monit.general.sslversion') and OPNsense.monit.general.sslversion|default('') != '' %}
+{%        set ssloptions = "version: " ~ OPNsense.monit.general.sslversion %}
+{%      endif %}
+{%      if helpers.exists('OPNsense.monit.general.sslverify') %}
+{%        if OPNsense.monit.general.sslverify == '1' %}
+{%          set ssloptions = ssloptions ~ " verify: enable" %}
+{%        else %}
+{%          set ssloptions = ssloptions ~ " verify: disable" %}
+{%        endif %}
+{%      endif %}
+{%      if ssloptions != '' %}
+{%        set ssl = ssl ~ " with options { " ~ ssloptions ~ " }" %}
+{%      endif %}
+{%    endif %}
 set mailserver {{ OPNsense.monit.general.mailserver }} {{ port }} {{ username }} {{ password }} {{ ssl }}
 {%  endif %}
 


### PR DESCRIPTION
This PR adds two SSL options to the alert mail server connection.
One to select the SSL version to be used and the other to verify the server certificate.
See #2892