### PR TITLE
Add AdvLinkMTU to Router Advertisements page

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -260,6 +260,13 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
             }
         }
 
+        if (!empty($dhcpv6ifconf['AdvLinkMTU'])) {
+            $overridemtu = $dhcpv6ifconf['AdvLinkMTU'];
+            if ($overridemtu < $mtu) {
+                $mtu = $overridemtu;
+            }
+        }
+
         $radvdconf .= "# Generated for DHCPv6 server $dhcpv6if\n";
         $radvdconf .= "interface {$realif} {\n";
         $radvdconf .= "\tAdvSendAdvert on;\n";

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -264,6 +264,8 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
             $overridemtu = $dhcpv6ifconf['AdvLinkMTU'];
             if ($overridemtu < $mtu) {
                 $mtu = $overridemtu;
+            } else {
+                log_error("Warning! AdvLinkMTU set in config is not lower than the interface MTU, therefore can't be applied.");
             }
         }
 

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -37,7 +37,7 @@ function val_int_in_range($value, $min, $max) {
     return (((string)(int)$value) == $value) && $value >= $min && $value <= $max;
 }
 
-$advanced_options = array('AdvDefaultLifetime', 'AdvValidLifetime', 'AdvPreferredLifetime', 'AdvRDNSSLifetime', 'AdvDNSSLLifetime', 'AdvRouteLifetime');
+$advanced_options = array('AdvDefaultLifetime', 'AdvValidLifetime', 'AdvPreferredLifetime', 'AdvRDNSSLifetime', 'AdvDNSSLLifetime', 'AdvRouteLifetime', 'AdvLinkMTU');
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (!empty($_GET['if']) && !empty($config['interfaces'][$_GET['if']])) {
         $if = $_GET['if'];
@@ -135,6 +135,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
         if (!empty($pconfig['AdvRouteLifetime']) && !val_int_in_range($pconfig['AdvRouteLifetime'], 1, 4294967295)) {
             $input_errors[] = sprintf(gettext('AdvRouteLifetime must be between %s and %s seconds.'),  1, 4294967295);
+        }
+        if (!empty($pconfig['AdvLinkMTU']) && !val_int_in_range($pconfig['AdvLinkMTU'], 1280, 8192)) {
+            $input_errors[] = sprintf(gettext('AdvLinkMTU must be between %s and %s bytes.'),  1280, 8192);
         }
     }
 


### PR DESCRIPTION
As I mentioned in #4063, some edge cases may cause instability issues on IPv6 connectivity by relying to the target interface MTU for RA. This PR adds an override to the AdvLinkMTU.