### PR TITLE
monit: widget improvements

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
@@ -211,7 +211,7 @@
          'get':'/api/monit/settings/getService/',
          'set':'/api/monit/settings/setService/',
          'add':'/api/monit/settings/addService/',
-         'del':'/api/monit/settings/del/service/',
+         'del':'/api/monit/settings/delService/',
          'toggle':'/api/monit/settings/toggleService/'
       });
 

--- a/src/www/widgets/widgets/monit.widget.php
+++ b/src/www/widgets/widgets/monit.widget.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2018 EURO-LOG AG
+ * Copyright (C) 2018 - 2019 EURO-LOG AG
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,9 +26,77 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+require_once("guiconfig.inc");
 require_once("widgets/include/monit.inc");
 
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+   if (isset($config['widgets']['monitheight']) && is_numeric($config['widgets']['monitheight'])) {
+      $pconfig['monitheight'] = $config['widgets']['monitheight'];
+   }
+   else {
+      $pconfig['monitheight'] = 9;
+   }
+   if (isset($config['widgets']['monitsearch'])) {
+      $pconfig['monitsearch'] = $config['widgets']['monitsearch'];
+   }
+   else {
+      unset($pconfig['monitsearch']);
+   }
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $pconfig = $_POST;
+    if (isset($pconfig['monitheight']) && is_numeric($pconfig['monitheight'])) {
+        $config['widgets']['monitheight'] = $pconfig['monitheight'];
+    } else {
+        $config['widgets']['monitheight'] = 9;
+    }
+    if (isset($pconfig['monitsearch'])) {
+        $config['widgets']['monitsearch'] = $pconfig['monitsearch'];
+    } else {
+        unset($config['widgets']['monitsearch']);
+    }
+    write_config("Saved Monit Widget Settings via Dashboard");
+    header(url_safe('Location: /index.php'));
+    exit;
+}
+
 ?>
+
+<style>
+
+   .monit-widget-table {
+      width: 100% 
+   }
+
+   .monit-widget-table > thead,
+   .monit-widget-table > tbody,
+   .monit-widget-table > thead > tr,
+   .monit-widget-table > tbody > tr,
+   .monit-widget-table > thead > tr > th,
+   .monit-widget-table > tbody > tr > td {
+      display: block;
+      line-height: 1.5em;
+   }
+
+   .monit-widget-table > tbody > tr:after,
+   .monit-widget-table > thead > tr:after {
+      content: ' ';
+      display: block;
+      visibility: hidden;
+      clear: both;
+   }
+
+   .monit-widget-table > tbody {
+      overflow-y: auto;
+      height: <?php echo ($pconfig['monitheight'] * 2) + 2; ?>em;
+   }
+
+   .monit-widget-table > tbody > tr > td,
+   .monit-widget-table > thead > tr > th {
+      width: 33%;
+      float: left;
+   }
+
+</style>
 <link rel="stylesheet" type="text/css" href="<?= cache_safe(get_themed_filename('/css/jquery.bootgrid.css')) ?>">
 <script src="<?= cache_safe('/ui/js/jquery.bootgrid.js') ?>"></script>
 
@@ -69,17 +137,32 @@ $( document ).ready(function() {
          if (data['result'] === 'ok') {
             pollInterval = data['status']['server']['poll'] * 1000;
             $.each(data['status']['service'], function(index, service) {
-               $("#grid-monit").bootgrid("append", [{name: service['name'], type: monitServiceTypes[service['@attributes']['type']], status: monitStatusTypes[service['status']]}]);
+               $("#grid-monit").bootgrid("append", [{
+                  name: service['name'],
+                  type: monitServiceTypes[service['@attributes']['type']],
+                  status: monitStatusTypes[service['status']]
+               }]);
             });
          }
+         <?php
+            // apply search filter
+            if (isset($config['widgets']['monitsearch'])) {
+               echo '$("#grid-monit").bootgrid("search", "' .
+                        $config['widgets']['monitsearch'] . '");';
+            }
+         ?>
          setTimeout(monitStatusPoll, pollInterval);
       });
    };
 
    if (monitPollInit === false) {
       $("#grid-monit").bootgrid({
-         navigation: 2,
-         rowCount: 7
+         navigation: 0,
+         rowCount: -1
+      }).on("loaded.rs.jquery.bootgrid", function() {
+         // set right margin according to the scrollbar width
+         let scrollWidth = $('.monit-widget-table > tbody')[0].offsetWidth - $('.monit-widget-table > tbody')[0].clientWidth;
+         $('.monit-widget-table > thead').css('margin-right', scrollWidth);
       });
       monitStatusPoll();
    }
@@ -87,7 +170,44 @@ $( document ).ready(function() {
 
 </script>
 
-<table id="grid-monit" class="table table-condensed table-hove table-striped table-responsive bootgrid-table">
+<div id="monit-settings" class="widgetconfigdiv" style="display:none;">
+   <form class="form-inline" action="/widgets/widgets/monit.widget.php" method="post" name="iformd">
+      <div class="table-responsive">
+         <table class="table table-striped table-condensed">
+            <tr>
+               <td>
+                  <div class="control-label" id="control_label_monitheight">
+                     <b><?= gettext('Rows') ?></b>
+                  </div>
+               </td>
+               <td>
+                  <input type="text" class="form-control" size="25" name="monitheight" id="monitheight" value="<?= $config['widgets']['monitheight'] ?>" />
+               </td>
+            </tr>
+            <tr>
+               <td>
+                  <div class="control-label" id="control_label_monitsearch">
+                     <b><?= gettext('Search') ?></b>
+                  </div>
+               </td>
+               <td>
+                  <input type="text" class="form-control" size="25" name="monitsearch" id="monitsearch" value="<?= $config['widgets']['monitsearch'] ?>" />
+               </td>
+            </tr>
+            <tr>
+               <td>
+                  <button id="submitd" name="submitd" type="submit" class="btn btn-primary" value="yes">
+                     <b><?= gettext('Save') ?></b>
+                  </button>
+               </td>
+               <td> </td>
+            </tr>
+         </table>
+      </div>
+   </form>
+</div>
+
+<table id="grid-monit" class="table table-condensed table-hove table-striped table-responsive bootgrid-table monit-widget-table">
    <thead>
       <tr>
          <th data-column-id="name"><?= gettext('Name') ?></th>
@@ -100,3 +220,10 @@ $( document ).ready(function() {
    <tfoot>
    </tfoot>
 </table>
+
+<!-- needed to display the widget settings menu -->
+<script>
+//<![CDATA[
+  $("#monit-configure").removeClass("disabled");
+//]]>
+</script>


### PR DESCRIPTION
This PR solves #3126.

Changes:
- fix issue with deleting services via GUI
- replace the pagination with a scrollbar
- make the number of rows to be shown configurable
- add a search filter

Unfortunately I have two small problems that I cannot solve.
The number of rows that are effectively shown is based on a rough estimation of the rendered row height. That can lead to different table heights on different themes.

And there is no translation for the word 'Rows'.
