### PR TITLE
Updated Pattern Options for IDS/IPS

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -161,7 +161,9 @@
               <BlankDesc>Default</BlankDesc>
               <OptionValues>
                   <ac>Aho-Corasick</ac>
-                  <hs>Hyperscan</hs>
+                  <ac-bs>Aho-Corasick, reduced memory implementation</ac-bs>
+                  <ac-ks>Aho-Corasick, "Ken Steele" variant</ac-ks>
+                  <hs>Hyperscan</hs>               
               </OptionValues>
               <ValidationMessage>Please select a valid pattern matcher algorithm</ValidationMessage>
             </MPMAlgo>


### PR DESCRIPTION
Adding:
Aho-Corasick, reduced memory implementation
Aho-Corasick, "Ken Steele" variant

Controls the pattern matcher algorithm. Aho–Corasick is the default. On supported platforms, Hyperscan is the best option. On commodity hardware if Hyperscan is not available the suggested setting is "Aho–Corasick Ken Steele variant" as it performs better than "Aho–Corasick".

https://github.com/opnsense/core/blob/master/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml#L1439

https://suricata.readthedocs.io/en/suricata-5.0.3/performance/tuning-considerations.html#mpm-algo-ac-hs-ac-bs-ac-ks

Documentation updated as well: https://github.com/opnsense/docs/pull/256