### PR TITLE
Fix #2960: Limit line length in log widget

### DIFF
--- a/src/www/diag_logs_common.inc
+++ b/src/www/diag_logs_common.inc
@@ -63,7 +63,16 @@ function print_dump($logarr)
     }
 }
 
-function dump_clog($logfile, $tail, $grepfor = '')
+function limit_log_line_length(string $line, int $lineCharLimit): string
+{
+    if (strlen($line) <= $lineCharLimit) {
+        return $line;
+    } else {
+        return substr($line, 0, $lineCharLimit - 1) . '…';
+    }
+}
+
+function dump_clog($logfile, $tail, $grepfor = '', int $lineCharLimit = 0)
 {
     global $config;
 
@@ -89,10 +98,16 @@ function dump_clog($logfile, $tail, $grepfor = '')
         $logarr = sprintf(gettext('File %s yielded no results.'), $logfile);
     }
 
+    if ($lineCharLimit != 0) {
+        $logarr = array_map(function($value) use ($lineCharLimit) {
+            return limit_log_line_length($value, $lineCharLimit);
+        }, $logarr);
+    }
+
     print_dump($logarr);
 }
 
-function dump_log($logfile, $tail, $grepfor = '')
+function dump_log($logfile, $tail, $grepfor = '', int $lineCharLimit = 0)
 {
     global $config;
 
@@ -116,6 +131,12 @@ function dump_log($logfile, $tail, $grepfor = '')
 
     if (is_array($logarr) && !count($logarr)) {
         $logarr = sprintf(gettext('File %s yielded no results.'), $logfile);
+    }
+
+    if ($lineCharLimit != 0) {
+        $logarr = array_map(function($value) use ($lineCharLimit) {
+            return limit_log_line_length($value, $lineCharLimit);
+        }, $logarr);
     }
 
     print_dump($logarr);

--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -70,7 +70,7 @@ require_once('diag_logs_common.inc');
 
 <div id="system_log-widgets" class="content-box" style="overflow:scroll;">
   <table class="table table-striped">
-    <?php dump_clog($system_logfile, $syslogEntriesToFetch); ?>
+    <?php dump_clog($system_logfile, $syslogEntriesToFetch, '', 250); ?>
   </table>
 </div>
 


### PR DESCRIPTION
For consistency, I added the line char limit parameter to both `dump_clog` and `dump_log`.