### PR TITLE
[MVC] ModelRelationField: fix array merge for sortable items

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
@@ -211,7 +211,7 @@ class ModelRelationField extends BaseField
 
             $datanodes = explode(',', $this->internalValue);
             if ($this->internalIsSorted) {
-                $optKeys = $datanodes + array_keys(self::$internalOptionList[$this->internalCacheKey]);
+                $optKeys = array_keys(self::$internalOptionList[$this->internalCacheKey]) + $datanodes;
             } else {
                 $optKeys = array_keys(self::$internalOptionList[$this->internalCacheKey]);
             }


### PR DESCRIPTION
Fixes this bug:
https://github.com/opnsense/plugins/issues/1225

I had to look this up in the PHP docs:

>  The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored. 