### PR TITLE
Implemented IPsec Mobile client expert tunnel configuration

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -958,42 +958,23 @@ function ipsec_configure_do($verbose = false, $interface = '')
                 $strongswanTree['charon']['plugins']['attr']['28679'] = $a_client['pfs_group'];
             }
 
-            $disable_xauth = false;
+            $radius_enabled = false;
             foreach ($a_phase1 as $ph1ent) {
                 if (!isset($ph1ent['disabled']) && isset($ph1ent['mobile'])) {
                     if ($ph1ent['authentication_method'] == "eap-radius") {
-                        $disable_xauth = true; // disable Xauth when radius is used.
-                        $strongswanTree['charon']['plugins']['eap-radius'] = [];
-                        $strongswanTree['charon']['plugins']['eap-radius']['servers'] = [];
-                        $radius_server_num = 1;
-                        $radius_accounting_enabled = false;
-                        foreach (auth_get_authserver_list() as $auth_server) {
-                            if (in_array($auth_server['name'], explode(',', $ph1ent['authservers']))) {
-                                $server = [
-                                    'address' => $auth_server['host'],
-                                    'secret' => '"' . $auth_server['radius_secret'] . '"',
-                                    'auth_port' => $auth_server['radius_auth_port'],
-                                ];
-
-                                if (!empty($auth_server['radius_acct_port'])) {
-                                    $server['acct_port'] = $auth_server['radius_acct_port'];
-                                }
-                                $strongswanTree['charon']['plugins']['eap-radius']['servers']['server' . $radius_server_num] = $server;
-
-                                if (!empty($auth_server['radius_acct_port'])) {
-                                    $radius_accounting_enabled = true;
-                                }
-                                $radius_server_num += 1;
-                            }
-                        }
-                        if ($radius_accounting_enabled) {
-                            $strongswanTree['charon']['plugins']['eap-radius']['accounting'] = 'yes';
-                        }
+                        configure_eap_radius_plugin($ph1ent['authservers'], $strongswanTree);
+                        $radius_enabled = true;
                         break; // there can only be one mobile phase1, exit loop
                     }
                 }
             }
-            if (isset($a_client['enable']) && !$disable_xauth) {
+
+            if (!$radius_enabled && !empty($a_client['ipsec_conf_append'])) {
+                configure_eap_radius_plugin($a_client['user_source'], $strongswanTree);
+                $radius_enabled = true;
+            }
+
+            if (isset($a_client['enable']) && !$radius_enabled) {
                 $strongswanTree['charon']['plugins']['xauth-pam'] = [
                     'pam_service' => 'ipsec',
                     'session' => 'no',
@@ -1094,6 +1075,10 @@ function ipsec_configure_do($verbose = false, $interface = '')
                 $pskconf .= "{$ident} : {$identType} 0s".base64_encode($key['pre-shared-key'])."\n";
             }
             unset($key);
+        }
+
+        if (!empty($a_client['ipsec_secrets_append'])) {
+            $pskconf .= "\n" . $a_client['ipsec_secrets_append'] . "\n";
         }
 
         @file_put_contents("/usr/local/etc/ipsec.secrets", $pskconf);
@@ -1550,6 +1535,11 @@ EOD;
             }
         }
     }
+
+    if (!empty($a_client['ipsec_conf_append'])) {
+        $ipsecconf .= "\n" . $a_client['ipsec_conf_append'] . "\n";
+    }
+
     // dump file, replace tabs for 2 spaces
     @file_put_contents("/usr/local/etc/ipsec.conf", str_replace("\t", '  ', $ipsecconf));
     unset($ipsecconf);
@@ -1570,6 +1560,41 @@ EOD;
 
     if ($verbose) {
         echo "done.\n";
+    }
+}
+
+function configure_eap_radius_plugin($authservers, &$strongswanTree) {
+    $strongswanTree['charon']['plugins']['eap-radius'] = [];
+    $strongswanTree['charon']['plugins']['eap-radius']['servers'] = [];
+    $radius_server_num = 1;
+    $radius_accounting_enabled = false;
+    foreach (auth_get_authserver_list() as $auth_server) {
+        if ($auth_server['type'] !== 'radius') continue;
+
+        if (in_array($auth_server['name'], explode(',', $authservers))) {
+            $server = [
+                'address' => $auth_server['host'],
+                'secret' => '"' . $auth_server['radius_secret'] . '"',
+                'auth_port' => $auth_server['radius_auth_port'],
+            ];
+
+            if (!empty($auth_server['radius_acct_port'])) {
+                $server['acct_port'] = $auth_server['radius_acct_port'];
+            }
+            $strongswanTree['charon']['plugins']['eap-radius']['servers']['server' . $radius_server_num] = $server;
+
+            if (!empty($auth_server['radius_acct_port'])) {
+                $radius_accounting_enabled = true;
+            }
+            $radius_server_num += 1;
+        }
+    }
+
+    if ($radius_server_num > 1) {
+        if ($radius_accounting_enabled) {
+            $strongswanTree['charon']['plugins']['eap-radius']['accounting'] = 'yes';
+        }
+        $strongswanTree['charon']['plugins']['eap-radius']['class_group'] = 'yes';
     }
 }
 

--- a/src/www/vpn_ipsec_mobile.php
+++ b/src/www/vpn_ipsec_mobile.php
@@ -39,7 +39,7 @@ config_read_array('ipsec', 'phase1');
 // define formfields
 $form_fields = "user_source,local_group,pool_address,pool_netbits,net_list
 ,save_passwd,dns_domain,dns_split,dns_server1,dns_server2,dns_server3
