### PR TITLE
Webproxy: Make SNI selectable

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -283,7 +283,7 @@
             <field>
                 <id>proxy.forward.sslurlonly</id>
                 <label>Log SNI information only</label>
-                <type>checkbox</type>
+                <type>dropdown</type>
                 <help>Do not decode and/or filter SSL content, only log requested domains and IP addresses. Some old servers may not provide SNI, so their addresses will not be indicated.</help>
             </field>
             <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Migrations/M1_0_4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Migrations/M1_0_4.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ *    Copyright (C) 2016 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Proxy\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_0_4 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        // SNI is configurable per proxy-mode. Former true is equivalent to both.
+        if (!empty($model->forward->sslurlonly)) {
+            $model->forward->sslurlonly = 'both';
+        }
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/proxy</mount>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <description>
         (squid) proxy settings
     </description>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -272,9 +272,15 @@
                     </check001>
                 </Constraints>
             </sslbump>
-            <sslurlonly type="BooleanField">
-                <default>0</default>
+            <sslurlonly type="OptionField">
+                <default>off</default>
                 <Required>Y</Required>
+                <OptionValues>
+                    <off>Off</off>
+                    <explicit>Explicit</explicit>
+                    <transparent>Transparent</transparent>
+                    <both>Both (transparent+explicit)</both>
+                </OptionValues>
                 <Constraints>
                     <check001>
                         <reference>sslbump.check001</reference>

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -19,11 +19,11 @@
 
 {% if helpers.exists('OPNsense.proxy.forward.transparentMode') and OPNsense.proxy.forward.transparentMode == '1' %}
 # Setup transparent mode listeners on loopback interfaces
-{{ listener_config('127.0.0.1', OPNsense.proxy.forward.port, 'intercept') }}
-{{ listener_config('[::1]', OPNsense.proxy.forward.port, 'intercept') }}
+{{ listener_config('127.0.0.1', OPNsense.proxy.forward.port, 'name=transparenthttpv4 intercept') }}
+{{ listener_config('[::1]', OPNsense.proxy.forward.port, 'name=transparenthttpv6 intercept') }}
 {%     if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
-{{ listener_config('127.0.0.1', OPNsense.proxy.forward.sslbumpport, 'intercept', 'ssl') }}
-{{ listener_config('[::1]', OPNsense.proxy.forward.sslbumpport, 'intercept', 'ssl') }}
+{{ listener_config('127.0.0.1', OPNsense.proxy.forward.sslbumpport, 'name=transparenthttpsv4 intercept', 'ssl') }}
+{{ listener_config('[::1]', OPNsense.proxy.forward.sslbumpport, 'name=transparenthttpsv6 intercept', 'ssl') }}
 {%     endif %}
 {% endif %}
 
@@ -32,7 +32,7 @@
 {%     for interface in OPNsense.proxy.forward.interfaces.split(",") %}
 {%         for intf_key,intf_item in interfaces.items() %}
 {%             if intf_key == interface and intf_item.ipaddr and intf_item.ipaddr != 'dhcp' %}
-{{ listener_config(intf_item.ipaddr, OPNsense.proxy.forward.port) }}
+{{ listener_config(intf_item.ipaddr, OPNsense.proxy.forward.port, 'name=explicit') }}
 {%             endif %}
 {%         endfor %}
 {# virtual ip's #}
@@ -62,22 +62,29 @@ acl bump_step1 at_step SslBump1
 acl bump_step2 at_step SslBump2
 acl bump_step3 at_step SslBump3
 acl bump_nobumpsites ssl::server_name "/usr/local/etc/squid/nobumpsites.acl"
+{% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == 'transparent' %}
+acl bump_nobumpports myportname transparenthttpv4 transparenthttpsv4 transparenthttpv6 transparenthttpsv6
+{% endif %}
+{% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == 'explicit' %}
+acl bump_nobumpports myportname explicit
+{% endif %}
+{% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == 'both' %}
+acl bump_nobumpports myportname transparenthttpv4 transparenthttpsv4 transparenthttpv6 transparenthttpsv6 explicit
+{% endif %}
 
 # configure bump
-{% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == '1' %}
-ssl_bump peek bump_step1 all
-ssl_bump splice all
-ssl_bump peek bump_step2 all
-ssl_bump splice bump_step3 all
-ssl_bump bump
+# step1
+ssl_bump peek bump_step1
 
-{% else %}
-ssl_bump peek bump_step1 all
-ssl_bump peek bump_step2 bump_nobumpsites
-ssl_bump splice bump_step3 bump_nobumpsites
-ssl_bump stare bump_step2
-ssl_bump bump bump_step3
+# step2
+{% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly != 'off' %}
+ssl_bump splice bump_step2 bump_nobumpports
 {% endif %}
+ssl_bump splice bump_step2 bump_nobumpsites
+ssl_bump stare all
+
+# step3
+ssl_bump bump all
 
 sslproxy_cert_error deny all
 {% endif %}


### PR DESCRIPTION
Such a feature would be really helpful.
I need it to make Squid bump my LAN Network (with Windows-Clients) and to splice the Transparent-Proxy-Interfaces with Mobile-Clients (Phones/Tablets) where Certificates cannot be imported easily.
This would resolve my [FR 3394](https://github.com/opnsense/core/issues/3394).
But I don't know if it is the right way to do it.
It would be great if someone could review this.