### PR TITLE
Automatically show hidden advanced values

### DIFF
--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -929,7 +929,7 @@ include("head.inc");
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("MAC Address Control");?></td>
                       <td>
 <?php
-                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])) {;?>
+                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])) {?>
                         <div id="showmaccontrolbox">
                           <input type="button" onclick="show_maccontrol_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show MAC Address Control");?>
                         </div>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -928,18 +928,20 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("MAC Address Control");?></td>
                       <td>
+<?php
+                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])) {;?>
                         <div id="showmaccontrolbox">
                           <input type="button" onclick="show_maccontrol_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show MAC Address Control");?>
                         </div>
                         <div id="showmaccontrol" style="display:none">
+<?php                   } else { ?>
+                        <div id="showmaccontrol">
+<?php                   } ?>
                           <?= sprintf(gettext("Enter a list of partial MAC addresses to allow, comma-separated, no spaces, such as %s"), '00:00:00,01:E5:FF') ?>
                           <input name="mac_allow" type="text" id="mac_allow" value="<?= $pconfig['mac_allow'] ?>" />
                           <?= sprintf(gettext("Enter a list of partial MAC addresses to deny access, comma-separated, no spaces, such as %s"), '00:00:00,01:E5:FF') ?>
                           <input name="mac_deny" type="text" id="mac_deny" value="<?= $pconfig['mac_deny'] ?>" /><br />
                         </div>
-                          //unhide advanced feature if fields are filled                          
-<?php
-                          if ((! empty($pconfig['mac_allow']) || (! empty($pconfig['mac_deny'])) show_maccontrol_config();?>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -893,10 +893,16 @@ include("head.inc");
                     <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Dynamic DNS");?></td>
                     <td>
+<?php
+                      if (empty($pconfig['ddnsupdate'])): ?>
                       <div id="showddnsbox">
                         <input type="button" onclick="show_ddns_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show Dynamic DNS");?>
                       </div>
-                      <div id="showddns" style="display:none">
+                        <div id="showddns" style="display:none">
+<?php                   else: ?>
+                        <div id="showddns">
+<?php
+                         endif; ?>
                         <input type="checkbox" value="yes" name="ddnsupdate" <?=!empty($pconfig['ddnsupdate']) ? " checked=\"checked\"" :""; ?> />
                         <strong><?=gettext("Enable registration of DHCP client names in DNS.");?></strong><br />
                         <?=gettext("Enter the dynamic DNS domain which will be used to register client names in the DNS server.");?>
@@ -948,10 +954,16 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("NTP servers");?></td>
                       <td>
+ <?php
+                      if (empty($pconfig['ntp1']) && empty($pconfig['ntp2'])): ?>
                         <div id="showntpbox">
                           <input type="button" onclick="show_ntp_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show NTP configuration");?>
                         </div>
                         <div id="showntp" style="display:none">
+<?php                   else: ?>
+                        <div id="showntp">
+<?php
+                         endif; ?>
                           <input name="ntp1" type="text" id="ntp1" value="<?=$pconfig['ntp1'];?>" /><br />
                           <input name="ntp2" type="text" id="ntp2" value="<?=$pconfig['ntp2'];?>" />
                         </div>
@@ -960,10 +972,16 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("TFTP server");?></td>
                       <td>
-                        <div id="showtftpbox">
+<?php
+                      if (empty($pconfig['tftp']) && empty($pconfig['bootfilename'])): ?>
+                          <div id="showtftpbox">
                           <input type="button" onclick="show_tftp_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show TFTP configuration");?>
                         </div>
                         <div id="showtftp" style="display:none">
+<?php                   else: ?>
+                        <div id="showtftp">
+<?php
+                         endif; ?>
                           <?=gettext("Set TFTP hostname");?>
                           <input name="tftp" type="text" size="50" value="<?=$pconfig['tftp'];?>" /><br />
                           <?=gettext("Set Bootfile");?>
@@ -975,11 +993,18 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("LDAP URI");?></td>
                       <td>
-                        <div id="showldapbox">
+<?php
+                      if (empty($pconfig['ldap'])): ?>
+                          <div id="showldapbox">
                           <input type="button" onclick="show_ldap_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show LDAP configuration");?>
                         </div>
                         <div id="showldap" style="display:none">
