### PR TITLE
Make strongSwan's dpdaction configurable

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1320,10 +1320,14 @@ function ipsec_configure_do($verbose = false, $interface = '')
                 }
 
                 if (!empty($ph1ent['dpd_delay']) && !empty($ph1ent['dpd_maxfail'])) {
-                    if (in_array($conn_auto, array('route', 'start'))) {
-                        $dpdline = "dpdaction = restart";
+                    if (empty($ph1ent['dpd_action'])) {
+                        if (in_array($conn_auto, array('route', 'start'))) {
+                            $dpdline = "dpdaction = restart";
+                        } else {
+                            $dpdline = "dpdaction = clear";
+                        }
                     } else {
-                        $dpdline = "dpdaction = clear";
+                        $dpdline = "dpdaction = {$ph1ent['dpd_action']}";
                     }
                     $dpdline .= "\n\tdpddelay = {$ph1ent['dpd_delay']}s";
                     $dpdtimeout = $ph1ent['dpd_delay'] * ($ph1ent['dpd_maxfail'] + 1);

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -342,6 +342,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (!is_numeric($pconfig['dpd_maxfail'])) {
             $input_errors[] = gettext("A numeric value must be specified for DPD retries.");
         }
+        if (!empty($pconfig['dpd_action']) && !in_array($pconfig['dpd_action'], array("restart", "clear"))) {
+            $input_errors[] = gettext('Invalid argument for DPD action.');
+        }
     }
 
     if (!empty($pconfig['iketype']) && !in_array($pconfig['iketype'], array("ike", "ikev1", "ikev2"))) {

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -87,7 +87,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['iketype'] = "ikev2";
     $phase1_fields = "mode,protocol,myid_type,myid_data,peerid_type,peerid_data
     ,encryption-algorithm,lifetime,authentication_method,descr,nat_traversal,rightallowany
-    ,interface,iketype,dpd_delay,dpd_maxfail,remote-gateway,pre-shared-key,certref,margintime,rekeyfuzz
+    ,interface,iketype,dpd_delay,dpd_maxfail,dpd_action,remote-gateway,pre-shared-key,certref,margintime,rekeyfuzz
     ,caref,local-kpref,peer-kpref,reauth_enable,rekey_enable,auto,tunnel_isolation,authservers,mobike";
     if (isset($p1index) && isset($config['ipsec']['phase1'][$p1index])) {
         // 1-on-1 copy
@@ -171,6 +171,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (!isset($pconfig['dpd_enable'])) {
         unset($pconfig['dpd_delay']);
         unset($pconfig['dpd_maxfail']);
+        unset($pconfig['dpd_action']);
     }
 
     /* My identity */
@@ -417,6 +418,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (isset($pconfig['dpd_enable'])) {
             $ph1ent['dpd_delay'] = $pconfig['dpd_delay'];
             $ph1ent['dpd_maxfail'] = $pconfig['dpd_maxfail'];
+            $ph1ent['dpd_action'] = $pconfig['dpd_action'];
         }
 
         /* generate unique phase1 ikeid */
@@ -1159,6 +1161,16 @@ endforeach; ?>
                         <?=gettext("retries"); ?>
                         <div class="hidden" data-for="help_for_dpd_enable">
                           <?=gettext("Number of consecutive failures allowed before disconnect."); ?>
+                        </div>
+                        <br />
+                        <select name="dpd_action">
+                          <option value="" <?=empty($pconfig['dpd_action']) ?  "selected=\"selected\"" : ""; ?>><?=gettext("default");?></option>
+                          <option value="restart" <?=$pconfig['dpd_action'] == "restart" ?  "selected=\"selected\"" : ""; ?>><?=gettext("Restart the tunnel");?></option>
+                          <option value="clear" <?=$pconfig['dpd_action'] == "clear" ?  "selected=\"selected\"" : ""; ?>><?=gettext("Stop the tunnel");?></option>
+                        </select>
+                        <?=gettext("DPD action"); ?>
+                        <div class="hidden" data-for="help_for_dpd_enable">
+                          <?=gettext("Choose the behavior here what to do if a peer is detected to be unresponsive to DPD requests."); ?>
                         </div>
                       </div>
                     </td>


### PR DESCRIPTION
As stated in #3821, making the `dpdaction` configurable comes in handy for IPsec `start on traffic` CARP clusters for a clean failover.

I've added a `default` option, to not break existing setups.