### PR TITLE
Volt base forms: Effectively remove unused 3rd colgroup by reducing default mgszone_width=0

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -928,6 +928,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 {{ partial("layout_partials/base_dialog_processing") }}
 
-{{ partial("layout_partials/base_dialog",['fields':formDialogRule,'id':'DialogRule','label':lang._('Rule details'),'hasSaveBtn':'true','msgzone_width':1])}}
-{{ partial("layout_partials/base_dialog",['fields':formDialogRuleset,'id':'DialogRuleset','label':lang._('Ruleset details'),'hasSaveBtn':'true','msgzone_width':1])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogRule,'id':'DialogRule','label':lang._('Rule details'),'hasSaveBtn':'true'])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogRuleset,'id':'DialogRuleset','label':lang._('Ruleset details'),'hasSaveBtn':'true'])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogUserDefined,'id':'DialogUserDefined','label':lang._('Rule details'),'hasSaveBtn':'true'])}}

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -67,10 +67,15 @@
                 <form id="frm_{{base_dialog_id}}">
                   <div class="table-responsive">
                     <table class="table table-striped table-condensed">
+                        {# See discussion about colgroups/msgzone_width at:                                   #}
+                         # https://forum.opnsense.org/index.php?topic=14958.0 (2019-11-12)                    #}
+                         # Tl;dr it's easier to default 3rd colgroup -> 0 cols, than to modify entire codebase removing 3rd col.
+                         # Also reversible/settable if ever needed. 
+                         # If modified in future, the same code below, and also base_form.volt, will also need updating. #}
                         <colgroup>
                             <col class="col-md-3"/>
-                            <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
-                            <col class="col-md-{{ msgzone_width|default(5) }}"/>
+                            <col class="col-md-{{ 12-3-msgzone_width|default(0) }}"/>
+                            <col class="col-md-{{ msgzone_width|default(0) }}"/>
                         </colgroup>
                         <tbody>
                         {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
@@ -100,10 +105,11 @@
   </div>
   <div class="table-responsive {{field['style']|default('')}}">
     <table class="table table-striped table-condensed">
+        {# See important note above, if  colgroups/msgzone_width definitions change in future. #}
         <colgroup>
             <col class="col-md-3"/>
-            <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
-            <col class="col-md-{{ msgzone_width|default(5) }}"/>
+            <col class="col-md-{{ 12-3-msgzone_width|default(0) }}"/>
+            <col class="col-md-{{ msgzone_width|default(0) }}"/>
         </colgroup>
         <thead>
           <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -53,10 +53,15 @@
 <form id="{{base_form_id}}" class="form-inline" data-title="{{data_title|default('')}}">
   <div class="table-responsive">
     <table class="table table-striped table-condensed">
+        {# See discussion about colgroups/msgzone_width at:                                   #}
+         # https://forum.opnsense.org/index.php?topic=14958.0 (2019-11-12)                    #}
+         # Tl;dr it's easier to default 3rd colgroup -> 0 cols, than to modify entire codebase removing 3rd col.
+         # Also reversible/settable if ever needed. 
+         # If modified in future, the same code below, and also base_dialog.volt, will also need updating. #}
         <colgroup>
             <col class="col-md-3"/>
-            <col class="col-md-4"/>
-            <col class="col-md-5"/>
+            <col class="col-md-9"/>
+            <col class="col-md-0"/>
         </colgroup>
         <tbody>
 {% if advanced|default(false) or help|default(false) %}
@@ -77,10 +82,11 @@
   </div>
   <div class="table-responsive {{field['style']|default('')}}">
     <table class="table table-striped table-condensed table-responsive">
+        {# See important note above, if  colgroups/msgzone_width definitions change in future. #}
         <colgroup>
             <col class="col-md-3"/>
-            <col class="col-md-4"/>
-            <col class="col-md-5"/>
+            <col class="col-md-9"/>
+            <col class="col-md-0"/>
         </colgroup>
         <thead>
           <tr {% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -1770,6 +1770,19 @@ pre code {
   padding-right: 20px;
 }
 
+/*    .col-md-0 is defined separately from, and not just included in, the above list
+      because it's used at the right side of dialogs to indicate "no 3rd column".
+      So it doesn't need the padding-left/right that non-zero .col-md-* are styled with, in the list.
+
+      It's currently only relevant to base_form.volt and base_dialog.volt, and can be
+      removed from CSS if no longer used in the code.
+*/
+
+.col-md-0 {
+  position: relative;
+  min-height: 1px;
+}
+
 .col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
   float: left;
 }
@@ -2188,10 +2201,16 @@ pre code {
   }
 }
 @media (min-width: 992px) {
-  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+  .col-md-0, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
     float: left;
   }
 
+  .col-md-0 {
+    width: 0;
+  }
+  /* See above note around line 1773: col-md-0 is in effect added, to allow removal of the right hand of 3 colgroups 
+     in base_form.volt and base_dialog.volt. */
+  
   .col-md-1 {
     width: 8.3333333333%;
   }

--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -1776,6 +1776,10 @@ pre code {
 
       It's currently only relevant to base_form.volt and base_dialog.volt, and can be
       removed from CSS if no longer used in the code.
+
+      Leaving this comment here because ultimately, this is a good fix rather than an ideal solution.
+      See discussion about colgroups/msgzone_width at:  https://forum.opnsense.org/index.php?topic=14958.0 (2019-11-12)
+      Tl;dr it's easier to create col-md-0 for a zero width 3rd colgroup, than to modify entire codebase removing 3rd col.
 */
 
 .col-md-0 {


### PR DESCRIPTION
See discussion about colgroups/msgzone_width [on the forums](https://forum.opnsense.org/index.php?topic=14958.0) (2019-11-12).

**Tl;dr** - dialogs generated by volt define a 3rd colgroup (5/12 = 42% of the total dialog width), and a much narrowed 2nd colgroup. But this 3rd colgroup isn't ever used, other than in 1 form, and even then it's only referred to by setting its width to near zero to try and remove it.  So it has no useful uses right now. Its only actual - as opposed to originally intended - effect is to stop helptext and fields from occupying the right half of dialogs, which is never used anyway and always white spaced. This makes white space poorly used and forms often longer due to excessive line wrapping.

@AdSchellevis ' comment on this issue in the linked forum thread was:

> Originally it [msgzone_width] came from https://github.com/opnsense/core/commit/4c736c65060c926ecc9eb7539b93454559e9d2d4 intended to display "wide" forms, see "Administration -> Intrusion detection -> Rule" for its usage.
> 
> It's not at the top of my priority list, but I wouldn't mind removing the parameter if both form types still look decent. As far as I see, we only use it in IDS at the moment, so it should be easy to refactor and test.

However, actusally removing it would mean changing almost every volt-generated table with a third empty `<td></td>` or `colspan`. in the entire codebase - impractical and pointless, waste of dev time and testing laborious.  It's much easier to simply change the default size of the 3rd colgroup to 0 cols and add trivial CSS to consistently define a zero-width colgroup without L/R padding, than to modify the entire codebase removing it.  It also makes it easily reversible/settable if ever needed.

I've copiously commented this in the edited .volt base files and the css, because it may not be obvious to future devs what's behind the code chosen.

It tests very well here, but as it affects a lot of things, please check to make sure I haven't missed anything!