### PR TITLE
handle <if>|<ip> interface notation

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3996,6 +3996,13 @@ function get_interface_ip($interface = 'wan')
         return get_configured_carp_interface_list($interface);
     }
 
+    // handle <if>|<ip> notation. it's used for ip alias vip ips,
+    // e.g. gre parent interface with ip alias
+    $pipe_pos = strpos($interface, '|');
+    if ($pipe_pos !== FALSE) {
+	return substr($interface, $pipe_pos + 1);
+    }
+
     return null;
 }
 


### PR DESCRIPTION
This patch was necessary to initialize GRE tunnel with IP alias VIP.

