### PR TITLE
Fix HTML errors

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4357,7 +4357,7 @@ function get_interfaces_info()
         if ($bridge) {
             $bridge_text = `/sbin/ifconfig {$bridge}`;
             if (stristr($bridge_text, "blocking") <> false) {
-                $ifinfo['bridge'] = "<b><font color='red'>" . gettext("blocking") . "</font></b> - " . gettext("check for ethernet loops");
+                $ifinfo['bridge'] = "<b><span style='color: red'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
                 $ifinfo['bridgeint'] = $bridge;
             } elseif (stristr($bridge_text, "learning") <> false) {
                 $ifinfo['bridge'] = gettext("learning");

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4357,7 +4357,7 @@ function get_interfaces_info()
         if ($bridge) {
             $bridge_text = `/sbin/ifconfig {$bridge}`;
             if (stristr($bridge_text, "blocking") <> false) {
-                $ifinfo['bridge'] = "<b><span style='color: red'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
+                $ifinfo['bridge'] = "<b><span class='text-danger'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
                 $ifinfo['bridgeint'] = $bridge;
             } elseif (stristr($bridge_text, "learning") <> false) {
                 $ifinfo['bridge'] = gettext("learning");

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -462,7 +462,7 @@ $( document ).ready(function() {
                         <input name="<?=$fieldId;?>" type="password" value="<?=$field['value'];?>" />
 <?php
                         elseif ($field['type'] == 'textarea'):?>
-                        <textarea name="<?=$fieldId;?>" type="text" rows="10"><?=$pconfig[$fieldId];?></textarea>
+                        <textarea name="<?=$fieldId;?>" rows="10"><?=$pconfig[$fieldId];?></textarea>
 <?php
                         endif;?>
                         <div class="hidden" data-for="help_for_<?=$fieldId;?>">

--- a/src/www/diag_ipsec_spd.php
+++ b/src/www/diag_ipsec_spd.php
@@ -73,9 +73,9 @@ legacy_html_escape_form_data($spd);
                 <tr>
                   <td colspan="2"></td>
                   <td colspan="3">
-                    <span class="fa fa-arrow-right fa-fw" aria-hidden="true" alt="in"></span>
+                    <span class="fa fa-arrow-right fa-fw" aria-hidden="true"></span>
                     <?= gettext("incoming (as seen by firewall)"); ?> <br/>
-                    <span class="fa fa-arrow-left fa-fw" aria-hidden="true" alt="out"></span>
+                    <span class="fa fa-arrow-left fa-fw" aria-hidden="true"></span>
                     <?= gettext("outgoing (as seen by firewall)"); ?>
                   </td>
                 </tr>

--- a/src/www/diag_limiter_info.php
+++ b/src/www/diag_limiter_info.php
@@ -68,7 +68,7 @@ include("head.inc");
       });
   }
   function activitycallback(transport) {
-    jQuery('#limiteractivitydiv').html('<font face="Courier" size="2"><pre style="text-align:left;">' + transport.responseText  + '<\/pre><\/font>');
+    jQuery('#limiteractivitydiv').html('<pre class="text-left">' + transport.responseText  + '</pre>');
     setTimeout('getlimiteractivity()', 2000);
   }
   setTimeout('getlimiteractivity()', 1000);

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -2066,7 +2066,7 @@ include("head.inc");
                     </thead>
                        <body>
                           <tr>
-                          <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext('Service Provider') ?></td>
+                          <td style="width: 22%;"><i class="fa fa-info-circle text-muted"></i> <?=gettext('Service Provider') ?></td>
                           <td>
                             <select name="rfc3118_isp" class="selectpicker" data-style="btn-default" id="rfc3118_isp">
 <?php

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -1024,7 +1024,7 @@ include("head.inc");
                             foreach($numberoptions as $item):?>
                               <tr>
                                 <td>
-                                  <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                                  <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                                 </td>
                                 <td>
                                   <input name="numberoptions_number[]" type="text" value="<?=$item['number'];?>" />
@@ -1071,7 +1071,7 @@ include("head.inc");
                             <tfoot>
                               <tr>
                                 <td colspan="4">
-                                  <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                                  <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                                 </td>
                               </tr>
                             </tfoot>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -684,7 +684,7 @@ if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
                             foreach($numberoptions as $item):?>
                               <tr>
                                 <td>
-                                  <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                                  <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                                 </td>
                                 <td>
                                   <input name="numberoptions_number[]" type="text" value="<?=$item['number'];?>" />
@@ -731,7 +731,7 @@ if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
                             <tfoot>
                               <tr>
                                 <td colspan="4">
-                                  <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                                  <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                                 </td>
                               </tr>
                             </tfoot>

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -248,7 +248,7 @@ include("head.inc");
                       foreach($aliases as $item):?>
                         <tr>
                           <td>
-                            <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                            <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                           </td>
                           <td>
                             <input name="aliases_host[]" type="text" value="<?=$item['host'];?>" />
@@ -266,7 +266,7 @@ include("head.inc");
                       <tfoot>
                         <tr>
                           <td colspan="4">
-                            <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                            <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                           </td>
                         </tr>
                       </tfoot>

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -272,7 +272,7 @@ include("head.inc");
                         foreach($pconfig['timeservers_host'] as $item_idx => $timeserver):?>
                           <tr>
                             <td>
-                              <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                              <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                             </td>
                             <td>
                               <input name="timeservers_host[]" type="text" value="<?=$timeserver;?>" />
@@ -290,7 +290,7 @@ include("head.inc");
                         <tfoot>
                           <tr>
                             <td colspan="4">
-                              <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                              <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                             </td>
                           </tr>
                         </tfoot>

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -279,7 +279,7 @@ if (!isset($_GET['act'])) {
                       foreach ($acl_networks as $item_idx => $item):?>
                         <tr>
                           <td>
-                            <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                            <div style="cursor:pointer;" class="act-removerow btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                           </td>
                           <td>
                             <input name="acl_networks_acl_network[]" type="text" id="acl_network_<?=$item_idx;?>" value="<?=$item['acl_network'];?>" />
@@ -305,7 +305,7 @@ if (!isset($_GET['act'])) {
                       <tfoot>
                         <tr>
                           <td colspan="4">
-                            <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                            <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                           </td>
                         </tr>
                       </tfoot>
@@ -342,7 +342,7 @@ if (!isset($_GET['act'])) {
                     <th><?=gettext("Network"); ?></th>
                   </tr>
                 </thead>
-                <body>
+                <tbody>
 <?php foreach (unbound_acls_subnets() as $subnet): ?>
                   <tr>
                     <td><?= gettext('Internal') ?></td>

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -497,7 +497,7 @@ endif;?>
 <?php if (!empty($data['if'])): ?>
 <?php if ($data['type'] == 'dynamic'): ?>
                         <a class="btn btn-default btn-xs" href="services_dhcpv6_edit.php?if=<?=$data['if'];?>&amp;duid=<?=$data['duid'];?>&amp;hostname=<?=$data['hostname'];?>">
-                          <i class="fa fa-plus fa-fw" alt="add"></i>
+                          <i class="fa fa-plus fa-fw"></i>
                         </a>
 <?php if ($data['online'] != 'online'): ?>
                     <a class="act_delete btn btn-default btn-xs" href="#" data-deleteip="<?=$data['ip'];?>" title="<?= html_safe(gettext('Delete')) ?>" data-toggle="tooltip">

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -760,10 +760,10 @@ $main_buttons = array(
                   </table>
                 </td>
                 <td class="text-nowrap">
-                  <a href="system_camanager.php?act=edit&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit CA");?>" alt="<?=gettext("edit CA");?>" class="btn btn-default btn-xs">
+                  <a href="system_camanager.php?act=edit&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("edit CA");?>" class="btn btn-default btn-xs">
                     <i class="fa fa-pencil fa-fw"></i>
                   </a>
-                  <a href="system_camanager.php?act=exp&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("export CA cert");?>" alt="<?=gettext("export CA cert");?>" class="btn btn-default btn-xs">
+                  <a href="system_camanager.php?act=exp&amp;id=<?=$i;?>" data-toggle="tooltip" title="<?=gettext("export CA cert");?>" class="btn btn-default btn-xs">
                     <i class="fa fa-download fa-fw"></i>
                   </a>
 <?php

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -938,7 +938,7 @@ $( document ).ready(function() {
                           <input name="altname_value[]" type="text" size="20" value="" />
                         </td>
                         <td>
-                          <div style="cursor:pointer;" class="act-removerow-altnm btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                          <div style="cursor:pointer;" class="act-removerow-altnm btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                         </td>
                       </tr>
 <?php
@@ -958,7 +958,7 @@ $( document ).ready(function() {
                             <input name="altname_value[]" type="text" size="20" value="<?=$item;?>" />
                           </td>
                           <td>
-                            <div style="cursor:pointer;" class="act-removerow-altnm btn btn-default btn-xs" alt="remove"><i class="fa fa-minus fa-fw"></i></div>
+                            <div style="cursor:pointer;" class="act-removerow-altnm btn btn-default btn-xs"><i class="fa fa-minus fa-fw"></i></div>
                           </td>
                         </tr>
 
@@ -970,7 +970,7 @@ $( document ).ready(function() {
                       <tr>
                         <td colspan="2"></td>
                         <td>
-                          <div id="addNewAltNm" style="cursor:pointer;" class="btn btn-default btn-xs" alt="add"><i class="fa fa-plus fa-fw"></i></div>
+                          <div id="addNewAltNm" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                         </td>
                       </tr>
                     </tfoot>

--- a/src/www/vpn_ipsec_settings.php
+++ b/src/www/vpn_ipsec_settings.php
@@ -214,7 +214,7 @@ if (isset($input_errors) && count($input_errors) > 0) {
 <?php                   foreach (array("Silent", "Basic", "Audit", "Control", "Raw", "Highest") as $lidx => $lvalue) :
                           $lidx -= 1;
 ?>
-                          <option value="<?=$lidx?>" <?= (isset($pconfig["ipsec_{$lkey}"]) && $pconfig["ipsec_{$lkey}"] == $lidx) || (!isset($pconfig["ipsec_{$lkey}"]) && $lidx == "0")  ? "selected=\"selected\"" : "";?> ?>
+                          <option value="<?=$lidx?>" <?= (isset($pconfig["ipsec_{$lkey}"]) && $pconfig["ipsec_{$lkey}"] == $lidx) || (!isset($pconfig["ipsec_{$lkey}"]) && $lidx == "0")  ? "selected=\"selected\"" : "";?>
                                 <?=$lvalue?>
                           </option>
 <?php

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1077,7 +1077,7 @@ endif; ?>
                     </tr>
                     <tr>
                       <td style="width:22%" id="ipv4_tunnel_network"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
-                      <td width="78%">
+                      <td style="width:78%">
                         <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
                         <div class="hidden" data-for="help_for_tunnel_network">
                             <?=gettext("This is the IPv4 virtual network used for private " .

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1077,7 +1077,7 @@ endif; ?>
                     </tr>
                     <tr>
                       <td style="width:22%" id="ipv4_tunnel_network"><a id="help_for_tunnel_network" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("IPv4 Tunnel Network"); ?></td>
-                      <td witdh="78%">
+                      <td width="78%">
                         <input name="tunnel_network" type="text" class="form-control unknown" size="20" value="<?=$pconfig['tunnel_network'];?>" />
                         <div class="hidden" data-for="help_for_tunnel_network">
                             <?=gettext("This is the IPv4 virtual network used for private " .

--- a/src/www/widgets/widgets/carp_status.widget.php
+++ b/src/www/widgets/widgets/carp_status.widget.php
@@ -54,13 +54,13 @@ config_read_array('virtualip', 'vip');
 <?php
       if (get_single_sysctl('net.inet.carp.allow') <= 0 ) {
           $status = gettext("DISABLED");
-          echo "<span class=\"fa fa-remove fa-fw text-danger\" title=\"$status\" alt=\"$status\" ></span>";
+          echo "<span class=\"fa fa-remove fa-fw text-danger\" title=\"$status\" ></span>";
       } elseif ($status == gettext("MASTER")) {
-          echo "<span class=\"fa fa-play fa-fw text-success\" title=\"$status\" alt=\"$status\" ></span>";
+          echo "<span class=\"fa fa-play fa-fw text-success\" title=\"$status\" ></span>";
       } elseif ($status == gettext("BACKUP")) {
-          echo "<span class=\"fa fa-play fa-fw text-muted\" title=\"$status\" alt=\"$status\" ></span>";
+          echo "<span class=\"fa fa-play fa-fw text-muted\" title=\"$status\" ></span>";
       } elseif ($status == gettext("INIT")) {
-          echo "<span class=\"fa fa-info-circle fa-fw\" title=\"$status\" alt=\"$status\" ></span>";
+          echo "<span class=\"fa fa-info-circle fa-fw\" title=\"$status\" ></span>";
       }
       if (!empty($carp['subnet'])):?>
         &nbsp;

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -885,9 +885,6 @@ include("head.inc");
                                     if ($field['typehint'] <> "") {
                                         echo $field['typehint'];
                                     }
-                                    if ($field['warning'] <> "") {
-                                        echo "<br /><b><span class='text-warning'>" . $field['warning'] . "</font></b>";
-                                    }
 
                                     if (!$field['combinefieldsbegin']) {
                                         if (!$field['dontcombinecells'])

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -477,7 +477,7 @@ include("head.inc");
                                         case "text":
                                             echo "<td colspan=\"2\" style=\"text-align:center\">\n";
                                             if ($field['description'] <> "") {
-                                                echo "<center><br /> " . gettext($field['description']) . "</center>";
+                                                echo "<div class='text-center'><br /> " . gettext($field['description']) . "</div>";
                                             }
                                             break;
                                         case "inputalias":
@@ -886,7 +886,7 @@ include("head.inc");
                                         echo $field['typehint'];
                                     }
                                     if ($field['warning'] <> "") {
-                                        echo "<br /><b><font color=\"red\">" . $field['warning'] . "</font></b>";
+                                        echo "<br /><b><span class='text-warning'>" . $field['warning'] . "</font></b>";
                                     }
 
                                     if (!$field['combinefieldsbegin']) {


### PR DESCRIPTION
This fixes some typos, deprecated elements and the usage of the `alt` attribute on `<div>` elements (which is not allowed and does not work either).