### PR TITLE
dhcpdv6, fix stateless mode for track6 interfaces

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1311,12 +1311,13 @@ function dhcpd_dhcp6_configure($verbose = false, $blacklist = array())
                     $dhcpdv6cfg[$ifname]['prefixrange']['to'] = Net_IPv6::compress($range['end']);
                 }
             } else {
-                /* get config entry and marry it to the live prefix */
-                $dhcpdv6cfg[$ifname]['range'] = array(
-                    'from' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['from']),
-                    'to' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['to']),
-                );
-
+                if (!empty($dhcpdv6cfg[$ifname]['range']['from']) && !empty($dhcpdv6cfg[$ifname]['range']['to'])) {
+                    /* get config entry and marry it to the live prefix */
+                    $dhcpdv6cfg[$ifname]['range'] = array(
+                        'from' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['from']),
+                        'to' => make_ipv6_64_address($ifcfgipv6, $dhcpdv6cfg[$ifname]['range']['to']),
+                    );
+                }
                 if (!empty($dhcpdv6cfg[$ifname]['prefixrange']['from']) && !empty($dhcpdv6cfg[$ifname]['prefixrange']['to'])) {
                     $pd_prefix_from_array = explode(':', $dhcpdv6cfg[$ifname]['prefixrange']['from']);
                     $pd_prefix_to_array = explode(':', $dhcpdv6cfg[$ifname]['prefixrange']['to']);


### PR DESCRIPTION
Only marry live prefix to user-specified range if range is not empty.
Bug report in the forum: https://forum.opnsense.org/index.php?topic=17423.0