### PR TITLE
VIP alias/dhcp6 fix for issue #3310

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2595,7 +2595,19 @@ function interface_track6_configure($interface = 'lan', $lancfg, $linkupevent = 
         return;
     }
 
+    // remove VIPs from tracked interface if they are there, they'll get put back later.
+
+     if (isset($config['virtualip']['vip'])) {
+        foreach ($config['virtualip']['vip'] as $vip) {
+            if ($vip['interface'] == $interface && $vip['mode'] == 'ipalias' && is_ipaddrv6($vip['subnet'])) {
+                 /** Remove this alias whilst v6 configures **/
+                interface_vip_bring_down($vip);
+            }
+        }
+    }
+
     $trackcfg = $config['interfaces'][$lancfg['track6-interface']];
+
     if (!isset($trackcfg['enable'])) {
         log_error("Interface {$interface} tracking non-existent interface {$lancfg['track6-interface']}");
         return;
@@ -2635,6 +2647,12 @@ function interface_track6_configure($interface = 'lan', $lancfg, $linkupevent = 
                 killbypid("/var/run/dhcp6c_{$parentrealif}.pid", 'HUP');
             }
             break;
+    }
+    foreach ($config['virtualip']['vip'] as $vip) {
+        if ($vip['interface'] == $interface && is_ipaddrv6($vip['subnet']) && $vip['mode'] == 'ipalias') {            
+                /** Put back the v6 alias **/        
+                interface_ipalias_configure($vip);
+            }
     }
 }
 


### PR DESCRIPTION
Remove the Interface v6 alias during reconfigure by dhcp6c and re-apply once complete. This commit has a further check that the closed commit I previously issued did not. It now also checks that the alias to be removed and re-added is a v6 address, thus removing the possibility that it could remove a v4 alias on the interface. Whilst the dhcp6c v6 address is being added there should not be an alias on that interface anyway so this makes sure. Ref issue #3310 