### PR TITLE
Fix to add the duid length to th duid file

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2858,13 +2858,19 @@ function interface_dhcpv6_configure($interface = 'wan', $wancfg)
 
     /* write DUID if override was set */
     if (!empty($config['system']['ipv6duid'])) {
-        $temp = str_replace(':', '', $config['system']['ipv6duid']);
-        $duid_binstring = pack('H*', $temp);
-        $fd = fopen('/var/db/dhcp6c_duid', 'wb');
-        if ($fd) {
-            fwrite($fd, $duid_binstring);
-            fclose($fd);
-        }
+        $values = explode(":", $config['system']['ipv6duid']);
+		$num_values = count($values);
+		$num_values = sprintf("%02x",$num_values);
+		array_unshift($values, $num_values, '00');
+		$duid_to_write = implode(':', $values);
+		log_error("write: {$duid_to_write}");
+		$temp = str_replace(':', '', $duid_to_write);    
+		$duid_binstring = pack('H*', $temp);  
+		$fd = fopen('/var/db/dhcp6c_duid', 'wb');
+		if ($fd) {
+			fwrite($fd, $duid_binstring);
+			fclose($fd);
+		}
     }
 
     if (!is_array($wancfg)) {


### PR DESCRIPTION
When using different DUID types the lenght varies. Although not seen in the GUI, you must add the length as the first byte to the DUID file that dhcp6c reads, the second byte is null, then the duid itself.