### PR TITLE
captive portal/ipsec: add description to restart actions

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
+++ b/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
@@ -39,6 +39,7 @@ command:/usr/local/etc/rc.d/captiveportal restart
 parameters:
 type:script
 message:restarting captiveportal services
+description:Restart Captive Portal service
 
 [fetch_template]
 command:/usr/local/opnsense/scripts/OPNsense/CaptivePortal/fetch_template.py

--- a/src/opnsense/service/conf/actions.d/actions_ipsec.conf
+++ b/src/opnsense/service/conf/actions.d/actions_ipsec.conf
@@ -39,6 +39,7 @@ command:/usr/local/sbin/ipsec restart
 parameters:
 type:script
 message:IPsec service restart
+description:Restart IPsec service
 
 [reconfigure]
 command:/usr/local/sbin/pluginctl -c ipsec


### PR DESCRIPTION
This adds descriptions to the restart action of Captive Portal and IPSec. Both services may use a Let's Encrypt certificate.

This is necessary in order to setup an automation in our Let's Encrypt plugin to automatically restart the service when the certificate was renewed:

https://github.com/opnsense/plugins/blob/a878826c05ff470ab2a5001cf9f26b153a1f7bcf/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml#L860-L866

Without a description the action is not visible in the GUI (for good reasons).

refs https://github.com/opnsense/plugins/issues/1534