### PR TITLE
Fix deprecated Netscape extensions in OpenSSL config

### DIFF
--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -174,7 +174,7 @@ basicConstraints=CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-#nsComment			= "OPNsense Generated Client Certificate"
+nsComment			= "OPNsense Generated Client Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -198,7 +198,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 # Extensions for a typical CA
 
 # This will be displayed in Netscape's comment listbox.
-#nsComment			= "OPNsense Generated Certificate Authority"
+nsComment			= "OPNsense Generated Certificate Authority"
 
 # PKIX recommendation.
 
@@ -231,7 +231,7 @@ authorityKeyIdentifier=keyid:always
 basicConstraints=CA:FALSE
 
 # This will be displayed in Netscape's comment listbox.
-#nsComment			= "OPNsense Generated Certificate Revocation List"
+nsComment			= "OPNsense Generated Certificate Revocation List"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -274,8 +274,8 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 
 # Make a cert with nsCertType=server
 basicConstraints=CA:FALSE
-#nsCertType			= server
-#nsComment			= "OPNsense Generated Server Certificate"
+nsCertType			= server
+nsComment			= "OPNsense Generated Server Certificate"
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth,1.3.6.1.5.5.8.2.2
@@ -286,7 +286,7 @@ keyUsage = digitalSignature, keyEncipherment
 [ combined_server_client ]
 
 basicConstraints=CA:FALSE
-#nsComment			   = "OPNsense Generated Combined Client/Server Certificate"
+nsComment			   = "OPNsense Generated Combined Client/Server Certificate"
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage       = clientAuth,serverAuth,1.3.6.1.5.5.8.2.2
@@ -297,7 +297,7 @@ keyUsage               = nonRepudiation, digitalSignature, keyEncipherment
 
 [ sign_csr ]
 
-#nsComment              = "OPNsense Generated Certificate Signing Request"
+nsComment              = "OPNsense Generated Certificate Signing Request"
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid,issuer:always
 

--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -222,6 +222,9 @@ basicConstraints = CA:true
 # issuerAltName=issuer:copy
 authorityKeyIdentifier=keyid:always
 
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OPNsense Generated Certificate Revocation List"
+
 [ proxy_cert_ext ]
 # These extensions should be added when creating a proxy certificate
 
@@ -231,7 +234,7 @@ authorityKeyIdentifier=keyid:always
 basicConstraints=CA:FALSE
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OPNsense Generated Certificate Revocation List"
+nsComment			= "OPNsense Generated Proxy Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash

--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -174,7 +174,7 @@ basicConstraints=CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+nsComment			= "OPNsense Generated Client Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -197,6 +197,8 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # Extensions for a typical CA
 
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OPNsense Generated Certificate Authority"
 
 # PKIX recommendation.
 
@@ -229,7 +231,7 @@ authorityKeyIdentifier=keyid:always
 basicConstraints=CA:FALSE
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+nsComment			= "OPNsense Generated Certificate Revocation List"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -273,7 +275,7 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 # Make a cert with nsCertType=server
 basicConstraints=CA:FALSE
 nsCertType			= server
-nsComment			= "OpenSSL Generated Server Certificate"
+nsComment			= "OPNsense Generated Server Certificate"
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth,1.3.6.1.5.5.8.2.2
@@ -295,7 +297,7 @@ keyUsage               = nonRepudiation, digitalSignature, keyEncipherment
 
 [ sign_csr ]
 
-nsComment              = "OPNsense Generated Certificate"
+nsComment              = "OPNsense Generated Certificate Signing Request"
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid,issuer:always
 

--- a/src/etc/ssl/opnsense.cnf
+++ b/src/etc/ssl/opnsense.cnf
@@ -174,7 +174,7 @@ basicConstraints=CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OPNsense Generated Client Certificate"
+#nsComment			= "OPNsense Generated Client Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -198,7 +198,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 # Extensions for a typical CA
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OPNsense Generated Certificate Authority"
+#nsComment			= "OPNsense Generated Certificate Authority"
 
 # PKIX recommendation.
 
@@ -231,7 +231,7 @@ authorityKeyIdentifier=keyid:always
 basicConstraints=CA:FALSE
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OPNsense Generated Certificate Revocation List"
+#nsComment			= "OPNsense Generated Certificate Revocation List"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -274,8 +274,8 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 
 # Make a cert with nsCertType=server
 basicConstraints=CA:FALSE
-nsCertType			= server
-nsComment			= "OPNsense Generated Server Certificate"
+#nsCertType			= server
+#nsComment			= "OPNsense Generated Server Certificate"
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth,1.3.6.1.5.5.8.2.2
@@ -286,7 +286,7 @@ keyUsage = digitalSignature, keyEncipherment
 [ combined_server_client ]
 
 basicConstraints=CA:FALSE
-nsComment			   = "OPNsense Generated Combined Client/Server Certificate"
+#nsComment			   = "OPNsense Generated Combined Client/Server Certificate"
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage       = clientAuth,serverAuth,1.3.6.1.5.5.8.2.2
@@ -297,7 +297,7 @@ keyUsage               = nonRepudiation, digitalSignature, keyEncipherment
 
 [ sign_csr ]
 
-nsComment              = "OPNsense Generated Certificate Signing Request"
+#nsComment              = "OPNsense Generated Certificate Signing Request"
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid,issuer:always
 


### PR DESCRIPTION
This PR fixes text inconsistencies in nsComment and disables nsComment and nsCertType extensions as they are deprecated. See [OpenSSL manual](https://www.openssl.org/docs/man1.0.2/man5/x509v3_config.html) for details.

I divided this PR into two independent commits so that you could accept only the first one in case you are against disabling deprecated Netscape extensions for any reason. However, as the use of such extensions is officially discouraged and major authorities (e.g. DigiCert, Let's Encrypt) do not include them into their certificates, it seems reasonable to follow the recommendations. Those who need these extensions may always enable them manually in OpenSSL configuration file.

The tables below illustrate nsComment and nsCertType values depending on certificate type.

###### Before the proposed inconsistency fix:
| Certificate Type | nsCertType | nsComment |
| :---------------- | :----------: | :-------------- |
| CA | none | none |
| CRL | none | OpenSSL Generated Certificate |
| CSR | none | OPNsense Generated Certificate |
| Client | none | OpenSSL Generated Certificate |
| Server | server | OpenSSL Generated Server Certificate |
| Combined | none | OPNsense Generated Combined Client/Server Certificate |

###### After the proposed inconsistency fix, before disabling deprecated extensions:
| Certificate Type | nsCertType | nsComment |
| :---------------- | :----------: | :-------------- |
| CA | none | OPNsense Generated Certificate Authority |
| CRL | none | OPNsense Generated Certificate Revocation List |
| CSR | none | OPNsense Generated Certificate Signing Request |
| Client | none | OPNsense Generated Client Certificate |
| Server | server | OPNsense Generated Server Certificate |
| Combined | none | OPNsense Generated Combined Client/Server Certificate |

###### After disabling deprecated extensions:
| Certificate Type | nsCertType | nsComment |
| :---------------- | :----------: | :-------------: |
| CA | none | none |
| CRL | none | none |
| CSR | none | none |
| Client | none | none |
| Server | none | none |
| Combined | none | none |