### PR TITLE
monit: add validation for test type

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
@@ -73,8 +73,22 @@ class Monit extends BaseModel
                 $parentNode = $node->getParentNode();
                 // perform plugin specific validations
                 switch ($parentNode->getInternalXMLTagName()) {
+                    case 'test':
+                        // test node validations
+                        switch ($node->getInternalXMLTagName()) {
+                            case 'type':
+                                if ($node->isFieldChanged() && 
+                                    $this->isTestServiceRelated($parentNode->getAttribute('uuid'))) {
+                                    $messages->appendMessage(new \Phalcon\Validation\Message(
+                                        gettext("Cannot change the type. Test is linked to a service."),
+                                        $key
+                                    ));
+                                }
+                                break;
+                        }
+                        break;
                     case 'service':
-                        // service type node validations
+                        // service node validations
                         switch ($node->getInternalXMLTagName()) {
                             case 'tests':
                                 // test dependencies defined in $this->testSyntax
@@ -185,5 +199,23 @@ class Monit extends BaseModel
     public function configClean()
     {
         return @unlink("/tmp/monit.dirty");
+    }
+
+    /**
+     * determine if services have links to this test node
+     * @param uuid of the test node 
+     * @return bool
+     */
+    public function isTestServiceRelated($testUUID = null)
+    {
+        $serviceNodes = $this->service->getNodes();
+        foreach ($serviceNodes as $serviceNode) {
+            if (is_array($serviceNode['tests']) && 
+                array_key_exists($testUUID, $serviceNode['tests']) &&
+                $serviceNode['tests'][$testUUID]['selected'] == 1) {
+                    return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This PR adds test type validation.
It simply checks if a service has a link to a test and refuses to change the type of the test if so.
That means if you want to change the type of a test you have either to remove all links from services or delete and recreate it which does the same in turn.
If I'm not mistaken deleting an alias which is in use by a rule has a similar behavior.

The validation is not performed on full model validations only if the field has changed.
The test type - service type validation is made by the service validation.

I've put it in an extra model function isTestServiceRelated to enable/disable the Test Type dropdown in the GUI later based on the result of this function.
(Don't know how to grab the uuid yet :smiley: )
