### PR TITLE
dhcp: add icons next to online/offline lease status

### DIFF
--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -421,9 +421,8 @@ legacy_html_escape_form_data($leases);
                   <td><?=$data['descr'];?></td>
                   <td><?= !empty($data['start']) ? adjust_utc($data['start']) : '' ?></td>
                   <td><?= !empty($data['end']) ? adjust_utc($data['end']) : '' ?></td>
-                  <td class="text-nowrap">
-                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>"></i>
-                    <?=$data['online'];?>
+                  <td>
+                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>" title="<?=$data['online'];?>" data-toggle="tooltip"></i>
                   </td>
                   <td><?=$data['act'];?></td>
                   <td class="text-nowrap">

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -421,7 +421,10 @@ legacy_html_escape_form_data($leases);
                   <td><?=$data['descr'];?></td>
                   <td><?= !empty($data['start']) ? adjust_utc($data['start']) : '' ?></td>
                   <td><?= !empty($data['end']) ? adjust_utc($data['end']) : '' ?></td>
-                  <td><?=$data['online'];?></td>
+                  <td class="text-nowrap">
+                    <span class="glyphicon glyphicon-<?=$data['online']=='online' ? 'signal' : 'ban-circle';?>" aria-hidden="true"></span>
+                    <?=$data['online'];?>
+                  </td>
                   <td><?=$data['act'];?></td>
                   <td class="text-nowrap">
 <?php if (!empty($data['if'])): ?>

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -422,7 +422,7 @@ legacy_html_escape_form_data($leases);
                   <td><?= !empty($data['start']) ? adjust_utc($data['start']) : '' ?></td>
                   <td><?= !empty($data['end']) ? adjust_utc($data['end']) : '' ?></td>
                   <td class="text-nowrap">
-                    <span class="glyphicon glyphicon-<?=$data['online']=='online' ? 'signal' : 'ban-circle';?>" aria-hidden="true"></span>
+                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>"></i>
                     <?=$data['online'];?>
                   </td>
                   <td><?=$data['act'];?></td>

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -483,7 +483,10 @@ endif;?>
                   <td><?=htmlentities($data['descr']);?></td>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['start']) : "";?></td>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['end']) : "";?></td>
-                  <td><?=$data['online'];?></td>
+                  <td class="text-nowrap">
+                    <span class="glyphicon glyphicon-<?=$data['online']=='online' ? 'signal' : 'ban-circle';?>" aria-hidden="true"></span>
+                    <?=$data['online'];?>
+                  </td>
                   <td><?=$data['act'];?></td>
                   <td class="text-nowrap">
 <?php if (!empty($data['if'])): ?>

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -483,9 +483,8 @@ endif;?>
                   <td><?=htmlentities($data['descr']);?></td>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['start']) : "";?></td>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['end']) : "";?></td>
-                  <td class="text-nowrap">
-                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>"></i>
-                    <?=$data['online'];?>
+                  <td>
+                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>" title="<?=$data['online'];?>" data-toggle="tooltip"></i>
                   </td>
                   <td><?=$data['act'];?></td>
                   <td class="text-nowrap">

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -484,7 +484,7 @@ endif;?>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['start']) : "";?></td>
                   <td><?=$data['type'] != "static" ? adjust_utc($data['end']) : "";?></td>
                   <td class="text-nowrap">
-                    <span class="glyphicon glyphicon-<?=$data['online']=='online' ? 'signal' : 'ban-circle';?>" aria-hidden="true"></span>
+                    <i class="fa fa-<?=$data['online']=='online' ? 'signal' : 'ban';?>"></i>
                     <?=$data['online'];?>
                   </td>
                   <td><?=$data['act'];?></td>


### PR DESCRIPTION
[X] I have read the contributing guide lines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md

[X] I have searched the existing issues and I'm convinced that mine is new.

**Is your pull request related to a problem? Please describe.**
I find it difficult to distinguish between "offline" and "online" when I look at the list of DHCP Leases. The two words look very similar, and it is hard to scan the column visually.

**Describe the solution**
My commit adds an icon in front of the "online" or "offline" text to make it easier to distinguish the two states from each other at a glance. I chose the `signal` and `ban-circle` glyphicons. I don't have a strong opinion about the particular icons used as long as they make sense and maintain a good enough visual distinction.

**Describe alternatives you've considered**
I played with setting Bootstrap danger/warning/success classes on the status cell (`<td>`) or on the whole row (`<tr>`), but this seemed like overkill and didn't look very good to me.


**Additional context**
Here are before and after screenshots:

![without-indicator](https://user-images.githubusercontent.com/2757540/73821227-0b294f80-47b9-11ea-9388-19407c1bbb35.png)

![with-indicator](https://user-images.githubusercontent.com/2757540/73821243-17ada800-47b9-11ea-884b-67bbd1570759.png)