### PR TITLE
Firewall log Live View to show multibyte characters correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ CORE_DEPENDS?=		${CORE_DEPENDS_${CORE_ARCH}} \
 			php${CORE_PHP}-hash \
 			php${CORE_PHP}-json \
 			php${CORE_PHP}-ldap \
+			php${CORE_PHP}-mbstring \
 			php${CORE_PHP}-mcrypt \
 			php${CORE_PHP}-openssl \
 			php${CORE_PHP}-pdo \

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -37,7 +37,7 @@ function fix_rule_label($descr)
 {
     $descr = str_replace('"', '', $descr);
     if (strlen($descr) > 63) {
-        return substr($descr, 0, 60) . "...";
+        return mb_strcut($descr, 0, 60) . "...";
     } else {
         return $descr;
     }


### PR DESCRIPTION
This is not a serious bug.

On firewall logs Live View, rule description written in Japanese was corrupt.

As test description "あああああああああああああああああああああああああああああ" (test without quote) is like below.

<img width="385" alt="キャプチャ2" src="https://user-images.githubusercontent.com/5049333/54069837-1d93c400-429e-11e9-89ab-f93fa746d831.PNG">

This is because `substr` cuts string on designated byte even if it is a part of UTF-8 character, leading to the corrupt UTF-8 string. In this example first byte of "あ" and added ".." makes a 3-byte UTF-8 character that I don't know.

Since "USER_RULE: " is added and this is limited to 60 bytes, first 49 bytes are used. Since most of Japanese characters are expressed in 3 bytes in UTF-8, so this happens in most Japanese only texts. this may happen in other languages with multibyte characters.

`mb_strcut` works almost the same as `substr`, but gives up the (part of) last Unicode character if it does not fit in limitation.

<img width="386" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54069934-af033600-429e-11e9-9cbb-53812aafcd8a.PNG">

For testing I manually installed `php71-mbstring` by `pkg` and  copied filter.inc manually, but at least my testing environment, it took effect after reboot. I didn't check why it needs it.