### PR TITLE
unbound: remove 192.0.0.0/24 from rebinding prevention list

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -128,7 +128,6 @@ private-address: 100.64.0.0/10
 private-address: 127.0.0.0/8     # Loopback Localhost
 private-address: 169.254.0.0/16
 private-address: 172.16.0.0/12
-private-address: 192.0.0.0/24    # IANA IPv4 special purpose net
 private-address: 192.0.2.0/24    # Documentation network TEST-NET
 private-address: 192.168.0.0/16
 private-address: 198.18.0.0/15   # Used for testing inter-network communications


### PR DESCRIPTION
192.0.0.0/24 is not a private net. ipv4only.arpa resolves to 192.0.0.170 and 192.0.0.171. This is required for DNS64 prefix detection (RFC7050).
(Quick way to verify: Lookup ipv4only.arpa via Google DNS / Cloudflare DNS / whatever. Resolves to 192.0.0.170 / 192.0.0.171. But doesn't resolve via OPNsense's unbound.)