### PR TITLE
fix advanced field bug in dialogs

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -106,7 +106,7 @@ label           :   dialog label
             <col class="col-md-{{ msgzone_width|default(5) }}"/>
         </colgroup>
         <thead>
-          <tr>
+          <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>
             <th colspan="3"><h2>{{field['label']}}</h2></th>
           </tr>
         </thead>


### PR DESCRIPTION
copied that line from the base form - it makes advanced headers working in dialogs (base_form already has it).