### PR TITLE
Captive portal: optimise ipfw rule parsing.

### DIFF
--- a/src/opnsense/scripts/OPNsense/CaptivePortal/allow.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/allow.py
@@ -61,12 +61,7 @@ if parameters['ip_address'] is not None and parameters['zoneid'] is not None:
                                ip_address=parameters['ip_address'],
                                mac_address=mac_address
                                )
-    # check if address is not already registered before adding it to the ipfw table
-    if not cpIPFW.ip_or_net_in_table(table_number=parameters['zoneid'], address=parameters['ip_address']):
-        cpIPFW.add_to_table(table_number=parameters['zoneid'], address=parameters['ip_address'])
-
-    # add accounting for this ip address
-    cpIPFW.add_accounting(parameters['ip_address'])
+    cpIPFW.add_to_table(table_number=parameters['zoneid'], address=parameters['ip_address'])
     response['clientState'] = 'AUTHORIZED'
 else:
     response = {'clientState': 'UNKNOWN'}

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
@@ -161,17 +161,12 @@ class CPBackgroundProcess(object):
                             self.ipfw.delete(zoneid, db_client['ipAddress'])
                         self.db.update_client_ip(zoneid, db_client['sessionId'], current_ip)
                         self.ipfw.add_to_table(zoneid, current_ip)
-                        self.ipfw.add_accounting(current_ip)
 
                 # check session, if it should be active, validate its properties
                 if drop_session_reason is None:
-                    # registered client, but not active according to ipfw (after reboot)
-                    if cpnet not in registered_addresses:
+                    # registered client, but not active or missing accounting according to ipfw (after reboot)
+                    if cpnet not in registered_addresses or cpnet not in registered_addr_accounting:
                         self.ipfw.add_to_table(zoneid, cpnet)
-
-                    # is accounting rule still available? need to reapply after reload / reboot
-                    if cpnet not in registered_addr_accounting:
-                        self.ipfw.add_accounting(cpnet)
                 else:
                     # remove session
                     syslog.syslog(syslog.LOG_NOTICE, drop_session_reason)

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -114,8 +114,8 @@ add {{loop.index  + 1000}} skipto 60000 icmp from any to { 255.255.255.255 or me
 # zone {{item.zone}} ({{item.zoneid}}) / {{item.if}} configuration
 #===================================================================================
 {# authenticated clients #}
-add {{3000 + item.zoneid|int }}  skipto {{10001 + item.zoneid|int * 1000  }} ip from table({{item.zoneid|int}}) to any via {{item.if}}
-add {{3000 + item.zoneid|int }}  skipto {{10001 + item.zoneid|int * 1000  }} ip from any to table({{item.zoneid|int}}) via {{item.if}}
+add {{3000 + item.zoneid|int }}  skipto tablearg ip from table({{item.zoneid|int}}) to any via {{item.if}}
+add {{3000 + item.zoneid|int }}  skipto tablearg ip from any to table({{item.zoneid|int}}) via {{item.if}}
 {% endfor %}
 
 
@@ -144,20 +144,8 @@ add 6199 skipto 60000 all from any to any
 
 
 #======================================================================================
-# setup zone accounting section
+# 30000 .... 49999 reserved for captive portal accounting rules
 #======================================================================================
-{% for item in cp_interface_list %}
-# zone {{item.zone}} ({{item.zoneid}})
-add {{ (item.zoneid|int * 1000) + 10001 }} count ip from any to any via {{item.if}}
-add {{ (item.zoneid|int * 1000) + 10998 }} skipto 30000 all from any to any via {{item.if}}
-add {{ (item.zoneid|int * 1000) + 10999 }} deny all from any to any not via {{item.if}}
-{% endfor %}
-
-
-#======================================================================================
-# setup accounting section, first rule is counting all CP traffic
-#======================================================================================
-add 30000 set 0 count ip from any to any
 
 
 #======================================================================================


### PR DESCRIPTION
closes https://github.com/opsense/core/issues/3559

Our current generated ruleset creates two count rules to match incoming and outgoing traffic to and from the client for accounting purposes. Since ipfw doesn't support table stats, the options are limited to know the amount of traffic processed and last accessed times.

This patch basically replaces the accounting section with seperate blocks, which are jumped to using the exising table (which contains address + rulenumber now), logically this would lower the time needed to parse the accounting section (since only the count rules for the specif ip's are evaulated now).

In terms of ruleset, this will generate 3 rules per address (count from, count to and jump to end of ruleset), like:

```
30001   342    27744 count ip from xxx.xxx.xxx.xxx to any
30001  1194   225783 count ip from any to xxx.xxx.xxx.xxx
30001  1536   253527 skipto 60000 ip from any to any       [ <--- NEW ]
```

Since we need the address to collect rules, we can't simply this count to one rule (IPFW.list_accounting_info() parses the address from the ruleset).

Our per zone "skipto" section, uses a tablearg in stead of static rule number now:

```
03001  2362   386004 skipto tablearg ip from table(1) to any via em2
03001  5701  4761746 skipto tablearg ip from any to table(1) via em2
```