### PR TITLE
Implemented wildcard includes for ipsec/strongswan

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1003,6 +1003,7 @@ function ipsec_configure_do($verbose = false, $interface = '')
         }
 
         $strongswan = generate_strongswan_conf($strongswanTree);
+        $strongswan .= "\ninclude /usr/local/etc/strongswan.*.conf\n";
         @file_put_contents("/usr/local/etc/strongswan.conf", $strongswan);
         unset($strongswan);
 
@@ -1096,6 +1097,7 @@ function ipsec_configure_do($verbose = false, $interface = '')
             unset($key);
         }
 
+        $pskconf .= "\ninclude /usr/local/etc/ipsec.*.secrets\n";
         @file_put_contents("/usr/local/etc/ipsec.secrets", $pskconf);
         chmod("/usr/local/etc/ipsec.secrets", 0600);
         unset($pskconf);
@@ -1550,6 +1552,7 @@ EOD;
             }
         }
     }
+    $ipsecconf .= "\ninclude /usr/local/etc/ipsec.*.conf\n";
     // dump file, replace tabs for 2 spaces
     @file_put_contents("/usr/local/etc/ipsec.conf", str_replace("\t", '  ', $ipsecconf));
     unset($ipsecconf);


### PR DESCRIPTION
So this is the PR mentioned here
https://github.com/opnsense/core/pull/3298

It just adds wildcard includes to
ipsec.conf
ipsec.secrets
strongswan.conf

Best regards
Rainer
