### PR TITLE
Fix usage of include_once in load_phalcon.php

### DIFF
--- a/src/opnsense/mvc/script/load_phalcon.php
+++ b/src/opnsense/mvc/script/load_phalcon.php
@@ -30,7 +30,7 @@ use Phalcon\DI\FactoryDefault;
 use Phalcon\Loader;
 
 $di = new FactoryDefault();
-$phalcon_config = include_once("/usr/local/opnsense/mvc/app/config/config.php");
+$phalcon_config = include("/usr/local/opnsense/mvc/app/config/config.php");
 
 $loader = new Loader();
 $loader->registerDirs(


### PR DESCRIPTION
include_once returns TRUE if the file has already been loaded. This is not what you want if you're setting a variable from it.
http://php.net/manual/en/function.include-once.php

This fixes notices when including certain old scripts from modern controllers, as well as a notice when running run_migrations.php.