### PR TITLE
Interfaces Overview - Cleanup

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -846,3 +846,8 @@ div[data-for*="help_for"] {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+
+form[name$="link_form"] > button[type="submit"] {
+  margin-left: .7em;
+  margin-right: .7em;
+}

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7545,6 +7545,11 @@ div[data-for*=help_for] {
   max-width: 100%;
 }
 
+form[name$="link_form"] > button[type="submit"] {
+  margin-left: .7em;
+  margin-right: .7em;
+}
+
 /* fields in firewall schedule */
 [data-state=lightcoral] {
   background-color: lightcoral;

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -115,7 +115,7 @@ include("head.inc");
                         <form name="dhcplink_form" method="post">
                           <input type="hidden" name="if" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['dhcplink'] ?>" />
-                          <?= $ifinfo['dhcplink'] ?>&nbsp;&nbsp;
+                          <?= $ifinfo['dhcplink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
                           <button type="submit" name="submit" class="btn btn-xs" value="local"><?= $ifinfo['dhcplink'] == "up" ? gettext("Release") : gettext("Renew") ?></button>
                         </form>
@@ -130,7 +130,7 @@ include("head.inc");
                         <form name="dhcp6link_form" method="post">
                           <input type="hidden" name="if" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['dhcp6link'] ?>" />
-                          <?= $ifinfo['dhcp6link'] ?>&nbsp;&nbsp;
+                          <?= $ifinfo['dhcp6link'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
                           <button type="submit" name="submit" class="btn btn-xs" value="local"><?= $ifinfo['dhcp6link'] == "up" ? gettext("Release") : gettext("Renew") ?></button>
                         </form>
@@ -145,7 +145,7 @@ include("head.inc");
                         <form name="pppoelink_form" method="post">
                           <input type="hidden" name="if" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['pppoelink'] ?>" />
-                          <?= $ifinfo['pppoelink'] ?>&nbsp;&nbsp;
+                          <?= $ifinfo['pppoelink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
                           <button type="submit" name="submit" class="btn btn-xs" value="local"><?= $ifinfo['pppoelink'] == "up" ? gettext("Disconnect") : gettext("Connect") ?></button>
                         </form>
@@ -160,7 +160,7 @@ include("head.inc");
                         <form name="pptplink_form" method="post">
                           <input type="hidden" name="if" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['pptplink'] ?>" />
-                          <?= $ifinfo['pptplink'] ?>&nbsp;&nbsp;
+                          <?= $ifinfo['pptplink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
                           <button type="submit" name="submit" class="btn btn-xs" value="local"><?= $ifinfo['pptplink'] == "up" ? gettext("Disconnect") : gettext("Connect") ?></button>
                         </form>
@@ -175,7 +175,7 @@ include("head.inc");
                         <form name="l2tplink_form" method="post">
                           <input type="hidden" name="if" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['l2tplink'] ?>" />
-                          <?=$ifinfo['l2tplink'];?>&nbsp;&nbsp;
+                          <?=$ifinfo['l2tplink'];?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
                           <button type="submit" name="submit" class="btn btn-xs" value="local"><?= $ifinfo['l2tplink'] == "up" ? gettext("Disconnect") : gettext("Connect") ?></button>
                         </form>

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -34,8 +34,8 @@ require_once("services.inc");
 require_once("interfaces.inc");
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!empty($_POST['if']) && !empty($_POST['submit'])) {
-        $interface = $_POST['if'];
+    if (!empty($_POST['ifdescr']) && !empty($_POST['submit'])) {
+        $interface = $_POST['ifdescr'];
         if ($_POST['submit'] == 'remote') {
             configdp_run('interface reconfigure', array($interface));
         } elseif (!empty($_POST['status']) && $_POST['status'] == 'up') {
@@ -113,7 +113,7 @@ include("head.inc");
                       <td> <?=gettext("DHCP");?></td>
                       <td>
                         <form name="dhcplink_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['dhcplink'] ?>" />
                           <?= $ifinfo['dhcplink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
@@ -128,7 +128,7 @@ include("head.inc");
                       <td> <?=gettext("DHCP6");?></td>
                       <td>
                         <form name="dhcp6link_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['dhcp6link'] ?>" />
                           <?= $ifinfo['dhcp6link'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
@@ -143,7 +143,7 @@ include("head.inc");
                       <td><?=gettext("PPPoE"); ?></td>
                       <td>
                         <form name="pppoelink_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['pppoelink'] ?>" />
                           <?= $ifinfo['pppoelink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
@@ -158,7 +158,7 @@ include("head.inc");
                       <td><?= gettext("PPTP") ?></td>
                       <td>
                         <form name="pptplink_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['pptplink'] ?>" />
                           <?= $ifinfo['pptplink'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
@@ -173,7 +173,7 @@ include("head.inc");
                       <td><?=gettext("L2TP"); ?></td>
                       <td>
                         <form name="l2tplink_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['l2tplink'] ?>" />
                           <?=$ifinfo['l2tplink'];?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>
@@ -188,7 +188,7 @@ include("head.inc");
                       <td><?=gettext("PPP"); ?></td>
                       <td>
                         <form name="ppplink_form" method="post">
-                          <input type="hidden" name="if" value="<?= $ifdescr ?>" />
+                          <input type="hidden" name="ifdescr" value="<?= $ifdescr ?>" />
                           <input type="hidden" name="status" value="<?= $ifinfo['ppplink'] ?>" />
                           <?= $ifinfo['pppinfo'] ?>
                           <button type="submit" name="submit" class="btn btn-primary btn-xs" value="remote"><?= gettext('Reload') ?></button>


### PR DESCRIPTION
Use CSS for layout spacing rather than non-breaking white-spaces.

Correct interface post item naming
Interface description is being posted, so name the posted item accordingly for clarity.