### PR TITLE
Set absolute path to root.hints

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -282,7 +282,7 @@ chroot: /var/unbound
 username: unbound
 directory: /var/unbound
 pidfile: /var/run/unbound.pid
-root-hints: /root.hints
+root-hints: /var/unbound/root.hints
 use-syslog: yes
 port: {$port}
 verbosity: {$verbosity}


### PR DESCRIPTION
root.hints file is located at /var/unbound not /

Current users may not be leveraging root.hints with unbound deployments.