### PR TITLE
Dev/ipfwcaptiveportal

### DIFF
--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -101,13 +101,11 @@ add 203 skipto 60000 ipv4 from any to 127.0.0.0/8
 #======================================================================================
 # Allow traffic to this host
 #======================================================================================
-{% for item in cp_interface_list %}
-add {{loop.index  + 1000}} skipto 60000 udp from any to me dst-port 53 via {{item.if}} keep-state
-add {{loop.index  + 1000}} skipto 60000 ip from any to { 255.255.255.255 or me } in via {{item.if}}
-add {{loop.index  + 1000}} skipto 60000 ip from { 255.255.255.255 or me } to any out via {{item.if}}
-add {{loop.index  + 1000}} skipto 60000 icmp from { 255.255.255.255 or me } to any out via {{item.if}} icmptypes 0
-add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or me } in via {{item.if}} icmptypes 8
-{% endfor %}
+add 1001 skipto 60000 udp from any to me dst-port 53 keep-state
+add 1002 skipto 60000 ip from any to { 255.255.255.255 or me } in
+add 1003 skipto 60000 ip from { 255.255.255.255 or me } to any out
+add 1004 skipto 60000 icmp from { 255.255.255.255 or me } to any out icmptypes 0
+add 1005 skipto 60000 icmp from any to { 255.255.255.255 or me } in icmptypes 8
 
 {% for item in cp_interface_list %}
 #===================================================================================

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -10,7 +10,7 @@
 {%        for cp_intf in cp_item.interfaces.split(',') %}
 {%          if intf_key == cp_intf %}
 {%              if cp_item.enabled|default('0') == '1' %}
-{%                  do cp_interface_list.append({'zone':cp_item.description, 'zoneid':cp_item.zoneid,'if':interface.if, 'obj':cp_item}) %}
+{%                  do cp_interface_list.append({'zone':cp_item.description, 'zoneid':cp_item.zoneid,'if':interface.if,'interfaces':cp_item.interfaces.split(','),'obj':cp_item}) %}
 {%                  do is_cp.append(1) %}
 {%              endif %}
 {%          endif %}
@@ -115,7 +115,7 @@ add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or {{
 # Allow traffic to this hosts VIPs
 #======================================================================================
 {% for item in virtualip.vip %}
-{% if ':' not in item.subnet %}
+{% if item.interface in cp_interface_list|sum(attribute="interfaces", start=[]) and ':' not in item.subnet %}
 add {{loop.index  + 2000}} skipto 60000 udp from any to {{ item.subnet }} dst-port 53 keep-state
 add {{loop.index  + 2000}} skipto 60000 ip from any to { 255.255.255.255 or {{item.subnet}} } in
 add {{loop.index  + 2000}} skipto 60000 ip from { 255.255.255.255 or {{item.subnet}} } to any out

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -99,22 +99,14 @@ add 202 skipto 60000 ipv6 from any to ::1
 add 203 skipto 60000 ipv4 from any to 127.0.0.0/8
 
 #======================================================================================
-# Allow traffic to this hosts static ip's
-#======================================================================================
-{% for intf_key,interface in interfaces.iteritems() %}
-{% if intf_key != "wan" and interface.ipaddr not in ["dhcp", "ppp", "pppoe", "l2tp", "pptp"] and interface.ipaddr|default("") != "" %}
-add {{loop.index  + 1000}} skipto 60000 ip from any to { 255.255.255.255 or {{interface.ipaddr}} } in
-add {{loop.index  + 1000}} skipto 60000 ip from { 255.255.255.255 or {{interface.ipaddr}} } to any out
-add {{loop.index  + 1000}} skipto 60000 icmp from { 255.255.255.255 or {{interface.ipaddr}} } to any out icmptypes 0
-add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or {{interface.ipaddr}} } in icmptypes 8
-{% endif %}
-{% endfor %}
-
-#======================================================================================
-# Allow DNS to this host
+# Allow traffic to this host
 #======================================================================================
 {% for item in cp_interface_list %}
-add {{loop.index  + 2000}} skipto 60000 udp from any to me dst-port 53 via {{item.if}} keep-state
+add {{loop.index  + 1000}} skipto 60000 udp from any to me dst-port 53 via {{item.if}} keep-state
+add {{loop.index  + 1000}} skipto 60000 ip from any to { 255.255.255.255 or me } in via {{item.if}}
+add {{loop.index  + 1000}} skipto 60000 ip from { 255.255.255.255 or me } to any out via {{item.if}}
+add {{loop.index  + 1000}} skipto 60000 icmp from { 255.255.255.255 or me } to any out via {{item.if}} icmptypes 0
+add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or me } in via {{item.if}} icmptypes 8
 {% endfor %}
 
 {% for item in cp_interface_list %}

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -10,7 +10,7 @@
 {%        for cp_intf in cp_item.interfaces.split(',') %}
 {%          if intf_key == cp_intf %}
 {%              if cp_item.enabled|default('0') == '1' %}
-{%                  do cp_interface_list.append({'zone':cp_item.description, 'zoneid':cp_item.zoneid,'if':interface.if,'interfaces':cp_item.interfaces.split(','),'obj':cp_item}) %}
+{%                  do cp_interface_list.append({'zone':cp_item.description, 'zoneid':cp_item.zoneid,'if':interface.if,'obj':cp_item}) %}
 {%                  do is_cp.append(1) %}
 {%              endif %}
 {%          endif %}
@@ -103,7 +103,6 @@ add 203 skipto 60000 ipv4 from any to 127.0.0.0/8
 #======================================================================================
 {% for intf_key,interface in interfaces.iteritems() %}
 {% if intf_key != "wan" and interface.ipaddr not in ["dhcp", "ppp", "pppoe", "l2tp", "pptp"] and interface.ipaddr|default("") != "" %}
