### PR TITLE
Unbound: Add options for logging queries and extended statistics.

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -225,6 +225,8 @@ EOF;
     $infra_cache_numhosts = !empty($config['unbound']['infra_cache_numhosts']) ? $config['unbound']['infra_cache_numhosts'] : "10000";
     $unwanted_reply_threshold = !empty($config['unbound']['unwanted_reply_threshold']) && is_numeric($config['unbound']['unwanted_reply_threshold']) ? $config['unbound']['unwanted_reply_threshold'] : "0";
     $verbosity = isset($config['unbound']['log_verbosity']) ? $config['unbound']['log_verbosity'] : 1;
+    $extended_statistics = !empty($config['unbound']['extended_statistics']) ? 'yes' : 'no';
+    $log_queries = !empty($config['unbound']['log_queries']) ? 'yes' : 'no';
     $msgcachesize = !empty($config['unbound']['msgcachesize']) ? $config['unbound']['msgcachesize'] : 4;
     $rrsetcachesize = $msgcachesize * 2;
     $dnssecstripped = !empty($config['unbound']['dnssecstripped']) ? 'yes' : 'no';
@@ -286,6 +288,8 @@ root-hints: /var/unbound/root.hints
 use-syslog: yes
 port: {$port}
 verbosity: {$verbosity}
+extended-statistics: {$extended_statistics}
+log-queries: {$log_queries}
 hide-identity: {$hide_id}
 hide-version: {$hide_version}
 harden-referral-path: no

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -358,7 +358,7 @@ include_once("head.inc");
                           <td>
                               <input name="extended_statistics" type="checkbox" id="extended_statistics" value="yes" <?= empty($pconfig['extended_statistics']) ? '' : 'checked="checked"' ?> />
                               <div class="hidden" data-for="help_for_extended_statistics">
-                                  <?= gettext("If  enabled, extended  statistics are printed. Default is off, because keeping track of more statistics takes time.") ?>
+                                  <?= gettext("If enabled, extended statistics are printed.") ?>
                               </div>
                           </td>
                       </tr>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -367,7 +367,7 @@ include_once("head.inc");
                           <td>
                               <input name="log_queries" type="checkbox" id="log_queries" value="yes" <?= empty($pconfig['log_queries']) ? '' : 'checked="checked"' ?> />
                               <div class="hidden" data-for="help_for_log_queries">
-                                  <?= gettext("Prints one line per query to the log, with the log timestamp and IP address, name, type and class.  Default is no.  Note that  it takes time to print these lines which makes the server (significantly) slower.  Odd  (nonprintable)  characters  in  names  are printed as '?'.") ?>
+                                  <?= gettext("If enabled, prints one line per query to the log, with the log timestamp and IP address, name, type and class.") ?>
                               </div>
                           </td>
                       </tr>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -59,6 +59,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['log_verbosity'] = "1";
 
     // boolean fields
+    $pconfig['extended_statistics'] = isset($config['unbound']['extended_statistics']);
+    $pconfig['log_queries'] = isset($config['unbound']['log_queries']);
     $pconfig['hideidentity'] = isset($config['unbound']['hideidentity']);
     $pconfig['hideversion'] = isset($config['unbound']['hideversion']);
     $pconfig['prefetch'] = isset($config['unbound']['prefetch']);
