### PR TITLE
proxy: move bump_step1 down in squid.conf

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -65,8 +65,8 @@ acl bump_step3 at_step SslBump3
 acl bump_nobumpsites ssl::server_name "/usr/local/etc/squid/nobumpsites.acl"
 
 # configure bump
-ssl_bump peek bump_step1 all
 {% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == '1' %}
+ssl_bump peek bump_step1 all
 ssl_bump splice all
 ssl_bump peek bump_step2 all
 ssl_bump splice bump_step3 all


### PR DESCRIPTION
If sslurlonly is 0 `ssl_bump peek bump_step1 all` is listed twice.
Might be cosmetic only since it's working though ...