### PR TITLE
Stable/18.7> dhcpdv4: adding opt67 (bootfilename) and staticmap netboot

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -934,12 +934,27 @@ EOD;
                     $dhhostname = str_replace(".", "_", $dhhostname);
                     $dhcpdconf .= "  option host-name \"{$dhhostname}\";\n";
                 }
-                if (!empty($sm['filename'])) {
-                    $dhcpdconf .= "  filename \"{$sm['filename']}\";\n";
-                }
 
-                if (!empty($sm['rootpath'])) {
-                    $dhcpdconf .= "  option root-path \"{$sm['rootpath']}\";\n";
+                if (isset($sm['netboot'])) {
+                    if (!empty($sm['nextserver'])) {
+                        $dhcpdconf .= "  next-server {$sm['nextserver']};\n";
+                    }
+                    if (!empty($sm['filename']) && !empty($sm['filename32']) && !empty($sm['filename64'])) {
+                        $dhcpdconf .= "  if option arch = 00:06 {\n";
+                        $dhcpdconf .= "    filename \"{$sm['filename32']}\";\n";
+                        $dhcpdconf .= "  } else if option arch = 00:07 {\n";
+                        $dhcpdconf .= "    filename \"{$sm['filename64']}\";\n";
+                        $dhcpdconf .= "  } else if option arch = 00:09 {\n";
+                        $dhcpdconf .= "    filename \"{$sm['filename64']}\";\n";
+                        $dhcpdconf .= "  } else {\n";
+                        $dhcpdconf .= "    filename \"{$sm['filename']}\";\n";
+                        $dhcpdconf .= "  }\n\n";
+                    } elseif (!empty($sm['filename'])) {
+                        $dhcpdconf .= "  filename \"{$sm['filename']}\";\n";
+                    }
+                    if (!empty($sm['rootpath'])) {
+                        $dhcpdconf .= "  option root-path \"{$sm['rootpath']}\";\n";
+                    }
                 }
 
                 if (!empty($sm['gateway']) && ($sm['gateway'] != $dhcpifconf['gateway'])) {

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -778,6 +778,11 @@ EOPP;
                 $dhcpdconf .= "    option tftp-server-name \"{$poolconf['tftp']}\";\n";
             }
 
+            // bootfile-name
+            if (!empty($poolconf['bootfilename']) && (empty($dhcpifconf['bootfilename']) || $poolconf['bootfilename'] != $dhcpifconf['bootfilename'])) {
+                $dhcpdconf .= "    option bootfile-name \"{$poolconf['bootfilename']}\";\n";
+            }
+
             // ldap-server
             if (!empty($poolconf['ldap']) && (empty($dhcpifconf['ldap']) || $poolconf['ldap'] != $dhcpifconf['ldap'])) {
                 $dhcpdconf .= "    option ldap-server \"{$poolconf['ldap']}\";\n";
@@ -844,6 +849,11 @@ EOD;
         // tftp-server-name
         if (!empty($dhcpifconf['tftp'])) {
             $dhcpdconf .= "  option tftp-server-name \"{$dhcpifconf['tftp']}\";\n";
+        }
+
+        // bootfile-name
+        if (!empty($dhcpifconf['bootfilename'])) {
+            $dhcpdconf .= "  option bootfile-name \"{$dhcpifconf['bootfilename']}\";\n";
         }
 
         // add pac url if it applies
@@ -981,6 +991,11 @@ EOD;
                 // tftp-server-name
                 if (!empty($sm['tftp']) && ($sm['tftp'] != $dhcpifconf['tftp'])) {
                     $dhcpdconf .= "  option tftp-server-name \"{$sm['tftp']}\";\n";
+                }
+
+                // bootfile-name
+                if (!empty($sm['bootfilename']) && ($sm['bootfilename'] != $dhcpifconf['bootfilename'])) {
+                    $dhcpdconf .= "  option bootfile-name \"{$sm['bootfilename']}\";\n";
                 }
 
                 $dhcpdconf .= "}\n";

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -96,9 +96,9 @@ function reconfigure_dhcpd()
 
 $config_copy_fieldsnames = array('enable', 'staticarp', 'failover_peerip', 'dhcpleaseinlocaltime','descr',
   'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'denyunknown', 'ddnsdomain',
-  'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsupdate', 'mac_allow', 'mac_deny', 'tftp', 'ldap',
-  'netboot', 'nextserver', 'filename', 'filename32', 'filename64', 'rootpath', 'netmask', 'numberoptions',
-  'interface_mtu', 'wpad');
+  'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsupdate', 'mac_allow', 
+  'mac_deny', 'tftp', 'bootfilename', 'ldap', 'netboot', 'nextserver', 'filename', 'filename32', 'filename64', 
+  'rootpath', 'netmask', 'numberoptions', 'interface_mtu', 'wpad');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     // handle identifiers and action
@@ -940,8 +940,11 @@ include("head.inc");
                           <input type="button" onclick="show_tftp_config()" class="btn btn-default btn-xs" value="<?=gettext("Advanced");?>" /> - <?=gettext("Show TFTP configuration");?>
                         </div>
                         <div id="showtftp" style="display:none">
-                          <input name="tftp" type="text" size="50" value="<?=$pconfig['tftp'];?>" />
-                          <?=gettext("Leave blank to disable. Enter a full hostname or IP for the TFTP server.");?>
+                          <?=gettext("Set TFTP hostname");?>
+                          <input name="tftp" type="text" size="50" value="<?=$pconfig['tftp'];?>" /><br />
+                          <?=gettext("Set Bootfile");?>
+                          <input name="bootfilename" type="text" size="1024" value="<?=$pconfig['bootfilename'];?>" /><br />
+                          <?=gettext("Leave blank to disable. Enter a full hostname or IP for the TFTP server and optionally a full path for a bootfile (dhcp option 67).");?><br />
                         </div>
                       </td>
                     </tr>

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -53,8 +53,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig = array();
     $config_copy_fieldnames = array('mac', 'cid', 'hostname', 'filename', 'rootpath', 'descr', 'arp_table_static_entry',
       'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'winsserver', 'dnsserver', 'ddnsdomain',
-      'ddnsupdate', 'ntpserver', 'tftp', 'ipaddr',
-      'winsserver', 'dnsserver');
+      'ddnsupdate', 'ntpserver', 'tftp', 'bootfilename', 'ipaddr', 'winsserver', 'dnsserver');
+    
     foreach ($config_copy_fieldnames as $fieldname) {
         if (isset($if) && isset($id) && isset($config['dhcpd'][$if]['staticmap'][$id][$fieldname])) {
             $pconfig[$fieldname] = $config['dhcpd'][$if]['staticmap'][$id][$fieldname];
@@ -225,8 +225,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $mapent = array();
         $config_copy_fieldnames = array('mac', 'cid', 'ipaddr', 'hostname', 'descr', 'filename', 'rootpath',
           'arp_table_static_entry', 'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist',
-          'ddnsdomain', 'ddnsupdate', 'tftp',
-          'ldap', 'winsserver', 'dnsserver');
+          'ddnsdomain', 'ddnsupdate', 'tftp', 'bootfilename', 'ldap', 'winsserver', 'dnsserver');
 
         foreach ($config_copy_fieldnames as $fieldname) {
             if (!empty($pconfig[$fieldname])) {
@@ -502,8 +501,11 @@ include("head.inc");
                       <input type="button" onclick="show_tftp_config()" class="btn btn-xs btn-default" value="<?=gettext("Advanced");?>" /> - <?=gettext("Show TFTP configuration");?>
                     </div>
                     <div id="showtftp" style="display:none">
+                    <?=gettext("Set TFTP hostname");?>
                       <input name="tftp" type="text" id="tftp" size="50" value="<?=$pconfig['tftp'];?>" /><br />
-                      <?=gettext("Leave blank to disable. Enter a full hostname or IP for the TFTP server.");?>
+                      <?=gettext("Set Bootfile");?>
+                      <input name="bootfilename" type="text" id="bootfilename" size="1024" value="<?=$pconfig['bootfilename'];?>" /><br />
+                      <?=gettext("Leave blank to disable. Enter a full hostname or IP for the TFTP server and optionally a full path for a bootfile (dhcp option 67).");?><br />
                     </div>
                   </td>
                 </tr>

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -51,9 +51,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // read form data
     $pconfig = array();
-    $config_copy_fieldnames = array('mac', 'cid', 'hostname', 'filename', 'rootpath', 'descr', 'arp_table_static_entry',
+    $config_copy_fieldnames = array('mac', 'cid', 'hostname', 'descr', 'arp_table_static_entry',
       'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'winsserver', 'dnsserver', 'ddnsdomain',
-      'ddnsupdate', 'ntpserver', 'tftp', 'bootfilename', 'ipaddr', 'winsserver', 'dnsserver');
+      'ddnsupdate', 'ntpserver', 'tftp', 'bootfilename', 'netboot', 'nextserver', 'filename', 'filename32', 'filename64', 
+      'rootpath', 'ipaddr', 'winsserver', 'dnsserver');
     
     foreach ($config_copy_fieldnames as $fieldname) {
         if (isset($if) && isset($id) && isset($config['dhcpd'][$if]['staticmap'][$id][$fieldname])) {
@@ -84,6 +85,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (isset($pconfig['ntpserver'][1])) {
         $pconfig['ntp2'] = $pconfig['ntpserver'][1];
     }
+
+    // handle booleans
+    $pconfig['netboot'] = isset($pconfig['netboot']);
+
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pconfig = $_POST;
 
@@ -223,9 +228,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     if (count($input_errors) == 0){
         $mapent = array();
-        $config_copy_fieldnames = array('mac', 'cid', 'ipaddr', 'hostname', 'descr', 'filename', 'rootpath',
+        $config_copy_fieldnames = array('mac', 'cid', 'ipaddr', 'hostname', 'descr',
           'arp_table_static_entry', 'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist',
-          'ddnsdomain', 'ddnsupdate', 'tftp', 'bootfilename', 'ldap', 'winsserver', 'dnsserver');
+          'ddnsdomain', 'ddnsupdate', 'tftp', 'bootfilename', 'netboot', 'nextserver', 'filename', 'filename32',
+          'filename64', 'rootpath',  'ldap', 'winsserver', 'dnsserver');
 
         foreach ($config_copy_fieldnames as $fieldname) {
             if (!empty($pconfig[$fieldname])) {
@@ -304,6 +310,12 @@ include("head.inc");
     $("#showtftpbox").hide();
     $("#showtftp").show();
   }
+  
+  function show_netboot_config() {
+    $("#shownetbootbox").html('');
+    $("#shownetboot").show();
+  }
+
 //]]>
 </script>
 <?php include("fbegin.inc"); ?>
@@ -506,6 +518,33 @@ include("head.inc");
                       <?=gettext("Set Bootfile");?>
                       <input name="bootfilename" type="text" id="bootfilename" size="1024" value="<?=$pconfig['bootfilename'];?>" /><br />
                       <?=gettext("Leave blank to disable. Enter a full hostname or IP for the TFTP server and optionally a full path for a bootfile (dhcp option 67).");?><br />
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable network booting");?></td>
+                  <td>
+                    <div id="shownetbootbox">
+                      <input type="button" onclick="show_netboot_config()" class="btn btn-default btn-xs" value="<?=gettext("Advanced");?>" /> - <?=gettext("Show Network booting");?>
+                    </div>
+                    <div id="shownetboot" style="display:none">
+                      <input type="checkbox" value="yes" name="netboot" id="netboot" <?=!empty($pconfig['netboot']) ? " checked=\"checked\"" : ""; ?> />
+                      <strong><?=gettext("Enables network booting.");?></strong>
+                      <br/><br/>
+                      <?=gettext('Set next-server IP');?>
+                      <input name="nextserver" type="text" id="nextserver" value="<?=$pconfig['nextserver'];?>" /><br />
+                      <?=gettext('Set default bios filename');?>
+                      <input name="filename" type="text" id="filename" value="<?=$pconfig['filename'];?>" /><br />
+                      <?=gettext('Set UEFI 32bit filename');?>
+                      <input name="filename32" type="text" id="filename32" value="<?=$pconfig['filename32'];?>" /><br />
+                      <?=gettext('Set UEFI 64bit filename');?>
+                      <input name="filename64" type="text" id="filename64" value="<?=$pconfig['filename64'];?>" /><br />
+                      <?=gettext("Note: You need both a filename and a boot server configured for this to work!");?><br/>
+                      <?=gettext("You will need all three filenames and a boot server configured for UEFI to work!");?>
+                      <br/><br/>
+                      <?=gettext('Set root-path string');?>
+                      <input name="rootpath" type="text" id="rootpath" size="90" value="<?=$pconfig['rootpath'];?>" /><br />
+                      <?=gettext("Note: string-format: iscsi:(servername):(protocol):(port):(LUN):targetname");?>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION

This is my first attempt on contributing to OPNsense and maybe not the correct path but anyway...

I switched from an old (manually configured) router to OPNsense which works great for most of the situations i have to solve. Two problems remained.

1. DHCP option 67 can't be set for a sub pool
----------------------------------------------------
This problem occurs with VoIP networks and different phone devices which should be autoprovisioned via option 66 (tftp server) and option 67 (bootfile name). Phone vendors "misuse" these two options.
Also, often the options (configuration path in 67) are completely different and can't be set network-wide. Using an asterisk softpbx like "Gemeinschaft" or "Gemeinschaft" based softpbx systems are an example for this situation.
There are several devices which are found via vendor MAC-Prefix (like snom with 00:04:13) and then auto-provisioned/redirected to 66> http://ip.of.pbx with 67> gemeinschaft/prov/snom/settings.php={mac}.

The first commit solves this problem, adding Option67 to the TFTP Setting.


2. Netboot settings can't be set for a static configured host
------------------------------------------------------------------
It seems to be impossible to maintain a static list of configured host with different netboot setting per-host. The second commit solves this problem, adding the "netboot" block to the staticmap.
While i was adding it, i found old settings "filename" and "rootpath" in the services.inc - it seems that it was possible in the past to configure netboot in the staticmap? Maybe, this is just re-adding the options.

-----
One new problem will maybe still remain: this MR is for stable/18.7 because i am using it.
I have no clue if MR's are also accepted to stable branches and what i have to do for the master branch (or how i can test it).
