### PR TITLE
Multi-WAN Failover

### DIFF
--- a/src/etc/rc.syshook.d/monitor/10-dpinger
+++ b/src/etc/rc.syshook.d/monitor/10-dpinger
@@ -35,6 +35,6 @@ fi
 /usr/bin/logger -t dpinger "GATEWAY ALARM: ${GATEWAY} (Addr: ${2} Alarm: ${3} RTT: ${4}ms RTTd: ${5}ms Loss: ${6}%)"
 
 echo -n "Reloading filter: "
-configctl filter reload
+/usr/local/sbin/configctl filter reload
 
 exit 0


### PR DESCRIPTION
An issue has been identified in issue 4160 whereby when dpinger detects a failure the gateway is not switching.  Although the script 10-dpinger is called the call to 'configctl filter reload' does not function, changing this to give the full path to configctl appears to fix the issue.