### PR TITLE
radvd.conf for tracking LAN interfaces, cleanup

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -480,16 +480,15 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
         $radvdconf .= "# Generated config for {$autotype} delegation from {$trackif} on {$if}\n";
         $radvdconf .= "interface {$realif} {\n";
         $radvdconf .= "\tAdvSendAdvert on;\n";
-        $radvdconf .= "\tMinRtrAdvInterval 3;\n";
-        $radvdconf .= "\tMaxRtrAdvInterval 10;\n";
         $radvdconf .= sprintf("\tAdvLinkMTU %s;\n", !empty($mtu) ? $mtu : 1280);
+        $radvdconf .= "\tAdvManagedFlag on;\n";
         $radvdconf .= "\tAdvOtherConfigFlag on;\n";
         $radvdconf .= "\tprefix {$networkv6} {\n";
         if ($autotype == 'slaac') {
             /* XXX also of interest in the future, see hardcoded prefix above */
             $radvdconf .= "\t\tBase6Interface $realtrackif;\n";
-            $radvdconf .= "\t\tDeprecatePrefix on;\n";
         }
+        $radvdconf .= "\t\tDeprecatePrefix on;\n";
         $radvdconf .= "\t\tAdvOnLink on;\n";
         $radvdconf .= "\t\tAdvAutonomous on;\n";
         $radvdconf .= "\t};\n";


### PR DESCRIPTION
As discussed in #3310. For tracking LAN interfaces with manual configuration disabled, some odd radvd configuration choices were made:
MinRtrAdvInterval / MaxRtrAdvInterval were set to very low values (3 / 10) for no apparent reason. Now removed so radvd defaults (200 / 600) will be used.
The DHCPv6 server is enabled and configured with a range6, but the Managed flag was not set. Now set to on.
DeprecatePrefix was only set if the IPv6 configuration type of the tracked WAN interface was SLAAC. Now always set to on.