### PR TITLE
Fix IPv4 dhcp-relay 

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1641,7 +1641,7 @@ function dhcpd_dhcrelay4_configure($verbose = false)
         if (!isset($destif)) {
             foreach (get_staticroutes() as $rtent) {
                 if (ip_in_subnet($srvip, $rtent['network'])) {
-                    $destif = $a_gateways[$rtent['gateway']]['interface'];
+                    $destif = get_real_interface($a_gateways[$rtent['gateway']]['interface']);
                     break;
                 }
             }


### PR DESCRIPTION
DHCP-relay service will fail with the following error if DHCP server IP is know in static route:

dhcrelay: Can't attach interface {ifname} to bpf device /dev/bpf0: Device not configured

This is the only place where get_real_interface( ) isn't used in IPv4 dhcp-relay