### PR TITLE
Remove nonexistant CSS properties

### DIFF
--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -502,7 +502,7 @@ $( document ).ready(function() {
                   <tfoot>
                     <tr class="hidden-xs hidden-sm">
                       <td colspan="13">
-                        <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
+                        <table style="width:100%; border:0;">
                           <tr>
                             <td><i class="fa fa-play fa-fw text-success"></i></td>
                             <td><?=gettext("Enabled rule"); ?></td>

--- a/src/www/firewall_nat_npt_edit.php
+++ b/src/www/firewall_nat_npt_edit.php
@@ -194,7 +194,7 @@ include("head.inc");
                   <tr>
                     <td><a id="help_for_src" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Source") . " / ". gettext("Address:"); ?></td>
                     <td>
-                      <table style="border:0; cellspacing:0; cellpadding:0">
+                      <table style="border:0;">
                         <tr>
                           <td style="width:348px">
                             <input name="src" type="text" value="<?=$pconfig['src'];?>" aria-label="<?=gettext("Source address");?>"/>
@@ -232,7 +232,7 @@ include("head.inc");
                   <tr>
                     <td><a id="help_for_dst" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Destination") . " / ". gettext("Address:"); ?></td>
                     <td>
-                      <table style="border:0; cellspacing:0; cellpadding:0">
+                      <table style="border:0;">
                         <tr>
                           <td style="width:348px">
                             <input name="dst" type="text" value="<?=$pconfig['dst'];?>" aria-label="<?=gettext("Source address");?>"/>

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -748,7 +748,7 @@ $( document ).ready(function() {
                 <tfoot>
                   <tr class="hidden-xs hidden-sm">
                     <td colspan="11">
-                      <table style="width:100%; border:0; cellspacing:0; cellpadding:0">
+                      <table style="width:100%; border:0;">
                         <tr>
                           <td style="width:16px"><span class="fa fa-play text-success"></span></td>
                           <td style="width:100px"><?=gettext("pass");?></td>

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -906,7 +906,7 @@ include("head.inc");
                         <tr>
                           <td>
                             <div>
-                              <table style="border:0; cellpadding:0; cellspacing:0">
+                              <table style="border:0;">
                                 <tbody>
                                   <tr>
                                       <td style="width:348px">
@@ -1035,7 +1035,7 @@ include("head.inc");
                         </tr>
                         <tr>
                           <td>
-                            <table style="border:0; cellpadding:0; cellspacing:0">
+                            <table style="border:0;">
                               <tbody>
                                 <tr>
                                     <td style="width:348px">
@@ -1371,7 +1371,7 @@ include("head.inc");
                   <tr class="opt_advanced hidden">
                       <td><a id="help_for_max-src-conn-rate" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max new connections");?> </td>
                       <td>
-                        <table style="border:0; cellspacing:0; cellpadding:0">
+                        <table style="border:0;">
                           <tbody>
                             <tr>
                               <td>

--- a/src/www/firewall_schedule_edit.php
+++ b/src/www/firewall_schedule_edit.php
@@ -928,7 +928,7 @@ $( function() { $('#iform td').css({ 'background-color' : '' }); })
                       <tr>
                         <td><a id="help_for_time" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Time");?></td>
                         <td>
-                          <table style="cellspacing:2" class="tabcont">
+                          <table class="tabcont">
                             <tr>
                               <td><?=gettext("Start Time");?></td>
                               <td><?=gettext("Stop Time");?></td>

--- a/src/www/firewall_scrub_edit.php
+++ b/src/www/firewall_scrub_edit.php
@@ -396,7 +396,7 @@ include("head.inc");
                         <tr>
                           <td>
                             <div>
-                              <table style="border:0; cellpadding:0; cellspacing:0">
+                              <table style="border:0;">
                                 <tbody>
                                   <tr>
                                       <td style="width:348px">
@@ -495,7 +495,7 @@ include("head.inc");
                         </tr>
                         <tr>
                           <td>
-                            <table style="border:0; cellpadding:0; cellspacing:0">
+                            <table style="border:0;">
                               <tbody>
                                 <tr>
                                     <td style="width:348px">

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -363,7 +363,7 @@ $( document ).ready(function() {
                   <tr>
                       <td><a id="help_for_address" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Address");?></td>
                       <td>
-                        <table style="border:0; cellspacing:0; cellpadding:0">
+                        <table style="border:0;">
                           <tr>
                             <td style="width:348px">
                               <input name="subnet" type="text" class="form-control" id="subnet" size="28" value="<?=$pconfig['subnet'];?>" />

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -758,7 +758,7 @@ if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
           <section class="col-xs-12">
             <div class="tab-content content-box col-xs-12">
                 <div class="table-responsive">
-                  <table class="tabcont table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0">
+                  <table class="tabcont table table-striped" style="width:100%; border:0;">
                     <tr>
                       <th colspan="5"><?= gettext('DHCPv6 Static Mappings for this interface.') ?></th>
                     </tr>

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -693,7 +693,7 @@ $main_buttons = array(
           <input type="hidden" name="id" id="id" value="<?=isset($id) ? $id :"";?>"/>
           <input type="hidden" name="act" id="action" value="<?=$act;?>"/>
         </form>
-        <table style="width:100%; border:0; cellpadding:0; cellspacing:0" class="table table-striped">
+        <table style="width:100%; border:0;" class="table table-striped">
           <thead>
             <tr>
               <th><?=gettext("Name");?></th>

--- a/src/www/system_groupmanager.php
+++ b/src/www/system_groupmanager.php
@@ -251,7 +251,7 @@ $( document ).ready(function() {
               <tr>
                 <td><a id="help_for_groups" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Group Memberships");?></td>
                 <td>
-                  <table class="table" style="width:100%; border:0; cellpadding:0; cellspacing:0">
+                  <table class="table" style="width:100%; border:0;">
                     <thead>
                       <tr>
                         <th><?=gettext("Not Member Of"); ?></th>

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -690,7 +690,7 @@ $( document ).ready(function() {
                   <tr>
                     <td><a id="help_for_groups" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Group Memberships");?></td>
                     <td>
-                      <table class="table" style="width:100%; border:0; cellpadding:0; cellspacing:0">
+                      <table class="table" style="width:100%; border:0;">
                         <thead>
                           <tr>
                             <th><?=gettext("Not Member Of"); ?></th>

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -198,7 +198,7 @@ if (isset($config['ipsec']['phase2'])) {
 else {
 ?>
 <div style="display:block">
-   <table class="table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0;">
+   <table class="table table-striped" style="width:100%; border:0;">
     <tr>
       <td>
         <?= gettext('Note: There are no configured IPsec Tunnels') ?>

--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -69,7 +69,7 @@ require_once('diag_logs_common.inc');
 </div>
 
 <div id="system_log-widgets" class="content-box" style="overflow:scroll;">
-  <table class="table table-striped" style="cellspacing:0; cellpadding:0">
+  <table class="table table-striped">
     <?php dump_clog($system_logfile, $syslogEntriesToFetch); ?>
   </table>
 </div>


### PR DESCRIPTION
The table attributes 'cellspacing' and 'cellpadding' were moved inside the style attribute via a script. However, they are not valid CSS properties, so browsers should (and do) ignore them.
This commit removes them. The 'table' class, set on most tables, should take care of proper formatting anyway.