### PR TITLE
Add updatefreq for GeoIP aliases.

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -151,6 +151,7 @@
                 case 'geoip':
                     $("#alias_type_geoip").show();
                     $("#alias\\.proto").selectpicker('show');
+                    $("#row_alias\\.updatefreq").show();                
                     break;
                 case 'external':
                     break;


### PR DESCRIPTION
Add updatefreq for GeoIP, config file is currently generated with no updatefreq; alias.expire() function called from update_tables.py returns False by default if no ttl is present. This creates a condition where unless you manually change the file to trigger alias.change() with no ttl present it will never trigger to update the GeoIP aliases. Tested that it sets updatefreq in config file and now GeoIP aliases will update automatically through update_tables.py.