### PR TITLE
DHCPv6, fix for domain-search option

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1404,7 +1404,7 @@ EOD;
         }
 
         if (!empty($dhcpv6ifconf['domainsearchlist'])) {
-            $dnscfgv6 .= "  option domain-search \"" . join("\",\"", preg_split("/[ ;]+/", $dhcpv6ifconf['domainsearchlist'])) . "\";\n";
+            $dnscfgv6 .= "  option dhcp6.domain-search \"" . join("\",\"", preg_split("/[ ;]+/", $dhcpv6ifconf['domainsearchlist'])) . "\";\n";
         }
 
         $newzone = array();


### PR DESCRIPTION
The "domain-search" option in dhcpdv6.conf must be prefixed with "dhcp6". This fixes one of the issues from #2336 which are still open.