### PR TITLE
ArrayField - Don't sort unless a sort by field is provided

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ArrayField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ArrayField.php
@@ -169,11 +169,14 @@ class ArrayField extends BaseField
             $sortedData[$sortKey] = $node;
         }
 
-        // sort by key on ascending or descending order
-        if (!$descending) {
-            ksort($sortedData, $sort_flags);
-        } else {
-            krsort($sortedData, $sort_flags);
+        // proceed with sorting if at least one field name was provided
+        if ($fieldNames[0]) {
+            // sort by key on ascending or descending order
+            if (!$descending) {
+                ksort($sortedData, $sort_flags);
+            } else {
+                krsort($sortedData, $sort_flags);
+            }
         }
 
         return array_values($sortedData);


### PR DESCRIPTION
Avoids default sorting by the 'uuid' so that the default is unsorted.  i.e. config order