### PR TITLE
OpenVPN wizard server cert check

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -206,7 +206,7 @@ function step6_stepbeforeformdisplay()
             }
         }
         if ($no_internal_ca) {
-        $stepid++;
+            $stepid++;
         }
     }
 }
@@ -276,7 +276,7 @@ function step8_stepbeforeformdisplay()
             }
         }
         if ($no_server_cert) {
-        $stepid++;
+            $stepid++;
         }
     }
 }

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -205,10 +205,9 @@ function step6_stepbeforeformdisplay()
                 break;
             }
         }
-    }
-
-    if ($no_internal_ca) {
+        if ($no_internal_ca) {
         $stepid++;
+        }
     }
 }
 
@@ -265,10 +264,20 @@ function step7_submitphpaction()
 function step8_stepbeforeformdisplay()
 {
     global $stepid, $config;
+    $no_server_cert = true;
 
-    if (empty($config['cert']) || (count($config['cert']) == 1 &&
-        stristr($config['cert'][0]['descr'], "webconf"))) {
+    if (empty($config['cert'])) {
         $stepid++;
+    } else {
+        foreach ($config['cert'] as $cert) {
+            if (cert_get_purpose($cert['crt'])['server'] == 'Yes') {
+                $no_server_cert=false;
+                break;
+            }
+        }
+        if ($no_server_cert) {
+        $stepid++;
+        }
     }
 }
 

--- a/src/www/wizard.php
+++ b/src/www/wizard.php
@@ -628,7 +628,7 @@ include("head.inc");
                                                 echo "<option value='" . $field['add_to_cert_selection'] . "'" . $SELECTED . ">" . $field['add_to_cert_selection'] . "</option>\n";
                                             }
                                             foreach ($config['cert'] as $ca) {
-                                                if (stristr($ca['descr'], "webconf"))
+                                                if (cert_get_purpose($ca['crt'])['server'] == 'No')
                                                     continue;
                                                 $name = htmlspecialchars($ca['descr']);
                                                 $SELECTED = '';


### PR DESCRIPTION
This PR fixes the issue I described in #3617.

In the case that both server and non-server certs are present, I chose to have the wizard just filter out non-server certificates from the Server Certificate Selection dropdown.

This is in contrast to the vpn_openvpn_server.php which shows the user all certificates, let's you select a non-server certificate, but then displays an error when trying to save (screenshot of error in issue report.) We can echo this behavior if you think this is a better UX.