### PR TITLE
unbound: add option to disable ptr records on Overrides/Aliases

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -601,6 +601,7 @@ function unbound_add_host_entries()
                 'domain' => $host['domain'],
                 'descr' => $host['descr'],
                 'host' => $host['host'],
+                'ptr' => empty($host['noptr']),
             ));
 
             if (!empty($host['aliases']['item'])) {
@@ -609,6 +610,7 @@ function unbound_add_host_entries()
                         'domain' => !empty($alias['domain']) ? $alias['domain'] : $aliases[0]['domain'],
                         'descr' => !empty($alias['descr']) ? $alias['descr'] : $aliases[0]['descr'],
                         'host' => !empty($alias['host']) ? $alias['host'] : $aliases[0]['host'],
+                        'ptr' => empty($alias['noptr']),
                     );
                 }
             }
@@ -631,7 +633,9 @@ function unbound_add_host_entries()
                             $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
                             $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host['rr']} {$host['ip']}\"\n";
                         } else {
-                            $unbound_entries .= "local-data-ptr: \"{$host['ip']} {$alias['host']}{$alias['domain']}\"\n";
+                            if($alias['ptr']) {
+                                $unbound_entries .= "local-data-ptr: \"{$host['ip']} {$alias['host']}{$alias['domain']}\"\n";
+                            }
                             $unbound_entries .= "local-data: \"{$alias['host']}{$alias['domain']} IN {$host['rr']} {$host['ip']}\"\n";
                         }
                         break;

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -40,7 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $id = $_GET['id'];
     }
     $pconfig = array();
-    foreach (array('rr', 'host', 'domain', 'ip', 'mxprio', 'mx', 'descr', 'aliases') as $fieldname) {
+    foreach (array('rr', 'host', 'domain', 'ip', 'mxprio', 'mx', 'descr', 'noptr', 'aliases') as $fieldname) {
         if (isset($id) && !empty($a_hosts[$id][$fieldname])) {
             $pconfig[$fieldname] = $a_hosts[$id][$fieldname];
         } else {
@@ -66,6 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 'domain' => $pconfig['aliases_domain'][$opt_seq],
                 'descr' => $pconfig['aliases_descr'][$opt_seq],
                 'host' => $opt_host,
+                'noptr' => !in_array('yes-' . $opt_seq, $pconfig['aliases_ptr']),
             );
         }
     }
@@ -133,6 +134,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $hostent['mxprio'] = $pconfig['mxprio'];
         $hostent['mx'] = $pconfig['mx'];
         $hostent['descr'] = $pconfig['descr'];
+        $hostent['noptr'] = empty($pconfig['ptr']);
         $hostent['aliases'] = $pconfig['aliases'];
 
         if (isset($id)) {
@@ -192,6 +194,14 @@ include("head.inc");
         } else {
             $(this).parent().parent().remove();
         }
+        indexRows();
+    }
+    function indexRows() {
+        var i = 0;
+        $('#aliases_table > tbody > tr > td > input[type=checkbox]').each(function(){
+          $(this).val("yes-"+i);
+          i++;
+        });
     }
     // add new detail record
     $("#addNew").click(function(){
@@ -201,6 +211,7 @@ include("head.inc");
           $(this).val("");
         });
         $(".act-removerow").click(removeRow);
+        indexRows();
     });
     $(".act-removerow").click(removeRow);
   });
@@ -302,6 +313,15 @@ include("head.inc");
                     </td>
                   </tr>
                   <tr>
+                    <td><a id="help_for_ptr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("PTR Record");?></td>
+                    <td>
+                      <input name="ptr" type="checkbox" id="ptr" value="yes" <?=empty($pconfig['noptr']) ? 'checked="checked"' : '';?> />
+                      <div class="hidden" data-for="help_for_ptr">
+                        <?= gettext("If this option is set, a PTR Record will be created."); ?>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
                     <td><a id="help_for_alias" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Aliases"); ?></td>
                     <td>
                       <table class="table table-striped table-condensed" id="aliases_table">
