### PR TITLE
Firewall:NAT:Port Forward - missing (disabled Linked rule) - fix

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_0_2.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_0_2.php
@@ -58,9 +58,7 @@ class M1_0_2 extends BaseModelMigration
                 $node->enabled = '0';
                 // Description can be up to 255 characters, truncate as necessary.
                 $node->description = substr(
-                    $node->description . ' - Old GeoIP rule, disabled by migration',
-                    0,
-                    255
+                    $node->description . ' - Old GeoIP rule, disabled by migration', 0, 255
                 );
             }
         }

--- a/src/opnsense/scripts/netflow/lib/__init__.py
+++ b/src/opnsense/scripts/netflow/lib/__init__.py
@@ -56,3 +56,4 @@ class Config(object):
         for key in kwargs:
             if hasattr(self, key):
                 setattr(self, key, kwargs[key])
+

--- a/src/opnsense/www/css/bootstrap-select-1.13.3.css
+++ b/src/opnsense/www/css/bootstrap-select-1.13.3.css
@@ -25,7 +25,7 @@ select.selectpicker {
 .bootstrap-select > .dropdown-toggle.bs-placeholder:hover,
 .bootstrap-select > .dropdown-toggle.bs-placeholder:focus,
 .bootstrap-select > .dropdown-toggle.bs-placeholder:active {
-  color: #444;
+  color: #999;
 }
 .bootstrap-select > .dropdown-toggle.bs-placeholder.btn-primary,
 .bootstrap-select > .dropdown-toggle.bs-placeholder.btn-secondary,

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -499,33 +499,34 @@ $( document ).ready(function() {
                   </tr>
 <?php endif ?>
                 </tbody>
-                  <tfoot>
-                    <tr>
-                      <td style="width:16px"><i class="fa fa-play fa-fw text-success"></i></td>
-                      <td colspan="12"><?=gettext("Enabled rule"); ?></td>
-                    </tr>
-                    <tr>
-                      <td><i class="fa fa-play fa-fw text-muted"></i></td>
-                      <td colspan="12"><?=gettext("Disabled rule"); ?></td>
-                    </tr>
-                    <tr>
-                      <td><i class="fa fa-exclamation fa-fw text-success"></i></td>
-                      <td colspan="12"><?=gettext("No redirect"); ?></td>
-                    </tr>
-                    <tr>
-                      <td><i class="fa fa-arrows-h fa-fw text-success"></i></td>
-                      <td colspan="12"><?=gettext("Linked rule");?></td>
-                    </tr>
-                    <tr>
-                      <td><i class="fa fa-arrows-h fa-fw text-muted"></i></td>
-                      <td colspan="12"><?=gettext("Disabled Linked rule");?></td>
-                    </tr>
-                    <tr>
-                      <td><i class="fa fa-list fa-fw text-primary"></i></td>
-                      <td colspan="12"><?=gettext("Alias (click to view/edit)");?></td>
-                    </tr>
-                  </tfoot>
-                </table>
+                <tfoot>
+                  <tr class="hidden-xs hidden-sm">
+                    <td colspan="11">
+                      <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
+                        <tr>
+                          <td style="width:16px"><i class="fa fa-play fa-fw text-success"></i></td>
+                          <td colspan="12"><?=gettext("Enabled rule"); ?></td>
+                          <td><i class="fa fa-exclamation fa-fw text-success"></i></td>
+                          <td colspan="12"><?=gettext("No redirect"); ?></td>
+                          <td><i class="fa fa-arrows-h fa-fw text-success"></i></td>
+                          <td colspan="12"><?=gettext("Linked rule");?></td>
+                        </tr>
+                        <tr>
+                          <td><i class="fa fa-play fa-fw text-muted"></i></td>
+                          <td colspan="12"><?=gettext("Disabled rule"); ?></td>
+                          <td><i class="fa fa-exclamation fa-fw text-muted"></i></td>
+                          <td colspan="12"><?=gettext("Disabled no redirect"); ?></td>
+                          <td><i class="fa fa-arrows-h fa-fw text-muted"></i></td>
+                          <td colspan="12"><?=gettext("Disabled linked rule");?></td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><i class="fa fa-list fa-fw text-primary"></i></td>
+                    <td colspan="12"><?=gettext("Alias (click to view/edit)");?></td>
+                  </tr>
+                </tfoot>
               </div>
             </form>
           </div>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -517,6 +517,10 @@ $( document ).ready(function() {
                       <td colspan="12"><?=gettext("Linked rule");?></td>
                     </tr>
                     <tr>
+                      <td><i class="fa fa-arrows-h fa-fw text-muted"></i></td>
+                      <td colspan="12"><?=gettext("Disabled Linked rule");?></td>
+                    </tr>
+                    <tr>
                       <td><i class="fa fa-list fa-fw text-primary"></i></td>
                       <td colspan="12"><?=gettext("Alias (click to view/edit)");?></td>
                     </tr>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -501,23 +501,23 @@ $( document ).ready(function() {
                 </tbody>
                 <tfoot>
                   <tr class="hidden-xs hidden-sm">
-                    <td colspan="11">
+                    <td colspan="12">
                       <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
                         <tr>
-                          <td style="width:16px"><i class="fa fa-play fa-fw text-success"></i></td>
-                          <td colspan="12"><?=gettext("Enabled rule"); ?></td>
+                          <td><i class="fa fa-play fa-fw text-success"></i></td>
+                          <td><?=gettext("Enabled rule"); ?></td>
                           <td><i class="fa fa-exclamation fa-fw text-success"></i></td>
-                          <td colspan="12"><?=gettext("No redirect"); ?></td>
+                          <td><?=gettext("No redirect"); ?></td>
                           <td><i class="fa fa-arrows-h fa-fw text-success"></i></td>
-                          <td colspan="12"><?=gettext("Linked rule");?></td>
+                          <td><?=gettext("Linked rule");?></td>
                         </tr>
                         <tr>
                           <td><i class="fa fa-play fa-fw text-muted"></i></td>
-                          <td colspan="12"><?=gettext("Disabled rule"); ?></td>
+                          <td><?=gettext("Disabled rule"); ?></td>
                           <td><i class="fa fa-exclamation fa-fw text-muted"></i></td>
-                          <td colspan="12"><?=gettext("Disabled no redirect"); ?></td>
+                          <td><?=gettext("Disabled no redirect"); ?></td>
                           <td><i class="fa fa-arrows-h fa-fw text-muted"></i></td>
-                          <td colspan="12"><?=gettext("Disabled linked rule");?></td>
+                          <td><?=gettext("Disabled linked rule");?></td>
                         </tr>
                       </table>
                     </td>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -527,6 +527,7 @@ $( document ).ready(function() {
                     <td colspan="12"><?=gettext("Alias (click to view/edit)");?></td>
                   </tr>
                 </tfoot>
+                </table>
               </div>
             </form>
           </div>

--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -501,7 +501,7 @@ $( document ).ready(function() {
                 </tbody>
                 <tfoot>
                   <tr class="hidden-xs hidden-sm">
-                    <td colspan="12">
+                    <td colspan="14">
                       <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
                         <tr>
                           <td><i class="fa fa-play fa-fw text-success"></i></td>
@@ -524,7 +524,7 @@ $( document ).ready(function() {
                   </tr>
                   <tr>
                     <td><i class="fa fa-list fa-fw text-primary"></i></td>
-                    <td colspan="12"><?=gettext("Alias (click to view/edit)");?></td>
+                    <td colspan="14"><?=gettext("Alias (click to view/edit)");?></td>
                   </tr>
                 </tfoot>
                 </table>

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -246,40 +246,6 @@ $( document ).ready(function() {
                   </td>
                 </tr>
                 <tr>
-                  <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>
-                  <td>
-                    <input name="port" type="text" id="port" size="6" placeholder="53" <?=!empty($pconfig['port']) ? "value=\"{$pconfig['port']}\"" : "";?> />
-                    <div class="hidden" data-for="help_for_port">
-                      <?=gettext("The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.");?>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td><a id="help_for_interfaces" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Network Interfaces') ?></td>
-                  <td>
-                    <select id="interface" name="interface[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (recommended)')) ?>">
-<?php foreach (get_configured_interface_with_descr() as  $iface => $ifacename): ?>
-                      <option value="<?= html_safe($iface) ?>" <?=in_array($iface, $pconfig['interface']) ? 'selected="selected"' : "" ?>>
-                        <?= html_safe($ifacename) ?>
-                      </option>
-<?php endforeach ?>
-                    </select>
-                    <div class="hidden" data-for="help_for_interfaces">
-                      <?=gettext("Interface IPs used by Dnsmasq for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
-                    </div>
-                  </td>
-                </tr>
-                  <td><a id="help_for_strictbind" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Bind Mode') ?></td>
-                  <td>
-                    <input name="strictbind" type="checkbox" id="strictbind" value="yes" <?= !empty($pconfig['strictbind']) ? "checked=\"checked\"" : "";?> />
-                    <?= gettext('Strict Interface Binding') ?>
-                    <div class="hidden" data-for="help_for_strictbind">
-                      <?= gettext("If this option is set, Dnsmasq will only bind to the interfaces containing the IP addresses selected above, rather than binding to all interfaces and discarding queries to other addresses."); ?>
-                      <?= gettext("This option does not work with IPv6. If set, Dnsmasq will not bind to IPv6 addresses."); ?>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
                   <td><i class="fa fa-info-circle text-muted"></i> <?=gettext('DNSSEC') ?></td>
                   <td>
                     <input name="dnssec" type="checkbox" value="yes" <?=!empty($pconfig['dnssec']) ? 'checked="checked"' : '' ?> />
@@ -377,6 +343,40 @@ $( document ).ready(function() {
                   </td>
                 </tr>
                 <tr>
+                  <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>
+                  <td>
+                    <input name="port" type="text" id="port" size="6" placeholder="53" <?=!empty($pconfig['port']) ? "value=\"{$pconfig['port']}\"" : "";?> />
+                    <div class="hidden" data-for="help_for_port">
+                      <?=gettext("The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.");?>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td><a id="help_for_interfaces" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Interfaces"); ?></td>
+                  <td>
+                    <select id="interface" name="interface[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (recommended)')) ?>">
+<?php foreach (get_configured_interface_with_descr() as  $iface => $ifacename): ?>
+                      <option value="<?= html_safe($iface) ?>" <?=in_array($iface, $pconfig['interface']) ? 'selected="selected"' : "" ?>>
+                        <?= html_safe($ifacename) ?>
+                      </option>
+<?php endforeach ?>
+                    </select>
+                    <div class="hidden" data-for="help_for_interfaces">
+                      <?=gettext("Interface IPs used by Dnsmasq for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
+                    </div>
+                  </td>
+                </tr>
+                  <td><a id="help_for_strictbind" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Bind Mode') ?></td>
+                  <td>
+                    <input name="strictbind" type="checkbox" id="strictbind" value="yes" <?= !empty($pconfig['strictbind']) ? "checked=\"checked\"" : "";?> />
+                    <?= gettext('Strict Interface Binding') ?>
+                    <div class="hidden" data-for="help_for_strictbind">
+                      <?= gettext("If this option is set, Dnsmasq will only bind to the interfaces containing the IP addresses selected above, rather than binding to all interfaces and discarding queries to other addresses."); ?>
+                      <?= gettext("This option does not work with IPv6. If set, Dnsmasq will not bind to IPv6 addresses."); ?>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
                   <td><a id="help_for_advanced" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Advanced') ?></td>
                   <td>
                     <div id="showadvbox" <?= !empty($pconfig['custom_options']) ? "style='display:none'" : '' ?>>
@@ -401,7 +401,7 @@ $( document ).ready(function() {
                     <?= sprintf(gettext("If Dnsmasq is enabled, the DHCP".
                     " service (if enabled) will automatically serve the LAN IP".
                     " address as a DNS server to DHCP clients so they will use".
-                    " the Dnsmasq forwarder. Dnsmasq will use the DNS servers".
+                    " the forwarder. Dnsmasq will use the DNS servers".
                     " entered in %sSystem: General setup%s".
                     " or those obtained via DHCP or PPP on WAN if the \"Allow".
                     " DNS server list to be overridden by DHCP/PPP on WAN\"".

--- a/src/www/services_dnsmasq_edit.php
+++ b/src/www/services_dnsmasq_edit.php
@@ -32,6 +32,11 @@ require_once("guiconfig.inc");
 require_once("services.inc");
 require_once("interfaces.inc");
 
+function hostcmp($a, $b)
+{
+    return strcasecmp($a['host'], $b['host']);
+}
+
 $a_hosts = &config_read_array('dnsmasq', 'hosts');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
@@ -123,12 +128,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         } else {
             $a_hosts[] = $hostent;
         }
-        usort($config['dnsmasq']['hosts'], function ($a, $b) {
-            return strcasecmp($a['host'], $b['host']);
-        });
-
-        write_config();
+        usort($config['dnsmasq']['hosts'], "hostcmp");
         mark_subsystem_dirty('hosts');
+        write_config();
         header(url_safe('Location: /services_dnsmasq.php'));
         exit;
     }

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -124,7 +124,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 unset($a_unboundcfg['outgoing_interface']);
             }
 
-            write_config('Unbound general configuration changed.');
+            write_config("DNS Resolver configured.");
             mark_subsystem_dirty('unbound');
             header(url_safe('Location: /services_unbound.php'));
             exit;
@@ -161,8 +161,9 @@ include_once("head.inc");
     <div class="container-fluid">
       <div class="row">
         <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
+        <?php if (isset($savemsg)) print_info_box($savemsg); ?>
         <?php if (is_subsystem_dirty('unbound')): ?><br/>
-        <?php print_info_box_apply(gettext('The Unbound configuration has been changed.') . ' ' . gettext('You must apply the changes in order for them to take effect.')) ?>
+        <?php print_info_box_apply(gettext("The configuration for the DNS Resolver, has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));?><br />
         <?php endif; ?>
         <form method="post" name="iform" id="iform">
           <section class="col-xs-12">
@@ -171,7 +172,7 @@ include_once("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <tbody>
                       <tr>
-                        <td style="width:22%"><strong><?= gettext('General options') ?></strong></td>
+                        <td style="width:22%"><strong><?=gettext("General DNS Resolver Options");?></strong></td>
                         <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
@@ -181,13 +182,13 @@ include_once("head.inc");
                         <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
                         <td>
                           <input name="enable" type="checkbox" value="yes" <?=!empty($pconfig['enable']) ? "checked=\"checked\"" : "";?> />
-                          <?= gettext('Enable Unbound') ?>
+                          <?= gettext('Enable DNS Resolver') ?>
                         </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>
                         <td>
-                            <input name="port" type="text" id="port" placeholder="53" size="6" value="<?=$pconfig['port'];?>" />
+                            <input name="port" type="text" id="port" size="6" value="<?=$pconfig['port'];?>" />
                             <div class="hidden" data-for="help_for_port">
                                 <?=gettext("The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.");?>
                             </div>
@@ -202,7 +203,22 @@ include_once("head.inc");
 <?php endforeach ?>
                           </select>
                           <div class="hidden" data-for="help_for_active_interface">
-                            <?=gettext("Interface IP addresses used for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
+                            <?=gettext("Interface IPs used by the DNS Resolver for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.");?>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><a id="help_for_local_zone_type" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local Zone Type"); ?></td>
+                        <td>
+                          <select name="local_zone_type" size="3" class="selectpicker" >
+<?php
+                            foreach (unbound_local_zone_types() as $value => $name):?>
+                            <option value="<?= html_safe($value) ?>" <?= $value == $pconfig['local_zone_type'] ? 'selected="selected"' : '' ?>><?= html_safe($name) ?></option>
+<?php
+                            endforeach; ?>
+                          </select>
+                          <div class="hidden" data-for="help_for_local_zone_type">
+                            <?=sprintf(gettext('The local zone type used for the system domain. Type descriptions are available under "local-zone:" in the %sunbound.conf(5)%s manual page. The default is \'transparent\'.'), '<a target="_blank" href="https://www.unbound.net/documentation/unbound.conf.html">', '</a>');?>
                           </div>
                         </td>
                       </tr>
@@ -214,14 +230,24 @@ include_once("head.inc");
                         </td>
                       </tr>
                       <tr>
+                        <td><a id="help_for_forwarding" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Query Forwarding");?></td>
+                        <td>
+                          <input name="forwarding" type="checkbox" value="yes" <?=!empty($pconfig['forwarding']) ? "checked=\"checked\"" : "";?> />
+                          <?= gettext('Enable Forwarding Mode') ?>
+                          <div class="hidden" data-for="help_for_forwarding">
+                            <?= gettext('The configured system nameservers will be used to forward queries to.') ?>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
                         <td><a id="help_for_regdhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Registration");?></td>
                         <td>
                           <input name="regdhcp" type="checkbox" id="regdhcp" value="yes" <?=!empty($pconfig['regdhcp']) ? "checked=\"checked\"" : "";?> />
-                          <?= gettext('Register DHCP leases') ?>
+                          <?= gettext('Register DHCP leases in the DNS Resolver') ?>
                           <div class="hidden" data-for="help_for_regdhcp">
                             <?= gettext("If this option is set, then machines that specify " .
                             "their hostname when requesting a DHCP lease will be registered " .
-                            "in Unbound, so that their name can be resolved."); ?>
+                            "in the DNS Resolver, so that their name can be resolved."); ?>
                           </div>
                         </td>
                       </tr>
@@ -241,10 +267,10 @@ include_once("head.inc");
                         <td><a id="help_for_regdhcpstatic" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('DHCP Static Mappings');?></td>
                         <td>
                           <input name="regdhcpstatic" type="checkbox" id="regdhcpstatic" value="yes" <?=!empty($pconfig['regdhcpstatic']) ? "checked=\"checked\"" : "";?> />
-                          <?= gettext('Register DHCP static mappings') ?>
+                          <?= gettext('Register DHCP static mappings in the DNS Resolver') ?>
                           <div class="hidden" data-for="help_for_regdhcpstatic">
                             <?= sprintf(gettext("If this option is set, then DHCP static mappings will ".
-                                "be registered in Unbound, so that their name can be ".
+                                "be registered in the DNS Resolver, so that their name can be ".
                                 "resolved. You should also set the domain in %s".
                                 "System: General setup%s to the proper value."),'<a href="system_general.php">','</a>');?>
                           </div>
@@ -254,11 +280,11 @@ include_once("head.inc");
                         <td><a id="help_for_reglladdr6" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('IPv6 Link-local') ?></td>
                         <td>
                           <input name="reglladdr6" type="checkbox" id="reglladdr6" value="yes" <?= !empty($pconfig['reglladdr6']) ? 'checked="checked"' : '' ?>/>
-                          <?= gettext('Register IPv6 link-local addresses') ?>
+                          <?= gettext('Register IPv6 link-local addresses in the DNS Resolver') ?>
                           <div class="hidden" data-for="help_for_reglladdr6">
                             <?= gettext("If this option is unset, then IPv6 link-local " .
-                            "addresses will not be registered in Unbound, preventing " .
-                            "return of unreachable address when more " .
+                            "addresses will not be registered in the DNS Resolver, preventing " .
+                            "return of unreachable address from the DNS resolver when more " .
                             "than one listen interface is configured."); ?>
                           </div>
                         </td>
@@ -267,32 +293,8 @@ include_once("head.inc");
                         <td><a id="help_for_txtsupport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("TXT Comment Support");?></td>
                         <td>
                           <input name="txtsupport" type="checkbox" value="yes" <?=!empty($pconfig['txtsupport']) ? "checked=\"checked\"" : "";?> />
-                          <?= gettext('Create corresponding TXT records') ?>
                           <div class="hidden" data-for="help_for_txtsupport">
                             <?=gettext("If this option is set, then any descriptions associated with Host entries and DHCP Static mappings will create a corresponding TXT record.");?><br />
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td><a id="help_for_forwarding" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Query Forwarding");?></td>
-                        <td>
-                          <input name="forwarding" type="checkbox" value="yes" <?=!empty($pconfig['forwarding']) ? "checked=\"checked\"" : "";?> />
-                          <?= gettext('Enable Forwarding Mode') ?>
-                          <div class="hidden" data-for="help_for_forwarding">
-                            <?= gettext('The configured system nameservers will be used to forward queries to.') ?>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td><a id="help_for_local_zone_type" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local Zone Type"); ?></td>
-                        <td>
-                          <select name="local_zone_type" size="3" class="selectpicker" >
-<?php foreach (unbound_local_zone_types() as $value => $name): ?>
-                            <option value="<?= html_safe($value) ?>" <?= $value == $pconfig['local_zone_type'] ? 'selected="selected"' : '' ?>><?= html_safe($name) ?></option>
-<?php endforeach ?>
-                          </select>
-                          <div class="hidden" data-for="help_for_local_zone_type">
-                            <?=sprintf(gettext('The local zone type used for the system domain. Type descriptions are available under "local-zone:" in the %sunbound.conf(5)%s manual page. The default is \'transparent\'.'), '<a target="_blank" href="https://www.unbound.net/documentation/unbound.conf.html">', '</a>');?>
                           </div>
                         </td>
                       </tr>
@@ -307,7 +309,7 @@ include_once("head.inc");
                         <td>
                           <textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=$pconfig['custom_options'];?></textarea>
                           <div class="hidden" data-for="help_for_custom_options">
-                            <?=gettext("Enter any additional options you would like to add to the Unbound configuration here."); ?>
+                            <?=gettext("Enter any additional options you would like to add to the DNS Resolver configuration here."); ?>
                           </div>
                         </td>
                       </tr>
@@ -323,7 +325,7 @@ include_once("head.inc");
 
                           </select>
                           <div class="hidden" data-for="help_for_outgoing_interface">
-                            <?=gettext("Utilize different network interfaces that Unbound will use to send queries to authoritative servers and receive their replies. By default all interfaces are used. Note that setting explicit outgoing interfaces only works when they are statically configured.");?>
+                            <?=gettext("Utilize different network interface(s) that the DNS Resolver will use to send queries to authoritative servers and receive their replies. By default all interfaces are used. Note that setting explicit outgoing interfaces only works when they are statically configured.");?>
                           </div>
                         </td>
                       </tr>
@@ -345,10 +347,10 @@ include_once("head.inc");
                       </tr>
                       <tr>
                         <td colspan="2">
-                          <?= sprintf(gettext("If Unbound is enabled, the DHCP".
+                          <?= sprintf(gettext("If the DNS Resolver is enabled, the DHCP".
                           " service (if enabled) will automatically serve the LAN IP".
                           " address as a DNS server to DHCP clients so they will use".
-                          " Unbound resolver. If forwarding is enabled, Unbound".
+                          " the DNS Resolver. If Forwarding, is enabled, the DNS Resolver".
                           " will use the DNS servers entered in %sSystem: General setup%s".
                           " or those obtained via DHCP or PPP on WAN if the \"Allow".
                           " DNS server list to be overridden by DHCP/PPP on WAN\"".

--- a/src/www/services_unbound_acls.php
+++ b/src/www/services_unbound_acls.php
@@ -95,7 +95,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 $input_errors[] = gettext("You must enter a valid netmask for {$row['acl_network']}/{$row['mask']}.");
             }
         }
-
         // save form data
         if (count($input_errors) == 0) {
             $acl_entry = array();
@@ -109,9 +108,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             } else {
                 $a_acls[] = $acl_entry;
             }
-
+            mark_subsystem_dirty("unbound");
             write_config();
-            mark_subsystem_dirty('unbound');
             header(url_safe('Location: /services_unbound_acls.php'));
             exit;
         }
@@ -171,7 +169,7 @@ if (!isset($_GET['act'])) {
       // delete single
       BootstrapDialog.show({
         type:BootstrapDialog.TYPE_DANGER,
-        title: "<?= gettext('Unbound') ?>",
+        title: "<?= gettext("DNS Resolver");?>",
         message: "<?=gettext("Do you really want to delete this access list?"); ?>",
         buttons: [{
                   label: "<?= gettext("No");?>",
@@ -195,10 +193,11 @@ if (!isset($_GET['act'])) {
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
-        <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
-        <?php if (is_subsystem_dirty('unbound')): ?>
-        <?php print_info_box_apply(gettext('The Unbound configuration has been changed.') . ' ' . gettext('You must apply the changes in order for them to take effect.')) ?>
-        <?php endif; ?>
+<?php
+        if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors);
+        if (isset($savemsg)) print_info_box($savemsg);
+        if (is_subsystem_dirty("unbound")) print_info_box_apply(gettext("The configuration for the DNS Resolver, has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+        ?>
         <section class="col-xs-12">
           <div class="tab-content content-box col-xs-12 __mb">
             <form method="post" name="iform" id="iform">

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -1,31 +1,31 @@
 <?php
 
 /*
- * Copyright (C) 2014-2016 Deciso B.V.
- * Copyright (C) 2011 Warren Baker <warren@decoy.co.za>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+    Copyright (C) 2014-2016 Deciso B.V.
+    Copyright (C) 2011 Warren Baker <warren@decoy.co.za>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
 
 require_once("guiconfig.inc");
 require_once("system.inc");
@@ -94,8 +94,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         foreach ($copy_fields as $fieldname) {
             $config['unbound'][$fieldname] = $pconfig[$fieldname];
         }
-
-        write_config('Unbound advanced configuration changed.');
+        write_config("DNS Resolver configured.");
         mark_subsystem_dirty('unbound');
         header(url_safe('Location: /services_unbound_advanced.php'));
         exit;
@@ -113,8 +112,10 @@ include_once("head.inc");
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
-        <?php if (is_subsystem_dirty('unbound')): ?>
-        <?php print_info_box_apply(gettext('The Unbound configuration has been changed.') . ' ' . gettext('You must apply the changes in order for them to take effect.')) ?>
+        <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
+        <?php if (isset($savemsg)) print_info_box($savemsg); ?>
+        <?php if (is_subsystem_dirty('unbound')): ?><br/>
+        <?php print_info_box_apply(gettext("The configuration of the DNS Resolver, has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));?><br />
         <?php endif; ?>
         <section class="col-xs-12">
           <div class="tab-content content-box col-xs-12">

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -1,38 +1,43 @@
 <?php
 
 /*
- * Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
- * Copyright (C) 2014-2016 Deciso B.V.
- * Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
- * Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com>
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+    Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
+    Copyright (C) 2014-2016 Deciso B.V.
+    Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
+    Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com>
+    Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
 
 require_once("guiconfig.inc");
 require_once("services.inc");
 require_once("interfaces.inc");
+
+function hostcmp($a, $b)
+{
+    return strcasecmp($a['host'], $b['host']);
+}
 
 $a_hosts = &config_read_array('unbound', 'hosts');
 
@@ -97,7 +102,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $input_errors[] = gettext("A valid resource record type must be specified.");
             break;
     }
-
     if (count($input_errors) == 0) {
         $hostent = array();
         $hostent['host'] = $pconfig['host'];
@@ -115,10 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $a_hosts[] = $hostent;
         }
 
-        usort($a_hosts, function ($a, $b) {
-            return strcasecmp($a['host'], $b['host']);
-        });
-
+        usort($a_hosts, "hostcmp");
         mark_subsystem_dirty('unbound');
         write_config();
         header(url_safe('Location: /services_unbound_overrides.php'));
@@ -168,7 +169,7 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td style="width:22%"><strong><?= gettext('Edit entry') ?></strong></td>
+                    <td style="width:22%"><strong><?=gettext("Edit DNS Resolver entry");?></strong></td>
                     <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -1,32 +1,32 @@
 <?php
 
 /*
- * Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
- * Copyright (C) 2014-2016 Deciso B.V.
- * Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+    Copyright (C) 2015 Manuel Faux <mfaux@conf.at>
+    Copyright (C) 2014-2016 Deciso B.V.
+    Copyright (C) 2014 Warren Baker <warren@decoy.co.za>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
 
 require_once("guiconfig.inc");
 require_once("services.inc");
@@ -86,7 +86,7 @@ include_once("head.inc");
       // delete single
       BootstrapDialog.show({
         type:BootstrapDialog.TYPE_DANGER,
-        title: "<?= gettext('Unbound') ?>",
+        title: "<?= gettext("DNS Resolver");?>",
         message: "<?=gettext("Do you really want to delete this host?");?>",
         buttons: [{
                   label: "<?= gettext("No");?>",
@@ -109,7 +109,7 @@ include_once("head.inc");
       // delete single
       BootstrapDialog.show({
         type:BootstrapDialog.TYPE_DANGER,
-        title: "<?= gettext('Unbound') ?>",
+        title: "<?= gettext("DNS Resolver");?>",
         message: "<?=gettext("Do you really want to delete this domain override?");?>",
         buttons: [{
                   label: "<?= gettext("No");?>",
@@ -132,8 +132,10 @@ include_once("head.inc");
   <section class="page-content-main">
     <div class="container-fluid">
       <div class="row">
-        <?php if (is_subsystem_dirty('unbound')): ?>
-        <?php print_info_box_apply(gettext('The Unbound configuration has been changed.') . ' ' . gettext('You must apply the changes in order for them to take effect.')) ?>
+        <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
+        <?php if (isset($savemsg)) print_info_box($savemsg); ?>
+        <?php if (is_subsystem_dirty('unbound')): ?><br/>
+        <?php print_info_box_apply(gettext("The configuration for the DNS Resolver, has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));?><br />
         <?php endif; ?>
         <form method="post" name="iform" id="iform">
           <section class="col-xs-12">


### PR DESCRIPTION
@fichtner -> the "disabled Linked rule" symbol was missing in the current port forwarding settings
see also https://github.com/opnsense/core/issues/2968