### PR TITLE
Add option to create key pair without saving onto firewall on "Create Internal Certificate"

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -205,7 +205,7 @@ function cert_import(& $cert, $crt_str, $key_str)
     return true;
 }
 
-function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha256', $x509_extensions = 'usr_cert', $private_key = null)
+function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha256', $x509_extensions = 'usr_cert')
 {
     $ca = &lookup_ca($caref);
     if (!$ca) {
@@ -234,8 +234,7 @@ function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha
     );
 
     // generate a new key pair
-    $res_key = $private_key === null ? openssl_pkey_new($args)
-                                     : $private_key;
+    $res_key = openssl_pkey_new($args);
     if (!$res_key) {
         return false;
     }

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -205,7 +205,7 @@ function cert_import(& $cert, $crt_str, $key_str)
     return true;
 }
 
-function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha256', $x509_extensions = 'usr_cert')
+function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha256', $x509_extensions = 'usr_cert', $private_key = null)
 {
     $ca = &lookup_ca($caref);
     if (!$ca) {
@@ -234,7 +234,8 @@ function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $digest_alg = 'sha
     );
 
     // generate a new key pair
-    $res_key = openssl_pkey_new($args);
+    $res_key = $private_key === null ? openssl_pkey_new($args)
+                                     : $private_key;
     if (!$res_key) {
         return false;
     }

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -366,7 +366,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         echo $result_stderr;
       }
       exit;
-
     } elseif ($act == 'csr_info_json') {
       header("Content-Type: application/json;charset=UTF-8");
 
@@ -1549,13 +1548,16 @@ $( document ).ready(function() {
                 </td>
               </tr>
               <tr>
-                <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Private key location");?></td>
+                <td><a id="help_for_private_key_location" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Private key location");?></td>
                 <td>
-                <!-- TODO: add hint later -->
                   <select name="private_key_location" id="private_key_location">
                     <option value="firewall" <?= $pconfig['private_key_location'] === 'firewall' ? 'selected="selected"' : ''; ?>><?= gettext('Save on this firewall'); ?></option>
                     <option value="local"    <?= $pconfig['private_key_location'] === 'local'    ? 'selected="selected"' : ''; ?>><?= gettext('Download and do not save'); ?></option>
                   </select>
+                  <div class="hidden" data-for="help_for_private_key_location">
+                    <strong><?= gettext('Save on this firewall'); ?></strong>: <?= gettext("Normally choose this."); ?><br/>
+                    <strong><?= gettext('Download and do not save'); ?></strong>: <?= gettext("If the certificate is for use by a device other than this firewall, and you can download private key soon after Saving, choose this. By this option you can download the private key, which is not saved onto this firewall."); ?><br/>
+                  </div>
                 </td>
               </tr>
               <tr>

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -1110,12 +1110,12 @@ if (empty($act)) {
   });
 
   function refresh_download_link(jquery_key, content, filename) {
-      if (navigator.userAgent.indexOf('MSIE ') !== -1 || navigator.userAgent.indexOf('Trident') !== -1) {
-          // IE11 support; they do not have <a download="">
-          $(jquery_key).attr('href', '/system_certmanager.php?act=download_pem_file&content=' + encodeURIComponent(content) + '&filename=' + encodeURIComponent(filename));
-      } else {
+      if (document.createElement('a').download !== undefined) { // check <a download=""> support
           $(jquery_key).attr('href', URL.createObjectURL(new Blob([content])));
           $(jquery_key).attr('download', filename + '.pem');
+      } else {
+          // IE11 support; they do not have <a download="">
+          $(jquery_key).attr('href', '/system_certmanager.php?act=download_pem_file&content=' + encodeURIComponent(content) + '&filename=' + encodeURIComponent(filename));
       }
   }
   </script>

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -391,20 +391,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
       echo json_encode($parsed_result);
       exit;
-
-    } elseif ($act == 'download_pem_file') {
-      //  Browser without <a download=""> (like IE11) support
-      if (!isset($_GET['content']) || !isset($_GET['filename']) || !ctype_lower($_GET['filename'])) {
-        http_response_code(400);
-        header('Content-Type: text/plain;charset=UTF-8');
-        echo gettext('Invalid request');
-        exit;
-      }
-
-      header('Content-Type: text/plain;charset=UTF-8');
-      header('Content-Disposition:attachment; filename="' . $_GET['filename'] . '.pem"');
-      echo $_GET['content'];
-      exit;
     }
 
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -1114,8 +1100,8 @@ if (empty($act)) {
           $(jquery_key).attr('href', URL.createObjectURL(new Blob([content])));
           $(jquery_key).attr('download', filename + '.pem');
       } else {
-          // IE11 support; they do not have <a download="">
-          $(jquery_key).attr('href', '/system_certmanager.php?act=download_pem_file&content=' + encodeURIComponent(content) + '&filename=' + encodeURIComponent(filename));
+          // <a download=""> is not supported, so remove the link
+          $(jquery_key).remove();
       }
   }
   </script>

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -405,26 +405,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       header('Content-Disposition:attachment; filename="' . $_GET['filename'] . '.pem"');
       echo $_GET['content'];
       exit;
-
-    } elseif ($act == 'generate_private_key') {
-      if (!isset($_GET['keylen']) || !isset($_GET['digest_alg'])) {
-        http_response_code(400);
-        header('Content-Type: text/plain;charset=UTF-8');
-        echo gettext('Invalid request');
-        exit;
-      }
-
-      header('Content-Type: text/plain;charset=UTF-8');
-      $args = array(
-          'private_key_type' => OPENSSL_KEYTYPE_RSA,
-          'private_key_bits' => (int) $_GET['keylen'],
-          'digest_alg'       => $_GET['digest_alg'],
-          'encrypt_key'      => false,
-      );
-
-      openssl_pkey_export(openssl_pkey_new($args), $str_key);
-      echo $str_key;
-      exit;
     }
 
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
This is a proposal for #3272 . This enables creating a private only for the device who opens admin web page.

This is not elegant for the point that secret key is sent back to the OPNsense, which produces double traffic, but on situation that OPNsense does not want to save the secret key, I thought significant improvement against this is hard.