@@ -311,13 +331,15 @@ include("head.inc");
                             <th id="detailsHeading1"><?=gettext("Host"); ?></th>
                             <th id="detailsHeading3"><?=gettext("Domain"); ?></th>
                             <th id="updatefreqHeader" ><?=gettext("Description");?></th>
+                            <th id="ptr" ><?=gettext("PTR Record");?></th>
                           </tr>
                         </thead>
                         <tbody>
 <?php
                         $aliases = !empty($pconfig['aliases']['item']) ? $pconfig['aliases']['item'] : array();
-                        $aliases[] = array('number' => null, 'value' => null, 'type' => null);
+                        $aliases[] = array('number' => null, 'value' => null, 'type' => null, 'noptr' => false);
 
+                        $i = 0;
                         foreach($aliases as $item): ?>
                           <tr>
                             <td>
@@ -332,13 +354,17 @@ include("head.inc");
                             <td>
                               <input name="aliases_descr[]" type="text" value="<?=$item['descr'];?>" />
                             </td>
+                            <td>
+                              <input name="aliases_ptr[]" type="checkbox" value="yes-<?=$i;?>" <?=empty($item['noptr']) ? 'checked="checked"' : '';?> />
+                            </td>
                           </tr>
 <?php
+                          $i++;
                         endforeach;?>
                         </tbody>
                         <tfoot>
                           <tr>
-                            <td colspan="4">
+                            <td colspan="5">
                               <div id="addNew" style="cursor:pointer;" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></div>
                             </td>
                           </tr>

--- a/src/www/services_unbound_host_edit.php
+++ b/src/www/services_unbound_host_edit.php
@@ -55,6 +55,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $input_errors = array();
     $pconfig = $_POST;
 
+    if(!isset($pconfig['aliases_ptr'])) {
+        $pconfig['aliases_ptr'] = array();
+    }
+
     $pconfig['aliases'] =  array();
     if (isset($pconfig['aliases_host'])) {
         $pconfig['aliases']['item'] = array();

--- a/src/www/services_unbound_overrides.php
+++ b/src/www/services_unbound_overrides.php
@@ -152,6 +152,7 @@ include_once("head.inc");
                         <td><strong><?= gettext('Type') ?></strong></td>
                         <td><strong><?= gettext('Value') ?></strong></td>
                         <td><strong><?= gettext('Description') ?></strong></td>
+                        <td><strong><?= gettext('PTR Record') ?></strong></td>
                         <td class="text-nowrap">
                           <a href="services_unbound_host_edit.php" class="btn btn-default btn-xs"><i class="fa fa-plus fa-fw"></i></a>
                         </td>
@@ -178,6 +179,7 @@ include_once("head.inc");
                           }?>
                         </td>
                         <td><?=$hostent['descr'];?></td>
+                        <td><span class="fa <?= empty($hostent['noptr']) ? 'fa-check-square-o' : 'fa-square-o';?>"></span></td>
                         <td class="text-nowrap">
                           <a href="services_unbound_host_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><i class="fa fa-pencil fa-fw"></i></a>
                           <a href="#" data-id="<?=$i;?>" class="act_delete_host btn btn-xs btn-default"><i class="fa fa-trash fa-fw"></i></a>
@@ -191,6 +193,7 @@ include_once("head.inc");
                         <td><?=strtoupper($hostent['rr']);?></td>
                         <td><?= gettext('Alias for');?> <?=$hostent['host'] ? htmlspecialchars($hostent['host'] . '.' . $hostent['domain']) : htmlspecialchars($hostent['domain']);?></td>
                         <td><?= !empty($alias['descr']) ? $alias['descr'] : $hostent['descr'] ?></td>
+                        <td><span class="fa <?= empty($hostent['noptr']) ? 'fa-check-square-o' : 'fa-square-o';?>"></span></td>
                         <td class="text-nowrap">
                           <a href="services_unbound_host_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><i class="fa fa-pencil fa-fw"></i></a>
                         </td>


### PR DESCRIPTION
**Problem:**
I don´t always need/want PTR Records for Domain Overrides.

**Solution:**
Add functionality to disable PTR Records for individual Overrides or Aliases.
Defaults to yes. So existing Overrides don’t get broken.