### PR TITLE
Reporting: Health: Inverse option applied to data series by name

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemhealthController.php
@@ -274,7 +274,7 @@ class SystemhealthController extends ApiControllerBase
                     $nan = false; // Not a NaN value, so add to list
                 }
                 if ($value != "NaN" && $applyInverse) {
-                    if ($key % 2 != 0) {
+                    if (in_array($name, array('loss', 'outpass', 'outblock', 'outpass6', 'outblock6', 'interrupt', 'processes'))) {
                         $value = $value * -1;
                     }
                 }


### PR DESCRIPTION
The inverses option is applied to data series on an odd/even basis (every other data series).
This is fine for things like packets and traffic where every other data series is in/out (odd/even).
But for quality and system the data series that are inverted make no sense.

Here the mod method of odd/even is replaced by data series names.
'loss', 'outpass', 'outblock', 'outpass6', 'outblock6', 'interrupt', 'processes'