### PR TITLE
Cleanup/misc

### DIFF
--- a/src/opnsense/scripts/shell/setaddr.php
+++ b/src/opnsense/scripts/shell/setaddr.php
@@ -362,11 +362,9 @@ function console_configure_ip_address($version)
                         if ($intip == gen_subnet($intip, $intbits)) {
                             echo 'You cannot set network address to an interface';
                             continue 2;
-                            $intbits_ok = false;
                         } elseif ($intip == gen_subnet_max($intip, $intbits)) {
                             echo 'You cannot set broadcast address to an interface';
                             continue 2;
-                            $intbits_ok = false;
                         }
                     }
                 } while (!$intbits_ok);

--- a/src/sbin/3gstats.php
+++ b/src/sbin/3gstats.php
@@ -80,4 +80,3 @@ while (true) {
     $i++;
 }
 fclose($handle);
-?>

--- a/src/www/getserviceproviders.php
+++ b/src/www/getserviceproviders.php
@@ -130,4 +130,3 @@ if (isset($_REQUEST['country']) && !isset($_REQUEST['provider'])) {
 } else {
     country_list();
 }
-?>


### PR DESCRIPTION
Redundant closing tags are forbidden by PSR-2, as they can cause subtle bugs.