### PR TITLE
system: expose defaults for security-related sysctls

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -193,6 +193,16 @@
       <tunable>hw.ibrs_disable</tunable>
       <value>default</value>
     </item>
+    <item>
+      <descr><![CDATA[Hide processes running as other groups]]></descr>
+      <tunable>security.bsd.see_other_gids</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr><![CDATA[Hide processes running as other users]]></descr>
+      <tunable>security.bsd.see_other_uids</tunable>
+      <value>default</value>
+    </item>
   </sysctl>
   <system>
     <optimization>normal</optimization>

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -106,6 +106,8 @@ function get_default_sysctl_value($id)
         'net.link.bridge.pfil_member' => '1',
         'net.link.bridge.pfil_onlyip' => '0',
         'net.link.tap.user_open' => '1',
+        'security.bsd.see_other_gids' => '0',
+        'security.bsd.see_other_uids' => '0',
         'vfs.read_max' => '32',
         'vm.pmap.pti' => '1',
     );


### PR DESCRIPTION
It took me some time to figure out that the default value for these sysctls is `0` on OPNsense. So I thought it would be a good idea to expose these defaults in the GUI and make it more obvious.