### PR TITLE
Hardening: Disable PCRE JIT in PHP config

### DIFF
--- a/src/etc/rc.subr.d/recover
+++ b/src/etc/rc.subr.d/recover
@@ -209,6 +209,7 @@ log_errors=on
 error_log=/tmp/PHP_errors.log
 date.timezone="Etc/UTC"
 session.save_path=/var/lib/php/sessions
+pcre.jit=0
 
 EOF;
 

--- a/src/opnsense/service/templates/OPNsense/WebGui/php.ini
+++ b/src/opnsense/service/templates/OPNsense/WebGui/php.ini
@@ -26,3 +26,5 @@ log_errors=on
 error_log=/tmp/PHP_errors.log
 date.timezone="{{system.timezone|default('Etc/UTC')}}"
 session.save_path=/var/lib/php/sessions
+
+pcre.jit=0

--- a/src/opnsense/service/templates/OPNsense/WebGui/php.ini
+++ b/src/opnsense/service/templates/OPNsense/WebGui/php.ini
@@ -26,5 +26,4 @@ log_errors=on
 error_log=/tmp/PHP_errors.log
 date.timezone="{{system.timezone|default('Etc/UTC')}}"
 session.save_path=/var/lib/php/sessions
-
 pcre.jit=0


### PR DESCRIPTION
PCRE's JIT is incompatible with PaX NOEXEC. In order for PaX NOEXEC to
work well with PHP, disable PCRE's JIT.

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>
Sponsored-by:	BlackhawkNest