### PR TITLE
Proxy: Add Parent Proxy feature

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -227,13 +227,17 @@
             <field>
                 <id>proxy.general.parentproxy.localdomains</id>
                 <label>Local Domains</label>
-                <type>text</type>
+                <type>select_multiple</type>
+                <style>tokenize</style>
+                <allownew>true</allownew>
                 <help>List of domains not to be sent via parent proxy.</help>
             </field>
             <field>
                 <id>proxy.general.parentproxy.localips</id>
                 <label>Local IPs</label>
-                <type>text</type>
+                <type>select_multiple</type>
+                <style>tokenize</style>
+                <allownew>true</allownew>
                 <help>List of IP addresses not to be sent via parent proxy.</help>
             </field>
         </subtab>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -205,6 +205,38 @@
                 <help><![CDATA[Enter the allowed per host bandwidth in kilobits per second (leave empty to disable).]]></help>
             </field>
         </subtab>
+        <subtab id="proxy-general-parentproxy" description="Parent Proxy Settings">
+            <field>
+                <id>proxy.general.parentproxy.enabled</id>
+                <label>Enable Parent Proxy</label>
+                <type>checkbox</type>
+                <help>Enable parent proxy feature</help>
+            </field>
+            <field>
+                <id>proxy.general.parentproxy.host</id>
+                <label>Host</label>
+                <type>text</type>
+                <help>Parent proxy IP address or hostname.</help>
+            </field>
+            <field>
+                <id>proxy.general.parentproxy.port</id>
+                <label>Port</label>
+                <type>text</type>
+                <help>Parent proxy port.</help>
+            </field>
+            <field>
+                <id>proxy.general.parentproxy.localdomains</id>
+                <label>Local Domains</label>
+                <type>text</type>
+                <help>List of domains not to be sent via parent proxy.</help>
+            </field>
+            <field>
+                <id>proxy.general.parentproxy.localips</id>
+                <label>Local IPs</label>
+                <type>text</type>
+                <help>List of IP addresses not to be sent via parent proxy.</help>
+            </field>
+        </subtab>
     </tab>
     <tab id="proxy-forward" description="Forward Proxy">
         <subtab id="proxy-forward-general" description="General Forward Settings">

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -182,6 +182,24 @@
                     </Constraints>
                 </perHostTrotteling>
             </traffic>
+            <parentproxy>
+                <enabled type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </enabled>
+                <host type="HostnameField">
+                    <Required>N</Required>
+                </host>
+                <port type="PortField">
+                    <Required>N</Required>
+                </port>
+                <localdomains type="CSVListField">
+                    <Required>N</Required>
+                </localdomains>
+                <localips type="CSVListField">
+                    <Required>N</Required>
+                </localips>
+            </parentproxy>
         </general>
         <forward>
             <interfaces type="InterfaceField">

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/proxy</mount>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>
         (squid) proxy settings
     </description>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -189,9 +189,27 @@
                 </enabled>
                 <host type="HostnameField">
                     <Required>N</Required>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>A host must be set.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>enabled</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
                 </host>
                 <port type="PortField">
                     <Required>N</Required>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>A host must be set.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>enabled</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
                 </port>
                 <localdomains type="CSVListField">
                     <Required>N</Required>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -203,7 +203,7 @@
                     <Required>N</Required>
                     <Constraints>
                         <check001>
-                            <ValidationMessage>A host must be set.</ValidationMessage>
+                            <ValidationMessage>A port must be set.</ValidationMessage>
                             <type>DependConstraint</type>
                             <addFields>
                                 <field1>enabled</field1>

--- a/src/opnsense/service/templates/OPNsense/Proxy/+TARGETS
+++ b/src/opnsense/service/templates/OPNsense/Proxy/+TARGETS
@@ -4,6 +4,7 @@ cache.active:/var/squid/cache/active
 externalACLs.conf:/usr/local/etc/squid/externalACLs.conf
 newsyslog.conf:/etc/newsyslog.conf.d/squid
 nobumpsites.acl:/usr/local/etc/squid/nobumpsites.acl
+parentproxy.conf:/usr/local/etc/squid/pre-auth/parentproxy.conf
 post-auth.conf:/usr/local/etc/squid/post-auth/dummy.conf
 pre-auth.conf:/usr/local/etc/squid/pre-auth/dummy.conf
 rc.conf.d:/etc/rc.conf.d/squid/squid

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -23,4 +23,5 @@ never_direct allow ExcludePPDomains
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
 never_direct allow ExcludePPIPs
 {%   endif %}
