### PR TITLE
Sort interface groups in GUI to match firewall rule order

### DIFF
--- a/src/www/interfaces_groups_edit.php
+++ b/src/www/interfaces_groups_edit.php
@@ -30,6 +30,7 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
+require_once("filter.inc");
 
 $a_ifgroups = &config_read_array('ifgroups', 'ifgroupentry');
 
@@ -112,6 +113,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                       }
                   }
               }
+              mark_subsystem_dirty('filter');
           }
           $old_ifname = isset($id) ? $a_ifgroups[$id]['ifname'] : $pconfig['ifname'];
           // remove group members
@@ -123,9 +125,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
           // update item
           $a_ifgroups[$id] = $ifgroupentry;
       } else {
+          mark_subsystem_dirty('filter');
           // add new item
           $a_ifgroups[] = $ifgroupentry;
       }
+      usort($a_ifgroups, function($a, $b) {
+          return strnatcmp($a['ifname'], $b['ifname']);
+      });
+      filter_rules_sort();
       write_config();
       interface_group_setup($ifgroupentry);
       header(url_safe('Location: /interfaces_groups.php'));


### PR DESCRIPTION
This now makes it easy and predictable to add interfaces to multiple groups.

Before this change, the interfaces_groups GUI was sorted by the order that interface groups were added. However, this was not the order that the actual pf rules would then be generated making it unpredictable when adding interfaces to multiple groups.

The filter_rules_sort function already took care of the actual pf rule order.

I also took care of only marking the filter subsystem dirty when needed.  I tested this patch quite a bit on 19.1.8. When updating, users only need to make one change to the interface groups to have them sorted in the GUI.

I hope I did not miss anything because this patch is against master. In it’s current state, the patch can be directly applied to 19.1.x or master.