### PR TITLE
avoid log spam #1

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng.conf.in
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng.conf.in
@@ -11,6 +11,7 @@ options {
     flush_lines(0);
     threaded(yes);
     create_dirs(yes);
+    stats-freq(0);
 };
 
 source s_all {


### PR DESCRIPTION
avoid syslog-ng dumping statistics every 10 minutes