### PR TITLE
Allow explicitly setting Source Hash Key

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
@@ -51,6 +51,7 @@ class SNatRule extends Rule
         'target' => 'parsePlain, -> ',
         'natport' => 'parsePlain, port ',
         'poolopts' => 'parsePlain',
+        'poolopts_sourcehashkey' => 'parsePlain',
         'staticnatport' => 'parseBool,  static-port ',
         'descr' => 'parseComment'
     );
@@ -108,6 +109,10 @@ class SNatRule extends Rule
                     }
                     $rule[$fieldname] = "$".$rule[$fieldname];
                 }
+            }
+            if (empty($rule['poolopts']) || $rule['poolopts'] != "source-hash"){
+                // Make sure this is empty unless source-hash
+                $rule['poolopts_sourcehashkey'] = '';
             }
             if (!empty($rule['staticnatport']) || !empty($rule['nonat'])) {
                 $rule['natport'] = '';

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -99,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (isset($configId)) {
         // load data from config
         foreach (array('protocol','sourceport','dstport','natport','target','targetip'
-                ,'targetip_subnet','poolopts','interface','descr','nonat','log'
+                ,'targetip_subnet','poolopts','poolopts_sourcehashkey','interface','descr','nonat','log'
                 ,'disabled','staticnatport','nosync','ipprotocol','tag','tagged') as $fieldname) {
               if (isset($a_out[$configId][$fieldname])) {
                   $pconfig[$fieldname] = $a_out[$configId][$fieldname];
@@ -123,7 +123,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // initialize unused elements
     foreach (array('protocol','sourceport','dstport','natport','target','targetip',
-            'targetip_subnet','poolopts','interface','descr','nonat','tag','tagged',
+            'targetip_subnet','poolopts','poolopts_sourcehashkey','interface','descr','nonat','tag','tagged',
             'disabled','staticnatport','nosync','source','source_subnet','ipprotocol') as $fieldname) {
           if (!isset($pconfig[$fieldname])) {
               $pconfig[$fieldname] = null;
@@ -195,7 +195,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (!empty($pconfig['targetip']) && is_alias($pconfig['targetip']) && !empty($pconfig['poolopts']) && substr($pconfig['poolopts'], 0, 11) != 'round-robin') {
         $input_errors[] = gettext("Only Round Robin pool options may be chosen when selecting an alias.");
     }
-
+    /* Verify Source Hash Key if provided */
+    if (!empty($pconfig['poolopts']) && $pconfig['poolopts'] == 'source-hash' && !empty($pconfig['poolopts_sourcehashkey'])){
+        if (substr($pconfig['poolopts_sourcehashkey'], 0, 2) != "0x" || !ctype_xdigit(substr($pconfig['poolopts_sourcehashkey'], 2, 32)) ){
+            $input_errors[] = gettext("Source Hash Key must be 0x followed by 32 hexadecimal digits");
+        }
+    }
     // validate ipv4/v6, addresses should use selected address family
     foreach (array('source', 'destination', 'targetip') as $fieldname) {
         if (is_ipaddrv6($pconfig[$fieldname]) && $pconfig['ipprotocol'] != 'inet6') {
@@ -215,6 +220,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $natent['tag'] = $pconfig['tag'];
         $natent['tagged'] = $pconfig['tagged'];
         $natent['poolopts'] = $pconfig['poolopts'];
+        $natent['poolopts_sourcehashkey'] = $pconfig['poolopts_sourcehashkey'];
         $natent['ipprotocol'] = $pconfig['ipprotocol'];
 
         if (isset($a_out[$id]['created']) && is_array($a_out[$id]['created']) ){
@@ -715,37 +721,50 @@ include("head.inc");
                 <tr>
                   <td><a id="help_for_poolopts" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Pool Options:");?></td>
                   <td>
-                    <select name="poolopts" class="selectpicker">
-                      <option value="" <?=empty($pconfig['poolopts']) ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Default");?>
-                      </option>
-                      <option value="round-robin" <?=$pconfig['poolopts'] == "round-robin" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Round Robin");?>
-                      </option>
-                      <option value="round-robin sticky-address" <?=$pconfig['poolopts'] == "round-robin sticky-address" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Round Robin with Sticky Address");?>
-                      </option>
-                      <option value="random" <?=$pconfig['poolopts'] == "random" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Random");?>
-                      </option>
-                      <option value="random sticky-address" <?=$pconfig['poolopts'] == "random sticky-address" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Random with Sticky Address");?>
-                      </option>
-                      <option value="source-hash" <?=$pconfig['poolopts'] == "source-hash" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Source Hash");?>
-                      </option>
-                      <option value="bitmask" <?=$pconfig['poolopts'] == "bitmask" ? "selected=\"selected\"" : ""; ?>>
-                        <?=gettext("Bitmask");?>
-                      </option>
-                    </select>
-                    <div class="hidden" data-for="help_for_poolopts">
-                      <?=gettext("Only Round Robin types work with Host Aliases. Any type can be used with a Subnet.");?><br />
-                      * <?=gettext("Round Robin: Loops through the translation addresses.");?><br />
-                      * <?=gettext("Random: Selects an address from the translation address pool at random.");?><br />
-                      * <?=gettext("Source Hash: Uses a hash of the source address to determine the translation address, ensuring that the redirection address is always the same for a given source.");?><br />
-                      * <?=gettext("Bitmask: Applies the subnet mask and keeps the last portion identical; 10.0.1.50 -&gt; x.x.x.50.");?><br />
-                      * <?=gettext("Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.");?><br />
-                    </div>
+                  <table class="table table-condensed">
+                    <tbody>
+                      <tr>
+                        <td>
+                        <select name="poolopts" id="poolopts" class="selectpicker">
+                        <option value="" <?=empty($pconfig['poolopts']) ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Default");?>
+                        </option>
+                        <option value="round-robin" <?=$pconfig['poolopts'] == "round-robin" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Round Robin");?>
+                        </option>
+                        <option value="round-robin sticky-address" <?=$pconfig['poolopts'] == "round-robin sticky-address" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Round Robin with Sticky Address");?>
+                        </option>
+                        <option value="random" <?=$pconfig['poolopts'] == "random" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Random");?>
+                        </option>
+                        <option value="random sticky-address" <?=$pconfig['poolopts'] == "random sticky-address" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Random with Sticky Address");?>
+                        </option>
+                        <option value="source-hash" data-other="true" <?=$pconfig['poolopts'] == "source-hash" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Source Hash");?>
+                        </option>
+                        <option value="bitmask" <?=$pconfig['poolopts'] == "bitmask" ? "selected=\"selected\"" : ""; ?>>
+                            <?=gettext("Bitmask");?>
+                        </option>
+                        </select>
+                        <div class="hidden" data-for="help_for_poolopts">
+                        <?=gettext("Only Round Robin types work with Host Aliases. Any type can be used with a Subnet.");?><br />
+                        * <?=gettext("Round Robin: Loops through the translation addresses.");?><br />
+                        * <?=gettext("Random: Selects an address from the translation address pool at random.");?><br />
+                        * <?=gettext("Source Hash: Uses a hash of the source address to determine the translation address, ensuring that the redirection address is always the same for a given source. Optionally provide a Source Hash Key to make it persist when the ruleset is reloaded. Must be 0x followed by 32 hexadecimal digits.");?><br />
+                        * <?=gettext("Bitmask: Applies the subnet mask and keeps the last portion identical; 10.0.1.50 -&gt; x.x.x.50.");?><br />
+                        * <?=gettext("Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.");?><br />
+                        </div>
+                        </td>
+                        </tr>
+                        <tr>
+                        <td>
+                          <input type="text" id="poolopts_sourcehashkey" name="poolopts_sourcehashkey" for="poolopts" placeholder="Source Hash Key" value="<?=$pconfig['poolopts_sourcehashkey']?>"/>
+                        </td>
+                        </tr>
+                      </tbody>
+                    </table>
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
This key is randomly assigned unless set every time the ruleset is
loaded. In order to make it persist, allow setting it to a predetermined
value.