### PR TITLE
monit: add parent devices to interface list

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -233,6 +233,7 @@
          <interface type="InterfaceField">
             <Required>N</Required>
             <multiple>N</multiple>
+            <AddParentDevices>Y</AddParentDevices>
             <filters>
                 <enable>/^(?!0).*$/</enable>
                 <ipaddr>/^((?!dhcp).)*$/</ipaddr>


### PR DESCRIPTION
Monitoring the physical interface really makes sense.
Solves #3495 