### PR TITLE
Further changes to multiwan Option 2.  dhcp6c Added SIGUSR2 Option

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2966,7 +2966,39 @@ function interface_dhcpv6_id($interface)
 
     return $id;
 }
+function make_dhcp6c_command($restart = 'false',$force_release = 'false')
+{
+        /* Restart after a change of debug or no release settings */
+        /* Create our command */
+    $dhcp6c_command = exec_safe(
+        '/usr/local/sbin/dhcp6c -c %s -p %s',
+        array(
+            '/var/etc/dhcp6c.conf',
+            '/var/run/dhcp6c.pid',
+        )
+    );
 
+    if (!empty($syscfg['dhcp6_debug'])) {
+        $mode = [ '1' => ' -d', '2' => ' -D' ];
+        $dhcp6c_command .= $mode[$syscfg['dhcp6_debug']];
+    }
+
+    if (!empty($syscfg['dhcp6_norelease'])) {
+        $dhcp6c_command .= ' -n';
+    }
+    
+    if($restart ==  'false') {            
+        return $dhcp6c_command;
+    } else {
+        if($force_release == 'false') {
+            killbypid('/var/run/dhcp6c.pid', 'TERM');
+        } else {
+            // Force a release as DUID has changed
+            killbypid('/var/run/dhcp6c.pid', 'SIGUSR2'); 
+        }
+        mwexec($dhcp6c_command);
+    }
+}
 function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = false)
 {
     if (!is_array($wancfg)) {
@@ -3022,22 +3054,7 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = 
     @file_put_contents("/var/etc/dhcp6c_{$interface}_script.sh", $dhcp6cscript);
     @chmod("/var/etc/dhcp6c_{$interface}_script.sh", 0755);
 
-    $dhcp6ccommand = exec_safe(
-        '/usr/local/sbin/dhcp6c -c %s -p %s',
-        array(
-            '/var/etc/dhcp6c.conf',
-            '/var/run/dhcp6c.pid',
-        )
-    );
-
-    if (!empty($syscfg['dhcp6_debug'])) {
-        $mode = [ '1' => ' -d', '2' => ' -D' ];
-        $dhcp6ccommand .= $mode[$syscfg['dhcp6_debug']];
-    }
-
-    if (!empty($syscfg['dhcp6_norelease'])) {
-        $dhcp6ccommand .= ' -n';
-    }
+    $dhcp6ccommand = make_dhcp6c_command();
 
     $dhcp6cconf = '';
 
@@ -3053,6 +3070,9 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = 
         }
 
         $dhcp6cconf .= file_get_contents("/var/etc/dhcp6c_{$_interface}.conf");
+        /* XXX interfaces are read from config XXX. MUST be removed in 20.7 XXX */ 
+        /* Else it will use the tagged on interfaces */
+        //$dhcp6ccommand .= exec_safe(' %s', get_real_interface($_interface, 'inet6'));
     }
 
     @file_put_contents('/var/etc/dhcp6c.conf', $dhcp6cconf);

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -183,6 +183,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['ipv6_duid_ll_value'] = generate_new_duid('2');
     $pconfig['ipv6_duid_uuid_value'] = generate_new_duid('3');
     $pconfig['ipv6_duid_en_value'] = generate_new_duid('4');
+    
+
+    $old_ipv6duid = $pconfig['ipv6duid'];
+    $old_dhcp6_norelease =  $pconfig['dhcp6_norelease'];
+    $old_config_dhcp6_debug = $pconfig['dhcp6_debug'];
+    
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $input_errors = array();
     $pconfig = $_POST;
@@ -247,6 +253,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         write_config();
         interface_dhcpv6_configure('duidonly', null); /* XXX refactor */
         system_arp_wrong_if();
+
+        // check if any dhcp6c settings have changed.
+        if( $old_ipv6duid != $pconfig['ipv6duid'] || $old_dhcp6_norelease != $pconfig['dhcp6_norelease'] || $old_config['dhcp6_debug'] != $pconfig['dhcp6_debug']) {
+            // Restart
+            if($old_ipv6duid != $pconfig['ipv6duid'])
+            {
+                $force_release = 'true';
+            } else {
+                $force_release = 'false';   
+            }
+            make_dhcp6c_command('true',$force_release);    
+        }
     }
 }
 


### PR DESCRIPTION
This is the same as PR 4109 with the added option of using SIGUSR2 to force a release when changing DUID. This will require the use of dhcp6c with the SIGUSR2 option added. A seperate PR has been issued for this.