### PR TITLE
Update squid.conf for ipv6 listener support

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -27,12 +27,41 @@
 {%     endif %}
 {% endif %}
 
+# Setup transparent mode listeners on local scope ipv6 addresses
+{# for CARP use virtual IPs #}
+{%     if helpers.exists('virtualip') %}
+{%         for intf_item in helpers.toList('virtualip.vip') %}
+{%             if intf_item.subnet.find(':') > -1 and intf_item.type == 'single' %}
+{{ listener_config('['+intf_item.subnet+']', OPNsense.proxy.forward.port) }}
+{%                 if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
+{{ listener_config('['+intf_item.subnet+']', OPNsense.proxy.forward.sslbumpport, 'intercept', 'ssl') }}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{# for none CARP use intefaces #}
+{%    elif helpers.exists('OPNsense.proxy.forward.interfaces') %}
+{%         for interface in OPNsense.proxy.forward.interfaces.split(",") %}
+{%             for intf_key,intf_item in interfaces.items() %}
+{%                 if intf_key == interface and intf_item.ipaddrv6 and intf_item.ipaddrv6.find(':') > -1 %}
+{{ listener_config('['+intf_item.ipaddrv6+']', OPNsense.proxy.forward.port, 'intercept') }}
+{%                     if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
+{{ listener_config('['+intf_item.ipaddrv6+']', OPNsense.proxy.forward.sslbumpport, 'intercept', 'ssl') }}
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
+{% endif %}
+
 # Setup regular listeners configuration
 {% if helpers.exists('OPNsense.proxy.forward.interfaces') %}
 {%     for interface in OPNsense.proxy.forward.interfaces.split(",") %}
 {%         for intf_key,intf_item in interfaces.items() %}
 {%             if intf_key == interface and intf_item.ipaddr and intf_item.ipaddr != 'dhcp' %}
 {{ listener_config(intf_item.ipaddr, OPNsense.proxy.forward.port) }}
+{%             endif %}
+{%             if intf_key == interface and intf_item.ipaddrv6 and intf_item.ipaddrv6.find(':') > -1 %}
+{{ listener_config('['+intf_item.ipaddrv6+']', OPNsense.proxy.forward.port) }}
 {%             endif %}
 {%         endfor %}
 {# virtual ip's #}


### PR DESCRIPTION
Add ipv6 addresses to listening interfaces. Also add ipv6 transparent mode listeners:
- Either VIPs if using CARP
- Or interface address if not using CARP

All you need to do is adding a forwarding rule to local interface ip6 address for transparent mode, e.g.

int: lan:
src: lan
dst: any
proto: inet6
dstport: 80
target: lan-ipv6 address

ToDo: Add 'transparentv6_proxy' template in
https://github.com/opnsense/core/blob/master/src/www/firewall_nat_edit.php