-                          <input name="ldap" type="text" id="ldap" size="80" value="<?=$pconfig['ldap'];?>" /><br />
+<?php                   else: ?>
+                        <div id="showldap">
+<?php
+                         endif; ?>
+
+                            <input name="ldap" type="text" id="ldap" size="80" value="<?=$pconfig['ldap'];?>" /><br />
                           <?=sprintf(gettext("Leave blank to disable. Enter a full URI for the LDAP server in the form %s"),'ldap://ldap.example.com/dc=example,dc=com')?>
                         </div>
                       </td>
@@ -987,10 +1012,16 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable network booting");?></td>
                       <td>
-                        <div id="shownetbootbox">
+<?php
+                      if (empty($pconfig['netboot'])): ?>
+                          <div id="shownetbootbox">
                           <input type="button" onclick="show_netboot_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show Network booting");?>
                         </div>
                         <div id="shownetboot" style="display:none">
+<?php                   else: ?>
+                        <div id="shownetboot">
+<?php
+                         endif; ?>
                           <input type="checkbox" value="yes" name="netboot" id="netboot" <?=!empty($pconfig['netboot']) ? " checked=\"checked\"" : ""; ?> />
                           <strong><?=gettext("Enables network booting.");?></strong>
                           <br/><br/>
@@ -1014,10 +1045,16 @@ include("head.inc");
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("WPAD");?> </td>
                       <td>
-                        <div id="showwpadbox">
+<?php
+                      if (empty($pconfig['wpad'])): ?>
+                          <div id="showwpadbox">
                           <input type="button" onclick="show_wpad_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show WPAD");?>
                         </div>
                         <div id="showwpad" style="display:none">
+<?php                   else: ?>
+                        <div id="showwpad">
+<?php
+                         endif; ?>
                           <input name="wpad" id="wpad" type="checkbox" value="yes" <?=!empty($pconfig['wpad']) ? "checked=\"checked\"" : ""; ?> />
                           <strong><?= gettext("Enable Web Proxy Auto Discovery") ?></strong>
                         </div>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -929,14 +929,15 @@ include("head.inc");
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("MAC Address Control");?></td>
                       <td>
 <?php
-                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])) {?>
+                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])): ?>
                         <div id="showmaccontrolbox">
                           <input type="button" onclick="show_maccontrol_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show MAC Address Control");?>
                         </div>
                         <div id="showmaccontrol" style="display:none">
-<?php                   } else { ?>
+<?php                   else: ?>
                         <div id="showmaccontrol">
-<?php                   } ?>
+<?php
+                         endif; ?>
                           <?= sprintf(gettext("Enter a list of partial MAC addresses to allow, comma-separated, no spaces, such as %s"), '00:00:00,01:E5:FF') ?>
                           <input name="mac_allow" type="text" id="mac_allow" value="<?= $pconfig['mac_allow'] ?>" />
                           <?= sprintf(gettext("Enter a list of partial MAC addresses to deny access, comma-separated, no spaces, such as %s"), '00:00:00,01:E5:FF') ?>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -937,6 +937,9 @@ include("head.inc");
                           <?= sprintf(gettext("Enter a list of partial MAC addresses to deny access, comma-separated, no spaces, such as %s"), '00:00:00,01:E5:FF') ?>
                           <input name="mac_deny" type="text" id="mac_deny" value="<?= $pconfig['mac_deny'] ?>" /><br />
                         </div>
+                          //unhide advanced feature if fields are filled                          
+<?php
+                          if ((! empty($pconfig['mac_allow']) || (! empty($pconfig['mac_deny'])) show_maccontrol_config();?>
                       </td>
                     </tr>
                     <tr>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -929,7 +929,7 @@ include("head.inc");
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("MAC Address Control");?></td>
                       <td>
 <?php
-                        if ((empty($pconfig['mac_allow']) && (empty($pconfig['mac_deny'])): ?>
+                        if (empty($pconfig['mac_allow']) && empty($pconfig['mac_deny'])): ?>
                         <div id="showmaccontrolbox">
                           <input type="button" onclick="show_maccontrol_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show MAC Address Control");?>
                         </div>


### PR DESCRIPTION
Advanced features are hidden and can be 'unhidden' when a button is pushed. This is logical to hide all empty/default fields of the advanced features, but does not make sense when Advanced fields are actually filled with data. One would expect that data to be seen at once when opening a page.
 
Suggestion is to unhide hidden field data whenever there is data present in one of the hidden fields. See suggested code. Might be that there is another /easier way to apply this to all hidden fields generically?