### PR TITLE
Account for case sensitivity of diff function

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -470,6 +470,11 @@ class LDAP extends Base implements IAuthConnector
             natcasesort($sync_groups);
             natcasesort($user_groups);
             natcasesort($ldap_groups);
+            // convert contents of group arrays to lowercase 
+            $sync_groups = array_change_key_case($sync_groups, CASE_LOWER);
+            $user_groups = array_change_key_case($user_groups, CASE_LOWER);
+            $ldap_groups = array_change_key_case($ldap_groups, CASE_LOWER);
+            //
             $diff_ugrp = array_intersect($sync_groups, $user_groups);
             $diff_lgrp = array_intersect($sync_groups, array_keys($ldap_groups));
             if ($diff_lgrp != $diff_ugrp) {


### PR DESCRIPTION
After selecting the 'Synchronize groups' option within 'Servers > LDAP', OPNsense kept stripping me from the 'admins' group. After a great deal of troubleshooting, I determined that the diff function used to examine commonality of group inclusion between LDAP and local is case sensitive, whereas LDAP schemas are not (by default).  It turns out I had added an 'Admins' group to LDAP to conform with the standard capitalization format of LDAP schemas and OPNsense was not recognizing or respecting the sameness between 'Admins' and 'admins' (the latter being OPNsense default).

Noting that duplicate LDAP groups cannot be configured (e.g. attempting to create a group 'admins' when 'Admins' already exists), I've proposed that all user & group variables are normalized with lowercase text prior to analysis.

Although it holds up in various testing scenarios I put it through, this will need to be tested and/or vetted out by developers, as it could be very hacky. Also note that I first installed pkg 'php72-mbstring' in an attempt to address this using mb_strtolower, though I'm not certain this pull request requires it. I'm far from a PHP expert...those 3 "simple" lines took me ~4 hours to arrive at!