@@ -84,6 +86,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     } else {
         $pconfig = $_POST;
         // boolean fields
+        $config['unbound']['extended_statistics'] = !empty($pconfig['extended_statistics']);
+        $config['unbound']['log_queries'] = !empty($pconfig['log_queries']);
         $config['unbound']['hideidentity'] = !empty($pconfig['hideidentity']);
         $config['unbound']['hideversion'] = !empty($pconfig['hideversion']);
         $config['unbound']['prefetch'] = !empty($pconfig['prefetch']);
@@ -348,6 +352,24 @@ include_once("head.inc");
                             <?= gettext("Select the log verbosity. Level 0 means no verbosity, only errors. Level 1 gives operational information. Level 2 gives detailed operational information. Level 3 gives query level information, output per query. Level 4 gives algorithm level information. Level 5 logs client identification for cache misses. Default is level 1. ") ?>
                           </div>
                         </td>
+                      </tr>
+                      <tr>
+                          <td><a id="help_for_extended_statistics" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Extended statistics') ?></td>
+                          <td>
+                              <input name="extended_statistics" type="checkbox" id="extended_statistics" value="yes" <?= empty($pconfig['extended_statistics']) ? '' : 'checked="checked"' ?> />
+                              <div class="hidden" data-for="help_for_extended_statistics">
+                                  <?= gettext('If  enabled, extended  statistics are printed. Default is off, because keeping track of more statistics takes time.') ?>
+                              </div>
+                          </td>
+                      </tr>
+                      <tr>
+                          <td><a id="help_for_log_queries" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Log Queries') ?></td>
+                          <td>
+                              <input name="log_queries" type="checkbox" id="log_queries" value="yes" <?= empty($pconfig['log_queries']) ? '' : 'checked="checked"' ?> />
+                              <div class="hidden" data-for="help_for_log_queries">
+                                  <?= gettext('Prints one line per query to the log, with the log timestamp and IP address, name, type and class.  Default is no.  Note that  it takes time to print these lines which makes the server (significantly) slower.  Odd  (nonprintable)  characters  in  names  are printed as \'?\'.') ?>
+                              </div>
+                          </td>
                       </tr>
                       <tr>
                         <td></td>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -358,7 +358,7 @@ include_once("head.inc");
                           <td>
                               <input name="extended_statistics" type="checkbox" id="extended_statistics" value="yes" <?= empty($pconfig['extended_statistics']) ? '' : 'checked="checked"' ?> />
                               <div class="hidden" data-for="help_for_extended_statistics">
-                                  <?= gettext('If  enabled, extended  statistics are printed. Default is off, because keeping track of more statistics takes time.') ?>
+                                  <?= gettext("If  enabled, extended  statistics are printed. Default is off, because keeping track of more statistics takes time.") ?>
                               </div>
                           </td>
                       </tr>
@@ -367,12 +367,11 @@ include_once("head.inc");
                           <td>
                               <input name="log_queries" type="checkbox" id="log_queries" value="yes" <?= empty($pconfig['log_queries']) ? '' : 'checked="checked"' ?> />
                               <div class="hidden" data-for="help_for_log_queries">
-                                  <?= gettext('Prints one line per query to the log, with the log timestamp and IP address, name, type and class.  Default is no.  Note that  it takes time to print these lines which makes the server (significantly) slower.  Odd  (nonprintable)  characters  in  names  are printed as \'?\'.') ?>
+                                  <?= gettext("Prints one line per query to the log, with the log timestamp and IP address, name, type and class.  Default is no.  Note that  it takes time to print these lines which makes the server (significantly) slower.  Odd  (nonprintable)  characters  in  names  are printed as '?'.") ?>
                               </div>
                           </td>
                       </tr>
-                      <tr>
-                        <td></td>
+                      <tr><td></td>
                         <td>
                           <button type="submit" name="Save" class="btn btn-primary" id="save" value="Save"><?= gettext("Save") ?></button>
                         </td>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -371,7 +371,8 @@ include_once("head.inc");
                               </div>
                           </td>
                       </tr>
-                      <tr><td></td>
+                      <tr>
+                        <td></td>
                         <td>
                           <button type="submit" name="Save" class="btn btn-primary" id="save" value="Save"><?= gettext("Save") ?></button>
                         </td>


### PR DESCRIPTION
The 'custom options' field is deprecated + does not work for these fields since it places the contents out of the 'server:' context. E.g. adding:
```
log_queries: yes
extended_statistics: yes
```
To the field creates an invalid config which blocks the service from starting.

These boolean fields allow the options to be used and are future proof in case the custom options field gets removed.