+never_direct deny all
 {% endif %}

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -10,4 +10,17 @@ acl ExcludePPDomains dstdomain {{ OPNsense.proxy.general.parentproxy.localdomain
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
 acl ExcludePPIPs dst {{ OPNsense.proxy.general.parentproxy.localips }}
 {%   endif %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
+cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} deny ExcludePPDomains
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
+cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} deny ExcludePPIPs
+{%   endif %}
+cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} allow all
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
+never_direct allow ExcludePPDomains
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
+never_direct allow ExcludePPIPs
+{%   endif %}
 {% endif %}

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -1,9 +1,5 @@
 {% if helpers.exists('OPNsense.proxy.general.parentproxy.enabled') and OPNsense.proxy.general.parentproxy.enabled == '1' %}
-{%   if helpers.exists('OPNsense.proxy.general.parentproxy.host') and OPNsense.proxy.general.parentproxy.host != '' %}
-{%     if helpers.exists('OPNsense.proxy.general.parentproxy.port') and OPNsense.proxy.general.parentproxy.port != '' %}
 cache_peer {{ OPNsense.proxy.general.parentproxy.host }} parent {{ OPNsense.proxy.general.parentproxy.port }} 0 no-query default
-{%     endif %}
-{%   endif %}
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
 acl ExcludePPDomains dstdomain {{ OPNsense.proxy.general.parentproxy.localdomains.replace(',', ' ') }}
 {%   endif %}

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -1,0 +1,13 @@
+{% if helpers.exists('OPNsense.proxy.general.parentproxy.enabled') and OPNsense.proxy.general.parentproxy.enabled == '1' %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.host') and OPNsense.proxy.general.parentproxy.host != '' %}
+{%     if helpers.exists('OPNsense.proxy.general.parentproxy.port') and OPNsense.proxy.general.parentproxy.port != '' %}
+cache_peer {{ OPNsense.proxy.general.parentproxy.host }} parent {{ OPNsense.proxy.general.parentproxy.port }} 0 no-query default
+{%     endif %}
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
+acl ExcludePPDomains dstdomain {{ OPNsense.proxy.general.parentproxy.localdomains }}
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
+acl ExcludePPIPs dst {{ OPNsense.proxy.general.parentproxy.localips }}
+{%   endif %}
+{% endif %}

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -5,10 +5,10 @@ cache_peer {{ OPNsense.proxy.general.parentproxy.host }} parent {{ OPNsense.prox
 {%     endif %}
 {%   endif %}
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
-acl ExcludePPDomains dstdomain {{ OPNsense.proxy.general.parentproxy.localdomains }}
+acl ExcludePPDomains dstdomain {{ OPNsense.proxy.general.parentproxy.localdomains.replace(',', ' ') }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
-acl ExcludePPIPs dst {{ OPNsense.proxy.general.parentproxy.localips }}
+acl ExcludePPIPs dst {{ OPNsense.proxy.general.parentproxy.localips.replace(',', ' ') }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
 cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} deny ExcludePPDomains

--- a/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/parentproxy.conf
@@ -18,10 +18,10 @@ cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} deny ExcludePPIP
 {%   endif %}
 cache_peer_access {{ OPNsense.proxy.general.parentproxy.host }} allow all
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localdomains') and OPNsense.proxy.general.parentproxy.localdomains != '' %}
-never_direct allow ExcludePPDomains
+never_direct deny ExcludePPDomains
 {%   endif %}
 {%   if helpers.exists('OPNsense.proxy.general.parentproxy.localips') and OPNsense.proxy.general.parentproxy.localips != '' %}
-never_direct allow ExcludePPIPs
+never_direct deny ExcludePPIPs
 {%   endif %}
-never_direct deny all
+never_direct allow all
 {% endif %}


### PR DESCRIPTION
Closes #2068 

- [x] 1. I'm unsure about the required fields in model, should they be better set to yes?
- [x] 2. The templating creates a good config (in my point of view), but it's not sent via Parent, perhaps you have an idea why?


Example:

```
root@OPNsense:~/core # cat /usr/local/etc/squid/pre-auth/parentproxy.conf
cache_peer 10.24.66.3 parent 8080 0 no-query default
acl ExcludePPDomains dstdomain test.de bla.de
acl ExcludePPIPs dst 1.1.1.1 2.2.2.2
cache_peer_access 10.24.66.3 deny ExcludePPDomains
cache_peer_access 10.24.66.3 deny ExcludePPIPs
cache_peer_access 10.24.66.3 allow all
never_direct allow ExcludePPDomains
never_direct allow ExcludePPIPs
never_direct deny all

```

Reference:
https://forum.opnsense.org/index.php?topic=6763.msg29212#msg29212