### PR TITLE
Fix missing data in dashboard temperature widget.

### DIFF
--- a/src/www/widgets/api/plugins/temperature.inc
+++ b/src/www/widgets/api/plugins/temperature.inc
@@ -32,7 +32,7 @@
 function temperature_api()
 {
     $result = array();
-    exec('/sbin/sysctl -a | grep -E "(dev|hw)[^[:space:]]+temperature:"', $sysctlOutput);
+    exec('/sbin/sysctl -a | grep -E "(dev.cpu|hw.acpi.thermal)\.[^[:space:]]+temperature:"', $sysctlOutput);
     foreach ($sysctlOutput as $sysctl) {
         $parts = explode(':', $sysctl);
         if (count($parts) >= 2) {

--- a/src/www/widgets/api/plugins/temperature.inc
+++ b/src/www/widgets/api/plugins/temperature.inc
@@ -32,7 +32,7 @@
 function temperature_api()
 {
     $result = array();
-    exec("/sbin/sysctl -a | grep temperature", $sysctlOutput);
+    exec("/sbin/sysctl -a | grep temperature:", $sysctlOutput);
     foreach ($sysctlOutput as $sysctl) {
         $parts = explode(':', $sysctl);
         if (count($parts) >= 2) {

--- a/src/www/widgets/api/plugins/temperature.inc
+++ b/src/www/widgets/api/plugins/temperature.inc
@@ -32,7 +32,7 @@
 function temperature_api()
 {
     $result = array();
-    exec("/sbin/sysctl -a | grep temperature:", $sysctlOutput);
+    exec('/sbin/sysctl -a | grep -E "(dev|hw)[^[:space:]]+temperature:"', $sysctlOutput);
     foreach ($sysctlOutput as $sysctl) {
         $parts = explode(':', $sysctl);
         if (count($parts) >= 2) {


### PR DESCRIPTION
In certain circumstances (doesn't seem to happen for all), temperature widget on the dashboard does not show temperature values. Temperature readings correctly show in other logging areas.

Cause is grep in temperature plugin API returning extraneous rows (web request logging) that are not device readings. This, in turn, causes an error in the JQuery call on the widget.

Change is to tighten grep selection in the API to only return the appropriate rows.

See [No temperature data on Thermal Sensor widget after upgrade to 20.7.1](https://forum.opnsense.org/index.php?topic=18626).

