### PR TITLE
IPsec: Generate strongswan.conf Radius backend configuration from mobile client page

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -963,42 +963,23 @@ function ipsec_configure_do($verbose = false, $interface = '')
                 $strongswanTree['charon']['plugins']['attr']['28679'] = $a_client['pfs_group'];
             }
 
-            $disable_xauth = false;
+            $radius_enabled = false;
             foreach ($a_phase1 as $ph1ent) {
                 if (!isset($ph1ent['disabled']) && isset($ph1ent['mobile'])) {
                     if ($ph1ent['authentication_method'] == "eap-radius") {
-                        $disable_xauth = true; // disable Xauth when radius is used.
-                        $strongswanTree['charon']['plugins']['eap-radius'] = [];
-                        $strongswanTree['charon']['plugins']['eap-radius']['servers'] = [];
-                        $radius_server_num = 1;
-                        $radius_accounting_enabled = false;
-                        foreach (auth_get_authserver_list() as $auth_server) {
-                            if (in_array($auth_server['name'], explode(',', $ph1ent['authservers']))) {
-                                $server = [
-                                    'address' => $auth_server['host'],
-                                    'secret' => '"' . $auth_server['radius_secret'] . '"',
-                                    'auth_port' => $auth_server['radius_auth_port'],
-                                ];
-
-                                if (!empty($auth_server['radius_acct_port'])) {
-                                    $server['acct_port'] = $auth_server['radius_acct_port'];
-                                }
-                                $strongswanTree['charon']['plugins']['eap-radius']['servers']['server' . $radius_server_num] = $server;
-
-                                if (!empty($auth_server['radius_acct_port'])) {
-                                    $radius_accounting_enabled = true;
-                                }
-                                $radius_server_num += 1;
-                            }
-                        }
-                        if ($radius_accounting_enabled) {
-                            $strongswanTree['charon']['plugins']['eap-radius']['accounting'] = 'yes';
-                        }
+                        configure_eap_radius_plugin($ph1ent['authservers'], $strongswanTree);
+                        $radius_enabled = true;
                         break; // there can only be one mobile phase1, exit loop
                     }
                 }
             }
-            if (isset($a_client['enable']) && !$disable_xauth) {
+
+            if (!$radius_enabled) {
+                configure_eap_radius_plugin($a_client['user_source'], $strongswanTree);
+                $radius_enabled = true;
+            }
+
+            if (isset($a_client['enable']) && !$radius_enabled) {
                 $strongswanTree['charon']['plugins']['xauth-pam'] = [
                     'pam_service' => 'ipsec',
                     'session' => 'no',
@@ -1578,6 +1559,38 @@ EOD;
 
     if ($verbose) {
         echo "done.\n";
+    }
+}
+
+function configure_eap_radius_plugin($authservers, &$strongswanTree) {
+    $strongswanTree['charon']['plugins']['eap-radius'] = [];
+    $strongswanTree['charon']['plugins']['eap-radius']['servers'] = [];
+    $radius_server_num = 1;
+    $radius_accounting_enabled = false;
+    foreach (auth_get_authserver_list() as $auth_server) {
+        if ($auth_server['type'] !== 'radius') continue;
+
+        if (in_array($auth_server['name'], explode(',', $authservers))) {
+            $server = [
+                'address' => $auth_server['host'],
+                'secret' => '"' . $auth_server['radius_secret'] . '"',
+                'auth_port' => $auth_server['radius_auth_port'],
+            ];
+
+            if (!empty($auth_server['radius_acct_port'])) {
+                $server['acct_port'] = $auth_server['radius_acct_port'];
+            }
+            $strongswanTree['charon']['plugins']['eap-radius']['servers']['server' . $radius_server_num] = $server;
+
+            if (!empty($auth_server['radius_acct_port'])) {
+                $radius_accounting_enabled = true;
+            }
+            $radius_server_num += 1;
+        }
+    }
+
+    if ($radius_accounting_enabled) {
+        $strongswanTree['charon']['plugins']['eap-radius']['accounting'] = 'yes';
     }
 }
 


### PR DESCRIPTION
Hi,

this is the PR for https://github.com/opnsense/core/issues/3339 .

If there is a mobile phase 1 containing a EAP-Radius configuration the system behaves as before.

If there is no mobile phase 1 but a Radius server configured in the VPN-IPsec-Mobile client page the radius plugin config will be configured from there.

If the plan is to have - at some point in the future - more than only one mobile phase this is the first step  (remove the configuration of the per-user based authentication backends away from the tunnel config into the Mobile client config).