### PR TITLE
dhcp6c server additions

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1127,6 +1127,9 @@ function interface_bring_down($interface = "wan", $ifacecfg = false)
 
         if (!empty(trim(@file_get_contents("/tmp/{$realifv6}_routerv6")))) {
             $pfctlflush[$realifv6] = 1;
+        } else if (!empty(trim(@file_get_contents("/tmp/{$realifv6}_serverv6")))) {
+			// XXX - might be a dhcp6c gateway
+            $pfctlflush[$realifv6] = 1;
         }
 
         $ip6 = find_interface_ipv6($realifv6);
@@ -1158,6 +1161,7 @@ function interface_bring_down($interface = "wan", $ifacecfg = false)
     @unlink("/tmp/{$realif}_router");
     @unlink("/tmp/{$realifv6}_routerv6");
     @unlink("/tmp/{$realifv6}_pdinfo");
+	@unlink("/tmp/{$realifv6}_serverv6");
 }
 
 function interfaces_ptpid_used($ptpid)
@@ -3006,6 +3010,11 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = 
     $dhcp6cscript .= "\trm -f /tmp/{$wanif}_pdinfo\n";
     $dhcp6cscript .= "else\n";
     $dhcp6cscript .= "\techo \${PDINFO} > /tmp/{$wanif}_pdinfo\n";
+    $dhcp6cscript .= "fi\n";
+	$dhcp6cscript .= "if [ -z \"\${SERVER}\" ]; then\n";
+    $dhcp6cscript .= "\trm -f /tmp/{$wanif}_pdinfo\n";
+    $dhcp6cscript .= "else\n";
+    $dhcp6cscript .= "\techo \${SERVER} > /tmp/{$wanif}_serverv6\n";
     $dhcp6cscript .= "fi\n";
     $dhcp6cscript .= "if [ -n '" . (!empty($syscfg['dhcp6_debug']) ? 'debug' : '') . "' ]; then\n";
     $dhcp6cscript .= "\t/usr/bin/logger -t dhcp6c \"dhcp6c \$REASON on {$wanif}\"\n";

--- a/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
@@ -244,6 +244,14 @@ class Gateways
                         }
                         $gwkey = $this->newKey($thisconf['priority'], !empty($thisconf['defaultgw']));
                         $this->cached_gateways[$gwkey] = $thisconf;
+                    } elseif (file_exists("/tmp/{$ifcfg['if']}_server" . $fsuffix)) {
+						// XXX: No rtsold files, try dhcp6c server files
+                        $thisconf['gateway'] = trim(@file_get_contents("/tmp/{$ifcfg['if']}_server" . $fsuffix));
+                        if (empty($thisconf['monitor_disable']) && empty($thisconf['monitor'])) {
+                            $thisconf['monitor'] = $thisconf['gateway'];
+                        }
+                        $gwkey = $this->newKey($thisconf['priority'], !empty($thisconf['defaultgw']));
+                        $this->cached_gateways[$gwkey] = $thisconf;																					 															   
                     } elseif (!empty($ifcfg['gateway_interface']) || substr($ifcfg['if'], 0, 5) == "ovpnc") {
                         // XXX: ditch ovpnc in a major upgrade in the future, supersede with interface setting
                         //      gateway_interface


### PR DESCRIPTION
These additions are to be used for testing the updated dhcp6c serverv6 function, where dhcp6c now generates an ENV VAR containing the address of the server that gave out the lease(s). This can be used where RTSOLD gets no response. Much testing is needed, but on systems where I have disabled rtsdold this works.

ref https://github.com/opnsense/dhcp6c/pull/22