### PR TITLE
Update opnsense.xml

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/repositories/opnsense.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/repositories/opnsense.xml
@@ -33,10 +33,6 @@
             <description>FourDots (HTTPS, Belgrade, RS)</description>
         </mirror>
         <mirror>
-            <url>https://mirror.homelab.no/opnsense</url>
-            <description>Homelab.no (HTTPS, Horten, Norway)</description>
-        </mirror>
-        <mirror>
             <url>http://mirror.as24220.net/opnsense</url>
             <description>Hostcentral (HTTP, Melbourne, Australia)</description>
         </mirror>
@@ -75,6 +71,10 @@
         <mirror>
             <url>https://mirror.ragenetwork.de/opnsense</url>
             <description>RageNetwork (HTTPS, Munich, DE)</description>
+        </mirror>
+        <mirror>
+            <url>http://mirror.terrahost.no/opnsense</url>
+            <description>TerraHost (HTTP, Sandefjord, Norway)</description>
         </mirror>
         <mirror>
             <url>http://mirror.upb.edu.co/opnsense</url>


### PR DESCRIPTION
mirror.homelab.no has been moved from my basement to a datacenter, with new URL and owner. It is hosted on a 10 Gbit/s connection, with native IPv6, but only supports HTTP method. mirror.homelab.no currently redirects to the proper path on mirror.terrahost.no.