### PR TITLE
Shaper: Add DSCP matching

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
@@ -69,6 +69,13 @@
         <help>Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash</help>
     </field>
     <field>
+        <id>rule.dscp</id>
+        <label>DSCP</label>
+        <type>select_multiple</type>
+        <advanced>true</advanced>
+        <help>Match against one or multiple DSCP values.</help>
+    </field>
+    <field>
         <id>rule.direction</id>
         <label>direction</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
@@ -305,6 +305,33 @@
                     <EnableRanges>Y</EnableRanges>
                     <default>any</default>
                 </dst_port>
+                <dscp type="OptionField">
+                    <Required>N</Required>
+                    <Multiple>Y</Multiple>
+                    <OptionValues>
+                        <be>Best Effort</be>
+                        <ef>Expedited Forwarding</ef>
+                        <af11>AF11</af11>
+                        <af12>AF12</af12>
+                        <af13>AF13</af13>
+                        <af21>AF21</af21>
+                        <af22>AF22</af22>
+                        <af23>AF23</af23>
+                        <af31>AF31</af31>
+                        <af32>AF32</af32>
+                        <af33>AF33</af33>
+                        <af41>AF41</af41>
+                        <af42>AF42</af42>
+                        <af43>AF43</af43>
+                        <cs1>CS1</cs1>
+                        <cs2>CS2</cs2>
+                        <cs3>CS3</cs3>
+                        <cs4>CS4</cs4>                
+                        <cs5>CS5</cs5>
+                        <cs6>CS6</cs6>
+                        <cs7>CS7</cs7>
+                    </OptionValues>
+                </dscp>
                 <direction type="OptionField">
                     <Required>N</Required>
                     <default></default>

--- a/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/TrafficShaper</mount>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <description>
         OPNsense traffic shaper
     </description>

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -184,8 +184,9 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} recv {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif
-    %} xmit {{physical_interface(rule.interface2)
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }}
+    xmit {{physical_interface(rule.interface2)
     }} // {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
 {%                         if rule.direction == 'out' or not rule.direction %}
@@ -195,8 +196,9 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} xmit {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif
-    %} recv {{physical_interface(rule.interface2)
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }}
+    recv {{physical_interface(rule.interface2)
     }} // {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
 {%                       else %}
@@ -206,7 +208,8 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.source_not|default('0') == '1' %}not {% endif %}{{ rule.source }} to {%
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} {{rule.direction}} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} via {{
+    if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} {%
+    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }} via {{
     physical_interface(rule.interface)
     }} // {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                       endif %}

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -185,7 +185,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} recv {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
-    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }}
+    if rule.dscp|default('') != '' %} dscp {{ (rule.dscp.split(',')) }}{% endif %}
     xmit {{physical_interface(rule.interface2)
     }} // {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
@@ -197,7 +197,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} xmit {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
-    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }}
+    if rule.dscp|default('') != '' %} dscp {{ (rule.dscp.split(',')) }}{% endif %}
     recv {{physical_interface(rule.interface2)
     }} // {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                         endif %}
@@ -209,7 +209,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} {{rule.direction}} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} {%
-    if rule.dscp != '' %} dscp {{ (rule.dscp.split(',')) }} via {{
+    if rule.dscp|default('') != '' %} dscp {{ (rule.dscp.split(',')) }}{% endif %} via {{
     physical_interface(rule.interface)
     }} // {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
 {%                       endif %}


### PR DESCRIPTION
There was a request on Friday if we support DSCP matching for shaper. @fichtner and me said no, only for `pf` but then I checked ipfw manpage and it looks good.
The beauty of this is, that you can have multiple rules with match any any as you can match for differenct DSCP values, mostly set by SIP phones automatically. Would be a nice addition for enterprise demands.
If pf acts before ipfw in shared forwarding you could also mark rules with pf for DSCP and do the shaping afterwards :)