### PR TITLE
Add toggle for pinger service in proxy settings

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -121,6 +121,13 @@
                 <help>Select what to do with URI that contain whitespaces. The current Squid implementation of encode and chop violates RFC2616 by not using a 301 redirect after altering the URL.</help>
                 <advanced>true</advanced>
             </field>
+            <field>
+                <id>proxy.general.enablePinger</id>
+                <label>Enable pinger</label>
+                <type>checkbox</type>
+                <help>Toggles the Squid pinger service. This service is used in the selection of the best parent proxy.</help>
+                <advanced>true</advanced>
+            </field>
         </subtab>
         <subtab id="proxy-general-cache-local" description="Local Cache Settings">
             <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -81,6 +81,10 @@
                     <chop>Chop URI at first whitespace</chop>
                 </OptionValues>
             </uriWhitespaceHandling>
+            <enablePinger type="BooleanField">
+                <default>1</default>
+                <Required>Y</Required>
+            </enablePinger>
             <useViaHeader type="BooleanField">
                 <default>1</default>
                 <Required>N</Required>

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -356,7 +356,12 @@ refresh_pattern .		0	20%	4320
 dns_v4_first on
 {%      endif %}
 {% endif %}
-
+{% if helpers.exists('OPNsense.proxy.general.enablePinger') %}
+{%      if OPNsense.proxy.general.enablePinger == '0' %}
+# Disable the pinger service
+pinger_enable off
+{%      endif %}
+{% endif %}
 {% if helpers.exists('OPNsense.proxy.general.logging.enable.accessLog') %}
 {%      if OPNsense.proxy.general.logging.enable.accessLog == '0' %}
 # Disable access logging


### PR DESCRIPTION
This adds a checkbox to allow the pinger service in squid to be disabled. It edits the squid.conf to add 'pinger_enable off' which is currently on be default. The pinger service seems to be only really required when using peer / parent proxy.

I raised a question on the forum:
[https://forum.opnsense.org/index.php?topic=19289.0](https://forum.opnsense.org/index.php?topic=19289.0)

Squid doco:
[http://www.squid-cache.org/Doc/config/query_icmp/](http://www.squid-cache.org/Doc/config/query_icmp/)
[http://www.squid-cache.org/Doc/config/pinger_enable/ ](http://www.squid-cache.org/Doc/config/pinger_enable/ )

I'm really new to git, github, and programming in general, so accept apologies if I have gone about this the wrong way, and feel free to delete.