### PR TITLE
Add the iplen option to shaper rules

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/TrafficShaper/forms/dialogRule.xml
@@ -29,6 +29,13 @@
         <type>dropdown</type>
     </field>
     <field>
+        <id>rule.iplen</id>
+        <label>Max Packet Length</label>
+        <advanced>true</advanced>
+        <type>text</type>
+        <help>Specifies the maximum size of packets to match in bytes</help>
+    </field>
+    <field>
         <id>rule.source</id>
         <label>Source</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
@@ -273,6 +273,12 @@
                         <gre>gre</gre>
                     </OptionValues>
                 </proto>
+                <iplen type="IntegerField">
+                    <MinimumValue>2</MinimumValue>
+                    <MaximumValue>65535</MaximumValue>
+                    <Required>N</Required>
+                    <ValidationMessage>The absolute limitation for packet size is 64K (65535 bytes)</ValidationMessage>
+                </iplen>
                 <source type="NetworkField">
                     <Required>Y</Required>
                     <FieldSeparator>,</FieldSeparator>

--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -171,6 +171,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} recv {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     xmit {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
@@ -183,6 +184,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} xmit {{
     physical_interface(rule.interface) }} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %} {{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %}{%
+    if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     recv {{physical_interface(rule.interface2)
     }} // {{ rule['@uuid'] }} {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
@@ -195,6 +197,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.destination_not|default('0') == '1' %}not {% endif %}{{rule.destination
     }} src-port  {{ rule.src_port }} dst-port {{ rule.dst_port }} {{rule.direction}} {%
     if rule.proto.split('_')[1]|default('') == 'ack' %}{{ rule.proto.split('_')[2]|default('') }} tcpflags ack {% endif %} {%
+    if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %} via {{
     physical_interface(rule.interface)
     }} // {{ rule['@uuid'] }} {{rule.interface}}: {{helpers.getUUID(rule.target).description}}


### PR DESCRIPTION
As discussed in #4132 and prompted by #528 
This change enables users to set the maximum packet length a rule should be applied to. Tested on a production system. 