### PR TITLE
Fix behaviour of determining dhcp primary/secondary

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -533,8 +533,8 @@ EOD;
                             /* this is the interface! */
                             if (is_numeric($vipent['advskew']) && (intval($vipent['advskew']) < 20)) {
                                 $skew = 0;
-                                break;
                             }
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
When there is more than one CARP address per interface with different
skews, check only the first CARP if and skew in order to determine
primary. This prevents a misconfiguration where both hosts are
configured as dhcp primary due to each host having one VIP with skew <20.

Technically, active/active isn't advisable in general, however we have a setup where we balance clients using separate dhcp pools with different default routers, ensuring clients "stick" to the same firewall except in a failover/maintenance scenario.

Checking the skew of the first VIP should suffice either way, as the recommended configuration is to ensure the same skew for all VIPs on one host.