### PR TITLE
DHCP Client -> Option Modifiers breaking comma

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3344,7 +3344,7 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif)
 
     $option_modifiers = "";
     if ($wancfg['adv_dhcp_option_modifiers'] != '') {
-        $modifiers = preg_split('/\s*,\s*(?=(?:[^"]*"[^"]*")*[^"]*$)/', $wancfg['adv_dhcp_option_modifiers']);
+        $modifiers = preg_split('/\s*;\s*(?=(?:[^"]*"[^"]*")*[^"]*$)/', $wancfg['adv_dhcp_option_modifiers']);
         foreach ($modifiers as $modifier) {
             $option_modifiers .= "\t" . $modifier . ";\n";
         }


### PR DESCRIPTION
When I would like to write an option modifier statement like:
`ignore domain-name-servers, host-name, domain-name, routers;`
it's broken into multiple lines, cause dhclient not start due to wrong configuration.

Result I got in /var/etc/dhclient_wan.conf:
```
  ignore domain-name-servers;
  host-name;
  domain-name;
  routers;;
```

What's expected is to not break on comma, only on semicolon.
hence config will look like as expected:
```
   ignore domain-name-servers, host-name, domain-name, routers;;
```