-,dns_server4,wins_server1,wins_server2,pfs_group,login_banner";
+,dns_server4,wins_server1,wins_server2,pfs_group,login_banner,ipsec_conf_append,ipsec_secrets_append";
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     // pass savemessage
@@ -92,6 +92,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig['user_source'] = implode(",", $pconfig['user_source']);
         }
 
+        if (!empty($pconfig['ipsec_conf_append'])) {
+            $pconfig['ipsec_conf_append'] = str_replace("\r\n", "\n", $pconfig['ipsec_conf_append']);
+        }
+
+        if (!empty($pconfig['ipsec_secrets_append'])) {
+            $pconfig['ipsec_secrets_append'] = str_replace("\r\n", "\n", $pconfig['ipsec_secrets_append']);
+        }
+
         /* input validation */
         $reqdfields = explode(" ", "user_source");
         $reqdfieldsn =  array(gettext("User Authentication Source"));
@@ -139,7 +147,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $client = array();
             $copy_fields = "user_source,local_group,pool_address,pool_netbits,dns_domain,dns_server1
             ,dns_server2,dns_server3,dns_server4,wins_server1,wins_server2
-            ,dns_split,pfs_group,login_banner";
+            ,dns_split,pfs_group,login_banner,ipsec_conf_append,ipsec_secrets_append";
             foreach (explode(",", $copy_fields) as $fieldname) {
                             $fieldname = trim($fieldname);
                 if (!empty($pconfig[$fieldname])) {
@@ -196,6 +204,7 @@ $( document ).ready(function() {
   wins_server_change();
   pfs_group_change();
   login_banner_change();
+  expert_tunnel_config_change();
 });
 
 function pool_change() {
@@ -296,6 +305,21 @@ function login_banner_change() {
   }
 }
 
+function expert_tunnel_config_change() {
+
+  if (document.iform.expert_tunnel_config_enable.checked) {
+    document.iform.ipsec_conf_append.disabled = 0;
+    document.iform.ipsec_secrets_append.disabled = 0;
+    $("#expert_tunnel_config_enable_inputs").addClass('show');
+    $("#expert_tunnel_config_enable_inputs").removeClass('hidden');
+  } else {
+    document.iform.ipsec_conf_append.disabled = 1;
+    document.iform.ipsec_secrets_append.disabled = 1;
+    $("#expert_tunnel_config_enable_inputs").addClass('hidden');
+    $("#expert_tunnel_config_enable_inputs").removeClass('show');
+  }
+}
+
 //]]>
 </script>
 
@@ -337,7 +361,7 @@ function print_legacy_box($msg, $name, $value)
 EOFnp;
 }
 
-if (!empty($pconfig['enable']) && !$ph1found) {
+if (!empty($pconfig['enable']) && !$ph1found && empty($config['ipsec']['client']['ipsec_conf_append'])) {
     print_legacy_box(gettext("Support for IPsec Mobile clients is enabled but a Phase1 definition was not found") . ".<br />" . gettext("Please click Create to define one."), "create", gettext("Create Phase1"));
 }
 if (isset($input_errors) && count($input_errors) > 0) {
@@ -546,6 +570,21 @@ endforeach;
                         <textarea name="login_banner" cols="65" rows="7" id="login_banner" class="formpre"><?=$pconfig['login_banner'];?></textarea>
                         <div class="hidden" data-for="help_for_login_banner_enable">
                             <?=gettext("Provide a login banner to clients"); ?><br />
+                        </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><a id="help_for_expert_tunnel_config" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Expert Tunnel Config"); ?></td>
+                    <td>
+                        <input name="expert_tunnel_config_enable" type="checkbox" id="expert_tunnel_config_enable" value="yes" <?= !empty($pconfig['ipsec_conf_append']) ? "checked=\"checked\"" : "";?> onclick="expert_tunnel_config_change()" />
+                        <div id="expert_tunnel_config_enable_inputs">
+                            <?=gettext("Append to ipsec.conf"); ?>:
+                            <textarea name="ipsec_conf_append" cols="80" rows="20" id="ipsec_conf_append" class="formpre" style="max-width: 100%"><?=$pconfig['ipsec_conf_append'];?></textarea>
+                            <?=gettext("Append to ipsec.secrets"); ?>:
+                            <textarea name="ipsec_secrets_append" cols="80" rows="5" id="ipsec_secrets_append" class="formpre" style="max-width: 100%"><?=$pconfig['ipsec_secrets_append'];?></textarea>
+                        </div>
+                        <div class="hidden" data-for="help_for_expert_tunnel_config">
+                            <?=gettext("Use for complex configurations instead of configuring IPsec Phase 1 and Phase 2 in the WebUI. Please see StrongSwan ipsec.conf manual for help. From here you are on your own."); ?><br />
                         </div>
                     </td>
                   </tr>


### PR DESCRIPTION
Hi,

we have the requirement to assign separate virtual IP pools to different IPsec mobile user groups. I understand that adjusting the WebUI to cater for our specific need is rather complex. I went through comparable requests from other people and realised their requirements are still well different from ours.

So my conclusion was that there are two possible setups
- The existing options are good enough for most people
- The desired options are so complex that a WebUi will never be sufficient

I opened therefore a feature request (https://github.com/opnsense/core/issues/3295 ) to allow for an expert tunnel configuration.

This PR is the result from above feature request.

We had to rearrange some of the code for generation strongswan.conf which is in our opinion backwards compatible.

The only new fixed addition is `class_group = yes` - but that should have no influence as well.

So we are awaiting possible feedback and hope to get that expert tunnel config included.

Best regards
Mark & Rainer