### PR TITLE
radvd: don't set Router Address flag

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -324,19 +324,16 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
                 case 'managed':
                     $radvdconf .= "\t\tAdvOnLink on;\n";
                     $radvdconf .= "\t\tAdvAutonomous off;\n";
-                    $radvdconf .= "\t\tAdvRouterAddr on;\n";
                     break;
                 case 'router':
                     $radvdconf .= "\t\tAdvOnLink off;\n";
                     $radvdconf .= "\t\tAdvAutonomous off;\n";
-                    $radvdconf .= "\t\tAdvRouterAddr on;\n";
                     break;
                 case 'assist':
                 case 'unmanaged':
                 case 'stateless':
                     $radvdconf .= "\t\tAdvOnLink on;\n";
                     $radvdconf .= "\t\tAdvAutonomous on;\n";
-                    $radvdconf .= "\t\tAdvRouterAddr on;\n";
                     break;
                 default:
                     break;
@@ -495,7 +492,6 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
         }
         $radvdconf .= "\t\tAdvOnLink on;\n";
         $radvdconf .= "\t\tAdvAutonomous on;\n";
-        $radvdconf .= "\t\tAdvRouterAddr on;\n";
         $radvdconf .= "\t};\n";
 
         if (count($dnslist) > 0) {


### PR DESCRIPTION
The Router Address flag "indicates that the Prefix field contains a complete IP address assigned to the sending router" (RFC 6275). This does not apply, we only send a prefix. This flag is only relevant for Mobile IPv6.
It has been there (for unknown reasons) since pfSense switched to radvd 8 years ago: https://github.com/pfsense/pfsense/commit/3f9cc8e44c5b50e588f0f916611ffa37f7ae0bcb