### PR TITLE
Volt: Add a new type "section_title" for related fields on forms without closing+restarting the form table

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -28,6 +28,16 @@
  # Handle input table row, usage the following parameters (as associative array):
  #
  # id          :   unique id of the attribute
+ # type        :   type of input or field. Valid types are:
+ #                   text               single line of text
+ #                   password           password field for sensitive input. The contents will not be displayed.
+ #                   textbox            multiline text box
+ #                   checkbox           checkbox
+ #                   dropdown           single item selection from dropdown
+ #                   select_multiple    multiple item select from dropdown
+ #                   hidden             hidden fields not for user interaction
+ #                   info               static text (help icon, no input or editing)
+ #                   section_title      label demarcating groups of fields (no help icon, no syntactic significance to mvc)
  # label       :   attribute label (visible text)
  # size        :   size (width in characters) attribute if applicable
  # height      :   height (length in characters) attribute if applicable
@@ -42,10 +52,14 @@
 
 <tr id="row_{{ id }}" {% if advanced|default(false)=='true' %} data-advanced="true"{% endif %}>
     <td>
-        <div class="control-label" id="control_label_{{ id }}">
+            {% if type == "section_title" %}
+                <div class="control-label volt_section_title" id="control_label_{{ id }}">
+            {% else %}
+                <div class="control-label" id="control_label_{{ id }}">
+            {% endif %}
             {% if help|default(false) %}
                 <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>
-            {% elseif help|default(false) == false %}
+            {% elseif help|default(false) == false and type != "section_title" %}
                 <i class="fa fa-info-circle text-muted"></i>
             {% endif %}
             <b>{{label}}</b>
@@ -77,7 +91,7 @@
             <input type="password" class="form-control {{style|default('')}}" size="{{size|default("50")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} >
         {% elseif type == "textbox" %}
             <textarea class="{{style|default('')}}" rows="{{height|default("5")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }}></textarea>
-        {% elseif type == "info" %}
+        {% elseif type == "info" or type == "section_title" %}
             <span  class="{style|default('')}}" id="{{ id }}"></span>
         {% endif %}
         {% if help|default(false) %}

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7567,3 +7567,9 @@ div[data-for*=help_for] {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+
+.volt_section_title {
+  font-size:110%;
+  padding-top:13px;
+  padding-bottom:9px;  
+}

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7569,7 +7569,7 @@ div[data-for*=help_for] {
 }
 
 .volt_section_title {
-  font-size:110%;
+  font-size:112%;
   padding-top:13px;
   padding-bottom:9px;  
 }


### PR DESCRIPTION
<s>(1) The type field is omitted in the list of valid fields.</s> **PRed and merged separately**

(2) There isn't currently an easy way to add "section headers" to groups of fields. While this doesn't have syntactic importance (it's just a "info"/"label" without "help" and with a tiny extra emphasis), it is useful as a distinct type because in-page sections to demarcate groups of fields are widely used in the UI (eg: `System: Settings: Administration` to add sections headers for Web GUI, Secure Shell, Console and Authentication)*.

**Rationale:**

The main issue is that section headers are like info fields **without** a "help" icon to the left (see `System: Settings: Administration` for thisd). But all other phalcon-defined types do have an active or dimmed help icon, and currentl;y there's no way other than on-load JS to remove it for section titles. Also they need slight emphasis - a tiny amount of spacing and size, compared to normal field labels (see same page).  Hence a new type is needed or worthwhile..

Adding `section_title` to the formal list of types is trivial from a code perspective, and ensures 

- Phalcon generated pages have consistent appearances for section_titles in the UI
- They're easy to add if required without perplexing extension devs as to how to do it within the xml :)

**Testing:**

- Pick any mvc `forms` `.xml` file
- Add an extra field at the top or halfway down (or both):
```
   <field>
      <id>optional.pick.any.id</id>
      <type>section_title</type>
      <label>Security Options:</label>
   </field>
```
- Delete the Phalcon cache and reload the page.

**Note:  The CSS is a "pretty good starting point", but if it needs changing, please change it.**

