### PR TITLE
log: add support for additional time formats

### DIFF
--- a/src/opnsense/scripts/systemhealth/queryLog.py
+++ b/src/opnsense/scripts/systemhealth/queryLog.py
@@ -41,6 +41,8 @@ from log_helper import reverse_log_reader, fetch_clog
 import argparse
 squid_ext_timeformat = r'.*(\[\d{1,2}/[A-Za-z]{3}/\d{4}:\d{1,2}:\d{1,2}:\d{1,2} \+\d{4}\]).*'
 squid_timeformat = r'^(\d{4}/\d{1,2}/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}).*'
+freeradius_timeformat = r'^([A-Za-z]{3}\s[A-Za-z]{3}\s\d{1,2}\s\d{2}:\d{2}:\d{2}\s\d{4}\s[:]).*'
+telegraf_timeformat = r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z).*'
 
 if __name__ == '__main__':
     # handle parameters
@@ -118,6 +120,18 @@ if __name__ == '__main__':
                             ts = datetime.datetime.strptime(grp, "%Y/%m/%d %H:%M:%S")
                             record['timestamp'] = ts.isoformat()
                             record['line'] = record['line'][19:].strip()
+                        elif re.match(freeradius_timeformat, record['line']):
+                            tmp = re.match(freeradius_timeformat, record['line'])
+                            grp = tmp.group(1)
+                            ts = datetime.datetime.strptime(grp, "%a %b %d %H:%M:%S %Y :")
+                            record['timestamp'] = ts.isoformat()
+                            record['line'] = record['line'][26:].strip()
+                        elif re.match(telegraf_timeformat, record['line']):
+                            tmp = re.match(telegraf_timeformat, record['line'])
+                            grp = tmp.group(1)
+                            ts = datetime.datetime.strptime(grp, "%Y-%m-%dT%H:%M:%SZ")
+                            record['timestamp'] = ts.isoformat()
+                            record['line'] = record['line'][20:].strip()
                         result['rows'].append(record)
                     elif result['total_rows'] > offset + limit:
                         # do not fetch data until end of file...


### PR DESCRIPTION
At first i tried to change the output format of freeradius or telegraf.
But this isn't possible. (AFAIK)
So i added support for this two formats like @AdSchellevis did with squid here https://github.com/opnsense/core/commit/eed35c92b7d699ed09cb6bdbb3c277d26894d7fd
I hope this is fine :)

**Describe the bug**
The logfile of freeradius and telegraf doesn't get parsed properly since moving to the new log view opnsense/plugins#1593 - #3831

![1582004397](https://user-images.githubusercontent.com/49376203/74707396-08e3de00-521a-11ea-9aea-5794b25316e2.png)


**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'Services' -> 'FreeRADIUS' or 'Telegraf' -> 'Log File'

**Expected behavior**
![1582004430](https://user-images.githubusercontent.com/49376203/74707473-3af54000-521a-11ea-8b1e-707a71c747df.png)

**Additional context**
I created corresponding issues opnsense/plugins#1701 and opnsense/plugins#1702

**Environment**
OPNsense 20.1.1-amd64
FreeBSD 11.2-RELEASE-p16-HBSD
OpenSSL 1.1.1d 10 Sep 2019
AMD GX-412TC SOC (4 cores)
APU Board 3c4
