### PR TITLE
When enabling rules prefixed with '# ' consume the extra space

### DIFF
--- a/src/opnsense/scripts/suricata/installRules.py
+++ b/src/opnsense/scripts/suricata/installRules.py
@@ -61,12 +61,8 @@ if __name__ == '__main__':
                     and rule_info_record['metadata']['sid'] in rule_updates:
                 # search last comment marker
                 for i in range(len(rule_info_record['rule'])):
-                    if rule[i] != '#':
+                    if rule[i] not in ['#', ' ']:
                         break
-
-                #consume an extra space before generating altered rule
-                if rule[i] == ' ':
-                    i += 1
 
                 # generate altered rule
                 if 'enabled' in rule_updates[rule_info_record['metadata']['sid']]:

--- a/src/opnsense/scripts/suricata/installRules.py
+++ b/src/opnsense/scripts/suricata/installRules.py
@@ -64,6 +64,10 @@ if __name__ == '__main__':
                     if rule[i] != '#':
                         break
 
+                #consume an extra space before generating altered rule
+                if rule[i] == ' ':
+                    i += 1
+
                 # generate altered rule
                 if 'enabled' in rule_updates[rule_info_record['metadata']['sid']]:
                     # enabled / disabled in configuration


### PR DESCRIPTION
Further to the changes in https://github.com/opnsense/core/commit/38ea28d0ad24ce82ac3106e2ee9dc35088fbdb92

The installRules.py script also needs to handle an extra space in the rule. 