### PR TITLE
Squid - Allow PURGE on cache

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -143,6 +143,15 @@ acl localnet src {{intf_item.subnet}}/{{intf_item.subnet_bits}} # Possible inter
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
 
+# ACL - Allow localhost for PURGE cache if enabled
+{% if helpers.exists('OPNsense.proxy.general.cache.local') %}
+{%  if OPNsense.proxy.general.cache.local.enabled == '1' %}
+acl PURGE method PURGE
+http_access allow localhost PURGE
+http_access deny PURGE
+{%  endif %}
+{% endif %}
+
 # ACL lists
 {% if helpers.exists('OPNsense.proxy.forward.acl.allowedSubnets') %}
 


### PR DESCRIPTION
Hello

This is a suggestion to enable the PURGE method for handling Squid cache.

Once local disk cache is enabled, the ACL is ready and at this moment on CLI:
squidclient -v -m PURGE http://....
will remove a wrong cached file

Could be available through portal and/or enhanced the current ACL to ask for authentication...

Thanks in advance for your attention.