### PR TITLE
Auth/LDAP: Fallback to 'commonName' if 'name' isn't available for full name

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -386,7 +386,8 @@ class LDAP extends Base implements IAuthConnector
                             $result[] = array(
                                 'name' => $searchResults[$i][$ldapAttr][0],
                                 'fullname' => !empty($searchResults[$i]['name'][0]) ?
-                                    $searchResults[$i]['name'][0] : "",
+                                    $searchResults[$i]['name'][0] : !empty($searchResults[$i]['cn'][0]) ?
+                                        $searchResults[$i]['cn'][0] : "",
                                 'dn' => $searchResults[$i]['dn']
                             );
                             break;


### PR DESCRIPTION
Per [rfc2253](http://www.rfc-editor.org/rfc/rfc2253.txt), `cn` is commonly used to represent LDAP user's full name and is probably supported across standard directory servers.