### PR TITLE
Replace uncommon <> notation with !=

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -196,7 +196,7 @@ function cert_import(& $cert, $crt_str, $key_str)
     $issuer = cert_get_issuer($crt_str, false);
 
     // Find my issuer unless self-signed
-    if($issuer <> $subject) {
+    if($issuer != $subject) {
         $issuer_crt =& lookup_ca_by_subject($issuer);
         if($issuer_crt) {
             $cert['caref'] = $issuer_crt['refid'];

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -365,7 +365,7 @@ function filter_configure_sync($verbose = false, $flush_states = false)
         $limitrules .= "set ruleset-optimization basic\n";
     }
 
-    if ($config['system']['optimization'] != "") {
+    if ($config['system']['optimization'] != '') {
         $limitrules .= "set optimization {$config['system']['optimization']}\n";
         if ($config['system']['optimization'] == "conservative") {
             $limitrules .= "set timeout { udp.first 300, udp.single 150, udp.multiple 900 }\n";

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -365,7 +365,7 @@ function filter_configure_sync($verbose = false, $flush_states = false)
         $limitrules .= "set ruleset-optimization basic\n";
     }
 
-    if ($config['system']['optimization'] <> "") {
+    if ($config['system']['optimization'] != "") {
         $limitrules .= "set optimization {$config['system']['optimization']}\n";
         if ($config['system']['optimization'] == "conservative") {
             $limitrules .= "set timeout { udp.first 300, udp.single 150, udp.multiple 900 }\n";

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -469,10 +469,10 @@ function interface_bridge_configure(&$bridge, $checkmember = 0)
         }
     }
 
-    if ($bridge['maxaddr'] != "") {
+    if ($bridge['maxaddr'] != '') {
         mwexec("/sbin/ifconfig {$bridgeif} maxaddr " . escapeshellarg($bridge['maxaddr']));
     }
-    if ($bridge['timeout'] != "") {
+    if ($bridge['timeout'] != '') {
         mwexec("/sbin/ifconfig {$bridgeif} timeout " . escapeshellarg($bridge['timeout']));
     }
     if (!empty($bridge['span'])) {
@@ -4190,7 +4190,7 @@ function get_failover_interface($interface, $family = 'all')
     $a_groups = return_gateway_groups_array();
     if (isset($a_groups[$interface])) {
         /* we found a gateway group, fetch the interface or vip */
-        if ($a_groups[$interface][0]['vip'] != "") {
+        if ($a_groups[$interface][0]['vip'] != '') {
             return $a_groups[$interface][0]['vip'];
         } else {
             return $a_groups[$interface][0]['int'];
@@ -4356,13 +4356,13 @@ function get_interfaces_info()
         $bridge = link_interface_to_bridge($ifdescr);
         if ($bridge) {
             $bridge_text = `/sbin/ifconfig {$bridge}`;
-            if (stristr($bridge_text, "blocking") != false) {
+            if (stristr($bridge_text, 'blocking') != false) {
                 $ifinfo['bridge'] = "<b><span class='text-danger'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
                 $ifinfo['bridgeint'] = $bridge;
-            } elseif (stristr($bridge_text, "learning") != false) {
+            } elseif (stristr($bridge_text, 'learning') != false) {
                 $ifinfo['bridge'] = gettext("learning");
                 $ifinfo['bridgeint'] = $bridge;
-            } elseif (stristr($bridge_text, "forwarding") != false) {
+            } elseif (stristr($bridge_text, 'forwarding') != false) {
                 $ifinfo['bridge'] = gettext("forwarding");
                 $ifinfo['bridgeint'] = $bridge;
             }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -79,7 +79,7 @@ function convert_ipv6_to_128bit($ipv6)
 
 function convert_128bit_to_ipv6($ip6bin)
 {
-    if (strlen($ip6bin) <> 128) {
+    if (strlen($ip6bin) != 128) {
         return false;
     }
 
@@ -469,10 +469,10 @@ function interface_bridge_configure(&$bridge, $checkmember = 0)
         }
     }
 
-    if ($bridge['maxaddr'] <> "") {
+    if ($bridge['maxaddr'] != "") {
         mwexec("/sbin/ifconfig {$bridgeif} maxaddr " . escapeshellarg($bridge['maxaddr']));
     }
-    if ($bridge['timeout'] <> "") {
+    if ($bridge['timeout'] != "") {
         mwexec("/sbin/ifconfig {$bridgeif} timeout " . escapeshellarg($bridge['timeout']));
     }
     if (!empty($bridge['span'])) {
@@ -1756,7 +1756,7 @@ function interface_wireless_clone($realif, $wlcfg)
 
         log_error("Cloning new wireless interface {$realif}");
         exec("/sbin/ifconfig wlan create wlandev {$baseif} {$mode} bssid name {$realif} 2>&1", $out, $ret);
-        if ($ret <> 0) {
+        if ($ret != 0) {
             log_error("Failed to clone interface {$baseif} with error code {$ret}, output {$out[0]}");
             return false;
         }
@@ -3985,7 +3985,7 @@ function ip_in_interface_alias_subnet($interface, $ipalias)
         foreach ($config['virtualip']['vip'] as $vip) {
             switch ($vip['mode']) {
                 case "ipalias":
-                    if ($vip['interface'] <> $interface) {
+                    if ($vip['interface'] != $interface) {
                         break;
                     }
                     $subnet = is_ipaddrv6($ipalias) ? gen_subnetv6($vip['subnet'], $vip['subnet_bits']) : gen_subnet($vip['subnet'], $vip['subnet_bits']);
@@ -4190,7 +4190,7 @@ function get_failover_interface($interface, $family = 'all')
     $a_groups = return_gateway_groups_array();
     if (isset($a_groups[$interface])) {
         /* we found a gateway group, fetch the interface or vip */
-        if ($a_groups[$interface][0]['vip'] <> "") {
+        if ($a_groups[$interface][0]['vip'] != "") {
             return $a_groups[$interface][0]['vip'];
         } else {
             return $a_groups[$interface][0]['int'];
@@ -4356,13 +4356,13 @@ function get_interfaces_info()
         $bridge = link_interface_to_bridge($ifdescr);
         if ($bridge) {
             $bridge_text = `/sbin/ifconfig {$bridge}`;
-            if (stristr($bridge_text, "blocking") <> false) {
+            if (stristr($bridge_text, "blocking") != false) {
                 $ifinfo['bridge'] = "<b><span class='text-danger'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
                 $ifinfo['bridgeint'] = $bridge;
-            } elseif (stristr($bridge_text, "learning") <> false) {
+            } elseif (stristr($bridge_text, "learning") != false) {
                 $ifinfo['bridge'] = gettext("learning");
                 $ifinfo['bridgeint'] = $bridge;
-            } elseif (stristr($bridge_text, "forwarding") <> false) {
+            } elseif (stristr($bridge_text, "forwarding") != false) {
                 $ifinfo['bridge'] = gettext("forwarding");
                 $ifinfo['bridgeint'] = $bridge;
             }

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -996,7 +996,7 @@ function openvpn_restart($mode, $settings)
     $a_groups = return_gateway_groups_array();
     if (is_array($a_groups[$settings['interface']])) {
         /* the interface is a gateway group. If a vip is defined and its a CARP backup then do not start */
-        if (($a_groups[$settings['interface']][0]['vip'] != "") &&
+        if (($a_groups[$settings['interface']][0]['vip'] != '') &&
             get_carp_interface_status($a_groups[$settings['interface']][0]['vip']) == "BACKUP") {
             return;
         }

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -996,7 +996,7 @@ function openvpn_restart($mode, $settings)
     $a_groups = return_gateway_groups_array();
     if (is_array($a_groups[$settings['interface']])) {
         /* the interface is a gateway group. If a vip is defined and its a CARP backup then do not start */
-        if (($a_groups[$settings['interface']][0]['vip'] <> "") &&
+        if (($a_groups[$settings['interface']][0]['vip'] != "") &&
             get_carp_interface_status($a_groups[$settings['interface']][0]['vip']) == "BACKUP") {
             return;
         }

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -76,7 +76,7 @@ function webgui_configure_do($verbose = false, $interface = '')
     $ca = '';
 
     /* non-standard port? */
-    if (isset($config['system']['webgui']['port']) && $config['system']['webgui']['port'] != "") {
+    if (isset($config['system']['webgui']['port']) && $config['system']['webgui']['port'] != '') {
         $portarg = "{$config['system']['webgui']['port']}";
     }
 

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -76,7 +76,7 @@ function webgui_configure_do($verbose = false, $interface = '')
     $ca = '';
 
     /* non-standard port? */
-    if (isset($config['system']['webgui']['port']) && $config['system']['webgui']['port'] <> "") {
+    if (isset($config['system']['webgui']['port']) && $config['system']['webgui']['port'] != "") {
         $portarg = "{$config['system']['webgui']['port']}";
     }
 

--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -31,7 +31,7 @@ function rrd_create($rrdcreatecmd)
     $rrdcreateoutput = array();
     $rrdcreatereturn = 0;
     $_gb = exec("$rrdcreatecmd 2>&1", $rrdcreateoutput, $rrdcreatereturn);
-    if ($rrdcreatereturn <> 0) {
+    if ($rrdcreatereturn != 0) {
         $rrdcreateoutput = implode(" ", $rrdcreateoutput);
         log_error(sprintf('RRD create failed exited with %s, the error is: %s', $rrdcreatereturn, $rrdcreateoutput));
     }
@@ -138,7 +138,7 @@ function rrd_configure($verbose = false)
         /* process all real and pseudo interfaces */
         foreach ($ifdescrs as $ifname => $ifdescr) {
             $temp = get_real_interface($ifname);
-            if ($temp <> "") {
+            if ($temp != "") {
                 $realif = $temp;
             }
 

--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -138,7 +138,7 @@ function rrd_configure($verbose = false)
         /* process all real and pseudo interfaces */
         foreach ($ifdescrs as $ifname => $ifdescr) {
             $temp = get_real_interface($ifname);
-            if ($temp != "") {
+            if ($temp != '') {
                 $realif = $temp;
             }
 

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -943,7 +943,7 @@ EOD;
                 }
 
                 if (isset($sm['ddnsupdate'])) {
-                    if (($sm['ddnsdomain'] != "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
+                    if (($sm['ddnsdomain'] != '') && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
                         $smdnscfg .= "    ddns-domainname \"{$sm['ddnsdomain']}\";\n";
                     }
                     $smdnscfg .= "    ddns-update-style interim;\n";

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -52,7 +52,7 @@ require_once('plugins.inc.d/unbound.inc');
 function generate_ipv6_from_mac($mac)
 {
     $elements = explode(":", $mac);
-    if (count($elements) <> 6) {
+    if (count($elements) != 6) {
         return false;
     }
 
@@ -943,7 +943,7 @@ EOD;
                 }
 
                 if (isset($sm['ddnsupdate'])) {
-                    if (($sm['ddnsdomain'] <> "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
+                    if (($sm['ddnsdomain'] != "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
                         $smdnscfg .= "    ddns-domainname \"{$sm['ddnsdomain']}\";\n";
                     }
                     $smdnscfg .= "    ddns-update-style interim;\n";

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -190,7 +190,7 @@ function system_resolvconf_generate($verbose = false)
         $dnsgw = "dns{$dnscounter}gw";
         if (isset($syscfg[$dnsgw])) {
             $gwname = $syscfg[$dnsgw];
-            if (($gwname != "") && ($gwname != "none")) {
+            if (($gwname != '') && ($gwname != 'none')) {
                 $gatewayip = lookup_gateway_ip_by_name($gwname);
                 if (is_ipaddrv4($gatewayip)) {
                     /* dns server array starts at 0 */

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -190,7 +190,7 @@ function system_resolvconf_generate($verbose = false)
         $dnsgw = "dns{$dnscounter}gw";
         if (isset($syscfg[$dnsgw])) {
             $gwname = $syscfg[$dnsgw];
-            if (($gwname <> "") && ($gwname <> "none")) {
+            if (($gwname != "") && ($gwname != "none")) {
                 $gatewayip = lookup_gateway_ip_by_name($gwname);
                 if (is_ipaddrv4($gatewayip)) {
                     /* dns server array starts at 0 */

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1138,7 +1138,7 @@ function set_sysctl($values)
     exec("/sbin/sysctl -i " . implode(" ", $value_list), $output, $success);
 
     /* Retry individually if failed (one or more read-only) */
-    if ($success <> 0 && count($value_list) > 1) {
+    if ($success != 0 && count($value_list) > 1) {
         foreach ($value_list as $value) {
             exec("/sbin/sysctl -i " . $value, $output);
         }

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -55,7 +55,7 @@ function get_vip_config_section()
         if ($section['mode'] != "carp") {
             continue;
         }
-        if (isset($section['advskew']) && $section['advskew'] != "") {
+        if (isset($section['advskew']) && $section['advskew'] != '') {
             $advskew = intval($section['advskew'])+100;
             if ($advskew > 254) {
                 $advskew = 254;
@@ -188,7 +188,7 @@ function carp_sync_xml($url, $username, $password, $sections, $method = 'opnsens
     // dhcpd, unchanged from legacy code (may need some inspection later)
     if (is_array($transport_data['dhcpd'])) {
         foreach($transport_data['dhcpd'] as $dhcpif => $dhcpifconf) {
-            if(isset($dhcpifconf['failover_peerip']) && $dhcpifconf['failover_peerip'] != "") {
+            if(isset($dhcpifconf['failover_peerip']) && $dhcpifconf['failover_peerip'] != '') {
                 $int = guess_interface_from_ip($dhcpifconf['failover_peerip']);
                 $intip = find_interface_ip($int);
                 $transport_data['dhcpd'][$dhcpif]['failover_peerip'] = $intip;

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -55,7 +55,7 @@ function get_vip_config_section()
         if ($section['mode'] != "carp") {
             continue;
         }
-        if (isset($section['advskew']) && $section['advskew'] <> "") {
+        if (isset($section['advskew']) && $section['advskew'] != "") {
             $advskew = intval($section['advskew'])+100;
             if ($advskew > 254) {
                 $advskew = 254;
@@ -188,7 +188,7 @@ function carp_sync_xml($url, $username, $password, $sections, $method = 'opnsens
     // dhcpd, unchanged from legacy code (may need some inspection later)
     if (is_array($transport_data['dhcpd'])) {
         foreach($transport_data['dhcpd'] as $dhcpif => $dhcpifconf) {
-            if(isset($dhcpifconf['failover_peerip']) && $dhcpifconf['failover_peerip'] <> "") {
+            if(isset($dhcpifconf['failover_peerip']) && $dhcpifconf['failover_peerip'] != "") {
                 $int = guess_interface_from_ip($dhcpifconf['failover_peerip']);
                 $intip = find_interface_ip($int);
                 $transport_data['dhcpd'][$dhcpif]['failover_peerip'] = $intip;

--- a/src/opnsense/mvc/app/library/OPNsense/Core/Shell.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Shell.php
@@ -100,7 +100,7 @@ class Shell
         if (!$this->simulate) {
             exec("$command 2>&1", $output, $retval);
 
-            if (($retval <> 0) && ($mute === false)) {
+            if (($retval != 0) && ($mute === false)) {
                 // TODO: log
                 unset($output);
             }

--- a/src/opnsense/scripts/dhcp/prefixes.php
+++ b/src/opnsense/scripts/dhcp/prefixes.php
@@ -53,7 +53,7 @@ foreach (file($leases_file) as $line) {
 
 $routes = array();
 foreach ($duid_arr as $entry) {
-    if ($entry['ia-pd'] <> "") {
+    if ($entry['ia-pd'] != "") {
         $routes[$entry['ia-na']] = $entry['ia-pd'];
     }
     array_shift($duid_arr);

--- a/src/opnsense/scripts/dhcp/prefixes.php
+++ b/src/opnsense/scripts/dhcp/prefixes.php
@@ -53,7 +53,7 @@ foreach (file($leases_file) as $line) {
 
 $routes = array();
 foreach ($duid_arr as $entry) {
-    if ($entry['ia-pd'] != "") {
+    if ($entry['ia-pd'] != '') {
         $routes[$entry['ia-na']] = $entry['ia-pd'];
     }
     array_shift($duid_arr);

--- a/src/opnsense/service/tests/template.py
+++ b/src/opnsense/service/tests/template.py
@@ -94,7 +94,7 @@ class TestTemplateMethods(unittest.TestCase):
         :return:
         """
         generated_filenames = self.tmpl.generate('OPNsense.Sample')
-        self.assertEquals(len(generated_filenames), 3, 'number of output files <> 3')
+        self.assertEquals(len(generated_filenames), 3, 'number of output files != 3')
 
     def test_all(self):
         """ Test if all expected templates are created, can only find test for static defined cases.

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -330,7 +330,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       if (!empty($pconfig['statetimeout']))
           $input_errors[] = gettext("You can only specify the state timeout (advanced option) for TCP protocol.");
     }
-    if ($pconfig['type'] != "pass") {
+    if ($pconfig['type'] != 'pass') {
       if (!empty($pconfig['max']))
           $input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for Pass type rules.");
       if (!empty($pconfig['max-src-nodes']))

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -330,7 +330,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       if (!empty($pconfig['statetimeout']))
           $input_errors[] = gettext("You can only specify the state timeout (advanced option) for TCP protocol.");
     }
-    if ($pconfig['type'] <> "pass") {
+    if ($pconfig['type'] != "pass") {
       if (!empty($pconfig['max']))
           $input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for Pass type rules.");
       if (!empty($pconfig['max-src-nodes']))

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -132,7 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if ($pconfig['mode'] == 'carp') {
             /* verify against reusage of vhids */
             foreach($config['virtualip']['vip'] as $vipId => $vip) {
-               if (isset($vip['vhid']) &&  $vip['vhid'] == $pconfig['vhid'] && $vip['interface'] == $pconfig['interface'] && $vipId <> $id) {
+               if (isset($vip['vhid']) &&  $vip['vhid'] == $pconfig['vhid'] && $vip['interface'] == $pconfig['interface'] && $vipId != $id) {
                    $input_errors[] = sprintf(gettext("VHID %s is already in use on interface %s. Pick a unique number on this interface."),$pconfig['vhid'], convert_friendly_interface_to_friendly_descr($pconfig['interface']));
                }
             }

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -271,7 +271,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           foreach ($_POST as $ifname => $ifport) {
               if (!is_array($ifport) && ($ifname == 'lan' || $ifname == 'wan' || substr($ifname, 0, 3) == 'opt')) {
                   $reloadif = false;
-                  if (!empty($config['interfaces'][$ifname]['if']) && $config['interfaces'][$ifname]['if'] <> $ifport) {
+                  if (!empty($config['interfaces'][$ifname]['if']) && $config['interfaces'][$ifname]['if'] != $ifport) {
                       interface_bring_down($ifname);
                       /* Mark this to be reconfigured in any case. */
                       $reloadif = true;

--- a/src/www/interfaces_bridge_edit.php
+++ b/src/www/interfaces_bridge_edit.php
@@ -193,7 +193,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($bridge['bridgeif']);
-            if ($confif != "") {
+            if ($confif != '') {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_bridge.php'));

--- a/src/www/interfaces_bridge_edit.php
+++ b/src/www/interfaces_bridge_edit.php
@@ -193,7 +193,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($bridge['bridgeif']);
-            if ($confif <> "") {
+            if ($confif != "") {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_bridge.php'));

--- a/src/www/interfaces_gif_edit.php
+++ b/src/www/interfaces_gif_edit.php
@@ -126,7 +126,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($gif['gifif']);
-            if ($confif <> "") {
+            if ($confif != "") {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_gif.php'));

--- a/src/www/interfaces_gif_edit.php
+++ b/src/www/interfaces_gif_edit.php
@@ -126,7 +126,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($gif['gifif']);
-            if ($confif != "") {
+            if ($confif != '') {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_gif.php'));

--- a/src/www/interfaces_gre_edit.php
+++ b/src/www/interfaces_gre_edit.php
@@ -100,7 +100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($gre['greif']);
-            if ($confif != "") {
+            if ($confif != '') {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_gre.php'));

--- a/src/www/interfaces_gre_edit.php
+++ b/src/www/interfaces_gre_edit.php
@@ -100,7 +100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($gre['greif']);
-            if ($confif <> "") {
+            if ($confif != "") {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_gre.php'));

--- a/src/www/interfaces_lagg_edit.php
+++ b/src/www/interfaces_lagg_edit.php
@@ -144,7 +144,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($lagg['laggif']);
-            if ($confif != "") {
+            if ($confif != '') {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_lagg.php'));

--- a/src/www/interfaces_lagg_edit.php
+++ b/src/www/interfaces_lagg_edit.php
@@ -144,7 +144,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             write_config();
             $confif = convert_real_interface_to_friendly_interface_name($lagg['laggif']);
-            if ($confif <> "") {
+            if ($confif != "") {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_lagg.php'));

--- a/src/www/interfaces_vlan_edit.php
+++ b/src/www/interfaces_vlan_edit.php
@@ -104,7 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     legacy_interface_destroy("{$a_vlans[$id]['if']}_vlan{$a_vlans[$id]['tag']}");
                     $confif = convert_real_interface_to_friendly_interface_name("{$a_vlans[$id]['if']}_vlan{$a_vlans[$id]['tag']}");
                 }
-                if ($confif <> "") {
+                if ($confif != "") {
                     $config['interfaces'][$confif]['if'] = "{$_POST['if']}_vlan{$_POST['tag']}";
                 }
                 $vlan['vlanif'] = interface_vlan_configure($vlan);
@@ -122,7 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
 
-            if ($confif <> "") {
+            if ($confif != "") {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_vlan.php'));

--- a/src/www/interfaces_vlan_edit.php
+++ b/src/www/interfaces_vlan_edit.php
@@ -122,7 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             write_config();
 
-            if ($confif != "") {
+            if ($confif != '') {
                 interface_configure(false, $confif);
             }
             header(url_safe('Location: /interfaces_vlan.php'));

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -436,7 +436,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $exec_filter_configure = true;
                 }
                 $previous = !empty($config['dhcpd'][$if]['failover_peerip']) ? $config['dhcpd'][$if]['failover_peerip'] : "";
-                if($previous <> $pconfig['failover_peerip']) {
+                if($previous != $pconfig['failover_peerip']) {
                     mwexec("/bin/rm -rf /var/dhcpd/var/db/*");
                 }
             }
@@ -1139,7 +1139,7 @@ include("head.inc");
                     $i = 0;
                     foreach ($config['dhcpd'][$if]['staticmap'] as $mapent): ?>
 <?php
-                        if($mapent['mac'] <> "" || $mapent['ipaddr'] <> ""): ?>
+                        if($mapent['mac'] != "" || $mapent['ipaddr'] != ""): ?>
                     <tr>
                       <td>
 <?php

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -1139,7 +1139,7 @@ include("head.inc");
                     $i = 0;
                     foreach ($config['dhcpd'][$if]['staticmap'] as $mapent): ?>
 <?php
-                        if($mapent['mac'] != "" || $mapent['ipaddr'] != ""): ?>
+                        if($mapent['mac'] != '' || $mapent['ipaddr'] != ''): ?>
                     <tr>
                       <td>
 <?php

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -183,11 +183,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $f = $f+2;
                     break;
                 case "client-hostname":
-                    if($data[$f+1] <> "") {
+                    if($data[$f+1] != "") {
                         $leases[$l]['hostname'] = preg_replace('/"/','',$data[$f+1]);
                     } else {
                         $hostname = gethostbyaddr($leases[$l]['ip']);
-                        if ($hostname <> "") {
+                        if ($hostname != "") {
                             $leases[$l]['hostname'] = $hostname;
                         }
                     }

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -252,11 +252,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $f = $f+2;
                     break;
                 case "client-hostname":
-                    if ($data[$f+1] != "") {
+                    if ($data[$f+1] != '') {
                         $entry['hostname'] = preg_replace('/"/','',$data[$f+1]);
                     } else {
                         $hostname = gethostbyaddr($entry['ip']);
-                        if ($hostname != "") {
+                        if ($hostname != '') {
                             $entry['hostname'] = $hostname;
                         }
                     }

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -252,11 +252,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $f = $f+2;
                     break;
                 case "client-hostname":
-                    if ($data[$f+1] <> "") {
+                    if ($data[$f+1] != "") {
                         $entry['hostname'] = preg_replace('/"/','',$data[$f+1]);
                     } else {
                         $hostname = gethostbyaddr($entry['ip']);
-                        if ($hostname <> "") {
+                        if ($hostname != "") {
                             $entry['hostname'] = $hostname;
                         }
                     }

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -55,7 +55,7 @@ function ca_import(& $ca, $str, $key="", $serial=0) {
     if (is_array($config['ca'])) {
         foreach ($config['ca'] as & $oca) {
             $issuer = cert_get_issuer($oca['crt']);
-            if($ca['refid']!=$oca['refid'] && $issuer==$subject) {
+            if ($ca['refid'] != $oca['refid'] && $issuer == $subject) {
                 $oca['caref'] = $ca['refid'];
             }
         }

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -44,7 +44,7 @@ function ca_import(& $ca, $str, $key="", $serial=0) {
     $issuer = cert_get_issuer($str, false);
 
     // Find my issuer unless self-signed
-    if($issuer <> $subject) {
+    if($issuer != $subject) {
         $issuer_crt =& lookup_ca_by_subject($issuer);
         if($issuer_crt) {
             $ca['caref'] = $issuer_crt['refid'];
@@ -55,7 +55,7 @@ function ca_import(& $ca, $str, $key="", $serial=0) {
     if (is_array($config['ca'])) {
         foreach ($config['ca'] as & $oca) {
             $issuer = cert_get_issuer($oca['crt']);
-            if($ca['refid']<>$oca['refid'] && $issuer==$subject) {
+            if($ca['refid']!=$oca['refid'] && $issuer==$subject) {
                 $oca['caref'] = $ca['refid'];
             }
         }

--- a/src/www/system_gateways_edit.php
+++ b/src/www/system_gateways_edit.php
@@ -148,7 +148,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     }
-    if (($pconfig['monitor'] != "") && !is_ipaddr($pconfig['monitor']) && $pconfig['monitor'] != "dynamic") {
+    if (($pconfig['monitor'] != '') && !is_ipaddr($pconfig['monitor']) && $pconfig['monitor'] != 'dynamic') {
         $input_errors[] = gettext("A valid monitor IP address must be specified.");
     }
     /* only allow correct IPv4 and IPv6 gateway addresses */

--- a/src/www/system_gateways_edit.php
+++ b/src/www/system_gateways_edit.php
@@ -148,7 +148,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     }
-    if (($pconfig['monitor'] <> "") && !is_ipaddr($pconfig['monitor']) && $pconfig['monitor'] != "dynamic") {
+    if (($pconfig['monitor'] != "") && !is_ipaddr($pconfig['monitor']) && $pconfig['monitor'] != "dynamic") {
         $input_errors[] = gettext("A valid monitor IP address must be specified.");
     }
     /* only allow correct IPv4 and IPv6 gateway addresses */

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -80,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       $dnsgwname="dns{$dnscounter}gw";
       if (!empty($pconfig[$dnsname]) && !is_ipaddr($pconfig[$dnsname])) {
         $input_errors[] = gettext("A valid IP address must be specified for DNS server $dnscounter.");
-      } elseif(!empty($pconfig[$dnsgwname]) && $pconfig[$dnsgwname] <> "none") {
+      } elseif(!empty($pconfig[$dnsgwname]) && $pconfig[$dnsgwname] != "none") {
             // A real gateway has been selected.
             if (is_ipaddr($pconfig[$dnsname])) {
                 if ((is_ipaddrv4($pconfig[$dnsname])) && (validate_address_family($pconfig[$dnsname], $pconfig[$dnsgwname]) === false )) {

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -80,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       $dnsgwname="dns{$dnscounter}gw";
       if (!empty($pconfig[$dnsname]) && !is_ipaddr($pconfig[$dnsname])) {
         $input_errors[] = gettext("A valid IP address must be specified for DNS server $dnscounter.");
-      } elseif(!empty($pconfig[$dnsgwname]) && $pconfig[$dnsgwname] != "none") {
+      } elseif(!empty($pconfig[$dnsgwname]) && $pconfig[$dnsgwname] != 'none') {
             // A real gateway has been selected.
             if (is_ipaddr($pconfig[$dnsname])) {
                 if ((is_ipaddrv4($pconfig[$dnsname])) && (validate_address_family($pconfig[$dnsname], $pconfig[$dnsgwname]) === false )) {

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -94,7 +94,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         foreach ($del_items as $p1entrydel) {
             /* remove static route if interface is not WAN */
-            if ($a_phase1[$p1entrydel]['interface'] != "wan") {
+            if ($a_phase1[$p1entrydel]['interface'] != 'wan') {
                 /* XXX does this even apply? only use of system.inc at the top! */
                 system_host_route($a_phase1[$p1entrydel]['remote-gateway'], $a_phase1[$p1entrydel]['remote-gateway'], true, false);
             }
@@ -387,7 +387,7 @@ $( document ).ready(function() {
 
                             $grouplist = return_gateway_groups_array();
                             foreach ($grouplist as $name => $group) {
-                                if ($group[0]['vip'] != "") {
+                                if ($group[0]['vip'] != '') {
                                     $vipif = $group[0]['vip'];
                                 } else {
                                     $vipif = $group[0]['int'];

--- a/src/www/vpn_ipsec.php
+++ b/src/www/vpn_ipsec.php
@@ -94,7 +94,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         foreach ($del_items as $p1entrydel) {
             /* remove static route if interface is not WAN */
-            if ($a_phase1[$p1entrydel]['interface'] <> "wan") {
+            if ($a_phase1[$p1entrydel]['interface'] != "wan") {
                 /* XXX does this even apply? only use of system.inc at the top! */
                 system_host_route($a_phase1[$p1entrydel]['remote-gateway'], $a_phase1[$p1entrydel]['remote-gateway'], true, false);
             }
@@ -387,7 +387,7 @@ $( document ).ready(function() {
 
                             $grouplist = return_gateway_groups_array();
                             foreach ($grouplist as $name => $group) {
-                                if ($group[0]['vip'] <> "") {
+                                if ($group[0]['vip'] != "") {
                                     $vipif = $group[0]['vip'];
                                 } else {
                                     $vipif = $group[0]['int'];

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -233,7 +233,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         (empty($pconfig['iketype']) || $pconfig['iketype'] == "ikev1")) {
         $t = 0;
         foreach ($a_phase1 as $ph1tmp) {
-            if ($p1index <> $t) {
+            if ($p1index != $t) {
                 if (isset($ph1tmp['remote-gateway']) && $ph1tmp['remote-gateway'] == $pconfig['remote-gateway'] && !isset($ph1tmp['disabled'])) {
                     $input_errors[] = sprintf(gettext('The remote gateway "%s" is already used by phase1 "%s".'), $pconfig['remote-gateway'], $ph1tmp['descr']);
                 }
@@ -410,8 +410,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
 
         /* if the remote gateway changed and the interface is not WAN then remove route */
-        if ($pconfig['interface'] <> "wan") {
-            if ($old_ph1ent['remote-gateway'] <> $pconfig['remote-gateway']) {
+        if ($pconfig['interface'] != "wan") {
+            if ($old_ph1ent['remote-gateway'] != $pconfig['remote-gateway']) {
                 /* XXX does this even apply? only use of system.inc at the top! */
                 system_host_route($old_ph1ent['remote-gateway'], $old_ph1ent['remote-gateway'], true, false);
             }
@@ -657,7 +657,7 @@ include("head.inc");
 
                       $grouplist = return_gateway_groups_array();
                       foreach ($grouplist as $name => $group) {
-                          if ($group[0]['vip'] <> "") {
+                          if ($group[0]['vip'] != "") {
                               $vipif = $group[0]['vip'];
                           } else {
                               $vipif = $group[0]['int'];

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -657,7 +657,7 @@ include("head.inc");
 
                       $grouplist = return_gateway_groups_array();
                       foreach ($grouplist as $name => $group) {
-                          if ($group[0]['vip'] != "") {
+                          if ($group[0]['vip'] != '') {
                               $vipif = $group[0]['vip'];
                           } else {
                               $vipif = $group[0]['int'];

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -642,7 +642,7 @@ $( document ).ready(function() {
                   if ($group['ipprotocol'] != "inet") {
                       continue;
                   }
-                  if ($group[0]['vip'] != "") {
+                  if ($group[0]['vip'] != '') {
                       $vipif = $group[0]['vip'];
                   } else {
                       $vipif = $group[0]['int'];

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -642,7 +642,7 @@ $( document ).ready(function() {
                   if ($group['ipprotocol'] != "inet") {
                       continue;
                   }
-                  if ($group[0]['vip'] <> "") {
+                  if ($group[0]['vip'] != "") {
                       $vipif = $group[0]['vip'];
                   } else {
                       $vipif = $group[0]['int'];

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -336,7 +336,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $server = array();
 
             // delete(rename) old interface so a new TUN or TAP interface can be created.
-            if (isset($id) && $pconfig['dev_mode'] <> $a_server[$id]['dev_mode']) {
+            if (isset($id) && $pconfig['dev_mode'] != $a_server[$id]['dev_mode']) {
                 openvpn_delete('server', $a_server[$id]);
             }
             // 1 on 1 copy of config attributes
@@ -762,7 +762,7 @@ $( document ).ready(function() {
                             if ($group['ipprotocol'] != "inet") {
                                 continue;
                             }
-                            if ($group[0]['vip'] <> "") {
+                            if ($group[0]['vip'] != "") {
                                 $vipif = $group[0]['vip'];
                             } else {
                                 $vipif = $group[0]['int'];

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -762,7 +762,7 @@ $( document ).ready(function() {
                             if ($group['ipprotocol'] != "inet") {
                                 continue;
                             }
-                            if ($group[0]['vip'] != "") {
+                            if ($group[0]['vip'] != '') {
                                 $vipif = $group[0]['vip'];
                             } else {
                                 $vipif = $group[0]['int'];

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -132,16 +132,16 @@ if ($pkg['step'][$stepid]['stepsubmitbeforesave']) {
 
 if ($_POST && !$input_errors) {
     foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-        if (!empty($field['bindstofield']) and $field['type'] != "submit") {
+        if (!empty($field['bindstofield']) and $field['type'] != 'submit') {
             $fieldname = $field['name'];
             $fieldname = str_replace(" ", "", $fieldname);
             $fieldname = strtolower($fieldname);
             // update field with posted values.
-            if ($field['unsetfield'] != "")
+            if ($field['unsetfield'] != '')
                 $unset_fields = "yes";
             else
                 $unset_fields = "";
-            if ($field['arraynum'] != "")
+            if ($field['arraynum'] != '')
                 $arraynum = $field['arraynum'];
             else
                 $arraynum = "";
@@ -152,7 +152,7 @@ if ($_POST && !$input_errors) {
     }
 
     // run custom php code embedded in xml config.
-    if ($pkg['step'][$stepid]['stepsubmitphpaction'] != "") {
+    if ($pkg['step'][$stepid]['stepsubmitphpaction'] != '') {
         eval($pkg['step'][$stepid]['stepsubmitphpaction']);
     }
 
@@ -178,9 +178,9 @@ function update_config_field($field, $updatetext, $unset, $arraynum, $field_type
         $field_conv .= "['" . $f . "']";
     if ($field_conv == "")
         return;
-    if ($arraynum != "")
+    if ($arraynum != '')
         $field_conv .= "[" . $arraynum . "]";
-    if (($field_type == "checkbox" and $updatetext != "on") || $updatetext == "") {
+    if (($field_type == 'checkbox' && $updatetext != 'on') || $updatetext == '') {
         /*
          * item is a checkbox, it should have the value "on"
          * if it was checked
@@ -274,7 +274,7 @@ include("head.inc");
 
 <?php include("fbegin.inc"); ?>
 
-<?php if ($pkg['step'][$stepid]['fields']['field'] != "") { ?>
+<?php if ($pkg['step'][$stepid]['fields']['field'] != '') { ?>
     <script>
         //<![CDATA[
 
@@ -419,7 +419,7 @@ include("head.inc");
                         <table class="table table-striped">
                             <?php
                             $inputaliases = array();
-                            if ($pkg['step'][$stepid]['fields']['field'] != "") {
+                            if ($pkg['step'][$stepid]['fields']['field'] != '') {
                                 foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
 
                                     $value = $field['value'];
@@ -434,7 +434,7 @@ include("head.inc");
                                         $field_split = explode("->", $field['bindstofield']);
                                         // arraynum is used in cases where there is an array of the same field
                                         // name such as dnsserver (2 of them)
-                                        if ($field['arraynum'] != "")
+                                        if ($field['arraynum'] != '')
                                             $arraynum = "[" . $field['arraynum'] . "]";
                                         foreach ($field_split as $f)
                                             $field_conv .= "['" . $f . "']";
@@ -470,13 +470,13 @@ include("head.inc");
                                                 echo " onchange='FieldValidate(this.value, \"{$field['validate']}\", \"{$field['message']}\");'";
                                             echo " />\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
                                             break;
                                         case "text":
                                             echo "<td colspan=\"2\" style=\"text-align:center\">\n";
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<div class='text-center'><br /> " . gettext($field['description']) . "</div>";
                                             }
                                             break;
@@ -501,7 +501,7 @@ include("head.inc");
                                                 echo " onchange='FieldValidate(this.value, \"{$field['validate']}\", \"{$field['message']}\");'";
                                             echo " />\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
                                             break;
@@ -513,13 +513,13 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
-                                            if ($field['multiple'] != "" and $field['multiple'] != "0") {
+                                            if ($field['size'] != '') $size = "size=\"{$field['size']}\"";
+                                            if ($field['multiple'] != '' and $field['multiple'] != '0') {
                                                 $multiple = "multiple=\"multiple\"";
                                                 $name .= "[]";
                                             }
                                             echo "<select class='form-control' id='{$name}' name='{$name}' {$size} {$multiple}>\n";
-                                            if ($field['add_to_interfaces_selection'] != "") {
+                                            if ($field['add_to_interfaces_selection'] != '') {
                                                 $SELECTED = "";
                                                 if ($field['add_to_interfaces_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_interfaces_selection'] . "'" . $SELECTED . ">" . $field['add_to_interfaces_selection'] . "</option>\n";
@@ -535,7 +535,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ifname . "'" . $SELECTED . ">" . $iface . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['interface_filter'] != "") {
+                                                if ($field['interface_filter'] != '') {
                                                     if (stristr($ifname, $field['interface_filter']) == true)
                                                         $canecho = 1;
                                                 } else
@@ -545,7 +545,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -567,7 +567,7 @@ include("head.inc");
                                                 echo " size='" . $field['size'] . "' ";
                                             echo " />\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -580,9 +580,9 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
+                                            if ($field['size'] != '') $size = "size=\"{$field['size']}\"";
                                             echo "<select id='{$name}' name='{$name}' {$size}>\n";
-                                            if ($field['add_to_certca_selection'] != "") {
+                                            if ($field['add_to_certca_selection'] != '') {
                                                 $SELECTED = "";
                                                 if ($field['add_to_certca_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_certca_selection'] . "'" . $SELECTED . ">" . $field['add_to_certca_selection'] . "</option>\n";
@@ -597,7 +597,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ca['refid'] . "'" . $SELECTED . ">" . $name . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['certca_filter'] != "") {
+                                                if ($field['certca_filter'] != '') {
                                                     if (stristr($name, $field['certca_filter']) == true)
                                                         $canecho = 1;
                                                 } else {
@@ -621,9 +621,9 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
+                                            if ($field['size'] != '') $size = "size=\"{$field['size']}\"";
                                             echo "<select id='{$name}' name='{$name}' {$size}>\n";
-                                            if ($field['add_to_cert_selection'] != "") {
+                                            if ($field['add_to_cert_selection'] != '') {
                                                 $SELECTED = "";
                                                 if ($field['add_to_cert_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_cert_selection'] . "'" . $SELECTED . ">" . $field['add_to_cert_selection'] . "</option>\n";
@@ -637,7 +637,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ca['refid'] . "'" . $SELECTED . ">" . $name . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['cert_filter'] != "") {
+                                                if ($field['cert_filter'] != '') {
                                                     if (stristr($name, $field['cert_filter']) == true)
                                                         $canecho = 1;
                                                 } else {
@@ -648,7 +648,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -678,7 +678,7 @@ include("head.inc");
                                             echo "</select>\n";
                                             echo "<!-- {$value} -->\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -699,7 +699,7 @@ include("head.inc");
                                                 echo "<td class=\"vtable\">\n";
                                             $onchange = "";
                                             foreach ($field['options']['option'] as $opt) {
-                                                if ($opt['enablefields'] != "") {
+                                                if ($opt['enablefields'] != '') {
                                                     $onchange = "onchange=\"enableitems(this.selectedIndex);\" ";
                                                 }
                                             }
@@ -718,7 +718,7 @@ include("head.inc");
                                             echo "</select>\n";
                                             echo "<!-- {$value} -->\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -743,7 +743,7 @@ include("head.inc");
                                             echo ">" . $value . "</textarea>\n";
 
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -752,7 +752,7 @@ include("head.inc");
                                             echo "<td colspan=\"2\" style=\"text-align:center\">";
                                             echo "<input type='submit' class=\"btn btn-primary\" name='" . $name . "' value=\"" . htmlspecialchars(gettext($field['name'])) . "\" />\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -790,7 +790,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -819,7 +819,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -850,7 +850,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -866,7 +866,7 @@ include("head.inc");
                                                 echo ":</td>";
                                             }
                                             $checked = "";
-                                            if ($value != "")
+                                            if ($value != '')
                                                 $checked = " checked=\"checked\"";
                                             echo "<td class=\"vtable\"><input value=\"on\" type='checkbox' id='" . $name . "' name='" . $name . "' " . $checked;
                                             if (isset($field['enablefields']) or isset($field['checkenablefields']))
@@ -875,14 +875,14 @@ include("head.inc");
                                                 echo " onclick=\"disablechange()\"";
                                             echo " />\n";
 
-                                            if ($field['description'] != "") {
+                                            if ($field['description'] != '') {
                                                 echo gettext($field['description']);
                                             }
 
                                             break;
                                     }
 
-                                    if ($field['typehint'] != "") {
+                                    if ($field['typehint'] != '') {
                                         echo $field['typehint'];
                                     }
 
@@ -899,11 +899,11 @@ include("head.inc");
 
                         </table>
                         <?php
-                        if ($pkg['step'][$stepid]['fields']['field'] != "") {
+                        if ($pkg['step'][$stepid]['fields']['field'] != '') {
                             foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
                                 switch ($field['type']) {
                                     case "refresh":
-                                        if ($field['page'] != "" && $field['time'] != "") {
+                                        if ($field['page'] != "" && $field['time'] != '') {
                                             echo '<meta http-equiv="refresh" content="' . $field['time'] . ';url=' . redirect_url() . '/' . $field['page'] . '">';
                                         }
                                         break 2;
@@ -965,15 +965,15 @@ include("head.inc");
 <?php
 
 $fieldnames_array = Array();
-if ($pkg['step'][$stepid]['disableallfieldsbydefault'] != "") {
+if ($pkg['step'][$stepid]['disableallfieldsbydefault'] != '') {
     // create a fieldname loop that can be used with javascript
     // hide and enable features.
     echo "\n<script>\n";
     echo "//<![CDATA[\n";
     echo "function disableall() {\n";
     foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-        if ($field['type'] != "submit" and $field['type'] != "listtopic") {
-            if (!$field['donotdisable'] != "") {
+        if ($field['type'] != 'submit' && $field['type'] != 'listtopic') {
+            if (!$field['donotdisable'] != '') {
                 array_push($fieldnames_array, $field['name']);
                 $fieldname = preg_replace("/\s+/", "", $field['name']);
                 $fieldname = strtolower($fieldname);
@@ -986,18 +986,18 @@ if ($pkg['step'][$stepid]['disableallfieldsbydefault'] != "") {
     echo "function enableitems(selectedindex) {\n";
     echo "disableall();\n";
     $idcounter = 0;
-    if ($pkg['step'][$stepid]['fields']['field'] != "") {
+    if ($pkg['step'][$stepid]['fields']['field'] != '') {
         echo "\tswitch(selectedindex) {\n";
         foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-            if ($field['options']['option'] != "") {
+            if ($field['options']['option'] != '') {
                 foreach ($field['options']['option'] as $opt) {
-                    if ($opt['enablefields'] != "") {
+                    if ($opt['enablefields'] != '') {
                         echo "\t\tcase " . $idcounter . ":\n";
                         $enablefields_split = explode(",", $opt['enablefields']);
                         foreach ($enablefields_split as $efs) {
                             $fieldname = preg_replace("/\s+/", "", $efs);
                             $fieldname = strtolower($fieldname);
-                            if ($fieldname != "") {
+                            if ($fieldname != '') {
                                 //$onchange = "\t\t\tdocument.forms[0]." . $fieldname . ".disabled = 0; \n";
                                 $onchange = "\t\t\tjQuery('#" . $fieldname . "').prop('disabled',false)\n";
                                 echo $onchange;
@@ -1030,12 +1030,12 @@ if ($pkg['step'][$stepid]['disableallfieldsbydefault'] != "") {
 </script>
 
 <?php
-if ($pkg['step'][$stepid]['stepafterformdisplay'] != "") {
+if ($pkg['step'][$stepid]['stepafterformdisplay'] != '') {
     // handle after form display event.
     eval($pkg['step'][$stepid]['stepafterformdisplay']);
 }
 
-if ($pkg['step'][$stepid]['javascriptafterformdisplay'] != "") {
+if ($pkg['step'][$stepid]['javascriptafterformdisplay'] != '') {
     // handle after form display event.
     echo "\n<script>\n";
     echo "//<![CDATA[\n";

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -132,16 +132,16 @@ if ($pkg['step'][$stepid]['stepsubmitbeforesave']) {
 
 if ($_POST && !$input_errors) {
     foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-        if (!empty($field['bindstofield']) and $field['type'] <> "submit") {
+        if (!empty($field['bindstofield']) and $field['type'] != "submit") {
             $fieldname = $field['name'];
             $fieldname = str_replace(" ", "", $fieldname);
             $fieldname = strtolower($fieldname);
             // update field with posted values.
-            if ($field['unsetfield'] <> "")
+            if ($field['unsetfield'] != "")
                 $unset_fields = "yes";
             else
                 $unset_fields = "";
-            if ($field['arraynum'] <> "")
+            if ($field['arraynum'] != "")
                 $arraynum = $field['arraynum'];
             else
                 $arraynum = "";
@@ -152,7 +152,7 @@ if ($_POST && !$input_errors) {
     }
 
     // run custom php code embedded in xml config.
-    if ($pkg['step'][$stepid]['stepsubmitphpaction'] <> "") {
+    if ($pkg['step'][$stepid]['stepsubmitphpaction'] != "") {
         eval($pkg['step'][$stepid]['stepsubmitphpaction']);
     }
 
@@ -178,9 +178,9 @@ function update_config_field($field, $updatetext, $unset, $arraynum, $field_type
         $field_conv .= "['" . $f . "']";
     if ($field_conv == "")
         return;
-    if ($arraynum <> "")
+    if ($arraynum != "")
         $field_conv .= "[" . $arraynum . "]";
-    if (($field_type == "checkbox" and $updatetext <> "on") || $updatetext == "") {
+    if (($field_type == "checkbox" and $updatetext != "on") || $updatetext == "") {
         /*
          * item is a checkbox, it should have the value "on"
          * if it was checked
@@ -274,7 +274,7 @@ include("head.inc");
 
 <?php include("fbegin.inc"); ?>
 
-<?php if ($pkg['step'][$stepid]['fields']['field'] <> "") { ?>
+<?php if ($pkg['step'][$stepid]['fields']['field'] != "") { ?>
     <script>
         //<![CDATA[
 
@@ -419,7 +419,7 @@ include("head.inc");
                         <table class="table table-striped">
                             <?php
                             $inputaliases = array();
-                            if ($pkg['step'][$stepid]['fields']['field'] <> "") {
+                            if ($pkg['step'][$stepid]['fields']['field'] != "") {
                                 foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
 
                                     $value = $field['value'];
@@ -434,7 +434,7 @@ include("head.inc");
                                         $field_split = explode("->", $field['bindstofield']);
                                         // arraynum is used in cases where there is an array of the same field
                                         // name such as dnsserver (2 of them)
-                                        if ($field['arraynum'] <> "")
+                                        if ($field['arraynum'] != "")
                                             $arraynum = "[" . $field['arraynum'] . "]";
                                         foreach ($field_split as $f)
                                             $field_conv .= "['" . $f . "']";
@@ -470,13 +470,13 @@ include("head.inc");
                                                 echo " onchange='FieldValidate(this.value, \"{$field['validate']}\", \"{$field['message']}\");'";
                                             echo " />\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
                                             break;
                                         case "text":
                                             echo "<td colspan=\"2\" style=\"text-align:center\">\n";
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<div class='text-center'><br /> " . gettext($field['description']) . "</div>";
                                             }
                                             break;
@@ -501,7 +501,7 @@ include("head.inc");
                                                 echo " onchange='FieldValidate(this.value, \"{$field['validate']}\", \"{$field['message']}\");'";
                                             echo " />\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
                                             break;
@@ -513,13 +513,13 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] <> "") $size = "size=\"{$field['size']}\"";
-                                            if ($field['multiple'] <> "" and $field['multiple'] <> "0") {
+                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
+                                            if ($field['multiple'] != "" and $field['multiple'] != "0") {
                                                 $multiple = "multiple=\"multiple\"";
                                                 $name .= "[]";
                                             }
                                             echo "<select class='form-control' id='{$name}' name='{$name}' {$size} {$multiple}>\n";
-                                            if ($field['add_to_interfaces_selection'] <> "") {
+                                            if ($field['add_to_interfaces_selection'] != "") {
                                                 $SELECTED = "";
                                                 if ($field['add_to_interfaces_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_interfaces_selection'] . "'" . $SELECTED . ">" . $field['add_to_interfaces_selection'] . "</option>\n";
@@ -535,7 +535,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ifname . "'" . $SELECTED . ">" . $iface . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['interface_filter'] <> "") {
+                                                if ($field['interface_filter'] != "") {
                                                     if (stristr($ifname, $field['interface_filter']) == true)
                                                         $canecho = 1;
                                                 } else
@@ -545,7 +545,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -567,7 +567,7 @@ include("head.inc");
                                                 echo " size='" . $field['size'] . "' ";
                                             echo " />\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -580,9 +580,9 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] <> "") $size = "size=\"{$field['size']}\"";
+                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
                                             echo "<select id='{$name}' name='{$name}' {$size}>\n";
-                                            if ($field['add_to_certca_selection'] <> "") {
+                                            if ($field['add_to_certca_selection'] != "") {
                                                 $SELECTED = "";
                                                 if ($field['add_to_certca_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_certca_selection'] . "'" . $SELECTED . ">" . $field['add_to_certca_selection'] . "</option>\n";
@@ -597,7 +597,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ca['refid'] . "'" . $SELECTED . ">" . $name . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['certca_filter'] <> "") {
+                                                if ($field['certca_filter'] != "") {
                                                     if (stristr($name, $field['certca_filter']) == true)
                                                         $canecho = 1;
                                                 } else {
@@ -608,7 +608,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -621,9 +621,9 @@ include("head.inc");
                                             echo ($field['displayname'] ? gettext($field['displayname']) : gettext($field['name'])) . ":\n";
                                             echo "</td>";
                                             echo "<td class=\"vtable\">\n";
-                                            if ($field['size'] <> "") $size = "size=\"{$field['size']}\"";
+                                            if ($field['size'] != "") $size = "size=\"{$field['size']}\"";
                                             echo "<select id='{$name}' name='{$name}' {$size}>\n";
-                                            if ($field['add_to_cert_selection'] <> "") {
+                                            if ($field['add_to_cert_selection'] != "") {
                                                 $SELECTED = "";
                                                 if ($field['add_to_cert_selection'] == $value) $SELECTED = " selected=\"selected\"";
                                                 echo "<option value='" . $field['add_to_cert_selection'] . "'" . $SELECTED . ">" . $field['add_to_cert_selection'] . "</option>\n";
@@ -637,7 +637,7 @@ include("head.inc");
                                                 $to_echo = "<option value='" . $ca['refid'] . "'" . $SELECTED . ">" . $name . "</option>\n";
                                                 $to_echo .= "<!-- {$value} -->";
                                                 $canecho = 0;
-                                                if ($field['cert_filter'] <> "") {
+                                                if ($field['cert_filter'] != "") {
                                                     if (stristr($name, $field['cert_filter']) == true)
                                                         $canecho = 1;
                                                 } else {
@@ -648,7 +648,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -678,7 +678,7 @@ include("head.inc");
                                             echo "</select>\n";
                                             echo "<!-- {$value} -->\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -699,7 +699,7 @@ include("head.inc");
                                                 echo "<td class=\"vtable\">\n";
                                             $onchange = "";
                                             foreach ($field['options']['option'] as $opt) {
-                                                if ($opt['enablefields'] <> "") {
+                                                if ($opt['enablefields'] != "") {
                                                     $onchange = "onchange=\"enableitems(this.selectedIndex);\" ";
                                                 }
                                             }
@@ -718,7 +718,7 @@ include("head.inc");
                                             echo "</select>\n";
                                             echo "<!-- {$value} -->\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -743,7 +743,7 @@ include("head.inc");
                                             echo ">" . $value . "</textarea>\n";
 
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -752,7 +752,7 @@ include("head.inc");
                                             echo "<td colspan=\"2\" style=\"text-align:center\">";
                                             echo "<input type='submit' class=\"btn btn-primary\" name='" . $name . "' value=\"" . htmlspecialchars(gettext($field['name'])) . "\" />\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -790,7 +790,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -819,7 +819,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -850,7 +850,7 @@ include("head.inc");
                                             }
                                             echo "</select>\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo "<br /> " . gettext($field['description']);
                                             }
 
@@ -866,7 +866,7 @@ include("head.inc");
                                                 echo ":</td>";
                                             }
                                             $checked = "";
-                                            if ($value <> "")
+                                            if ($value != "")
                                                 $checked = " checked=\"checked\"";
                                             echo "<td class=\"vtable\"><input value=\"on\" type='checkbox' id='" . $name . "' name='" . $name . "' " . $checked;
                                             if (isset($field['enablefields']) or isset($field['checkenablefields']))
@@ -875,14 +875,14 @@ include("head.inc");
                                                 echo " onclick=\"disablechange()\"";
                                             echo " />\n";
 
-                                            if ($field['description'] <> "") {
+                                            if ($field['description'] != "") {
                                                 echo gettext($field['description']);
                                             }
 
                                             break;
                                     }
 
-                                    if ($field['typehint'] <> "") {
+                                    if ($field['typehint'] != "") {
                                         echo $field['typehint'];
                                     }
 
@@ -899,11 +899,11 @@ include("head.inc");
 
                         </table>
                         <?php
-                        if ($pkg['step'][$stepid]['fields']['field'] <> "") {
+                        if ($pkg['step'][$stepid]['fields']['field'] != "") {
                             foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
                                 switch ($field['type']) {
                                     case "refresh":
-                                        if ($field['page'] <> "" && $field['time'] <> "") {
+                                        if ($field['page'] != "" && $field['time'] != "") {
                                             echo '<meta http-equiv="refresh" content="' . $field['time'] . ';url=' . redirect_url() . '/' . $field['page'] . '">';
                                         }
                                         break 2;
@@ -965,15 +965,15 @@ include("head.inc");
 <?php
 
 $fieldnames_array = Array();
-if ($pkg['step'][$stepid]['disableallfieldsbydefault'] <> "") {
+if ($pkg['step'][$stepid]['disableallfieldsbydefault'] != "") {
     // create a fieldname loop that can be used with javascript
     // hide and enable features.
     echo "\n<script>\n";
     echo "//<![CDATA[\n";
     echo "function disableall() {\n";
     foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-        if ($field['type'] <> "submit" and $field['type'] <> "listtopic") {
-            if (!$field['donotdisable'] <> "") {
+        if ($field['type'] != "submit" and $field['type'] != "listtopic") {
+            if (!$field['donotdisable'] != "") {
                 array_push($fieldnames_array, $field['name']);
                 $fieldname = preg_replace("/\s+/", "", $field['name']);
                 $fieldname = strtolower($fieldname);
@@ -986,18 +986,18 @@ if ($pkg['step'][$stepid]['disableallfieldsbydefault'] <> "") {
     echo "function enableitems(selectedindex) {\n";
     echo "disableall();\n";
     $idcounter = 0;
-    if ($pkg['step'][$stepid]['fields']['field'] <> "") {
+    if ($pkg['step'][$stepid]['fields']['field'] != "") {
         echo "\tswitch(selectedindex) {\n";
         foreach ($pkg['step'][$stepid]['fields']['field'] as $field) {
-            if ($field['options']['option'] <> "") {
+            if ($field['options']['option'] != "") {
                 foreach ($field['options']['option'] as $opt) {
-                    if ($opt['enablefields'] <> "") {
+                    if ($opt['enablefields'] != "") {
                         echo "\t\tcase " . $idcounter . ":\n";
                         $enablefields_split = explode(",", $opt['enablefields']);
                         foreach ($enablefields_split as $efs) {
                             $fieldname = preg_replace("/\s+/", "", $efs);
                             $fieldname = strtolower($fieldname);
-                            if ($fieldname <> "") {
+                            if ($fieldname != "") {
                                 //$onchange = "\t\t\tdocument.forms[0]." . $fieldname . ".disabled = 0; \n";
                                 $onchange = "\t\t\tjQuery('#" . $fieldname . "').prop('disabled',false)\n";
                                 echo $onchange;
@@ -1030,12 +1030,12 @@ if ($pkg['step'][$stepid]['disableallfieldsbydefault'] <> "") {
 </script>
 
 <?php
-if ($pkg['step'][$stepid]['stepafterformdisplay'] <> "") {
+if ($pkg['step'][$stepid]['stepafterformdisplay'] != "") {
     // handle after form display event.
     eval($pkg['step'][$stepid]['stepafterformdisplay']);
 }
 
-if ($pkg['step'][$stepid]['javascriptafterformdisplay'] <> "") {
+if ($pkg['step'][$stepid]['javascriptafterformdisplay'] != "") {
     // handle after form display event.
     echo "\n<script>\n";
     echo "//<![CDATA[\n";


### PR DESCRIPTION
`!=` is way more familiar to most people than `<>`. This makes the code base more consistent and slightly easier to understand.