### PR TITLE
certmanager: Avoid double encoding cert name

### DIFF
--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -1942,7 +1942,7 @@ $( document ).ready(function() {
 <?php
             $i = 0;
             foreach ($a_cert as $cert) :
-                $name = htmlspecialchars($cert['descr']);
+                $name = $cert['descr'];
                 $purpose = null;
 
                 if (!empty($cert['crt'])) {


### PR DESCRIPTION
We do not need to wrap `$cert['descr']` with `htmlspecialchars` since everything in `$cert` is already html encoded via `legacy_html_escape_form_data`.

Because of double wrapping, Let's Encrypt issued certificate have an awkward looking name as:
**`my.hostname.com (Let&#039;s Encrypt)`** 
