### PR TITLE
Proxy: ssl_crtd was removed with Squid 4.X

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -52,7 +52,7 @@
 
 {% if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
 # setup ssl re-cert
-sslcrtd_program /usr/local/libexec/squid/ssl_crtd -s /var/squid/ssl_crtd -M {{ OPNsense.proxy.forward.ssl_crtd_storage_max_size|default('4') }}MB
+sslcrtd_program /usr/local/libexec/squid/security_file_certgen -s /var/squid/ssl_crtd -M {{ OPNsense.proxy.forward.ssl_crtd_storage_max_size|default('4') }}MB
 sslcrtd_children {{ OPNsense.proxy.forward.sslcrtd_children|default('5') }}
 
 tls_outgoing_options options=NO_TLSv1 cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS


### PR DESCRIPTION
On current devel mode you get an error while starting squid.

2019/04/28 18:46:56 kid1| Too few /usr/local/libexec/squid/ssl_crtd -s /var/squid/ssl_crtd -M 4MB processes are running (need 1/5)
2019/04/28 18:46:56 kid1|   Took 0.00 seconds (  0.00 entries/sec).


Filename is now: 

security_file_certgen

Syntax is the same:
https://forum.lissyara.su/freebsd-f8/freebsd-11-squid-4-5-prozrachnoe-proksirovanie-s-p-t45437.html

Should stay in master as long as we are on Squid 3.5