### PR TITLE
filter/alias, update_tables.py slow with large alias lists

### DIFF
--- a/src/opnsense/scripts/filter/update_tables.py
+++ b/src/opnsense/scripts/filter/update_tables.py
@@ -149,8 +149,6 @@ if __name__ == '__main__':
                     alias_pf_content.append(line)
             if len(alias_content) != len(alias_pf_content):
                 alias_changed_or_expired = True
-        # Need to check that the url, urltable, or geoip tables are currently loaded. If not loaded for any reason
-        # this should flag the alias_changed_or_expired to cause them to load.
         else:   
             loaded_tables = list()
             sp = subprocess.run(['/sbin/pfctl', '-sT'], capture_output=True, text=True)


### PR DESCRIPTION
Avoid reading entire table for url/urltable/geoip output from pfctl on every execution  …
Reading all of the tables every minute this script runs can cause higher CPU utilization with larger tables. Url, urltable, geoip tables will only be updated once when created or if the file modified time hits expiration. They should never be updated manually so no comparison between loaded and on disk tables should be needed unless I am missing something. 

I have looked at Issue #2162 and https://github.com/opnsense/core/commit/c5555b2ebc4c2285fb40d3a1a22c1966820bc64e and I see why update_tables.py is set to run every minute. From the little bit of profiling I did it seems like much of the time is still from python importing libraries so I don't know if there is any better way around that without investing a lot more time. Of course the profiling takes forever compared to normal execution but in that I also went from around 212 seconds down to 82 with both taking around 72 seconds of that to even reach class AliasParser(object).

In real use with ~250k lines in my aliases on an apu2, before this change it takes 11.7s, after it takes 8.7s.

19.7.3 stock: time /usr/local/bin/flock -n -E 0 -o /tmp/filter_update_tables.lock /usr/local/opnsense/scripts/filter/update_tables.py
{"status": "ok"}
8.244u 3.378s 0:11.72 99.0%     69+579k 32+45io 0pf+0w

After changes: time /usr/local/bin/flock -n -E 0 -o /tmp/filter_update_tables.lock /usr/local/opnsense/scripts/filter/update_tables.py
{"status": "ok"}
5.664u 2.978s 0:08.68 99.4%     10+208k 26+0io 0pf+0w

I tested adding/removing/enable/disable urltable and geoip tables as well as touching the files to make them expire and it seems to be working for me. I applied patch 8678567 so I could make changes against what is currently in master. Thoughts?