### PR TITLE
Proxy: fix wrong button label for Download ACLs

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
@@ -428,7 +428,7 @@
                         ></button>
                         <button class="btn btn-primary" id="downloadAct"
                                 data-endpoint='/api/proxy/service/downloadacls'
-                                data-label="{{ lang._('Download ACLs & Apply') }}"
+                                data-label="{{ lang._('Download ACLs') }}"
                                 data-error-title="{{ lang._('Error fetching remote acls') }}"
                                 type="button"
                         ></button>


### PR DESCRIPTION
Fixed an issue that causes a duplicate label in https://opnsense/ui/proxy#remote_acls:
(2 x "Download ACLs & Apply instead of "Download ACLs & Apply" and "Download ACLs")

Signed-off-by: Wolfgang Hofbauer <wolfgang.hofbauer@techz.one>