### PR TITLE
do not merge : configure standard interfaces at last

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -892,6 +892,7 @@ function interfaces_configure($verbose = false)
     $delayed_list = array();
     $bridge_list = array();
     $track6_list = array();
+    $standard_list = array();
 
     foreach (get_configured_interface_with_descr() as $if => $ifname) {
         $realif = $config['interfaces'][$if]['if'];
@@ -902,7 +903,7 @@ function interfaces_configure($verbose = false)
         } elseif (!empty($config['interfaces'][$if]['ipaddrv6']) && $config['interfaces'][$if]['ipaddrv6'] == 'track6') {
             $track6_list[$if] = $ifname;
         } else {
-            interface_configure($verbose, $if);
+            $standard_list[$if] = $ifname;
         }
     }
 
@@ -931,6 +932,10 @@ function interfaces_configure($verbose = false)
     interfaces_bridge_configure(2);
 
     foreach ($bridge_list as $if => $ifname) {
+        interface_configure($verbose, $if);
+    }
+
+    foreach ($standard_list as $if => $ifname) {
         interface_configure($verbose, $if);
     }
 


### PR DESCRIPTION
Hi,
It's about issue #3199 

If you have a tracked interface on a bridge, setup to track a « standard » interface (ie. no grp, lagg, bridge, etc…) the bridge will set up after the standard interface, and the dhcp6c need that the tracked interface up to work.

The idea here is to set up the interfaces with no dependencies to others at the end.

I just tested on my situation and it resolves my issue. But this kind of change needs to be tested a lot.
