### PR TITLE
opnsense - core theme modal fix for (19.7)

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -118,6 +118,7 @@ $zindex: (
 html, body{
   height: 100%;
   font-family: 'SourceSansProRegular';
+  background-color: #FFF;
 }
 
 body{
@@ -366,6 +367,7 @@ main.page-content.col-lg-12 {
 #navigation.col-sidebar-left {
   width: 70px;
   overflow: hidden;
+  background-color: transparent !important;
   border: none !important;
   > div {
     &.row {

--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -365,7 +365,6 @@ main.page-content.col-lg-12 {
 
 #navigation.col-sidebar-left {
   width: 70px;
-  background-color: transparent !important;
   overflow: hidden;
   border: none !important;
   > div {

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7108,7 +7108,6 @@ main.page-content.col-lg-12 {
 
 #navigation.col-sidebar-left {
   width: 70px;
-  background-color: transparent !important;
   overflow: hidden;
   border: none !important;
 }

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -6888,6 +6888,7 @@ td.visible-print {
 html, body {
   height: 100%;
   font-family: "SourceSansProRegular";
+  background-color: #FFF;
 }
 
 body {
@@ -7109,6 +7110,7 @@ main.page-content.col-lg-12 {
 #navigation.col-sidebar-left {
   width: 70px;
   overflow: hidden;
+  background-color: transparent !important;
   border: none !important;
 }
 #navigation.col-sidebar-left > div.row {


### PR DESCRIPTION
background color fix (see screenshot)

![grafik](https://user-images.githubusercontent.com/34602360/57126158-3a271680-6d8c-11e9-99f5-2077068bf04f.png)


see also fixes for tukan and cicada
https://github.com/opnsense/plugins/pull/1321

@fichtner please merge to clean up the modal problem for all themes