### PR TITLE
Firewall Rules Edit:  Input validation on interface and ipprotocol fields

### DIFF
--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -242,13 +242,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             // Note that the last condition inherently checks $interface_from_url is a valid interface.
             $input_errors[] = gettext("The interface selected has been modified and the page must be reloaded. Please click 'cancel', and re-open this page.");
         }
-        if ($interface_from_url == "FloatingRules" xor empty($pconfig['floating'])) {
+        if ($interface_from_url == "FloatingRules" xor !empty($pconfig['floating'])) {
             // 'if=FloatingRules' in the URL isn't consistent with the 'floating' field in $_POST. Should both be present or both absent.
             $input_errors[] = gettext("The interface selected has been modified and the page must be reloaded. Please click 'cancel', and re-open this page.");
         }
 
         // Validate ipprotocol
-        if (!in_array($ipprotocol, $ipprotocols)) {
+        if (!in_array($pconfig['ipprotocol'], $ipprotocols)) {
             $input_errors[] = gettext('A valid IP Protocol must be selected.');
         }
 

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -571,7 +571,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         mark_subsystem_dirty('filter');
 
         header(url_safe('Location: /firewall_rules.php?if=%s', array(
-            !empty($pconfig['floating']) ? 'FloatingRules' : $pconfig['interface']
+            !empty($pconfig['floating']) ? 'FloatingRules' : $interface_from_url
         )));
         exit;
     }
@@ -1629,7 +1629,7 @@ include("head.inc");
                       <td>&nbsp;</td>
                       <td>
                         <input name="Submit" type="submit" class="btn btn-primary" value="<?=html_safe(gettext('Save')); ?>" />
-                        <input type="button" class="btn btn-default" value="<?=html_safe(gettext('Cancel'));?>" onclick="window.location.href='/firewall_rules.php?if=<?= !empty($pconfig['floating']) ? 'FloatingRules' : $pconfig['interface'] ?>'" />
+                        <input type="button" class="btn btn-default" value="<?=html_safe(gettext('Cancel'));?>" onclick="window.location.href='/firewall_rules.php?if=<?= !empty($pconfig['floating']) ? 'FloatingRules' : $interface_from_url ?>'" />
                       </td>
                     </tr>
                   </table>

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -78,6 +78,7 @@ function is_posnumericint($arg) {
 $a_filter = &config_read_array('filter', 'rule');
 
 // Whether POST or GET, the URL should still have a valid $_GET['id'] field controlling the interface edited
+// It's only validated on POST, but that's safe because only the initial page load is a GET and config only updates upon POST
 $interface_from_url = (empty($_GET['if']) || !is_string($_GET['if'])) ? "" : $_GET['if'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {


### PR DESCRIPTION
The current page doesn't validate any of these fields. Additionally, it doesn't check consistency in the different places that the interface can be received as data before acting on it ($_GET['if'], $_POST['floating'] and $_POST['interface']). 

Changes:

- grab valid if's into $interfaces[] so there's a single correct list for the rest of the code, which is also the list displayed in the form
- validate $_GET['if'] is acceptable and note this value applies equally to GET+POST, not just GET
- validate that after POST, $_POST['interface'] is non-empty and contains only valid interfaces
- validate that on POST, $_GET['if'], $_POST['floating'] and $_POST['interface'] are all consistent
- if the edit is to a specific interface (not "floating rules") then by definition we don't need to ask the interface - it's already in the URL. Any change would simply lead to invalid data due to inconsistency. Remove the dropdown box and replace with a hidden field containing the static interface value.
- validate on POST that ipprotocol is one of inet/inet6/inet46.