### PR TITLE
Use dhcp6c 'SERVER' ENV VAR

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3010,6 +3010,11 @@ function interface_dhcpv6_prepare($interface = 'wan', $wancfg, $linkdownevent = 
     $dhcp6cscript .= "\tif [ -n \"\${PDINFO}\" ]; then\n";
     $dhcp6cscript .= "\t\techo \${PDINFO} > /tmp/{$wanif}_pdinfo\n";
     $dhcp6cscript .= "\tfi\n";
+	$dhcp6cscript .= "\tif [ ! -e /tmp/{$wanif}_routerv6 ]; then\n";
+	$dhcp6cscript .= "\t\tif [ -n \"\${SERVER}\" ]; then\n";
+	$dhcp6cscript .= "\t\t\techo \${SERVER} > /tmp/{$wanif}_routerv6\n";
+	$dhcp6cscript .= "\t\tfi\n";
+	$dhcp6cscript .= "\tfi\n";
     $dhcp6cscript .= "\t/usr/bin/logger -t dhcp6c \"dhcp6c \$REASON on {$wanif} - running newipv6\"\n";
     $dhcp6cscript .= "\t/usr/local/opnsense/service/configd_ctl.py interface newipv6 {$wanif}\n";
     $dhcp6cscript .= "\t;;\n";


### PR DESCRIPTION
This is for use with the modified dhcp6c - https://github.com/opnsense/dhcp6c/pull/22

When rtsold does not supply a *_routerv6 file, then the file will be created using the server information supplied by dhcp6c. This 'SERVER' info is obtained by taking the address that replied to dhcp6c and creating the ENV VAR 'SERVER'.