### PR TITLE
DynDNS: Check IP Services - plugin support

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1493,7 +1493,7 @@ function dhcp6c_duid_clear()
     @unlink('/conf/dhcp6c_duid');
 }
 
-function get_dyndns_ip($int, $ipver = 4)
+function get_dyndns_ip($int, $ipver = 4, $checkip = null)
 {
     $ip_address = $ipver == 6 ? get_interface_ipv6($int) : get_interface_ip($int);
     if (empty($ip_address)) {
@@ -1504,15 +1504,20 @@ function get_dyndns_ip($int, $ipver = 4)
     if ($ipver != 6 && is_private_ip($ip_address)) {
         /* Chinese alternative is http://ip.3322.net/ */
         $hosttocheck = 'http://checkip.dyndns.org';
+        $regex = '<body>Current IP Address: (.*)</body>';
         $ip_ch = curl_init($hosttocheck);
         curl_setopt($ip_ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ip_ch, CURLOPT_INTERFACE, $ip_address);
         curl_setopt($ip_ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ip_ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ip_ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        if (is_array($checkip['curl_options'])) {
+            curl_setopt_array($ip_ch, $checkip['curl_options']);
+            $regex = $checkip['capture_regex'];
+        }
         $ip_result = curl_exec($ip_ch);
         if ($ip_result !== false) {
-            preg_match('=<body>Current IP Address: (.*)</body>=siU', $ip_result, $matches);
+            preg_match('=' . $regex . '=siU', $ip_result, $matches);
             $ip_address = trim($matches[1]);
         } else {
             log_error('Aborted IPv4 detection: ' . curl_error($ip_ch));

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -41,6 +41,18 @@ function std_bootgrid_reload(gridId) {
 
 
 /**
+ * show/hide boolean true/false
+ */
+function booleanformatter(column, row, hidetrue, hidefalse) {
+    if (parseInt(row[column.id], 2) === 1) {
+        return "<span class=\"fa fa-check "+hidetrue+"\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
+    } else {
+        return "<span class=\"fa fa-times "+hidefalse+"\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
+    }
+}
+
+
+/**
  * creates new bootgrid object and links actions to our standard templates
  * uses the following data properties to define functionality:
  *      data-editDialog : id of the edit dialog to use (  see base_dialog.volt template for details )
@@ -130,11 +142,16 @@ $.fn.UIBootgrid = function (params) {
                     }
                 },
                 "boolean": function (column, row) {
-                    if (parseInt(row[column.id], 2) === 1) {
-                        return "<span class=\"fa fa-check\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
-                    } else {
-                        return "<span class=\"fa fa-times\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
-                    }
+                    return booleanformatter(column, row, '', '');
+                },
+                "boolean-show-true": function (column, row) {
+                    return booleanformatter(column, row, '', 'hidden');
+                },
+                "boolean-show-false": function (column, row) {
+                    return booleanformatter(column, row, 'hidden', '');
+                },
+                "hyperlink": function (column, row) {
+                    return '<a target="_blank" rel="noopener noreferrer" href="'+encodeURI(row.url)+'">'+row[column.id]+'</a>'
                 },
             }
         };


### PR DESCRIPTION
Use the Check IP Services plugin if it is installed.

No functional change to the core default.
 * Optional function variable (service name, default null).
 * Capture regex as variable.
 * Only execute if the Check IP plugin is installed.

For Check IP Services - Plugin (opnsense/plugins#1731)