### PR TITLE
DHCPv6 static mappings, fix DNS registration

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -265,8 +265,20 @@ function _dnsmasq_add_host_entries()
                     }
 
                     $domain = $config['system']['domain'];
-                    if ($host['domain']) {
+                    // set domain to first entry of host's domain search list
+                    if ($host['domainsearchlist']) {
+                        $domain_array=preg_split("/[ ;]+/",$host['domainsearchlist']);
+                        $domain = $domain_array[0];
+                    // backward compatibilty: 'domain' was replaced by 'domainsearchlist'
+                    // in dhcpv6 static mappings, but may still exist in older configs
+                    } elseif ($host['domain']) {
                         $domain = $host['domain'];
+                    // set domain to first entry of interface's domain search list
+                    } elseif ($dhcpifconf['domainsearchlist']) {
+                        $domain_array=preg_split("/[ ;]+/",$dhcpifconf['domainsearchlist']);
+                        $domain = $domain_array[0];
+                    // backward compatibilty: 'domain' was removed from dhcpv6
+                    // interface settings, but may still exist in older configs
                     } elseif ($dhcpifconf['domain']) {
                         $domain = $dhcpifconf['domain'];
                     }

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -680,8 +680,20 @@ function unbound_add_host_entries()
                     }
 
                     $domain = $config['system']['domain'];