-add {{loop.index  + 1000}} skipto 60000 udp from any to {{ interface.ipaddr }} dst-port 53 keep-state
 add {{loop.index  + 1000}} skipto 60000 ip from any to { 255.255.255.255 or {{interface.ipaddr}} } in
 add {{loop.index  + 1000}} skipto 60000 ip from { 255.255.255.255 or {{interface.ipaddr}} } to any out
 add {{loop.index  + 1000}} skipto 60000 icmp from { 255.255.255.255 or {{interface.ipaddr}} } to any out icmptypes 0
@@ -112,16 +111,10 @@ add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or {{
 {% endfor %}
 
 #======================================================================================
-# Allow traffic to this hosts VIPs
+# Allow DNS to this host
 #======================================================================================
-{% for item in virtualip.vip %}
-{% if item.interface in cp_interface_list|sum(attribute="interfaces", start=[]) %}
-add {{loop.index  + 2000}} skipto 60000 udp from any to {{ item.subnet }} dst-port 53 keep-state
-add {{loop.index  + 2000}} skipto 60000 ip from any to { 255.255.255.255 or {{item.subnet}} } in
-add {{loop.index  + 2000}} skipto 60000 ip from { 255.255.255.255 or {{item.subnet}} } to any out
-add {{loop.index  + 2000}} skipto 60000 icmp from { 255.255.255.255 or {{item.subnet}} } to any out icmptypes 0
-add {{loop.index  + 2000}} skipto 60000 icmp from any to { 255.255.255.255 or {{item.subnet}} } in icmptypes 8
-{% endif %}
+{% for item in cp_interface_list %}
+add {{loop.index  + 2000}} skipto 60000 udp from any to me dst-port 53 via {{item.if}} keep-state
 {% endfor %}
 
 {% for item in cp_interface_list %}

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -111,6 +111,19 @@ add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or {{
 {% endif %}
 {% endfor %}
 
+#======================================================================================
+# Allow traffic to this hosts VIPs
+#======================================================================================
+{% for item in virtualip.vip %}
+{% if ':' not in item.subnet %}
+add {{loop.index  + 2000}} skipto 60000 udp from any to {{ item.subnet }} dst-port 53 keep-state
+add {{loop.index  + 2000}} skipto 60000 ip from any to { 255.255.255.255 or {{item.subnet}} } in
+add {{loop.index  + 2000}} skipto 60000 ip from { 255.255.255.255 or {{item.subnet}} } to any out
+add {{loop.index  + 2000}} skipto 60000 icmp from { 255.255.255.255 or {{item.subnet}} } to any out icmptypes 0
+add {{loop.index  + 2000}} skipto 60000 icmp from any to { 255.255.255.255 or {{item.subnet}} } in icmptypes 8
+{% endif %}
+{% endfor %}
+
 {% for item in cp_interface_list %}
 #===================================================================================
 # zone {{item.zone}} ({{item.zoneid}}) / {{item.if}} configuration

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -101,11 +101,13 @@ add 203 skipto 60000 ipv4 from any to 127.0.0.0/8
 #======================================================================================
 # Allow traffic to this host
 #======================================================================================
-add 1001 skipto 60000 udp from any to me dst-port 53 keep-state
-add 1002 skipto 60000 ip from any to { 255.255.255.255 or me } in
-add 1003 skipto 60000 ip from { 255.255.255.255 or me } to any out
-add 1004 skipto 60000 icmp from { 255.255.255.255 or me } to any out icmptypes 0
-add 1005 skipto 60000 icmp from any to { 255.255.255.255 or me } in icmptypes 8
+{% for item in cp_interface_list %}
+add {{loop.index  + 1000}} skipto 60000 udp from any to me dst-port 53 via {{item.if}} keep-state
+add {{loop.index  + 1000}} skipto 60000 ip from any to { 255.255.255.255 or me } in via {{item.if}}
+add {{loop.index  + 1000}} skipto 60000 ip from { 255.255.255.255 or me } to any out via {{item.if}}
+add {{loop.index  + 1000}} skipto 60000 icmp from { 255.255.255.255 or me } to any out via {{item.if}} icmptypes 0
+add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or me } in via {{item.if}} icmptypes 8
+{% endfor %}
 
 {% for item in cp_interface_list %}
 #===================================================================================

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -115,7 +115,7 @@ add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or {{
 # Allow traffic to this hosts VIPs
 #======================================================================================
 {% for item in virtualip.vip %}
-{% if item.interface in cp_interface_list|sum(attribute="interfaces", start=[]) and ':' not in item.subnet %}
+{% if item.interface in cp_interface_list|sum(attribute="interfaces", start=[]) %}
 add {{loop.index  + 2000}} skipto 60000 udp from any to {{ item.subnet }} dst-port 53 keep-state
 add {{loop.index  + 2000}} skipto 60000 ip from any to { 255.255.255.255 or {{item.subnet}} } in
 add {{loop.index  + 2000}} skipto 60000 ip from { 255.255.255.255 or {{item.subnet}} } to any out


### PR DESCRIPTION
I think this relates to #3089. I noticed that captive portal wasn't working unless I explicitly added the CARP VIPs to the "Allowed addresses" list.
This PR makes all VIPs on captive portal interfaces allowed by default by changing the template for ipfw.conf. I needed an extra array in cp_interface_list to allow checking against the if later.

Only VIPs on Captive Portal interfaces are added, in the same manner as "Allow traffic to this hosts static ip's".