### PR TITLE
Check IP Services

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -49,6 +49,10 @@ require_once('plugins.inc.d/openssh.inc');
 require_once('plugins.inc.d/openvpn.inc');
 require_once('plugins.inc.d/unbound.inc');
 
+//use \OPNsense\DynDNS\Service;
+//use \OPNsense\DynDNS\Factory_Default_Service;
+use \OPNsense\DynDNS\CheckIP;
+
 function generate_ipv6_from_mac($mac)
 {
     $elements = explode(":", $mac);
@@ -1705,7 +1709,7 @@ function services_dhcrelay6_configure($verbose = false)
     }
 }
 
-function get_dyndns_ip($int, $ipver = 4)
+function get_dyndns_ip($int, $ipver = 4, $service = null)
 {
     global $config;
 
@@ -1729,17 +1733,54 @@ function get_dyndns_ip($int, $ipver = 4)
     }
 
     if ($ipver != 6 && is_private_ip($ip_address)) {
-        /* Chinese alternative is http://ip.3322.net/ */
-        $hosttocheck = 'http://checkip.dyndns.org';
+
+        // Get the check IP services.
+//        $mdlCheckIPService = new Service();
+        $mdlCheckIPService = new CheckIP();
+        $a_checkipservices = $mdlCheckIPService->service->getNodes();
+
+        // Append the factory default check IP service to the list.
+//        $mdlCheckIPFDS = new Factory_Default_Service();
+        $mdlCheckIPFDS = new CheckIP();
+        $a_checkipservices['FDS'] = $mdlCheckIPFDS->factory_default_service->getNodes();
+
+        // Is the factory default service disabled?
+        if ($mdlCheckIPService->disable_factory_default_service->__toString() == "1") {
+            $a_checkipservices['FDS']['default'] = 0;
+        }
+
+        /* Use the service specified by name. /*
+        /* Else use the first service found with a matching interface and IP version assignment. /*
+        /* Else use the enabled default service. */
+        foreach ($a_checkipservices as $i => $checkipservice) {
+            if ($checkipservice['name'] == $service || 
+               (!$service && 
+                $checkipservice['interfaces'][$int]['selected'] && 
+                $checkipservice['ipv']['ipv'.$ipver]['selected'])) {
+                    $found = true;
+            }
+            if ($found || $checkipservice['default']) {
+                $hosttocheck = $checkipservice['url'];
+                $regex = $checkipservice['regex'];
+                $username = $checkipservice['username'];
+                $password = $checkipservice['password'];
+                $verifysslpeer = $checkipservice['verifysslpeer'] ? true : false;
+                if ($found) { break; }
+            }
+        }
+
         $ip_ch = curl_init($hosttocheck);
         curl_setopt($ip_ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ip_ch, CURLOPT_SSL_VERIFYPEER, $verifysslpeer);
         curl_setopt($ip_ch, CURLOPT_INTERFACE, $ip_address);
         curl_setopt($ip_ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ip_ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ip_ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        curl_setopt($ip_ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+        curl_setopt($ip_ch, CURLOPT_USERPWD, "{$username}:{$password}");
         $ip_result = curl_exec($ip_ch);
         if ($ip_result !== false) {
-            preg_match('=<body>Current IP Address: (.*)</body>=siU', $ip_result, $matches);
+            preg_match('=' . $regex . '=siU', $ip_result, $matches);
             $ip_address = trim($matches[1]);
         } else {
             log_error('Aborted IPv4 detection: ' . curl_error($ip_ch));

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipserviceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipserviceController.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+//namespace OPNsense\CheckIP\Api;
+namespace OPNsense\DynDNS\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Core\Backend;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\Cron
+ */
+class CheckIPServiceController extends ApiControllerBase
+{
+    /**
+     * test CheckIP service
+     */
+    public function testAction()
+    {
+        if ($this->request->isPost()) {
+            $this->sessionClose();
+
+            // Retrieve data from the form post.
+            $service = $this->request->getPost("service");
+            $interface = $this->request->getPost("interface");
+            $ipv = $this->request->getPost("ipv");
+
+            $service = ($service == 'null') ? '' : $service;
+
+            $backend = new Backend();
+
+            $result['function'] = "service test";
+            $result['result'] = trim($backend->configdpRun('dynamicdns checkip test', array($service, $interface, $ipv)));
+            return $result;
+        } else {
+            return array('status' => 'failed');
+        }
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipsettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipsettingsController.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *    Copyright (C) 2017-2018 EURO-LOG AG
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+//namespace OPNsense\CheckIP\Api;
+namespace OPNsense\DynDNS\Api;
+
+use \OPNsense\Base\ApiMutableModelControllerBase;
+use \OPNsense\Core\Config;
+use \OPNsense\DynDNS\CheckIP;
+use \OPNsense\Base\UIModelGrid;
+
+/**
+ * Class SettingsController
+ * @package OPNsense\CheckIP
+ */
+class CheckIPSettingsController extends ApiMutableModelControllerBase
+{
+
+//    static protected $internalModelName = 'CheckIP';
+//    static protected $internalModelClass = '\OPNsense\CheckIP\Service';
+    static protected $internalModelName = 'DynDNS';
+    static protected $internalModelClass = '\OPNsense\DynDNS\Service';
+
+    /**
+     * list with valid model node types
+     */
+    private $nodeTypes = array('service');
+
+    /**
+     * query CheckIP settings
+     * @param $nodeType
+     * @param $uuid
+     * @return result array
+     */
+    public function getAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isGet() && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+            } else {
+                $node = $mdlCheckIPService->$nodeType->Add();
+            }
+            if ($node != null) {
+                $result['checkip'] = array($nodeType => $node->getNodes());
+                $result['result'] = 'ok';
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * set CheckIP properties
+     * @param $nodeType
+     * @param $uuid
+     * @return status array
+     */
+    public function setAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed", "validations" => array());
+        if ($this->request->isPost() && $this->request->hasPost("checkip") && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+            } else {
+                $node = $mdlCheckIPService->$nodeType->Add();
+            }
+            if ($node != null) {
+                $checkIPInfo = $this->request->getPost("checkip");
+
+                $node->setNodes($checkIPInfo[$nodeType]);
+                $valMsgs = $mdlCheckIPService->performValidation();
+                foreach ($valMsgs as $field => $msg) {
+                    $fieldnm = str_replace($node->__reference, "checkip." . $nodeType, $msg->getField());
+                    $result["validations"][$fieldnm] = $msg->getMessage();
+                }
+                if (empty($result["validations"])) {
+                    unset($result["validations"]);
+                    $result['result'] = 'ok';
+
+                    // If enabling this node, disable all others.  Only one service is to be enabled as the default.
+                    if ($node->default->__toString() == "1") {
+                        $this->disableAll($mdlCheckIPService, $nodeType);  // first disable all
+                        $node->default = "1";
+                    }
+
+                    $mdlCheckIPService->serializeToConfig();
+                    Config::getInstance()->save();
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * delete CheckIP settings
+     * @param $nodeType
+     * @param $uuid
+     * @return status array
+     */
+    public function delAction($nodeType = null, $uuid = null)
+    {
+        return $this->delBase('service', $uuid);
+    }
+
+    /**
+     * toggle CheckIP items (enable/disable)
+     * @param $nodeType
+     * @param $uuid
+     * @return result array
+     */
+    public function toggleAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isPost() && $nodeType != null) {
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+
+                if ($node != null) {    // toggle the service
+                    $default = $node->default->__toString();
+                    $this->disableAll($mdlCheckIPService, $nodeType);  // first disable all
+                    if (!$default) {    // toggle to default i.e. enabled state
+                        $node->default = "1"; 
+                    }
+                } elseif ($uuid == 'FDS') {    // toggle the factory default service (inverted logic)
+                    $default = $mdlCheckIPService->disable_factory_default_service->__toString();
+                    $this->disableAll($mdlCheckIPService, $nodeType);  // first disable all
+                    if ($default) {    // toggle to default i.e. enabled state
+                        $mdlCheckIPService->disable_factory_default_service = "0";
+                    }
+                } else {
+                    $result['result'] = "not found";
+                }
+
+                if ($result['result'] != 'not found') {
+                    $mdlCheckIPService->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result["result"] = "ok";
+                }
+
+            } else {
+                $result['result'] = "uuid not given";
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * search CheckIP settings
+     * @param $nodeType
+     * @return result array
+     */
+    public function searchAction($nodeType = null)
+    {
+        $this->sessionClose();
+        if ($this->request->isPost() && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+
+            $grid = new UIModelGrid($mdlCheckIPService->$nodeType);
+            $fields = array("default", "name", "url", "regex", "username", "password", "verifysslpeer", "description");
+            $grid = $grid->fetchBindRequest($this->request, $fields);
+
+            // Include the factory default check IP service.
+            $grid = $this->includeFDS($mdlCheckIPService, $grid);
+
+            return $grid;
+        }
+    }
+
+    /**
+     * validate nodeType
+     * @param $nodeType
+     * @throws \Exception
+     */
+    private function validateNodeType($nodeType = null)
+    {
+        if (array_search($nodeType, $this->nodeTypes) === false) {
+            throw new \Exception('unknown nodeType: ' . $nodeType);
+        }
+    }
+
+    /**
+     * is_default (is at least one CheckIP service enabled as the default; FDS inclusive)
+     * @return result array
+     */
+    public function is_defaultAction($nodeType = null)
+    {
+        $is_default = false;
+        if ($nodeType != null) {
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+
+            $nodes = $mdlCheckIPService->$nodeType->getNodes();
+            foreach ($nodes as $nodeUuid => $node) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $nodeUuid);
+                $is_default = $node->default->__toString() == "1" ? true : $is_default;
+            }
+            $is_default = ($mdlCheckIPService->disable_factory_default_service->__toString() == "1") ? $is_default : true;
+        }
+        return array('result' => $is_default);
+    }
+
+    /**
+     * disable all CheckIP service items; FDS inclusive
+     * @param $nodeType
+     * @param &$mdlCheckIPService
+     */
+    private function disableAll(&$mdlCheckIPService, $nodeType)
+    {
+        $nodes = $mdlCheckIPService->$nodeType->getNodes();
+        foreach ($nodes as $nodeUuid => $node) {
+            $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $nodeUuid);
+            $node->default = "0";
+        }
+        $mdlCheckIPService->disable_factory_default_service = "1";
+    }
+
+    /**
+     * Include the factory default check IP service.
+     */
+    private function includeFDS($mdlCheckIPService, $grid)
+    {
+//        $mdlCheckIPFDS = new Factory_Default_Service();
+        $mdlCheckIPFDS = new CheckIP();
+
+        $fds = $mdlCheckIPFDS->factory_default_service->getNodes();
+        $fds['default'] = ($mdlCheckIPService->disable_factory_default_service->__toString() == "1") ? "0" : "1";
+        $fds['uuid'] = 'FDS';
+
+        $grid['rows'][] = $fds;
+        $grid['rowCount'] = $grid['rowCount'] + 1;
+        $grid['total'] = $grid['total'] + 1;
+
+        return $grid;
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckiptestController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckiptestController.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+//namespace OPNsense\CheckIP\Api;
+namespace OPNsense\DynDNS\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\DynDNS\CheckIP;
+use \OPNsense\Core\Config;
+
+/**
+ * Class TestController Handles test settings related API actions for the Check IP module
+ * @package OPNsense\Cron
+ */
+class CheckIPTestController extends ApiControllerBase
+{
+    /**
+     * retrieve CheckIP test settings
+     * @return array test settings
+     */
+    public function getAction($nodeType = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isGet() && $nodeType == 'service') {
+
+            // Get the default test entry settings.
+//            $mdlCheckIPTest = new Test();
+            $mdlCheckIPTest = new CheckIP();
+            $so = $mdlCheckIPTest->test->getNodes();
+
+            // Get the services entries.
+//            $mdlCheckIPService = new Service();
+            $mdlCheckIPService = new CheckIP();
+            $nodes = $mdlCheckIPService->$nodeType->getNodes();
+
+            // Include the factory default check IP service.
+            $nodes = $this->includeFDS($mdlCheckIPService, $nodes);
+
+            // Populate the service options.
+            if (is_array($nodes)) {
+                foreach ($nodes as $nodeUuid => $node) {
+                    $servicename = $node['name'];
+                    $selected = ($node['default'] == "1") ? 1 : 0;
+
+                    $suffix1 = ($nodeUuid == "FDS") ? " (" . gettext("FDS") . ")" : "";
+                    $suffix2 = ($node['default'] == "1") ? " (" . gettext("default") . ")" : "";
+
+                    $so[$nodeType][$servicename]['@attributes']['uuid'] = $nodeUuid;
+                    $so[$nodeType][$servicename]['value'] = $servicename . $suffix1 . $suffix2;
+                    $so[$nodeType][$servicename]['selected'] = $selected;
+                }
+            }
+
+            $result['checkip']['test'] = $so;
+            $result['result'] = 'ok';
+        }
+        return $result;
+    }
+
+    /**
+     * Include the factory default check IP service.
+     */
+    private function includeFDS($mdlCheckIPService, $nodes)
+    {
+//        $mdlCheckIPFDS = new Factory_Default_Service();
+        $mdlCheckIPFDS = new CheckIP();
+
+        $fds = $mdlCheckIPFDS->factory_default_service->getNodes();
+        $fds['default'] = ($mdlCheckIPService->disable_factory_default_service->__toString() == "1") ? "0" : "1";
+        $fds['uuid'] = 'FDS';
+
+        $nodes[] = $fds;
+
+        return $nodes;
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/CheckipController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/CheckipController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+//namespace OPNsense\CheckIP;
+namespace OPNsense\DynDNS;
+
+/**
+ * Class IndexController
+ * @package OPNsense\CheckIP
+ */
+class CheckIPController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        // pick the template to serve to our users.
+//        $this->view->pick('OPNsense/CheckIP/index');
+        $this->view->pick('OPNsense/DynDNS/checkip');
+        // fetch form data "service" in
+        $this->view->serviceForm = $this->getForm("checkip_service");
+        // fetch form data "test" in
+        $this->view->testForm = $this->getForm("checkip_test");
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_service.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_service.xml
@@ -1,0 +1,70 @@
+<form>
+    <field>
+        <id>checkip.service.default</id>
+        <label>Default</label>
+        <input_label>Set this service as the default</input_label>
+        <type>checkbox</type>
+        <help>Sets this check IP service to be used as the default.</help>
+        <hint>Enable this service</hint>
+    </field>
+    <field>
+        <id>checkip.service.name</id>
+        <label>Name</label>
+        <type>text</type>
+        <help>The service name may only consist of the characters "a-z, A-Z, 0-9 and _".</help>
+        <hint>Enter a valid name</hint>
+    </field>
+    <field>
+        <id>checkip.service.url</id>
+        <label>URL</label>
+        <type>text</type>
+        <help>The service URL to use.</help>
+    </field>
+    <field>
+        <id>checkip.service.regex</id>
+        <label>Address capture regular expression</label>
+        <type>text</type>
+        <help>The regular expression to capture IP address.<![CDATA[<br />Examples:<br />&emsp;&lt;body&gt;Current IP Address: (.*)&lt;/body&gt;<br />&emsp;^(.*)$]]></help>
+    </field>
+    <field>
+        <id>checkip.service.interfaces</id>
+        <label>Interfaces</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help><![CDATA[The network interfaces to use this service on.]]></help>
+        <hint>Type or select interface.</hint>
+    </field>
+    <field>
+        <id>checkip.service.ipv</id>
+        <label>IP version</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help><![CDATA[The IP versions to use this service with.]]></help>
+        <hint>Type or select IP version.</hint>
+    </field>
+    <field>
+        <id>checkip.service.username</id>
+        <label>Username</label>
+        <type>text</type>
+        <help>The username to authenticate with the service.</help>
+    </field>
+    <field>
+        <id>checkip.service.password</id>
+        <label>Password</label>
+        <type>password</type>
+        <help>The password to authenticate with the service.</help>
+    </field>
+    <field>
+        <id>checkip.service.verifysslpeer</id>
+        <label>Verify SSL peer</label>
+        <input_label>Require SSL peer verification</input_label>
+        <type>checkbox</type>
+        <help>Verify that the certificate received from the server is valid and trusted by one of the installed certificate authorities (CA cert).</help>
+    </field>
+    <field>
+        <id>checkip.service.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>A description for administrative reference (not parsed).</help>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_test.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_test.xml
@@ -1,0 +1,23 @@
+<form>
+    <field>
+        <id>checkip.test.service</id>
+        <label>Service</label>
+        <type>dropdown</type>
+        <help><![CDATA[The Check IP service to test.<br>Leave empty for the service to be automatically selected based on interface and IP version, or the enabled default service.]]></help>
+        <hint>Select check IP service.</hint>
+    </field>
+    <field>
+        <id>checkip.test.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>The network interface to use for the test.</help>
+        <hint>Select network interface.</hint>
+    </field>
+    <field>
+        <id>checkip.test.ipv</id>
+        <label>IP Version</label>
+        <type>dropdown</type>
+        <help>The Internet Protocol version to use for the test.</help>
+        <hint>Select IP version.</hint>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/DynDNS/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DynDNS/ACL/ACL.xml
@@ -1,0 +1,10 @@
+<acl>
+   <page-services-dyndns-checkip>
+      <name>WebCfg - Services: DynDNS - Check IP page</name>
+      <description>Allow access to the 'Services: DynDNS - Check IP' page.</description>
+      <patterns>
+         <pattern>ui/DynDNS/*</pattern>
+         <pattern>api/DynDNS/*</pattern>
+      </patterns>
+   </page-services-dyndns-checkip>
+</acl>

--- a/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.php
+++ b/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+//namespace OPNsense\CheckIP;
+namespace OPNsense\DynDNS;
+
+use OPNsense\Base\BaseModel;
+
+class CheckIP extends BaseModel
+{
+}

--- a/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.xml
@@ -1,0 +1,145 @@
+<model>
+   <mount>//OPNsense/DynDNS/CheckIP</mount>
+   <version>1.0.0</version>
+   <description>CheckIP settings - Test</description>
+   <items>
+      <factory_default_service>
+         <default type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+         </default>
+         <name type="TextField">
+            <default>DynDNS</default>
+            <Required>Y</Required>
+         </name>
+         <url type="TextField">
+            <default>http://checkip.dyndns.org/</default>
+            <Required>Y</Required>
+         </url>
+         <regex type="TextField">
+            <default><![CDATA[<body>Current IP Address: (.*)</body>]]></default>
+            <Required>Y</Required>
+         </regex>
+         <interfaces type="InterfaceField">
+            <Required>N</Required>
+            <default>wan</default>
+            <multiple>Y</multiple>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+            </filters>
+         </interfaces>
+         <ipv type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <multiple>Y</multiple>
+            <OptionValues>
+               <ipv4>4</ipv4>
+               <ipv6>6</ipv6>
+            </OptionValues>
+         </ipv>
+         <username type="TextField">
+            <default></default>
+            <Required>N</Required>
+         </username>
+         <password type="TextField">
+            <default></default>
+            <Required>N</Required>
+         </password>
+         <verifysslpeer type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+         </verifysslpeer>
+         <description type="TextField">
+            <default>Factory Default Service</default>
+            <Required>N</Required>
+         </description>
+      </factory_default_service>
+      <disable_factory_default_service type="BooleanField">
+         <default>0</default>
+         <Required>N</Required>
+      </disable_factory_default_service>
+      <service type="ArrayField">
+         <default type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+         </default>
+         <name type="TextField">
+            <default></default>
+            <Required>Y</Required>
+            <mask>/^([a-zA-Z0-9_]){0,255}$/u</mask>
+            <ValidationMessage>A valid service name is mandatory</ValidationMessage>
+         </name>
+         <url type="TextField">
+            <default></default>
+            <Required>Y</Required>
+            <ValidationMessage>A correctly formated URL is mandatory</ValidationMessage>
+         </url>
+         <regex type="TextField">
+            <default><![CDATA[<body>Current IP Address: (.*)</body>]]></default>
+            <Required>Y</Required>
+            <ValidationMessage>An address capture regular expression is mandatory</ValidationMessage>
+         </regex>
+         <interfaces type="InterfaceField">
+            <Required>N</Required>
+            <default>wan</default>
+            <multiple>Y</multiple>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+            </filters>
+         </interfaces>
+         <ipv type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <multiple>Y</multiple>
+            <OptionValues>
+               <ipv4>4</ipv4>
+               <ipv6>6</ipv6>
+            </OptionValues>
+         </ipv>
+         <username type="TextField">
+            <default></default>
+            <Required>N</Required>
+         </username>
+         <password type="TextField">
+            <default></default>
+            <Required>N</Required>
+         </password>
+         <verifysslpeer type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+         </verifysslpeer>
+         <description type="TextField">
+            <default></default>
+            <Required>N</Required>
+            <mask>/^.{1,255}$/u</mask>
+            <ValidationMessage>Description too long.  Upto 255 characters.</ValidationMessage>
+         </description>
+      </service>
+      <test>
+         <service type="OptionField">
+            <default>null</default>
+            <Required>Y</Required>
+            <OptionValues>
+               <null></null>
+            </OptionValues>
+         </service>
+         <interface type="InterfaceField">
+            <default>wan</default>
+            <Required>Y</Required>
+            <AddParentDevices>Y</AddParentDevices>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+               <type>/(?s)^((?!group).)*$/</type>
+            </filters>
+         </interface>
+         <ipv type="OptionField">
+            <default>ipv4</default>
+            <Required>Y</Required>
+            <OptionValues>
+               <ipv4>4</ipv4>
+               <ipv6>6</ipv6>
+            </OptionValues>
+         </ipv>
+      </test>
+   </items>
+</model>

--- a/src/opnsense/mvc/app/models/OPNsense/DynDNS/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DynDNS/Menu/Menu.xml
@@ -1,0 +1,13 @@
+<menu>
+   <Services>
+      <DynDNS VisibleName="DynDNS" cssClass="fa fa-tags fa-fw">
+        <DynamicDNS order="10" VisibleName="Dynamic DNS" url="/services_dyndns.php" cssClass="fa fa-tags fa-fw">
+            <Edit url="/services_dyndns_edit.php*" visibility="hidden"/>
+        </DynamicDNS>
+        <RFC2136 order="20" VisibleName="RFC 2136" url="/services_rfc2136.php" cssClass="fa fa-tags fa-fw">
+            <Edit url="/services_rfc2136_edit.php*" visibility="hidden"/>
+        </RFC2136>
+          <CheckIP order="30" VisibleName="Check IP" url="/ui/dyndns/checkip"/>
+      </DynDNS>
+   </Services>
+</menu>

--- a/src/opnsense/mvc/app/views/OPNsense/DynDNS/checkip.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/DynDNS/checkip.volt
@@ -1,0 +1,219 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2015 by Deciso B.V.
+Copyright © 2017-2018 by EURO-LOG AG
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script>
+
+$( document ).ready(function() {
+
+  /**
+   * service settings
+   **/
+
+  $("#grid-services").UIBootgrid({
+    'search':'/api/dyndns/checkipsettings/search/service/',
+    'get':'/api/dyndns/checkipsettings/get/service/',
+    'set':'/api/dyndns/checkipsettings/set/service/',
+    'add':'/api/dyndns/checkipsettings/set/service/',
+    'del':'/api/dyndns/checkipsettings/del/service/',
+    'toggle':'/api/dyndns/checkipsettings/toggle/service/'
+  });
+
+  // Determine if at least one service is enabled as the default.  Allow, but warn if not.
+  function is_service_default() {
+    ajaxCall(url="/api/dyndns/checkipsettings/is_default/service/", sendData={}, callback=function(data,status) {
+      if (status == 'success' && data['result']) {
+         $("#responseMsg").css({'background-color': '', 'color': ''});
+         $("#responseMsg").addClass('hidden');
+         $("#responseMsg").html('');
+      } else {
+         $("#responseMsg").html("<b>{{ lang._('WARNING') }}: </b>{{ lang._('There is no default check IP service enabled!') }}");
+         $("#responseMsg").css({'background-color': 'yellow', 'color': 'red'});
+         $("#responseMsg").removeClass('hidden');
+      }
+    });
+  }
+
+  // Apply changes to the DOM
+  function dom_update() {
+    // suppress FDS selection checkbox and command buttons, and keep unselected
+    $('table#grid-services tbody tr[data-row-id="FDS"]').each(function() {
+      $(this).find('td.select-cell input.select-box').addClass('hidden');
+      $(this).find('td button').filter('.command-edit,.command-copy,.command-delete').addClass('hidden');
+      $(this).find('td.select-cell input.select-box').prop('checked', false);
+      $(this).attr('aria-selected', false);
+      $(this).removeClass('active');
+    });
+
+    // suppress fa-times icon for verify ssl peer disabled
+    var col_num = $('table#grid-services thead tr th[data-column-id=verifysslpeer]').index() + 1;
+    $('table#grid-services tbody tr td:nth-child(' + col_num + ') span').removeClass('fa-times');
+
+    // hyper-link each service URL
+    var col_num = $('table#grid-services thead tr th[data-column-id=url]').index() + 1;
+    $('table#grid-services tbody tr td:nth-child(' + col_num + ')').each(function() {
+      $(this).html('<a target="Check_IP" rel="noopener noreferrer" href="'+$(this).text()+'">'+$(this).text()+'</a>');
+    });
+  }
+
+  // DOM observer
+  var targetNode = document.querySelector('table#grid-services tbody');
+  var config = { childList: true };
+  var callback = function() {
+    dom_update();
+    is_service_default();
+  };
+  var observer = new MutationObserver(callback);
+  observer.observe(targetNode, config);
+
+  $('div#services').removeClass('hidden');
+
+
+  /**
+   * service test
+   */
+
+  $('[data-toggle][href=#test]').click(function(){
+    $('#full_help_button').addClass('hidden');
+    var data_get_map = {'frm_TestSettings':"/api/dyndns/checkiptest/get/service/"};
+    mapDataToFormUI(data_get_map).done(function(data){
+      // place actions to run after load, for example update form styles.
+        formatTokenizersUI();
+        $('.selectpicker').selectpicker('refresh');
+        // request service status on load and update status box
+        updateServiceControlUI('checkip');
+    });
+  });
+
+  $('#btn_test').unbind('click').click(function(){
+    $('#btn_test_progress').addClass("fa fa-spinner fa-pulse");
+
+    var formData = {
+      'service' : $('#checkip\\.test\\.service').val(),
+      'interface' : $('#checkip\\.test\\.interface').val(),
+      'ipv' : $('#checkip\\.test\\.ipv').val(),
+    };
+
+    ajaxCall(url="/api/dyndns/checkipservice/test", sendData=formData, callback=function(data,status) {
+      $('#btn_test_progress').removeClass("fa fa-spinner fa-pulse");
+      $('#btn_test').blur();
+
+      var resultobj = JSON.parse(data['result']);
+
+      var responseMsg  = '' +
+             '<b>Service: </b>' + resultobj.Service   + '<br/>' +
+           '<b>Interface: </b>' + resultobj.Interface + '<br/>' +
+          '<b>IP Version: </b>' + resultobj.IPVersion + '<br/>' +
+          '<b>IP Address: </b>' + resultobj.IPAddress + '<br/>';
+
+      $("#responseMsg").html(responseMsg);
+      $("#responseMsg").css({'background-color': '', 'color': ''});
+      $("#responseMsg").removeClass("hidden");
+    });
+  });
+
+});
+
+</script>
+
+<div class="alert alert-info hidden" role="alert" id="responseMsg"></div>
+
+<ul class="nav nav-tabs" role="tablist" id="maintabs">
+  <li class="active"><a data-toggle="tab" href="#services">{{ lang._('Service Settings') }}</a></li>
+  <li><a data-toggle="tab" href="#test">{{ lang._('Service Test') }}</a></li>
+</ul>
+
+<div class="tab-content content-box">
+
+  <div id="services" class="tab-pane fade in active hidden">
+
+    <table id="grid-services" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogEditService">
+      <thead>
+        <tr>
+          <th data-column-id="default" data-width="6em" data-type="string" data-formatter="rowtoggle" data-css-class="text-center" data-header-css-class="text-center">{{ lang._('Default') }}</th>
+          <th data-column-id="name" data-width="6em" data-type="string">{{ lang._('Name') }}</th>
+          <th data-column-id="url" data-width="24em" data-type="string" data-sortable="false">{{ lang._('URL') }}</th>
+          <th data-column-id="verifysslpeer" data-width="9em" data-type="string" data-formatter="boolean" data-css-class="text-center" data-header-css-class="text-center">{{ lang._('Verify SSL Peer') }}</th>
+          <th data-column-id="description" data-width="15em" data-type="string">{{ lang._('Description') }}</th>
+          <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+          <th data-column-id="commands" data-width="8em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+      <tfoot>
+      <tr>
+        <td colspan="6"></td>
+          <td>
+            <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <table class="table">
+      <tr>
+        <td><a id="help_for_services" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a></td>
+        <td>
+          <div class="hidden" data-for="help_for_services">
+              <p><?= htmlspecialchars(gettext('These services will be used to check IP addresses for Dynamic DNS services, and RFC 2136 entries that have the "Use public IP" option enabled.')) ?></p>
+              <p><?= htmlspecialchars(gettext('If a check IP service with a matching interface and IP version assignment is not found. The one enabled here as the default will be used.')) ?></p>
+              <p><?= htmlspecialchars(gettext('The server must return the client IP address as a string in the format of the "address capture regular expression" option that is specified in the service configuration.')) ?></p>
+              <hr/>
+                 <?= htmlspecialchars(gettext('Examples of address capture regular expression')) ?><br/>
+                 <?= htmlspecialchars(gettext('HTML containing address:')) ?>
+            <pre><?= htmlspecialchars('<body>Current IP Address: (.*)</body>') ?></pre>
+                 <?= htmlspecialchars(gettext('Text only address:')) ?>
+            <pre><?= htmlspecialchars('^(.*)$') ?></pre>
+              <hr/>
+                 <?= htmlspecialchars(gettext('Examples of server PHP')) ?><br/>
+                 <?= htmlspecialchars(gettext('HTML:')) ?>
+            <pre><?= htmlspecialchars('<html><head><title>Current IP Check</title></head><body>Current IP Address: <?=$_SERVER[\'REMOTE_ADDR\']?></body></html>') ?></pre>
+                 <?= htmlspecialchars(gettext('Text:')) ?>
+            <pre><?= htmlspecialchars('<?=$_SERVER[\'REMOTE_ADDR\']?>') ?></pre>
+          </div>
+        </td>
+      </tr>
+    </table>
+
+  </div>
+
+  <div id="test" class="tab-pane fade in">
+    {{ partial("layout_partials/base_form",['fields':testForm,'id':'frm_TestSettings'])}}
+
+    <div class="col-md-12">
+      <hr/>
+        <button style='margin-bottom: 1em;' class="btn btn-primary" id="btn_test" type="button"><b>{{ lang._('Test Service') }}</b><i id="btn_test_progress" class=""></i></button>
+    </div>
+  </div>
+
+</div>
+
+{# include dialogs #}
+{{ partial("layout_partials/base_dialog",['fields':serviceForm,'id':'DialogEditService','label':'Edit Service'])}}

--- a/src/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
+++ b/src/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
@@ -1,0 +1,46 @@
+#!/usr/local/bin/php
+<?php
+/**
+ *    Copyright (C) 2018 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+require_once("config.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
+require_once("services.inc");
+
+  $service = (isset($argv[1])) ? trim($argv[1], " \n")    : '';
+$interface = (isset($argv[2])) ? trim($argv[2], " \n")    : 'wan';
+      $ipv = (isset($argv[3])) ? trim($argv[3], "ipv \n") : 4;
+
+$result = array(
+      'Service' => ($service ? $service : gettext('selected by interface and IP version, or the enabled default service')), 
+    'Interface' => $interface, 
+    'IPVersion' => $ipv, 
+    'IPAddress' => get_dyndns_ip($interface, $ipv, $service)
+);
+echo json_encode($result);
+?>

--- a/src/opnsense/service/conf/actions.d/actions_dynamicdns.conf
+++ b/src/opnsense/service/conf/actions.d/actions_dynamicdns.conf
@@ -1,0 +1,5 @@
+[checkip.test]
+command:/usr/local/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
+parameters:%s %s %s
+type:script_output
+message:testing check ip service


### PR DESCRIPTION
Allow other, public and private, check IP services to be used.

Features:
  * Interface specific configurable check IP services.  The service with matching interface and IP version, or the one that is enabled as the default, will be used by Dynamic DNS and RFC2136 services to check IP addresses.
  * Verify SSL peer option
  * Service backend test facility

services.inc changes overview:
  * The get_dyndns_ip function updated to support using check IP services based on service name or interface and IP version, and a default check IP service other than factory default.
  * Factory default check IP service as array from MVC Check IP model Factory_Default_Service class.
  * Facilitate verify SSL peer option
  * Facilitate authentication
  * Facilitate service specific regular expression address capture