### PR TITLE
monit: add migration/validation for service/test type dependency

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2019 EURO-LOG AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Monit\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+class M1_0_8 extends BaseModelMigration
+{
+    public function post($model)
+    {
+        foreach ($model->getNodeByReference('test')->__items as $test) {
+            $test->type = $model->getTestType($test->condition->getNodeData());
+        }
+        // validation will fail because we want to change the type of tests linked to services
+        $model->serializeToConfig(false, true);
+        Config::getInstance()->save();
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -186,6 +186,12 @@
             <Required>Y</Required>
             <mask>/^([0-9a-zA-Z\._\-\$]){1,255}$/u</mask>
             <ValidationMessage>Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and the dollar sign.</ValidationMessage>
+            <Constraints>
+               <check001>
+                  <ValidationMessage>Service name must be unique.</ValidationMessage>
+                  <type>UniqueConstraint</type>
+               </check001>
+            </Constraints>
          </name>
          <type type="OptionField">
             <Required>Y</Required>
@@ -298,6 +304,7 @@
                <ProgramStatus>Program Status</ProgramStatus>
                <NetworkInterface>Network Interface</NetworkInterface>
                <NetworkPing>Network Ping</NetworkPing>
+               <Connection>Connection</Connection>
                <Custom>Custom</Custom>
             </OptionValues>
          </type>


### PR DESCRIPTION
This PR implements the service/test type dependency.
Conditions are mapped to test types and these test types in turn are mapped to service types.

It prevents the user from adding wrong tests to a service.
That means that you still can select a wrong test for a service but get a validation error.
Furthermore, a test condition can only be changed if the test is not linked to a service or the condition results in 'Custom' type.
Every condition that cannot mapped to a type is a 'Custom' type.

The migration parses the condition field and sets the test type accordingly.
To bypass validation errors I use the post() method instead of run().