### PR TITLE
Fix Unbound stats autorefresh not working

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/stats.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/stats.volt
@@ -130,7 +130,7 @@ POSSIBILITY OF SUCH DAMAGE.
     $(document).ready(function() {
 
         // Autorefresh every 10 seconds.
-        setTimeout(function() {
+        setInterval(function() {
             if ($("#auto_refresh").is(':checked')) {
                 updateStats();
             }


### PR DESCRIPTION
Noticed this when checking the stats clearing problem. It would only update once.