### PR TITLE
Valid IPSec Phase 2 hash config warning raises GUI alert.

### DIFF
--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -710,7 +710,7 @@ endif; ?>
                   <td style="width:78%" class="vtable">
                     <select name="hash-algorithm-option[]" class="selectpicker" multiple="multiple">
 <?php foreach (ipsec_p2_halgos() as $algo => $algoname): ?>
-                      <option value="<?= html_safe($algo) ?>" <?= in_array($algo, $pconfig['hash-algorithm-option']) ? 'selected="selected"' : '' ?>>
+                      <option value="<?= html_safe($algo) ?>" <?= (is_array($pconfig['hash-algorithm-option']) && in_array($algo, $pconfig['hash-algorithm-option'])) ? 'selected="selected"' : '' ?>>
                         <?= html_safe($algoname) ?>
                       </option>
 <?php endforeach ?>


### PR DESCRIPTION
When AES-GCM encryption is selected the hashing algorithm should be NULL as AES-GCM has message authentication built in.

The PHP warning raised by supplying in_array() with an empty string results in warning on the dashboard that links to:

[12-Jun-2020 17:08:01 Pacific/Auckland] PHP Warning:  in_array() expects parameter 2 to be array, string given in /usr/local/www/vpn_ipsec_phase2.php on line 713