### PR TITLE
Update tcp (ACK packets only) to specifically target only ACK packets

### DIFF
--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -170,7 +170,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} recv {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack,!psh {% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     xmit {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
@@ -182,7 +182,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} xmit {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack,!psh {% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     recv {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -170,7 +170,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} recv {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack,!psh {% endif %}{%
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack iplen 52 {% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     xmit {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
@@ -182,7 +182,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} xmit {{
     physical_interface(rule.interface) }} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack,!psh {% endif %}{%
+    if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack iplen 52 {% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     recv {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
@@ -194,7 +194,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.source_not|default('0') == '1' %}not {% endif %}{{ rule.source }} to {%
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} {{rule.direction}} {%
-    if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} {%
+    if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack iplen 52 {% endif %} {%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %} via {{
     physical_interface(rule.interface)
     }} // {{ rule['@uuid'] }} {{rule.interface}}: {{helpers.getUUID(rule.target).description}}


### PR DESCRIPTION
Changed `tcpflags ack` to `tcpflags ack iplen 52` in src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf to prevent the option in firewall shaper from capturing all tcp traffic. Tested and confirmed to work on a production system with both `tcp (ACK packets only)` and `tcp (non-ACK packets)`. Change discussed and tested in #4132 with @Nimloth