-                    if ($host['domain']) {
+                    // set domain to first entry of host's domain search list
+                    if ($host['domainsearchlist']) {
+                        $domain_array=preg_split("/[ ;]+/",$host['domainsearchlist']);
+                        $domain = $domain_array[0];
+                    // backward compatibilty: 'domain' was replaced by 'domainsearchlist'
+                    // in dhcpv6 static mappings, but may still exist in older configs
+                    } elseif ($host['domain']) {
                         $domain = $host['domain'];
+                    // set domain to first entry of interface's domain search list
+                    } elseif ($dhcpifconf['domainsearchlist']) {
+                        $domain_array=preg_split("/[ ;]+/",$dhcpifconf['domainsearchlist']);
+                        $domain = $domain_array[0];
+                    // backward compatibilty: 'domain' was removed from dhcpv6
+                    // interface settings, but may still exist in older configs
                     } elseif ($dhcpifconf['domain']) {
                         $domain = $dhcpifconf['domain'];
                     }

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -272,6 +272,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             if (!empty($pconfig['ntp2'])) {
                 $dhcpdconf['ntpserver'][] = $pconfig['ntp2'];
             }
+            // set 'domain' to first entry of 'domainsearchlist'
+            // (used only for DNS registration of static mappings)
+            if (!empty($pconfig['domainsearchlist'])) {
+                $dhcpdconf['domain'] = $domain_array[0];
+            }
             $dhcpdconf['numberoptions'] = $pconfig['numberoptions'];
 
             // copy structures back in
@@ -558,7 +563,7 @@ if (isset($config['interfaces'][$if]['dhcpd6track6allowoverride'])) {
                       <td>
                         <input name="domainsearchlist" type="text" id="domainsearchlist" value="<?=$pconfig['domainsearchlist'];?>" />
                         <div class="hidden" data-for="help_for_domainsearchlist">
-                          <?=gettext("The default is to use the domain name of this system as the domain search list option provided by DHCPv6. You may optionally specify one or multiple domain(s) here. Use the semicolon character as separator.");?>
+                          <?=gettext("The default is to use the domain name of this system as the domain search list option provided by DHCPv6. You may optionally specify one or multiple domain(s) here. Use the semicolon character as separator. The first domain in this list will also be used for DNS registration of DHCP static mappings (if enabled).");?>
                         </div>
                       </td>
                     </tr>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $pconfig['prefixrange_to'] = $config['dhcpdv6'][$if]['prefixrange']['to'];
         $pconfig['prefixrange_length'] = $config['dhcpdv6'][$if]['prefixrange']['prefixlength'];
     }
-    $config_copy_fieldsnames = array('defaultleasetime', 'maxleasetime', 'domainsearchlist', 'ddnsdomain',
+    $config_copy_fieldsnames = array('defaultleasetime', 'maxleasetime', 'domain', 'domainsearchlist', 'ddnsdomain',
         'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'bootfile_url', 'netmask',
         'numberoptions', 'dhcpv6leaseinlocaltime', 'staticmap');
     foreach ($config_copy_fieldsnames as $fieldname) {
@@ -85,6 +85,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['dns2'] = !empty($config['dhcpdv6'][$if]['dnsserver'][1]) ? $config['dhcpdv6'][$if]['dnsserver'][1] : "";
     $pconfig['ntp1'] = !empty($config['dhcpdv6'][$if]['ntpserver'][0]) ? $config['dhcpdv6'][$if]['ntpserver'][0] : "";
     $pconfig['ntp2'] = !empty($config['dhcpdv6'][$if]['ntpserver'][1]) ? $config['dhcpdv6'][$if]['ntpserver'][1] : "";
+
+    // backward compatibility: migrate 'domain' to 'domainsearchlist'
+    if (empty($pconfig['domainsearchlist'])) {
+        $pconfig['domainsearchlist'] = $pconfig['domain'];
+    }
 
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // handle identifiers and actions
@@ -271,11 +276,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
             if (!empty($pconfig['ntp2'])) {
                 $dhcpdconf['ntpserver'][] = $pconfig['ntp2'];
-            }
-            // set 'domain' to first entry of 'domainsearchlist'
-            // (used only for DNS registration of static mappings)
-            if (!empty($pconfig['domainsearchlist'])) {
-                $dhcpdconf['domain'] = $domain_array[0];
             }
             $dhcpdconf['numberoptions'] = $pconfig['numberoptions'];
 

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -45,7 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // read form data
     $pconfig = array();
-    $config_copy_fieldnames = array('duid', 'hostname', 'ipaddrv6', 'filename' ,'rootpath' ,'descr', 'domainsearchlist');
+    $config_copy_fieldnames = array('duid', 'hostname', 'ipaddrv6', 'filename' ,'rootpath' ,'descr', 'domain', 'domainsearchlist');
     foreach ($config_copy_fieldnames as $fieldname) {
         if (isset($if) && isset($id) && isset($config['dhcpdv6'][$if]['staticmap'][$id][$fieldname])) {
             $pconfig[$fieldname] = $config['dhcpdv6'][$if]['staticmap'][$id][$fieldname];
@@ -55,6 +55,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig[$fieldname] = null;
         }
     }
+
+    // backward compatibility: migrate 'domain' to 'domainsearchlist'
+    if (empty($pconfig['domainsearchlist'])) {
+        $pconfig['domainsearchlist'] = $pconfig['domain'];
+    }
+
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $input_errors = array();
     $pconfig = $_POST;
@@ -120,12 +126,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             if (!empty($pconfig[$fieldname])) {
                 $mapent[$fieldname] = $pconfig[$fieldname];
             }
-        }
-
-        // set 'domain' to first entry of 'domainsearchlist'
-        // (used only for DNS registration)
-        if (!empty($pconfig['domainsearchlist'])) {
-            $mapent['domain'] = $domain_array[0];
         }
 
         if (isset($id)) {

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -122,6 +122,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
         }
 
+        // set 'domain' to first entry of 'domainsearchlist'
+        // (used only for DNS registration)
+        if (!empty($pconfig['domainsearchlist'])) {
+            $mapent['domain'] = $domain_array[0];
+        }
+
         if (isset($id)) {
             $config['dhcpdv6'][$if]['staticmap'][$id] = $mapent;
         } else {
@@ -210,7 +216,9 @@ include("head.inc");
                     <td>
                       <input name="domainsearchlist" type="text" value="<?=$pconfig['domainsearchlist'];?>" />
                       <div class="hidden" data-for="help_for_domainsearchlist">
-                        <?=gettext("The default is to use the domain name of this system as the domain search list option provided by DHCPv6. You may optionally specify one or multiple domain(s) here. Use the semicolon character as separator.");?>
+                        <?=gettext("If you want to use a custom domain search list for this host, you may optionally specify one or multiple domain(s) here. " .
+                        "Use the semicolon character as separator. The first domain in this list will also be used for DNS registration of this host (if enabled). " .
+                        "(If empty, the first domain in the interface's domain search list will be used. If this is empty, too, the system domain will be used.)");?>
                       </div>
                     </td>
                   </tr>

--- a/src/www/services_dnsmasq.php
+++ b/src/www/services_dnsmasq.php
@@ -293,13 +293,13 @@ $( document ).ready(function() {
                   </td>
                 </tr>
                 <tr>
-                  <td><a id="help_for_regdhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Registration");?></td>
+                  <td><a id="help_for_regdhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCPv4 Registration");?></td>
                   <td>
                     <input name="regdhcp" type="checkbox" id="regdhcp" value="yes" <?=!empty($pconfig['regdhcp']) ? "checked=\"checked\"" : "";?> />
-                    <?= gettext('Register DHCP leases') ?>
+                    <?= gettext('Register DHCPv4 leases') ?>
                     <div class="hidden" data-for="help_for_regdhcp">
                       <?= gettext("If this option is set, then machines that specify " .
-                        "their hostname when requesting a DHCP lease will be registered " .
+                        "their hostname when requesting a DHCPv4 lease will be registered " .
                         "in Dnsmasq, so that their name can be resolved.") ?>
                     </div>
                   </td>
@@ -322,10 +322,10 @@ $( document ).ready(function() {
                     <input name="regdhcpstatic" type="checkbox" id="regdhcpstatic" value="yes" <?=!empty($pconfig['regdhcpstatic']) ? "checked=\"checked\"" : "";?> />
                     <?= gettext('Register DHCP static mappings') ?>
                     <div class="hidden" data-for="help_for_regdhcpstatic">
-                      <?= sprintf(gettext("If this option is set, then DHCP static mappings will ".
+                      <?= sprintf(gettext("If this option is set, then DHCPv6 and DHCPv4 static mappings will ".
                           "be registered in Dnsmasq, so that their name can be ".
                           "resolved. You should also set the domain in %s".
-                          "System: General setup%s to the proper value."),'<a href="system_general.php">','</a>');?>
+                          "System: General setup%s, in the DHCP server settings or for specific static mappings."),'<a href="system_general.php">','</a>');?>
                     </div>
                   </td>
                 </tr>

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -229,13 +229,13 @@ include_once("head.inc");
                         </td>
                       </tr>
                       <tr>
-                        <td><a id="help_for_regdhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCP Registration");?></td>
+                        <td><a id="help_for_regdhcp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DHCPv4 Registration");?></td>
                         <td>
                           <input name="regdhcp" type="checkbox" id="regdhcp" value="yes" <?=!empty($pconfig['regdhcp']) ? 'checked="checked"' : '';?> />
-                          <?= gettext('Register DHCP leases') ?>
+                          <?= gettext('Register DHCPv4 leases') ?>
                           <div class="hidden" data-for="help_for_regdhcp">
                             <?= gettext("If this option is set, then machines that specify " .
-                            "their hostname when requesting a DHCP lease will be registered " .
+                            "their hostname when requesting a DHCPv4 lease will be registered " .
                             "in Unbound, so that their name can be resolved."); ?>
                           </div>
                         </td>
@@ -258,10 +258,10 @@ include_once("head.inc");
                           <input name="regdhcpstatic" type="checkbox" id="regdhcpstatic" value="yes" <?=!empty($pconfig['regdhcpstatic']) ? 'checked="checked"' : '';?> />
                           <?= gettext('Register DHCP static mappings') ?>
                           <div class="hidden" data-for="help_for_regdhcpstatic">
-                            <?= sprintf(gettext("If this option is set, then DHCP static mappings will ".
+                            <?= sprintf(gettext("If this option is set, then DHCPv6 and DHCPv4 static mappings will ".
                                 "be registered in Unbound, so that their name can be ".
                                 "resolved. You should also set the domain in %s".
-                                "System: General setup%s to the proper value."),'<a href="system_general.php">','</a>');?>
+                                "System: General setup%s, in the DHCP server settings or for specific static mappings."),'<a href="system_general.php">','</a>');?>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
'domain' was removed in #3824 because it is not used by dhcpdv6. But it is used by unbound and dnsmasq for DNS registration of DHCP static mappings. Just set it to the first entry of the domain search list.
Closes #3945.