### PR TITLE
Show ISP Assigned PD in status nterfaces

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1,4 +1,4 @@
-<?php
+   <?php
 
 /*
  * Copyright (C) 2015-2020 Franco Fichtner <franco@opnsense.org>
@@ -3007,7 +3007,11 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = 
     $dhcp6cscript .= "*)\n";
     $dhcp6cscript .= "\t;;\n";
     $dhcp6cscript .= "esac\n";
-
+    $dhcp6cscript .= "if [ -z \"\${PINFO}\"]; then\n";
+    $dhcp6cscript .= "rm -f /tmp/{$wanif}_pdinfo\n";
+    $dhcp6cscript .= "else\n";
+    $dhcp6cscript .= "echo \$PINFO > /tmp/{$wanif}_pdinfo\n";
+    $dhcp6cscript .= "fi\n";
     @file_put_contents("/var/etc/dhcp6c_{$interface}_script.sh", $dhcp6cscript);
     @chmod("/var/etc/dhcp6c_{$interface}_script.sh", 0755);
 

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -340,6 +340,14 @@ include("head.inc");
                     </tr>
 <?php
                     endif;
+                    if (file_exists("/tmp/{$ifinfo['if']}_pdinfo")): ?>                    
+                    <tr>
+                      <td><?= gettext("ISP assigned PD") ?></td>
+                      <td><?= file_get_contents("/tmp/{$ifinfo['if']}_pdinfo"); ?></td>
+                      
+                    </tr>  
+<?php
+                    endif;
                     if (!empty($ifinfo['gatewayv6'])): ?>
                     <tr>
                       <td><?= gettext("Gateway IPv6") ?></td>


### PR DESCRIPTION
uses the new feature within dhcp6c to display the ISPs allocated prefix. We may be able to use this rather than asking the user to enter the prefix size in interfaces.