### PR TITLE
Log access data of proxied end-user

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -218,7 +218,7 @@ fastcgi.server = ( ".php" =>
 
 EOD;
 
-    $lighty_modules = !empty($config['system']['webgui']['httpaccesslog']) ? ', "mod_accesslog"' : "";
+    $lighty_modules = !empty($config['system']['webgui']['httpaccesslog']) ? ', "mod_accesslog", "mod_extforward"' : "";
 
 
     $lighty_config = <<<EOD
@@ -447,6 +447,15 @@ compress.filetype  = ("text/plain","text/css", "text/xml", "text/javascript" )
 {$cgi_config}
 
 expire.url = ( "" => "access 50 hours" )
+
+extforward.params = ("host" => 1, # Overwrite Host with Forwarded value
+                     "remote_user" => 1 # Set REMOTE_USER with Forwarded value
+)
+extforward.forwarder = ("127.0.0.1" => "trust")
+extforward.headers = ("X-Forwarded-For", "Forwarded-For", "X-Real-IP")
+### Acknowledge possible probable need to address HAProxy in a different manner
+# extforward.hap-PROXY = ("enable")
+
 
 EOD;
 


### PR DESCRIPTION
At present, visibility of end-user identity is lost within OPNsense when accessing the Administration front-end through reverse proxy. Proposed here is native lighttpd support for capturing these data, which might serve as a baseline for expanded configuration scenarios moving forward. Shown here is the result: https://i.imgur.com/AHwlyTC.png

I have also tested the direct, non-proxied access of OPNsense via the configured lighttpd port (rather than nginx port), which results in the expected logging of end-user IP.

mod_extforward exists in the current version of lighttpd distributed with OPNsense, so no additional components are required beyond this revision to lighty-webConfigurator.conf. 

Of note:
1. I'm not certain that the inclusion of mod_extforward at line 221 is the expected behavior of core developers. Please confirm that this does not belong at line 238, noting that this module **must** be loaded after both mod_openssl and mod_accesslog to function properly.
2. The configuration proposed here supports proxied connections from localhost, which will not meet the needs of all deployments. Although the mod does support _extforward.forwarder = ( "all" => "trust")_ this is clearly a bad path-forward, so consideration may be given to adding a "Support Proxied Connections" option at System: Settings: Administration, wherein the user can select a checkbox and add a list of proxy IPs to allow. The intention of this functionality should be further clarified via help text to avoid user perception of this setting effectively _enabling_ a reverse proxy vs. only supporting connections from them.
3. mod_extforward also supports connections from HAProxy but enabling this configuration is beyond the scope of this pull request. I've acknowledged this observation in the contents of the code.