### PR TITLE
System/General - Set default navigation appearance

### DIFF
--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -148,7 +148,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             unset($config['system']['dnsallowoverride']);
         }
         
-        if (!empty($config['system']['navigation'])) {
+        if (empty($config['navigation'])) {
             $config['system']['navigation'] = 'standard';
         } elseif ($pconfig['navigation'] == "standard") {
             $config['system']['navigation'] = 'standard';
@@ -361,10 +361,10 @@ include("head.inc");
             <tr>
               <td><a id="help_for_navigation" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Navigation"); ?></td>
                 <td>
-                  <input name="navigation" class="navigation" id="navigation_standard" type="radio" value="standard" <?= $pconfig['navigation'] == "standard" ? 'checked="checked"' : '' ?>/>
-                  <?=gettext("Standard"); ?>
-                  <input name="navigation" class="navigation" id="navigation_sidebar" type="radio" value="sidebar" <?= $pconfig['navigation'] == "sidebar" ? 'checked="checked"' : '' ?>/>
-                  <?=gettext("Sidebar"); ?>
+                  <span style="margin-right:10px"><input name="navigation" class="navigation" id="navigation_standard" type="radio" value="standard" <?= $pconfig['navigation'] == "standard" ? 'checked="checked"' : '' ?>/>
+                  <?=gettext("Standard"); ?></span>
+                  <span><input name="navigation" class="navigation" id="navigation_sidebar" type="radio" value="sidebar" <?= $pconfig['navigation'] == "sidebar" ? 'checked="checked"' : '' ?>/>
+                  <?=gettext("Sidebar"); ?></span>
                   <br />
                   <div class="hidden" data-for="help_for_navigation">
                     <?=gettext('Set default navigation menu')?>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -47,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['language'] = $config['system']['language'];
     $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
     $pconfig['theme'] = $config['theme'];
+    $pconfig['navigation'] = $config['system']['navigation'];
     $pconfig['timezone'] = empty($config['system']['timezone']) ? 'Etc/UTC' : $config['system']['timezone'];
 
     $pconfig['gw_switch_default'] = isset($config['system']['gw_switch_default']);
@@ -133,6 +134,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $config['system']['language'] = $pconfig['language'];
         $config['system']['timezone'] = $pconfig['timezone'];
         $config['theme'] =  $pconfig['theme'];
+        $config['system']['navigation'] =  $pconfig['system']['navigation'];
 
         if (!empty($pconfig['prefer_ipv4'])) {
             $config['system']['prefer_ipv4'] = true;
@@ -144,6 +146,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $config['system']['dnsallowoverride'] = true;
         } elseif (isset($config['system']['dnsallowoverride'])) {
             unset($config['system']['dnsallowoverride']);
+        }
+        
+        if ($pconfig['navigation'] == "standard") {
+            $config['system']['navigation'] = 'standard';
+        } elseif ($pconfig['navigation'] == "sidebar") {
+            $config['system']['navigation'] = 'sidebar';
         }
 
         if ($pconfig['dnslocalhost'] == 'yes') {
@@ -347,6 +355,21 @@ include("head.inc");
                   <?= gettext('This will change the look and feel of the GUI.') ?>
                 </div>
               </td>
+            </tr>
+            <tr>
+              <td><a id="help_for_navigation" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Navigation"); ?></td>
+                <td>
+                  <input name="navigation" class="navigation" id="navigation_standard" type="radio" value="standard" <?= $pconfig['navigation'] == "standard" ? 'checked="checked"' : '' ?>/>
+                  <?=gettext("Standard"); ?>
+                  &nbsp;&nbsp;&nbsp;
+                  <input name="navigation" class="nnavigation" id="navigation_sidebar" type="radio" value="sidebar" <?= $pconfig['navigation'] == "sidebar" ? 'checked="checked"' : '' ?>/>
+                  <?=gettext("Sidebar"); ?>
+                  <br />
+                  <div class="hidden" data-for="help_for_navigation_menu">
+                    <?=sprintf(
+                      gettext('Choose between standard/default navigation or sidebar/collapsed navigation'));?>
+                  </div>
+                </td>
             </tr>
           </table>
         </div>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -148,7 +148,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             unset($config['system']['dnsallowoverride']);
         }
         
-        if ($pconfig['navigation'] == "standard") {
+        if (!empty($config['system']['navigation'])) {
+            $config['system']['navigation'] = 'standard';
+        } elseif ($pconfig['navigation'] == "standard") {
             $config['system']['navigation'] = 'standard';
         } elseif ($pconfig['navigation'] == "sidebar") {
             $config['system']['navigation'] = 'sidebar';
@@ -361,13 +363,11 @@ include("head.inc");
                 <td>
                   <input name="navigation" class="navigation" id="navigation_standard" type="radio" value="standard" <?= $pconfig['navigation'] == "standard" ? 'checked="checked"' : '' ?>/>
                   <?=gettext("Standard"); ?>
-                  &nbsp;&nbsp;&nbsp;
-                  <input name="navigation" class="nnavigation" id="navigation_sidebar" type="radio" value="sidebar" <?= $pconfig['navigation'] == "sidebar" ? 'checked="checked"' : '' ?>/>
+                  <input name="navigation" class="navigation" id="navigation_sidebar" type="radio" value="sidebar" <?= $pconfig['navigation'] == "sidebar" ? 'checked="checked"' : '' ?>/>
                   <?=gettext("Sidebar"); ?>
                   <br />
-                  <div class="hidden" data-for="help_for_navigation_menu">
-                    <?=sprintf(
-                      gettext('Choose between standard/default navigation or sidebar/collapsed navigation'));?>
+                  <div class="hidden" data-for="help_for_navigation">
+                    <?=gettext('Set default navigation menu')?>
                   </div>
                 </td>
             </tr>


### PR DESCRIPTION
My starting point for the following consideration was that whenever I log in to the web interface, I get the old menu view even though I almost exclusively use the collapsed menu view.

so i made a new entry in the system - general tab!
You can now select which menu will be displayed automatically after the login.
Saving the selected entry works fine!

![grafik](https://user-images.githubusercontent.com/34602360/53687852-51b93300-3d3a-11e9-9065-d38cad25aed6.png)


Unfortunately I do not know how to load either the default navigation or the sidebar navigation as standard menu after the login. Can anybody help me further?

Regards
René
