### PR TITLE
To fix: OpenVPN server wizard always asks to create a new CA

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -202,8 +202,8 @@ function step6_stepbeforeformdisplay()
     else foreach ($config['ca'] as $ca) {
         if (!empty($ca['prv'])) {
             $no_internal_ca=false;
-        }
-        
+            break;
+        }   
     }
     
     if ($no_internal_ca) {

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -194,10 +194,23 @@ function step5_submitphpaction()
 function step6_stepbeforeformdisplay()
 {
     global $stepid, $config;
+    $no_internal_ca = true;
 
-    if (!empty($config['ca'])) {
+    if (empty($config['ca'])) {
         $stepid++;
     }
+    else do {
+            foreach ($config['ca'] as $ca) {
+                if (!empty($ca['prv'])) {
+                    $no_internal_ca=false;
+                }
+            }
+    }
+    while ($no_internal_ca);
+
+    if ($no_internal_ca) {
+        $stepid++;
+    }  
 }
 
 function step6_submitphpaction()

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -199,15 +199,13 @@ function step6_stepbeforeformdisplay()
     if (empty($config['ca'])) {
         $stepid++;
     }
-    else do {
-            foreach ($config['ca'] as $ca) {
-                if (!empty($ca['prv'])) {
-                    $no_internal_ca=false;
-                }
-            }
+    else foreach ($config['ca'] as $ca) {
+        if (!empty($ca['prv'])) {
+            $no_internal_ca=false;
+        }
+        
     }
-    while ($no_internal_ca);
-
+    
     if ($no_internal_ca) {
         $stepid++;
     }  

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -198,17 +198,18 @@ function step6_stepbeforeformdisplay()
 
     if (empty($config['ca'])) {
         $stepid++;
-    }
-    else foreach ($config['ca'] as $ca) {
-        if (!empty($ca['prv'])) {
-            $no_internal_ca=false;
-            break;
-        }   
+    } else {
+        foreach ($config['ca'] as $ca) {
+            if (!empty($ca['prv'])) {
+                $no_internal_ca=false;
+                break;
+            }
+        }
     }
     
     if ($no_internal_ca) {
         $stepid++;
-    }  
+    }
 }
 
 function step6_submitphpaction()
@@ -458,7 +459,7 @@ function step10_submitphpaction()
     if (!isset($_POST['generatetlskey']) && isset($_POST['tlsauthentication'])) {
         if (!strstr($_POST['tlssharedkey'], "-----BEGIN OpenVPN Static key V1-----") ||
           !strstr($_POST['tlssharedkey'], "-----END OpenVPN Static key V1-----")) {
-              $input_errors[] = gettext("The field 'TLS Authentication Key' does not appear to be valid.");
+            $input_errors[] = gettext("The field 'TLS Authentication Key' does not appear to be valid.");
         }
     }
 


### PR DESCRIPTION
To fix: OpenVPN server wizard always asks to create a new CA #3568

Note: the wizard (and so my fix) currently restricts CAs for which the firewall has the private key. This is because if you choose to create a new server certificate in the next step, it will utilize the selected CA to sign the server certificate.

However, the CA certificate selected ends up filling the "Peer Certificate Authority" field of the OpenVPN Server, and the Peer Certificate Authority does not need to be a CA certificate with private key when you are not using the wizard. Some logic could be added in the future to the wizard to account for all the possible scenarios.