### PR TITLE
MVC: toggleBase returns 'failed' result when using $enabled

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -374,7 +374,7 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
      * Generic toggle function, assumes our model item has an enabled boolean type field.
      * @param string $path relative model path
      * @param string $uuid node key
-     * @param string $enabled desired state enabled(1)/disabled(1), leave empty for toggle
+     * @param string $enabled desired state enabled(1)/disabled(0), leave empty for toggle
      * @return array
      * @throws \Phalcon\Validation\Exception on validation issues
      * @throws \ReflectionException when binding to the model class fails
@@ -387,18 +387,36 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
             if ($uuid != null) {
                 $node = $mdl->getNodeByReference($path . '.' . $uuid);
                 if ($node != null) {
-                    if ($enabled == "0" || $enabled == "1") {
-                        $node->enabled = (string)$enabled;
-                    } elseif ((string)$node->enabled == "1") {
-                        $result['result'] = "Disabled";
-                        $node->enabled = "0";
-                    } else {
-                        $result['result'] = "Enabled";
-                        $node->enabled = "1";
+                    $isChanged = false;
+                    if ($enabled != null) {
+                        if ((string)$enabled == "0") {
+                            $result['result'] = "Disabled";
+                            $isChanged = (string)$node->enabled != "0";
+                            $node->enabled = "0";
+                        } elseif ((string)$enabled == "1") {
+                            $result['result'] = "Enabled";
+                            $isChanged = (string)$node->enabled != "1";
+                            $node->enabled = "1";
+                        } else {
+                            // Invalid parameter passed for $enabled only "0" or "1" are allowed
+                            $isChanged = false;
+                            $result['result'] = "failed";
+                        }
+                    } else {     // toggle current value
+                        $isChanged = true;
+                        if ((string)$node->enabled == "1") {
+                            $result['result'] = "Disabled";
+                            $node->enabled = "0";
+                        } else {
+                            $result['result'] = "Enabled";
+                            $node->enabled = "1";
+                        }
                     }
                     // if item has toggled, serialize to config and save
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
+                    if ($isChanged) {
+                        $mdl->serializeToConfig();
+                        Config::getInstance()->save();
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
OPNsense 19.1.b_167-amd64
FreeBSD 11.1-RELEASE-p15
OpenSSL 1.0.2p 14 Aug 2018
```

## Problem
ToggleBase always returns a "failed" message when $enabled is specified:
```
curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/1"
{"result":"failed"}

curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/0"
{"result":"failed"}
```
The item is changed and the model is updated with the correct value, but the result of the operation is not returned correctly to the client.

Also, passing any other value except "0" and "1" toggles the item instead of failing:
```
curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/5"
{"result":"Enabled"}

curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/5"
{"result":"Disabled"}
```

## Expected behavior
A result of either "Enabled" or "Disabled" should be returned when the action succeeds.

```
curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/1"
{"result":"Enabled"}

curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/0"
{"result":"Disabled"}
```
Passing any other value except "0" and "1" fails as expected:
```
curl -k -u "$key:$secret" -XPOST -d "" "$url/api/cron/settings/togglejob/$uuid/5"
{"result":"failed"}
```

## Cause
There is [no $result['result'] set](https://github.com/opnsense/core/blob/f7abc6269ddf8355e53e495bf382994605066d35/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php#L391) and this gets returned to the client as a "failed" message.

## Solution
This commit solves these items:
- [x] Add a $result['result'] = "Disabled" or "Enabled" message when $enabled was specified.
- [x] Add a check where using anything other than "0" or "1" for $enabled _will_ return a "failed" status instead of defaulting to a 'toggle' behaviour.
  Specifying a value should yield a predictable result. Defaulting to toggle in this case is not desirable.
- [x] Keep track if the value is actually changed and only saves the config when there is a change to the model.
- [x] Fix "enabled(1)/disabled(0)" typo in the header comments.

I might have overthought the code in the proposed solution, but this way the logic should be easy to follow. Any comments and suggestion are welcomed as always.