### PR TITLE
Firewall Rules: Add a "Detail" toggle button in the button bar, to allow more complete rule display

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -1027,6 +1027,9 @@ $( document ).ready(function() {
                   <tr>
                     <td colspan="2"></td>
                     <td colspan="2" class="view-info"></td>
+<?php if ($selected_if == "FloatingRules"): ?>
+                    <td class="view-fullinfo"></td>
+<?php endif; ?>
                     <td colspan="5" class="view-info hidden-xs hidden-sm"></td>
                     <td colspan="2" class="view-stats hidden-xs hidden-sm"></td>
                     <td colspan="2" class="view-stats"></td>


### PR DESCRIPTION
This PR makes a small but crucial change to the display of firewall rules.

At present, for layout purposes, some key information isn't displayed, which really is crucial to the rules. The example I have in mind is that for Floating Rules, you can't see which interfaces the rules apply on, without opening each rule individually in the editor. That's pretty crucial rule information.  But trying to show everything in the table would make the display unusable and ugly. Against this, for many users this info will be needed and many will have wide displays capable of showing full details in a row.  Not everything should be immediately displayed, but the key info needs to be at least easily _displayable_.  

Dilemma.

To overcome this issue, this PR does 2 things.

- Adds a neat unobtrusive button for "details", so extra key details or columns can be displayed.
- Uses the button so that when toggled, an extra column is displayed (in Floating Rules only) to show the rule interfaces, with useful interface hover info - the most immediate missing information at present.

This (1) solves the immediate problem of interface viewing for Floating Rules, and (2) provides a means for other important data to be expanded upon, or displayed, going forward, without disrupting the clean present display, hence generalising the benefits.

As an aside, I've made a minor change to rename the existing button from "Inspect" to "Statistics".  The main reason being that "Inspect" is actually pretty ambiguous in the context of partial info about rules (does it mean inspect rule details, or inspect the stats?).  "Statistics" is much more immediately obvious and is also very accurate, since activating it displays per-rule statistics.