### PR TITLE
Not to translate hostname example

### DIFF
--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -280,8 +280,6 @@ include("head.inc");
                 <input name="hostname" type="text" size="40" value="<?=$pconfig['hostname'];?>" />
                 <div class="hidden" data-for="help_for_hostname">
                   <?=gettext("Name of the firewall host, without domain part"); ?>
-                  <br />
-                  <?=gettext("e.g."); ?> <em>firewall</em>
                 </div>
               </td>
             </tr>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -281,7 +281,7 @@ include("head.inc");
                 <div class="hidden" data-for="help_for_hostname">
                   <?=gettext("Name of the firewall host, without domain part"); ?>
                   <br />
-                  <?=gettext("e.g."); ?> <em><?=gettext("firewall");?></em>
+                  <?=gettext("e.g."); ?> <em>firewall</em>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
On System > Settings > General, hostname example is translated.

<img width="478" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54086740-a2aad600-438f-11e9-970e-9ca94d2d74a9.PNG">

(Like: "Example: ファイヤーウォール" for hostname)

Same as here:

<img width="466" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54086906-3e891180-4391-11e9-894b-1596723d9d10.PNG">

This example contains invalid characters.

<img width="494" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54086765-c706b280-438f-11e9-9c58-8f3637c227b6.PNG">

(This alerts says that hostname can contain only a-z, 0-9, and -, which is correct.)

As long as I see, Czech and Japanese are affected. French, on the other hand, seems to have a French text which is valid hostname: "pare-feu".