### PR TITLE
monit: fix migration

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_0.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_0.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2017 EURO-LOG AG
+ * Copyright (C) 2017-2019 EURO-LOG AG
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,7 @@ use OPNsense\Core\Shell;
 
 class M1_0_0 extends BaseModelMigration
 {
-    public function run($model)
+    public function post($model)
     {
         $cfg = Config::getInstance();
         $cfgObj = $cfg->object();
@@ -85,15 +85,15 @@ class M1_0_0 extends BaseModelMigration
 
         /* define some tests */
         $defaultTests = array(
-            array("name" => "Ping", "condition" => "failed ping", "action" => "alert"),
-            array("name" => "NetworkLink", "condition" => "failed link", "action" => "alert"),
-            array("name" => "NetworkSaturation", "condition" => "saturation is greater than 75%", "action" => "alert"),
-            array("name" => "MemoryUsage", "condition" => "memory usage is greater than 75%", "action" => "alert"),
-            array("name" => "CPUUsage", "condition" => "cpu usage is greater than 75%", "action" => "alert"),
-            array("name" => "LoadAvg1", "condition" => "loadavg (1min) is greater than $LoadAvg1", "action" => "alert"),
-            array("name" => "LoadAvg5", "condition" => "loadavg (5min) is greater than $LoadAvg5", "action" => "alert"),
-            array("name" => "LoadAvg15", "condition" => "loadavg (15min) is greater than $LoadAvg15", "action" => "alert"),
-            array("name" => "SpaceUsage", "condition" => "space usage is greater than 75%", "action" => "alert")
+            array("name" => "Ping", "condition" => "failed ping", "action" => "alert", "type" => "NetworkPing"),
+            array("name" => "NetworkLink", "condition" => "failed link", "action" => "alert", "type" => "NetworkInterface"),
+            array("name" => "NetworkSaturation", "condition" => "saturation is greater than 75%", "action" => "alert", "type" => "NetworkInterface"),
+            array("name" => "MemoryUsage", "condition" => "memory usage is greater than 75%", "action" => "alert", "type" => "SystemResource"),
+            array("name" => "CPUUsage", "condition" => "cpu usage is greater than 75%", "action" => "alert", "type" => "SystemResource"),
+            array("name" => "LoadAvg1", "condition" => "loadavg (1min) is greater than $LoadAvg1", "action" => "alert", "type" => "SystemResource"),
+            array("name" => "LoadAvg5", "condition" => "loadavg (5min) is greater than $LoadAvg5", "action" => "alert", "type" => "SystemResource"),
+            array("name" => "LoadAvg15", "condition" => "loadavg (15min) is greater than $LoadAvg15", "action" => "alert", "type" => "SystemResource"),
+            array("name" => "SpaceUsage", "condition" => "space usage is greater than 75%", "action" => "alert", "type" => "SpaceUsage")
         );
 
         /* define system service */

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_6.php
@@ -32,12 +32,13 @@ use OPNsense\Base\BaseModelMigration;
 
 class M1_0_6 extends BaseModelMigration
 {
-    public function run($model)
+    public function post($model)
     {
         /* extend tests */
         $defaultTests = array();
         $defaultTests['ChangedStatus'] = array(
-          "name" => "ChangedStatus", "condition" => "changed status", "action" => "alert"
+          "name" => "ChangedStatus", "condition" => "changed status",
+          "action" => "alert", "type" => "ProgramStatus"
         );
 
         foreach ($defaultTests as &$newtest) {
@@ -52,6 +53,7 @@ class M1_0_6 extends BaseModelMigration
                 $found->name = $newtest['name'];
                 $found->condition = $newtest['condition'];
                 $found->action = $newtest['action'];
+                $found->type = $newtest['type'];
             }
             $newtest['uuid'] = $found->getAttribute('uuid');
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_7.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_7.php
@@ -32,14 +32,15 @@ use OPNsense\Base\BaseModelMigration;
 
 class M1_0_7 extends BaseModelMigration
 {
-    public function run($model)
+    public function post($model)
     {
         /* extend tests */
         $defaultTests = [];
         $defaultTests['NonZeroStatus'] = [
             'name' => 'NonZeroStatus',
             'condition' => 'status != 0',
-            'action' => 'alert'
+            'action' => 'alert',
+            'type' => 'ProgramStatus'
         ];
 
         foreach ($defaultTests as &$newtest) {
@@ -54,6 +55,7 @@ class M1_0_7 extends BaseModelMigration
                 $found->name = $newtest['name'];
                 $found->condition = $newtest['condition'];
                 $found->action = $newtest['action'];
+                $found->type = $newtest['type'];
             }
             $newtest['uuid'] = $found->getAttribute('uuid');
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Migrations/M1_0_8.php
@@ -41,5 +41,6 @@ class M1_0_8 extends BaseModelMigration
         // validation will fail because we want to change the type of tests linked to services
         $model->serializeToConfig(false, true);
         Config::getInstance()->save();
+        $model->configClean();
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.php
@@ -172,7 +172,11 @@ class Monit extends BaseModel
                                     $node->isFieldChanged() &&
                                     $this->isTestServiceRelated($testUuid)) {
                                     $messages->appendMessage(new \Phalcon\Validation\Message(
-                                        gettext("Cannot change the type. Test is linked to a service."),
+                                        sprintf(
+                                            gettext("Cannot change the test type to '%s'. Test '%s' is linked to a service."),
+                                            (string)$node,
+                                            (string)$this->getNodeByReference('test.' . $parentNode->getAttribute('uuid'))->name
+                                        ),
                                         $key
                                     ));
                                 }
@@ -185,7 +189,11 @@ class Monit extends BaseModel
                                     strcmp((string)$parentNode->type, $type) != 0 &&
                                     $this->isTestServiceRelated($parentNode->getAttribute('uuid'))) {
                                     $messages->appendMessage(new \Phalcon\Validation\Message(
-                                        gettext("Condition would change the type of the test but it is linked to a service."),
+                                        sprintf(
+                                            gettext("Condition '%s' would change the type of the test '%s' but it is linked to a service."),
+                                            (string)$node,
+                                            (string)$this->getNodeByReference('test.' . $parentNode->getAttribute('uuid'))->name
+                                        ),
                                         $key
                                     ));
                                 } else {


### PR DESCRIPTION
This PR adds missing test types to the migrations.
The migrations use the `post` method now instead of `run` to
avoid validation errors.
Solves #3659 