### PR TITLE
Mirrors: Add Beijing Foreign Studies University

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/repositories/opnsense.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/repositories/opnsense.xml
@@ -104,6 +104,10 @@
             <url>http://mirror.wjcomms.co.uk/opnsense</url>
             <description>WJComms (HTTP, London, GB)</description>
         </mirror>
+        <mirror>
+            <url>https://mirrors.bfsu.edu.cn/opnsense</url>
+            <description>Beijing Foreign Studies University (HTTPS, Beijing, CN)</description>
+        </mirror>
     </mirrors>
     <flavours>
         <flavour>


### PR DESCRIPTION
Considering that this project does not have a mirror located in mainland China, which makes it difficult for users in mainland China.

We communicated with the Beijing Foreign Studies University Open Source Mirror to increase the mirror of this project.

The Beijing Foreign Studies University Open Source Mirror was established with the support of Beijing Foreign Studies University Information Technology Center and operated and maintained by TUNA Association of Tsinghua University.

Related issue (Simplified Chinese): https://github.com/tuna/issues/issues/820