### PR TITLE
monit: Support declaring dependencies

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
@@ -73,6 +73,12 @@
       <help><![CDATA[This is a list with service tests.]]></help>
    </field>
    <field>
+      <id>monit.service.depends</id>
+      <label>Depends</label>
+      <type>select_multiple</type>
+      <help><![CDATA[This is a list with service dependencies.]]></help>
+   </field>
+   <field>
       <id>monit.service.description</id>
       <label>Description</label>
       <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -256,6 +256,18 @@
             <multiple>Y</multiple>
             <Required>N</Required>
          </tests>
+         <depends type="ModelRelationField">
+            <Model>
+               <template>
+                  <source>OPNsense.monit.monit</source>
+                  <items>service</items>
+                  <display>name</display>
+               </template>
+            </Model>
+            <ValidationMessage>Related item not found</ValidationMessage>
+            <multiple>Y</multiple>
+            <Required>N</Required>
+         </depends>
       </service>
       <test type="ArrayField">
          <name type="TextField">

--- a/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
@@ -201,6 +201,7 @@ POSSIBILITY OF SUCH DAMAGE.
          $('tr[id="row_monit.service.interface"]').addClass('hidden');
          $('tr[id="row_monit.service.start"]').removeClass('hidden');
          $('tr[id="row_monit.service.stop"]').removeClass('hidden');
+         $('tr[id="row_monit.service.depends"]').removeClass('hidden');
          switch (servicetype) {
             case 'process':
                var pidfile = $('#monit\\.service\\.pidfile').val();
@@ -236,6 +237,7 @@ POSSIBILITY OF SUCH DAMAGE.
             case 'system':
                $('tr[id="row_monit.service.start"]').addClass('hidden');
                $('tr[id="row_monit.service.stop"]').addClass('hidden');
+               $('tr[id="row_monit.service.depends"]').addClass('hidden');
                break;
             default:
                $('tr[id="row_monit.service.path"]').removeClass('hidden');

--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -128,6 +128,12 @@ check program {{ service.name }} {{ path }} {{ timeout }}
 check {{ service.type }} {{ service.name }} {{ path }}
 {%      endif %}
 {%     endif %}
+{%     if service.depends is defined %}
+{%      for dependency in service.depends.split(",") %}
+{%      set dependency = helpers.getUUID(dependency) %}
+   depends on {{dependency.name}}
+{%      endfor %}
+{%     endif %}
 {%     if service.start|default('') != '' %}
    start program = "{{ service.start }}"
 {%     endif %}


### PR DESCRIPTION
This PR allows setting dependencies in the UI. This allows advanced check behaviour, e.g. VPN <- hosts behind VPN <- service behind VPN on host.

At the moment, the selection of the service as its own dependency is possible, monit shows a dependency loop error in that case with a helpful message. I'm unsure how to restrict the available services to exclude itself from the dependency list.