### PR TITLE
Generate correct config for "Hybrid-RSA + XAuth" IPSec

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1239,8 +1239,7 @@ function ipsec_configure_do($verbose = false, $interface = '')
                         $authentication = "leftauth = pubkey\n\trightauth = pubkey";
                         break;
                     case 'hybrid_rsa_server':
-                        $authentication = "leftauth = xauth-generic\n\trightauth = pubkey";
-                        $authentication .= "\n\trightauth2 = xauth";
+                        $authentication = "leftauth = pubkey\n\trightauth = xauth";
                         break;
                 }
                 if (!empty($ph1ent['certref'])) {

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -201,6 +201,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $reqdfieldsn = array(gettext("Pre-Shared Key"));
             break;
         case "hybrid_rsa_server":
+            $reqdfields = explode(" ", "certref");
+            $reqdfieldsn = array(gettext("Certificate"));
+            break;
         case "xauth_rsa_server":
         case "rsasig":
             $reqdfields = explode(" ", "caref certref");
@@ -491,6 +494,9 @@ include("head.inc");
                     }
                     break;
                 case 'hybrid_rsa_server':
+                    $(".auth_eap_tls").show();
+                    $(".auth_eap_tls :input").prop( "disabled", false );
+                    break;
                 case 'xauth_rsa_server':
                 case 'rsasig':
                 case 'rsa_eap-mschapv2':

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -201,7 +201,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $reqdfieldsn = array(gettext("Pre-Shared Key"));
             break;
         case "hybrid_rsa_server":
-            $reqdfields = explode(" ", "certref");
+            $reqdfields = explode(' ', 'certref');
             $reqdfieldsn = array(gettext("Certificate"));
             break;
         case "xauth_rsa_server":
@@ -494,8 +494,8 @@ include("head.inc");
                     }
                     break;
                 case 'hybrid_rsa_server':
-                    $(".auth_eap_tls").show();
-                    $(".auth_eap_tls :input").prop( "disabled", false );
+                    $('.auth_eap_tls').show();
+                    $('.auth_eap_tls :input').prop('disabled', false);
                     break;
                 case 'xauth_rsa_server':
                 case 'rsasig':


### PR DESCRIPTION
This PR allows to use the Hybrid-RSA + XAuth mode of IKEv1. Without these changes, strongswan fails with following error message:

    looking for HybridInitRSA peer configs matching x.x.x.x...x.x.x.x[x.x.x.x]
    found 1 matching config, but none allows HybridInitRSA authentication using Main Mode

-----

First commit fixes a logical problem in the config form for IPSec Phase 1.

Second commit fixes a problem in the generated `ipsec.conf`: To use Hybrid-RSA with XAuth the authentication must be configured exactly as leftauth=pubkey, rightauth=xauth.
No rightauth2/leftauth2 may be set.
This can be seen here in the source code:
https://github.com/strongswan/strongswan/blob/be1c7e38157b336655894d99012d25f1b3b75429/src/libcharon/sa/ikev1/phase1.c#L506
