### PR TITLE
Add zone declarations of additional pools in dhcpd.conf - Fix for #4356

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -873,6 +873,14 @@ EOPP;
                     && (empty($dhcpifconf['ddnsdomain']) || $poolconf['ddnsdomain'] != $dhcpifconf['ddnsdomain'])
                 ) {
                     $pdnscfg .= "    ddns-domainname \"{$poolconf['ddnsdomain']}\";\n";
+
+                    $newddnszone = array();
+                    $newddnszone['domain-name'] = $poolconf['ddnsdomain'];
+                    $newddnszone['dns-servers'] = array($poolconf['ddnsdomainprimary']);
+                    $newddnszone['ddnsdomainkeyname'] = $poolconf['ddnsdomainkeyname'];
+                    $newddnszone['ddnsdomainkey'] = $poolconf['ddnsdomainkey'];
+                    $newddnszone['ddnsdomainalgorithm'] = !empty($poolconf['ddnsdomainalgorithm']) ? $poolconf['ddnsdomainalgorithm'] : "hmac-md5";
+                    $ddns_zones[] = $newddnszone;
                 }
                 $pdnscfg .= "    ddns-update-style interim;\n";
             }


### PR DESCRIPTION
Relating to #4356, when defining additional pools with DDNS values, the corresponding zone and key declarations were not added to /var/dhcpd/etc/dhcpd.conf
This will add zone and key declarations to dhcpd.conf based on DDNS values provided in each additional pool within a subnet.
