### PR TITLE
firewall: Display alias description and alias content in tooltip

### DIFF
--- a/src/etc/inc/legacy_bindings.inc
+++ b/src/etc/inc/legacy_bindings.inc
@@ -152,13 +152,16 @@ function legacy_move_config_list_items($source, $id, $items)
 
 /**
  * Retrieve description text of firewall alias by specifying the alias name.
+ *
  * @param string $name alias name to retrieve the description from
+ * @param bool   $with_content (optional) return description and content if set
+ *
  * @return string|null description of alias, or null if no description was set or alias
  *   does not exist.
  */
-function get_alias_description($name)
+function get_alias_description($name, $with_content = false)
 {
-    return OPNsense\Firewall\Util::aliasDescription($name);
+    return OPNsense\Firewall\Util::aliasDescription($name, $with_content);
 }
 
 function return_gateways_status()

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -121,9 +121,11 @@ class Util
     /**
      * return alias descriptions
      * @param string $name name
+     * @param bool   $with_content (optional) return description and content if set
+     *
      * @return string
      */
-    public static function aliasDescription($name)
+    public static function aliasDescription($name,  $with_content = false)
     {
         if (empty(self::$aliasDescriptions)) {
             // read all aliases at once, and cache descriptions.
@@ -131,8 +133,18 @@ class Util
                 if (empty(self::$aliasDescriptions[$alias['name']])) {
                     if (!empty($alias['descr'])) {
                         self::$aliasDescriptions[$alias['name']] = $alias['descr'];
+                        if($with_content) {
+                            $tmp = array_slice(explode("\n", $alias['content']), 0, 10);
+                            asort($tmp);
+                            self::$aliasDescriptions[$alias['name']] .= "<br/>".implode("<br/>", $tmp);
+                        }
                     } elseif (!empty($alias['description'])) {
                         self::$aliasDescriptions[$alias['name']] = $alias['description'];
+                        if($with_content) {
+                            $tmp = array_slice(explode("\n", $alias['content']), 0, 10);
+                            asort($tmp);
+                            self::$aliasDescriptions[$alias['name']] .= "<br/>".implode("<br/>", $tmp);
+                        }
                     } elseif (!empty($alias['content'])) {
                         $tmp = array_slice(explode("\n", $alias['content']), 0, 10);
                         asort($tmp);

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -807,7 +807,7 @@ $( document ).ready(function() {
                     </td>
                     <td class="view-info">
 <?php                 if (isset($filterent['source']['address']) && is_alias($filterent['source']['address'])): ?>
-                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['address']));?>" data-toggle="tooltip"  data-html="true">
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['address'], true));?>" data-toggle="tooltip"  data-html="true">
                           <?=htmlspecialchars(pprint_address($filterent['source']));?>&nbsp;
                         </span>
                         <a href="/ui/firewall/alias/index/<?=htmlspecialchars($filterent['source']['address']);?>"
@@ -821,7 +821,7 @@ $( document ).ready(function() {
 
                     <td class="view-info hidden-xs hidden-sm">
 <?php                 if (isset($filterent['source']['port']) && is_alias($filterent['source']['port'])): ?>
-                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['port']));?>" data-toggle="tooltip"  data-html="true">
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['source']['port'], true));?>" data-toggle="tooltip"  data-html="true">
                           <?=htmlspecialchars(pprint_port($filterent['source']['port'])); ?>&nbsp;
                         </span>
                         <a href="/ui/firewall/alias/index/<?=htmlspecialchars($filterent['source']['port']);?>"
@@ -835,7 +835,7 @@ $( document ).ready(function() {
 
                     <td class="view-info hidden-xs hidden-sm">
 <?php                 if (isset($filterent['destination']['address']) && is_alias($filterent['destination']['address'])): ?>
-                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['address']));?>" data-toggle="tooltip"  data-html="true">
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['address'], true));?>" data-toggle="tooltip"  data-html="true">
                           <?=htmlspecialchars(pprint_address($filterent['destination'])); ?>
                         </span>
                         <a href="/ui/firewall/alias/index/<?=htmlspecialchars($filterent['destination']['address']);?>"
@@ -849,7 +849,7 @@ $( document ).ready(function() {
 
                     <td class="view-info hidden-xs hidden-sm">
 <?php                 if (isset($filterent['destination']['port']) && is_alias($filterent['destination']['port'])): ?>
-                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['port']));?>" data-toggle="tooltip"  data-html="true">
+                        <span title="<?=htmlspecialchars(get_alias_description($filterent['destination']['port'], true));?>" data-toggle="tooltip"  data-html="true">
                           <?=htmlspecialchars(pprint_port($filterent['destination']['port'])); ?>&nbsp;
                         </span>
                         <a href="/ui/firewall/alias/index/<?=htmlspecialchars($filterent['destination']['port']);?>"


### PR DESCRIPTION
**Before:**
![1589849905](https://user-images.githubusercontent.com/49376203/82273170-10cc2f00-997d-11ea-81d2-bddce1af811a.png)

**After:**
![1589849912](https://user-images.githubusercontent.com/49376203/82273176-16297980-997d-11ea-8117-d72a3b3b0847.png)

**Description:**
Sometimes description and content of an alias is quite useful when working on firewall rules.
Currently its only possible to display either description (if set) or the content (if description is empty) of an alias in the tooltip.

With this PR both description (if set) and content (if any) will be shown in the tooltip.

I made the parameter `with_content` optional so existing stuff doesn't break.