### PR TITLE
Allow concurrent add and delete request with alias_util API

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
@@ -177,6 +177,9 @@ class AliasUtilController extends ApiControllerBase
         $this->sessionClose();
         if ($this->request->isPost() && $this->request->hasPost("address")) {
             $address = $this->request->getPost("address");
+
+            Config::getInstance()->lock();
+
             $cnfAlias = $this->getAlias($alias);
             if ($cnfAlias !== null && in_array($cnfAlias->type, array('host', 'network'))) {
                 // update local administration, remove address when found for static types
@@ -226,6 +229,9 @@ class AliasUtilController extends ApiControllerBase
             if (preg_match("/[^0-9a-f\:\.\/_]/", $address)) {
                 return array("status" => "not_an_address");
             }
+
+            Config::getInstance()->lock();
+
             $cnfAlias = $this->getAlias($alias);
             if ($cnfAlias !== null && in_array($cnfAlias->type, array('host', 'network'))) {
                 // update local administration, add address when not found for static types


### PR DESCRIPTION
Currently the API has a strange behavior when we try to add or delete in parallel several addresses in the same alias
For example, while we want to delete multiple address  (1 request = 1 address) all the request returns a 200 OK {"status": "done »}, but some address stay in the alias content
The same logic apply for the alias_utils/add endpoint

This behavior can be reproduced with this python script
import os
import subprocess

addr_list = ["10.1.0.0", "10.1.0.1", "10.1.0.2", "10.1.0.3", "10.1.0.4",
             "10.1.0.5", "10.1.0.6", "10.1.0.7", "10.1.0.8", "10.1.0.9", "10.1.0.10"]

secret = ""
key = ""
host = ""
existing_alias = ""

for addr in addr_list:
    subprocess.Popen(
        ["curl   --header \"Content-Type: application/json\"   --basic   --user \"" + secret + ":" + key + "\"   --request POST  --data  '{\"address\":\"" + addr + "\"}' http://" + host + "/api/firewall/alias_util/add/" + existing_alias], shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)

With a lock before accessing aliases in the 2 functions, adding and removing addresses works correctly in parallel