### PR TITLE
Clean up incorrect/unused variable assignments

### DIFF
--- a/src/etc/inc/IPv6.inc
+++ b/src/etc/inc/IPv6.inc
@@ -476,7 +476,6 @@ class Net_IPv6
             if ("" == $ip1) {
                 $c1 = -1;
             } else {
-                $pos = 0;
                 if (0 < ($pos = substr_count($ip1, ':'))) {
                     $c1 = $pos;
                 } else {
@@ -486,7 +485,6 @@ class Net_IPv6
             if ("" == $ip2) {
                 $c2 = -1;
             } else {
-                $pos = 0;
                 if (0 < ($pos = substr_count($ip2, ':'))) {
                     $c2 = $pos;
                 } else {
@@ -814,7 +812,6 @@ class Net_IPv6
         $binNetmask = str_repeat('1', $bitmask).
                       str_repeat('0', 128 - $bitmask);
         $maxNetmask = str_repeat('1', 128);
-        $netmask    = Net_IPv6::_bin2Ip($binNetmask);
 
         $startAddress = Net_IPv6::_bin2Ip(Net_IPv6::_ip2Bin($ip)
                                           & $binNetmask);

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -323,8 +323,8 @@ function filter_configure_sync($verbose = false, $flush_states = false)
     }
 
     $natrules = "\n# NAT Redirects\n";
-    $natrules = "no nat proto carp all\n";
-    $natrules = "no rdr proto carp all\n";
+    $natrules .= "no nat proto carp all\n";
+    $natrules .= "no rdr proto carp all\n";
     $natrules .= $fw->outputNatRules();
 
     if ($verbose) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -66,7 +66,6 @@ function convert_ipv6_to_128bit($ipv6)
         return false;
     }
 
-    $ip6arr = array();
     $ip6prefix = Net_IPv6::uncompress($ipv6);
     $ip6arr = explode(":", $ip6prefix);
     /* binary presentation of the prefix for all 128 bits. */
@@ -84,7 +83,6 @@ function convert_128bit_to_ipv6($ip6bin)
     }
 
     $ip6arr = array();
-    $ip6binarr = array();
     $ip6binarr = str_split($ip6bin, 16);
     foreach ($ip6binarr as $binpart) {
         $ip6arr[] = dechex(bindec($binpart));
@@ -1876,7 +1874,6 @@ function interface_wireless_configure($if, &$wl, &$wlcfg)
     /* set values for /path/program */
     $wpa_supplicant = '/usr/local/sbin/wpa_supplicant';
     $hostapd = '/usr/local/sbin/hostapd';
-    $killall = '/usr/bin/killall';
     $ifconfig = '/sbin/ifconfig';
     $sysctl = '/sbin/sysctl';
 
@@ -2813,7 +2810,6 @@ function interface_6to4_configure($interface = 'wan', $wancfg)
 
     /* convert the 128 bits for the broker address back into a valid IPv6 address */
     $stfbrarr = array();
-    $stfbrbinarr = array();
     $stfbrbinarr = str_split($stfbrokerbin, 16);
     foreach ($stfbrbinarr as $bin) {
         $stfbrarr[] = dechex(bindec($bin));
@@ -2822,14 +2818,12 @@ function interface_6to4_configure($interface = 'wan', $wancfg)
 
     /* convert the 128 bits for the broker address back into a valid IPv6 address */
     $stflanarr = array();
-    $stflanbinarr = array();
     $stflanbinarr = str_split($stflanbin, 16);
     foreach ($stflanbinarr as $bin) {
         $stflanarr[] = dechex(bindec($bin));
     }
     $stflanpr = Net_IPv6::compress(implode(":", $stflanarr));
     $stflanarr[7] = 1;
-    $stflan = Net_IPv6::compress(implode(":", $stflanarr));
 
     $stfiface = "{$wanif}_stf";
     if (does_interface_exist($stfiface)) {
@@ -4241,7 +4235,6 @@ function get_interfaces_info()
         $ifinfo['outerrs'] = $ifinfotmp['output errors'];
         $ifinfo['collisions'] = $ifinfotmp['collisions'];
 
-        $ifconfiginfo = "";
         $link_type = $config['interfaces'][$ifdescr]['ipaddr'];
         switch ($link_type) {
             case 'dhcp':
@@ -4352,7 +4345,6 @@ function get_interfaces_info()
             }
         }
 
-        $bridge = "";
         $bridge = link_interface_to_bridge($ifdescr);
         if ($bridge) {
             $bridge_text = `/sbin/ifconfig {$bridge}`;

--- a/src/etc/inc/legacy_bindings.inc
+++ b/src/etc/inc/legacy_bindings.inc
@@ -140,7 +140,6 @@ function legacy_move_config_list_items($source, $id, $items) {
  */
 function get_alias_description($name)
 {
-    $aliasMdl = new \OPNsense\Firewall\Alias();
     // MVC defined aliases
     foreach ((new \OPNsense\Firewall\Alias())->aliasIterator()  as $alias) {
         if ($alias['name'] == $name) {

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -178,7 +178,6 @@ function ntpd_configure_do($verbose = false, $start_ntpd = true)
 
     $driftfile = '/var/db/ntpd.drift';
     $statsdir = '/var/log/ntp';
-    $gps_device = '/dev/gps0';
 
     @mkdir($statsdir, 0755);
 

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -561,7 +561,6 @@ function openvpn_reconfigure($mode, $settings, $device_only = false)
     if (substr($settings['protocol'], 0, 3) == "TCP") {
         $proto = "{$proto}-{$mode}";
     }
-    $dev_mode = $settings['dev_mode'];
     $cipher = $settings['crypto'];
     // OpenVPN defaults to SHA1, so use it when unset to maintain compatibility.
     $digest = !empty($settings['digest']) ? $settings['digest'] : "SHA1";
@@ -1305,8 +1304,8 @@ function openvpn_get_active_servers($type = 'multipoint')
 
 function openvpn_get_server_status($server, $socket)
 {
-    $errval;
-    $errstr;
+    $errval = 0;
+    $errstr = '';
     $fp = @stream_socket_client($socket, $errval, $errstr, 1);
     if ($fp) {
         stream_set_timeout($fp, 1);
@@ -1402,8 +1401,8 @@ function openvpn_get_active_clients()
 
 function openvpn_get_client_status($client, $socket)
 {
-    $errval;
-    $errstr;
+    $errval = 0;
+    $errstr = '';
     $fp = @stream_socket_client($socket, $errval, $errstr, 1);
     if ($fp) {
         stream_set_timeout($fp, 1);
@@ -1469,7 +1468,6 @@ function openvpn_get_client_status($client, $socket)
         }
         fclose($fp);
     } else {
-        $DisplayNote=true;
         $client['remote_host'] = "Unable to contact daemon";
         $client['virtual_addr'] = "Service not running?";
         $client['bytes_recv'] = 0;

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -82,7 +82,7 @@ function unbound_xmlrpc_sync()
 
 function unbound_optimization()
 {
-    $optimization_settings = array();
+    $optimization = array();
 
     /*
      * Set the number of threads equal to the nearest power of 2 when counting the number of CPUs.
@@ -604,7 +604,6 @@ function unbound_add_host_entries()
     /* Static Host entries */
 
     if (isset($config['unbound']['hosts'])) {
-        $added_item = array();
 
         foreach ($config['unbound']['hosts'] as $host) {
             if ($host['host'] != "") {

--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -49,7 +49,6 @@ function rrd_configure($verbose = false)
     }
 
     $rrddbpath = "/var/db/rrd/";
-    $rrdgraphpath = "/usr/local/www/rrd";
 
     $traffic = "-traffic.rrd";
     $packets = "-packets.rrd";
@@ -66,10 +65,8 @@ function rrd_configure($verbose = false)
     $rrdtool = "/usr/local/bin/rrdtool";
     $netstat = "/usr/bin/netstat";
     $awk = "/usr/bin/awk";
-    $tar = "/usr/bin/tar";
     $pfctl = "/sbin/pfctl";
     $sysctl = "/sbin/sysctl";
-    $php = "/usr/local/bin/php";
     $cpustats = "/usr/local/sbin/cpustats";
     $ifconfig = "/sbin/ifconfig";
     $ntpq = "/usr/local/sbin/ntpq";
@@ -91,7 +88,6 @@ function rrd_configure($verbose = false)
     $wirelessvalid = $rrdwirelessinterval * 2;
     $packetsvalid = $rrdpacketsinterval * 2;
     $statesvalid = $rrdstatesinterval*2;
-    $lbpoolvalid = $rrdlbpoolinterval * 2;
     $procvalid = $rrdlbpoolinterval * 2;
     $memvalid = $rrdmeminterval * 2;
     $mbufvalid = $rrdmbufinterval * 2;
@@ -636,7 +632,6 @@ function rrd_export()
 
     $result = "\t<rrddata>\n";
     $rrd_files = glob("{$rrddbpath}/*.rrd");
-    $xml_files = array();
     foreach ($rrd_files as $rrd_file) {
         $basename = basename($rrd_file);
         $xml_file = preg_replace('/\.rrd$/', ".xml", $rrd_file);

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1128,7 +1128,6 @@ function services_dhcpdv6_configure($verbose = false, $blacklist = array())
             continue;
         }
         if (!empty($config['interfaces'][$ifname]['track6-interface'])) {
-            $realif = get_real_interface($ifname, 'inet6');
             $ifcfgipv6 = get_interface_ipv6($ifname);
             if (!is_ipaddrv6($ifcfgipv6)) {
                 continue;
@@ -1181,9 +1180,6 @@ function services_dhcpdv6_configure($verbose = false, $blacklist = array())
 
                 $pd_prefix_from_array[2] = sprintf("%02s", $pd_prefix_from_array[2]);
                 $pd_prefix_to_array[2] = sprintf("%02s", $pd_prefix_to_array[2]);
-
-                $pd_prefix_from_array_out = array();
-                $pd_prefix_to_array_out = array();
 
                 for ($x = 0; $x < 4; $x++) {
                     /* make the prefx long format otherwise dhcpd complains */
@@ -1272,7 +1268,6 @@ EOD;
     $dhcpdv6ifs = array();
     $ddns_zones = array();
     $nsupdate = false;
-    $dhcpv6num = 0;
 
     foreach ($dhcpdv6cfg as $dhcpv6if => $dhcpv6ifconf) {
         if (!isset($dhcpv6ifconf['enable']) || !isset($iflist[$dhcpv6if])) {
@@ -1537,7 +1532,6 @@ function services_dhcrelay_configure($verbose = false)
             array_shift($route_str);
             array_shift($route_str);
             array_shift($route_str);
-            $route_arr = array();
             foreach ($route_str as $routeline) {
                 $items = preg_split("/[ ]+/i", $routeline);
                 if (is_subnetv4($items[0])) {
@@ -1663,7 +1657,6 @@ function services_dhcrelay6_configure($verbose = false)
             array_shift($route_str);
             array_shift($route_str);
             array_shift($route_str);
-            $route_arr = array();
             foreach ($route_str as $routeline) {
                 $items = preg_split("/[ ]+/i", $routeline);
                 if (ip_in_subnet($srvip, $items[0])) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -372,7 +372,7 @@ function ip_range_to_subnet_array($startip, $endip)
 
     // Loop here to reduce subnet size and retest as needed. We need to make sure
     //   that the target subnet is wholly contained between $startip and $endip.
-    for ($cidr; $cidr <= 32; $cidr++) {
+    for (; $cidr <= 32; $cidr++) {
         // Find the network and broadcast addresses for the subnet being tested.
         $targetsub_min = gen_subnet($startip, $cidr);
         $targetsub_max = gen_subnet_max($startip, $cidr);

--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -107,7 +107,7 @@ function endElement($parser, $name)
 
 function cData($parser, $data)
 {
-    global $depth, $curpath, $parsedcfg, $havedata;
+    global $curpath, $parsedcfg, $havedata;
 
     $data = trim($data, "\t\n\r");
 
@@ -129,7 +129,7 @@ function cData($parser, $data)
 
 function parse_xml_config_raw($cffile, $rootobj, $isstring = "false")
 {
-    global $depth, $curpath, $parsedcfg, $havedata, $listtags;
+    global $depth, $curpath, $parsedcfg, $havedata;
     $parsedcfg = array();
     $curpath = array();
     $depth = 0;

--- a/src/etc/rc.openvpn
+++ b/src/etc/rc.openvpn
@@ -49,7 +49,6 @@ function gateway_is_gwgroup_member($name)
         if (isset($group['item'])) {
             foreach($group['item'] as $item) {
                 $elements = explode("|", $item);
-                $gwname = $elements[0];
                 if ($name == $elements[0]) {
                     $members[] = $group['name'];
                 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/NetworkinsightController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/NetworkinsightController.php
@@ -144,7 +144,6 @@ class NetworkinsightController extends ApiControllerBase
         $measure = $filter->sanitize($measure, "string");
         $max_hits = $filter->sanitize($max_hits, "int");
 
-        $result = array();
         if ($this->request->isGet()) {
             if ($this->request->get("filter_field") != null && $this->request->get("filter_value") != null) {
                 $filter_fields = explode(',', $this->request->get("filter_field"));

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
@@ -84,7 +84,6 @@ class SystemhealthController extends ApiControllerBase
     {
 
         $rowNumber = 0;
-        $containsValues = false; // used to break foreach on first row with collected data
 
         foreach ($data->database->row as $item => $row) {
             foreach ($row as $rowKey => $rowVal) {

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Local.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Local.php
@@ -118,7 +118,6 @@ class Local extends Base implements IAuthConnector
         $configObj = Config::getInstance()->object();
         if (!empty($configObj->system->webgui->enable_password_policy_constraints)) {
             if (!empty($configObj->system->webgui->password_policy_duration)) {
-                $duration = $configObj->system->webgui->password_policy_duration;
                 $userObject = $this->getUser($username);
                 if ($userObject != null) {
                     $now = microtime(true);

--- a/src/opnsense/scripts/shell/setaddr.php
+++ b/src/opnsense/scripts/shell/setaddr.php
@@ -80,7 +80,7 @@ function console_get_interface_from_ppp($realif)
 
 function prompt_for_enable_dhcp_server($version = 4)
 {
-    global $config, $fp, $interface;
+    global $config, $interface;
     if ($interface == "wan") {
         if ($config['interfaces']['lan']) {
             return false;

--- a/src/www/diag_states_summary.php
+++ b/src/www/diag_states_summary.php
@@ -62,7 +62,6 @@ function build_port_info($portarr, $proto) {
     $ports = array();
     asort($portarr);
     foreach (array_reverse($portarr, TRUE) as $port => $count) {
-        $str = "";
         $service = getservbyport($port, strtolower($proto));
         $port = "{$proto}/{$port}";
         if (!empty($service)) {

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -144,7 +144,7 @@ function endElement_attr($parser, $name) {
 }
 
 function cData_attr($parser, $data) {
-    global $depth, $curpath, $parsedcfg, $havedata;
+    global $curpath, $parsedcfg, $havedata;
 
     $data = trim($data, "\t\n\r");
 
@@ -212,7 +212,7 @@ function parse_xml_regdomain(&$rdattributes, $rdfile = '', $rootobj = 'regulator
 }
 
 function parse_xml_config_raw_attr($cffile, $rootobj, &$parsed_attributes, $isstring = "false") {
-    global $depth, $curpath, $parsedcfg, $havedata, $listtags, $parsedattrs;
+    global $depth, $curpath, $parsedcfg, $havedata, $parsedattrs;
     $parsedcfg = array();
     $curpath = array();
     $depth = 0;

--- a/src/www/widgets/api/plugins/traffic.inc
+++ b/src/www/widgets/api/plugins/traffic.inc
@@ -27,7 +27,6 @@
 
 function traffic_api()
 {
-    global $config;
     $result = array();
     $result['interfaces'] = legacy_interface_stats();
     $temp = gettimeofday();


### PR DESCRIPTION
This fixes several problems regarding variable assignments or initialisation. Most of these are variables that are declared but never used or declared but immediately overwritten. It also contains cases of an assignment operator instead of a compound string concatenate operator, and some cases of (nonworking) "C-style" variable declaration.