### PR TITLE
Filter egress 3594

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -936,7 +936,7 @@ $( document ).ready(function() {
                   <tr class="hidden-xs hidden-sm">
                     <td>
 <?php if ('FloatingRules' != $selected_if): ?>
-                      <?= sprintf(gettext('%s rules are evaluated on a first-match basis (i.e. ' .
+                      <?= sprintf(gettext('%s rules are evaluated on a first-match basis by default (i.e. ' .
                         'the action of the first rule to match a packet will be executed). ' .
                         'This means that if you use block rules, you will have to pay attention ' .
                         'to the rule order. Everything that is not explicitly passed is blocked ' .

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -156,9 +156,9 @@ function firewall_rule_item_icons($filterent)
             gettext("any")
         );
     }
-    if (empty($filterent['floating']) && $filterent['quick'] == null){
+    if (empty($filterent['floating']) && $filterent['quick'] === null){
         $is_quick = true;
-    } elseif (!empty($filterent['floating']) && $filterent['quick'] == null) {
+    } elseif (!empty($filterent['floating']) && $filterent['quick'] === null) {
         $is_quick = false;
     } else {
         $is_quick = $filterent['quick'];
@@ -649,6 +649,7 @@ $( document ).ready(function() {
                     );
                     if ($rule->isEnabled() && $is_selected):
                         $filterent = $rule->getRawRule();
+                        $filterent['quick'] = !isset($filterent['quick']) || $filterent['quick'];
                         legacy_html_escape_form_data($filterent);
                         $rule_stats = !empty($rule->getLabel()) ? $all_rule_stats[$rule->getLabel()] : array();?>
                     <tr class="internal-rule" style="display: none;">

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -140,7 +140,7 @@ function firewall_rule_item_proto($filterent)
 function firewall_rule_item_icons($filterent)
 {
     $result = "";
-    if (!empty($filterent['direction']) && $filterent['direction'] == "in") {
+    if (empty($filterent['direction']) || $filterent['direction'] == "in") {
         $result .= sprintf(
             "<i class=\"fa fa-long-arrow-right fa-fw text-info\" data-toggle=\"tooltip\" title=\"%s\"></i>",
             gettext("in")
@@ -150,20 +150,32 @@ function firewall_rule_item_icons($filterent)
             "<i class=\"fa fa-long-arrow-left fa-fw\" data-toggle=\"tooltip\" title=\"%s\"></i>",
             gettext("out")
         );
+    } else {
+        $result .= sprintf(
+            "<i class=\"fa fa-exchange fa-fw\" data-toggle=\"tooltip\" title=\"%s\"></i>",
+            gettext("any")
+        );
     }
-    if (!empty($filterent['floating'])) {
-        if (isset($filterent['quick']) && $filterent['quick'] === 'yes') {
-            $result .= sprintf(
-                "<i class=\"fa fa-flash fa-fw text-warning\" data-toggle=\"tooltip\" title=\"%s\"></i>",
-                gettext('first match')
-            );
-        } else {
-          $result .= sprintf(
-              "<i class=\"fa fa-flash fa-fw text-muted\" data-toggle=\"tooltip\" title=\"%s\"></i>",
-              gettext('last match')
-          );
-        }
+    if (empty($filterent['floating']) && $filterent['quick'] == null){
+        $is_quick = true;
+    } elseif (!empty($filterent['floating']) && $filterent['quick'] == null) {
+        $is_quick = false;
+    } else {
+        $is_quick = $filterent['quick'];
     }
+
+    if ($is_quick) {
+        $result .= sprintf(
+            "<i class=\"fa fa-flash fa-fw text-warning\" data-toggle=\"tooltip\" title=\"%s\"></i>",
+            gettext('first match')
+        );
+    } else {
+      $result .= sprintf(
+          "<i class=\"fa fa-flash fa-fw text-muted\" data-toggle=\"tooltip\" title=\"%s\"></i>",
+          gettext('last match')
+      );
+    }
+
     if (isset($filterent['log'])) {
           $result .= sprintf(
               "<i class=\"fa fa-info-circle fa-fw %s\"></i>",
@@ -885,10 +897,8 @@ $( document ).ready(function() {
                           <td style="width:100px"><?=gettext("log");?></td>
                           <td style="width:16px"><span class="fa fa-long-arrow-right text-info"></span></td>
                           <td style="width:100px"><?=gettext("in");?></td>
-<?php if ($selected_if == 'FloatingRules'): ?>
                           <td style="width:16px"><span class="fa fa-flash text-warning"></span></td>
                           <td style="width:100px"><?=gettext("first match");?></td>
-<?php endif ?>
                         </tr>
                         <tr>
                           <td><span class="fa fa-play text-muted"></span></td>
@@ -904,10 +914,8 @@ $( document ).ready(function() {
                           <td class="nowrap"><?=gettext("log (disabled)");?></td>
                           <td style="width:16px"><span class="fa fa-long-arrow-left"></span></td>
                           <td style="width:100px"><?=gettext("out");?></td>
-<?php if ($selected_if == 'FloatingRules'): ?>
                           <td style="width:16px"><span class="fa fa-flash text-muted"></span></td>
                           <td style="width:100px"><?=gettext("last match");?></td>
-<?php endif ?>
                         </tr>
                       </table>
                     </td>


### PR DESCRIPTION
Currently the direction of the traffic can only be chosen in floating rules, but in some scenario's it's much easier to create outbound rules (only inbound is supported now).

When using a lot of interfaces, which should all be allowed to access devices on one specific interface, this would save quite some rules and is easier to track for the administrator.

This feature adds direction as on option and while already changing these pages, also allow to create "non quick" rules on interfaces.
Functionally the "regular" rules would be more aligned with the "floating" rules as we have now, with the exception that you can't add multiple interfaces in a normal rule due to the inability to reorder a single rule in multiple rulesets (rules are positional).

Policy based routing on outbound rules is not supported on the interface rules for now, since it would probably lead to confusion.
The old configuration defaults still apply, when writing an entry, both quick and direction are saved as well (default quick + in).
