### PR TITLE
firewall: ignore empty values in alias migration

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Migrations/M1_0_0.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Migrations/M1_0_0.php
@@ -77,7 +77,7 @@ class M1_0_0 extends BaseModelMigration
                     $node->content = implode("\n", $content);
                 } elseif ($alias->address) {
                     // address entries
-                    $node->content = str_replace(" ", "\n", (string)$alias->address);
+                    $node->content = str_replace(" ", "\n", trim((string)$alias->address));
                 }
                 if ($alias->proto) {
                     $node->proto = (string)$alias->proto;


### PR DESCRIPTION
It just happened that the alias migration failed on a device that was in use for 3+ years. The error message was not very useful (because there's no hint which entry is erroneous):

```
Nov 22 23:20:12 opnsense config[71480]: [OPNsense\Firewall\Alias:aliases.alias.d8c784bb-e748-47fa-bada-2dc68b622c18.content] Entry "" is not a valid port number.
Nov 22 23:20:12 opnsense config[71480]: Model OPNsense\Firewall\Alias can't be saved, skip ( Phalcon\Validation\Exception: [OPNsense\Firewall\Alias:aliases.alias.d8c784bb-e748-47fa-bada-2dc68b622c18.content] Entry "" is not a valid port number.  in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:538 Stack trace: #0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(645): OPNsense\Base\BaseModel->serializeToConfig() #1 /usr/local/opnsense/mvc/script/run_migrations.php(56): OPNsense\Base\BaseModel->runMigrations() #2 {main} )
```

After searching through hundreds of alias entries I've finally found an entry that dates back to 2015:

```
    <alias>
      <name>my_alias</name>
      <detail>Entry added Thu, 10 Sep 2015 13:29:44 +0200||Entry added Thu, 10 Sep 2015 13:29:44 +0200||Entry added Thu, 10 Sep 2015 13:30:06 +0200</detail>
      <address>nexted_alias1 nested_alias2 </address>
      <type>port</type>
      <descr>test</descr>
    </alias>
```

Not easy to spot, but the `<address>` tag has a space at the end, and `<detail>` reveals that this should have been a 3rd entry. Since this dates back to 2015 I have no idea how this could have happened, but I'm 100% sure that I've never added an alias manually (i.e. by modifying config.xml). So this may be the result of an ancient bug.

I've seen some reports about failed alias migration, maybe a few others are affected by this specific "bug" too.

I've created a simple fix, which resulted in a flawless alias migration.