### PR TITLE
IDS: High CPU usage when IPS enabled - netmap number of threads option

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -12,6 +12,15 @@
         <help><![CDATA[Enable protection mode (block traffic).<br />Before enabling, please disable all hardware offloading first <a href="/system_advanced_network.php">in advanced network</a>.]]></help>
     </field>
     <field>
+        <id>ids.general.NetmapThreads</id>
+        <label>Number of IPS threads</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help><![CDATA[With this option, you can set the max number of threads will be started with
+        IPS enabled. If not set, will be set to automatic. Be careful to not
+        use a higher number than the available CPU cores. <a href="/index.php">Check here</a>.]]></help>
+    </field>
+    <field>
         <id>ids.general.promisc</id>
         <label>Promiscuous mode</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/IDS</mount>
-    <version>1.0.2</version>
+    <version>1.0.1</version>
     <description>
         OPNsense IDS
     </description>
@@ -98,6 +98,12 @@
                 <default>0</default>
                 <Required>Y</Required>
             </ips>
+            <NetmapThreads type="IntegerField">
+                <Required>N</Required>
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>9</MaximumValue>
+                <ValidationMessage>Enter a valid number of threads</ValidationMessage>
+            </NetmapThreads>
             <promisc type="BooleanField">
                 <default>0</default>
                 <Required>Y</Required>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -98,7 +98,7 @@ outputs:
                    ## Error, Warning, Notice, Info, Debug
       types:
         - alert:
-{% if not helpers.empty('OPNsense.IDS.general.LogPayload') %}
+{% if helpers.exists('OPNsense.IDS.general.LogPayload') and OPNsense.IDS.general.LogPayload|default('0') == '1' %}
              payload: yes
              payload-buffer-size: 100kb
              payload-printable: yes
@@ -239,7 +239,7 @@ outputs:
 
   # a line based alerts log similar to fast.log into syslog
   - syslog:
-      enabled: {% if helpers.empty('OPNsense.IDS.general.syslog') %}no{% else %}yes{% endif %}
+      enabled: {% if helpers.exists('OPNsense.IDS.general.syslog') and OPNsense.IDS.general.syslog|default('0') == '0' %}no{% else %}yes{% endif %}
 
       # reported identity to syslog. If ommited the program name (usually
       # suricata) will be used.
@@ -325,9 +325,13 @@ nflog:
 
 netmap:
   - interface: default
-    threads: auto
-    copy-mode: ips
-    disable-promisc: {% if helpers.empty('OPNsense.IDS.general.promisc') %}yes{% else %}no{% endif %} #  promiscuous mode
+  {% if helpers.exists('OPNsense.IDS.general.NetmapThreads') %}
+  threads: {{ OPNsense.IDS.general.NetmapThreads }}
+  {% else %}
+  threads: auto
+  {% endif %}
+  copy-mode: ips
+    disable-promisc: {% if helpers.exists('OPNsense.IDS.general.promisc') and OPNsense.IDS.general.promisc|default('0') == '0' %}yes{% else %}no{% endif %} #  promiscuous mode
     checksum-checks: auto
 
   {% if helpers.exists('OPNsense.IDS.general.interfaces') %}
@@ -684,8 +688,7 @@ flow-timeouts:
 stream:
   memcap: 32mb
   checksum-validation: yes      # reject wrong csums
-  inline: {% if OPNsense.IDS.general.ips|default("0") == "1" %}true{% else %}auto{% endif %}
-
+  inline: auto                  # auto will use inline mode in IPS mode, yes or no set it statically
   reassembly:
     memcap: 128mb
     depth: 1mb                  # reassemble 1mb into a stream
@@ -758,7 +761,7 @@ logging:
 
 pcap:
   - interface: default
-    promisc: {% if not helpers.empty('OPNsense.IDS.general.promisc') %}yes{% else %}no{% endif %} #  promiscuous mode
+    promisc: {% if helpers.exists('OPNsense.IDS.general.promisc') and OPNsense.IDS.general.promisc|default('0') == '1' %}yes{% else %}no{% endif %} #  promiscuous mode
 
 pcap-file:
   # Possible values are:


### PR DESCRIPTION
Greetings!

Following this forum [thread](https://forum.opnsense.org/index.php?topic=6590.0)

I was wondering a simple way to avoid suricata use all CPU available when IPS enabled.

We've applied this solution in our labs here and the results were quite good, with 50% of CPU usage with heavy load (with the proper number of threads set.)

