### PR TITLE
Hide leaking hostname on SSH password auth

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Auth/sshd.pam
+++ b/src/opnsense/service/templates/OPNsense/Auth/sshd.pam
@@ -10,9 +10,9 @@ auth		requisite	pam_opieaccess.so	no_warn allow_local
 #auth		sufficient	pam_krb5.so		no_warn try_first_pass
 #auth		sufficient	pam_ssh.so		no_warn try_first_pass
 {% if system.disableintegratedauth|default('0') == '0' %}
-auth		sufficient	pam_opnsense.so
+auth		sufficient	pam_opnsense.so		authtok_prompt=Password:
 {% endif %}
-auth		required	pam_unix.so		no_warn try_first_pass
+auth		required	pam_unix.so		no_warn try_first_pass authtok_prompt=Password:
 
 # account
 account		required	pam_nologin.so


### PR DESCRIPTION
As of today sshd prompts hostname on client side (leaking info):
`Password for root@OPNsense.private.:`

Proposal is to change it to be only:
`Password:`