### PR TITLE
added failover_split parameter to configure loadbalancing for DHCPD failover

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -623,7 +623,11 @@ EOD;
                 $my_port = "519";
                 $peer_port = "520";
                 $type = "primary";
-                $dhcpdconf_pri  = "split 128;\n";
+                if (!empty($dhcpifconf['failover_split'])) {
+                    $dhcpdconf_pri  = "split {$dhcpifconf['failover_split']};\n";
+                } else {
+                    $dhcpdconf_pri  = "split 128;\n";
+                }
                 $dhcpdconf_pri .= "  mclt 600;\n";
             } else {
                 $type = "secondary";

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -92,7 +92,7 @@ function reconfigure_dhcpd()
     clear_subsystem_dirty('staticmaps');
 }
 
-$config_copy_fieldsnames = array('enable', 'staticarp', 'failover_peerip', 'dhcpleaseinlocaltime','descr',
+$config_copy_fieldsnames = array('enable', 'staticarp', 'failover_peerip', 'failover_split', 'dhcpleaseinlocaltime','descr',
   'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'denyunknown', 'ddnsdomain',
   'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsupdate', 'mac_allow',
   'mac_deny', 'tftp', 'bootfilename', 'ldap', 'netboot', 'nextserver', 'filename', 'filename32', 'filename64',
@@ -302,6 +302,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
           (string)((int)$pconfig['interface_mtu']) != $pconfig['interface_mtu'] || $pconfig['interface_mtu'] < 68 || $pconfig['interface_mtu'] > 65535)
         ) {
             $input_errors[] = gettext("A valid MTU value must be specified.");
+        }
+        if (!empty($pconfig['failover_split']) && (
+          (string)((int)$pconfig['failover_split']) != $pconfig['failover_split'] || $pconfig['failover_split'] < 0 || $pconfig['failover_split'] > 256)
+        ) {
+            $input_errors[] = gettext("Failover split must be a number between 0 and 256.");
         }
 
         if (is_array($pconfig['numberoptions']['item'])) {
@@ -842,10 +847,20 @@ include("head.inc");
                       <td>
                         <input name="failover_peerip" type="text" class="form-control host" id="failover_peerip" value="<?=$pconfig['failover_peerip'];?>" />
                         <div class="hidden" data-for="help_for_failover_peerip">
-                          <?=gettext("Leave blank to disable. Enter the interface IP address of the other machine. Machines must be using CARP. Interface's advskew determines whether the DHCPd process is Primary or Secondary. Ensure one machine's advskew<20 (and the other is >20).");?>
+                          <?=gettext("Leave blank to disable. Enter the interface IP address of the other machine. Machines must be using CARP. Interface's advskew determines whether the DHCPd process is Primary or Secondary. Ensure one machine's advskew<20 (and the other is >20). Note that changing this value will delete the current leases-database!");?>
                         </div>
                       </td>
                     </tr>
+                    <td><a id="help_for_failover_split" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Failover split:");?></td>
+                      <td>
+                        <input name="failover_split" type="text" class="form-control host" id="failover_split" value="<?=$pconfig['failover_split'];?>" />
+                        <div class="hidden" data-for="help_for_failover_split">
+                          <?=gettext("Leave blank to use default (128) which should be fine for most cases. Enter a number (0-256) to specify the load-balancing split between the failover peers, the default of 128 means both peers will h
+andle approximately 50% of the clients, 256 will make the primary handle all the clients. This value is only used on the primary peer, leave blank on the secondary.");?>
+                        </div>
+                      </td>
+                    </tr>
+
                     <tr>
                       <td><a id="help_for_failover_staticarp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Static ARP");?></td>
                       <td>


### PR DESCRIPTION
While the hardcoded default split of 128 is a perfectly reasonable value there are scenarios where it may be preferrable to only have one peer (eg the primary) give out leases as long as both peers are running. The split-parameter allows to configure what percentage of clients should be handled by either peer in normal mode. It would probably also be an option to implement this as a choice and only allow values of 0, 128 and 256.

there is still an issue with handling of 0 as non-default in this code, I am not sure how to achieve this.
If someone finds the time to review this that would be great, its my first pull-request so I hope I did not screw something up...