### PR TITLE
IPSec: allow same Local Subnet if used in different Phase1

### DIFF
--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -274,7 +274,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (isset($pconfig['mobile'])) {
         /* User is adding phase 2 for mobile phase1 */
         foreach ($config['ipsec']['phase2'] as $key => $name) {
-            if (isset($name['mobile']) && $name['uniqid'] != $pconfig['uniqid']) {
+            if (isset($name['mobile']) && $pconfig['ikeid'] == $name['ikeid'] && $name['uniqid'] != $pconfig['uniqid']) {
                 /* check duplicate localids only for mobile clents */
                 $localid_data = ipsec_idinfo_to_cidr($name['localid'], false, $name['mode']);
                 $entered = array();


### PR DESCRIPTION
This fixes the problem noted in https://github.com/opnsense/core/issues/2833#issuecomment-432543007

This is necessary if you want to add different Phase1 Config for Mobile clients, e.g. IKEv1 for android and IKEv2 for windows 10, but have the same subnet(s) on the connections.