### PR TITLE
Update squid.conf to add ESD file types

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -330,9 +330,9 @@ refresh_pattern Release$        0       20%     4320 refresh-ims
 {% endif %}
 {% if helpers.exists('OPNsense.proxy.general.cache.local.cache_windows_updates') and OPNsense.proxy.general.cache.local.cache_windows_updates == '1' %}
 # http://wiki.squid-cache.org/SquidFaq/WindowsUpdate
-refresh_pattern -i microsoft.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip)     4320 80% 129600 reload-into-ims
-refresh_pattern -i windowsupdate.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip) 4320 80% 129600 reload-into-ims
-refresh_pattern -i windows.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip)       4320 80% 129600 reload-into-ims
+refresh_pattern -i microsoft.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip|esd)     4320 80% 129600 reload-into-ims
+refresh_pattern -i windowsupdate.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip|esd) 4320 80% 129600 reload-into-ims
+refresh_pattern -i windows.com/.*\.(cab|exe|ms[i|u|f]|[ap]sf|wm[v|a]|dat|zip|esd)       4320 80% 129600 reload-into-ims
 {% endif %}
 
 refresh_pattern ^ftp:		1440	20%	10080


### PR DESCRIPTION
adds ESD as file type for refresh_pattern of Microsoft Update files. 
example link used by Microsoft:  
http://fg.ds.b1.download.windowsupdate.com/d/Upgr/2018/09/17763.1.180914-1434.rs5_release_clientbusiness_vol_x64fre_en-us_d29ef094928a77496cdf53d072b5023eddea7281.esd