### PR TITLE
Cosmetic changes to Tunables section

### DIFF
--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -183,7 +183,7 @@ $( document ).ready(function() {
             print_info_box($savemsg);
         }
         if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
-            print_info_box_apply(gettext("The firewall tunables have changed. You must apply the configuration to take affect."));
+            print_info_box_apply(gettext("The firewall tunables have changed. You must apply the configuration to take affect. Tunables are composed of runtime settings for sysctl.conf which take effect immediately after apply and boot settings for loader.conf which require a reboot."));
         }
 ?>
       <form method="post" id="iform">

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -222,12 +222,6 @@ $( document ).ready(function() {
               </tr>
 <?php
               $i++; endforeach; ?>
-              <tr>
-                <td colspan="4">
-                  <?= gettext('Tunables are composed of runtime settings for sysctl.conf which take effect ' .
-                    'immediately after apply and boot settings for loader.conf which require a reboot.') ?>
-                </td>
-              </tr>
             </table>
 <?php
             else : ?>

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -183,7 +183,7 @@ $( document ).ready(function() {
             print_info_box($savemsg);
         }
         if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
-            print_info_box_apply(gettext('The firewall tunables have changed. You must apply the configuration to take affect.'). ' ' .gettext('Tunables are composed of runtime settings for sysctl.conf which take effect ' .
+            print_info_box_apply(gettext('The firewall tunables have changed. You must apply the configuration to take affect.'). '<br>' .gettext('Tunables are composed of runtime settings for sysctl.conf which take effect ' .
                     'immediately after apply and boot settings for loader.conf which require a reboot.'));
         }
 ?>

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -183,7 +183,7 @@ $( document ).ready(function() {
             print_info_box($savemsg);
         }
         if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
-            print_info_box_apply(gettext("The firewall tunables have changed. You must apply the configuration to take affect. Tunables are composed of runtime settings for sysctl.conf which take effect immediately after apply and boot settings for loader.conf which require a reboot."));
+            print_info_box_apply(gettext("The firewall tunables have changed. You must apply the configuration to take affect. <br />Tunables are composed of runtime settings for sysctl.conf which take effect immediately after apply and boot settings for loader.conf which require a reboot."));
         }
 ?>
       <form method="post" id="iform">

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -184,7 +184,7 @@ $( document ).ready(function() {
         }
         if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
             print_info_box_apply(gettext('The firewall tunables have changed. You must apply the configuration to take affect.'). ' ' .gettext('Tunables are composed of runtime settings for sysctl.conf which take effect ' .
-                    'immediately after apply and boot settings for loader.conf which require a reboot.');
+                    'immediately after apply and boot settings for loader.conf which require a reboot.'));
         }
 ?>
       <form method="post" id="iform">

--- a/src/www/system_advanced_sysctl.php
+++ b/src/www/system_advanced_sysctl.php
@@ -183,7 +183,8 @@ $( document ).ready(function() {
             print_info_box($savemsg);
         }
         if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
-            print_info_box_apply(gettext("The firewall tunables have changed. You must apply the configuration to take affect. <br />Tunables are composed of runtime settings for sysctl.conf which take effect immediately after apply and boot settings for loader.conf which require a reboot."));
+            print_info_box_apply(gettext('The firewall tunables have changed. You must apply the configuration to take affect.'). ' ' .gettext('Tunables are composed of runtime settings for sysctl.conf which take effect ' .
+                    'immediately after apply and boot settings for loader.conf which require a reboot.');
         }
 ?>
       <form method="post" id="iform">


### PR DESCRIPTION
There is a note at the bottom of the tuneables which states that some changes are applied directly and some require a reboot. 

In my opinion a more logical notification would be to show that sentence in the Apply notice box in stead of at the bottom of this page. That location can be easily overlooked.