### PR TITLE
Monit, remove __items and fix migration issue

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
@@ -35,7 +35,7 @@ class M1_0_8 extends BaseModelMigration
 {
     public function post($model)
     {
-        foreach ($model->getNodeByReference('test')->__items as $test) {
+        foreach ($model->test->iterateItems() as $test) {
             $test->type = $model->getTestType($test->condition->getNodeData());
         }
         // validation will fail because we want to change the type of tests linked to services

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
@@ -168,7 +168,8 @@ class Monit extends BaseModel
                         switch ($node->getInternalXMLTagName()) {
                             case 'type':
                                 $testUuid = $parentNode->getAttribute('uuid');
-                                if ($node->isFieldChanged() &&
+                                if (strcmp((string)$node, 'Custom') != 0 &&
+                                    $node->isFieldChanged() &&
                                     $this->isTestServiceRelated($testUuid)) {
                                     $messages->appendMessage(new \Phalcon\Validation\Message(
                                         gettext("Cannot change the type. Test is linked to a service."),


### PR DESCRIPTION
This fixes #3334.

@AdSchellevis I had to revert your commit eb280f6 partially because it brakes the migration.
The BaseModel::runMigrations() function makes a serializeToConfig() after BaseModelMigration::run().
But run() fills the test->type with the default 'Custom' which was not allowed.


