### PR TITLE
Unboundplus: fix DoT validations

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
@@ -8,7 +8,7 @@
         </privatedomain>
         <dotservers type="CSVListField">
             <Required>N</Required>
-            <mask>/^[a-fA-F0-9\.\@]{1,46}$/</mask>
+            <mask>/^[a-fA-F0-9\.\,\:\@]{1,512}$/</mask>
         </dotservers>
     </items>
 </model>


### PR DESCRIPTION
CSVListField needs comma for validator, also 46 chars is only one v6 address without shortening.