### PR TITLE
resize function adapts to the sidebar height

### DIFF
--- a/src/opnsense/www/js/opnsense_theme.js
+++ b/src/opnsense/www/js/opnsense_theme.js
@@ -41,6 +41,10 @@ $(document).ready(function () {
     layer2_div = $('#mainmenu > div > div > div'),
     navigation = $('#navigation'),
     mainmenu = $('#mainmenu'),
+    countA = $('#mainmenu > div > a').length,
+    footH = $('.page-foot').height(),
+    headerH = $('.navbar-header').height(),
+    navHeight = (countA * 70) + ((footH + headerH) - (20 + countA)),
     events = {
         mouseenter: function () {
             $('#navigation.col-sidebar-left').css('width', '415px');
@@ -180,7 +184,7 @@ $(document).ready(function () {
         $(window).on('resize', function () {
             var win = $(this);
             winHeight = win.height();
-            if ((win.height() < 675 || win.width() < 760) && navigation.not('col-sidebar-hidden')) {
+            if ((win.height() < navHeight || win.width() < 760) && navigation.not('col-sidebar-hidden')) {
                 navigation.addClass('col-sidebar-hidden');
                 mouse_events_off();
                 if (navigation.hasClass('col-sidebar-left')) {
@@ -188,7 +192,7 @@ $(document).ready(function () {
                     mouse_events_off();
                     transition_duration(350);
                 }
-            } else if ((win.height() >= 675 && win.width() >= 760) && navigation.hasClass('col-sidebar-hidden')) {
+            } else if ((win.height() >= navHeight && win.width() >= 760) && navigation.hasClass('col-sidebar-hidden')) {
                 navigation.removeClass('col-sidebar-hidden');
                 transition_duration(0);
                 if (window.sessionStorage && sessionStorage.getItem('toggle_sidebar_preset') == 1) {

--- a/src/opnsense/www/js/opnsense_theme.js
+++ b/src/opnsense/www/js/opnsense_theme.js
@@ -187,6 +187,7 @@ $(document).ready(function () {
             if ((win.height() < navHeight || win.width() < 760) && navigation.not('col-sidebar-hidden')) {
                 navigation.addClass('col-sidebar-hidden');
                 mouse_events_off();
+                toggle_btn.hide();
                 if (navigation.hasClass('col-sidebar-left')) {
                     opnsense_sidebar_toggle(false);
                     mouse_events_off();
@@ -195,6 +196,7 @@ $(document).ready(function () {
             } else if ((win.height() >= navHeight && win.width() >= 760) && navigation.hasClass('col-sidebar-hidden')) {
                 navigation.removeClass('col-sidebar-hidden');
                 transition_duration(0);
+                toggle_btn.show();
                 if (window.sessionStorage && sessionStorage.getItem('toggle_sidebar_preset') == 1) {
                     opnsense_sidebar_toggle(false);
                 }


### PR DESCRIPTION
since the navigation bar can change in height at any time due to the installation of plugins, and since we may want to redistribute the plugins, I have decided to dynamically adapt the resize function for navigation. now it does not matter how many menu items are in the sidebar. the resize function of sidebar navigation is now dynamic.