### PR TITLE
firewall: live view improvments

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php
@@ -74,8 +74,10 @@ class FirewallController extends ApiControllerBase
                 } elseif ((string)$node->if == 'openvpn') {
                     continue;
                 }
-                $interfaces[] = !empty((string)$node->descr) ? (string)$node->descr : $key;
+                $interfaces[$key] = !empty((string)$node->descr) ? (string)$node->descr : $key;
             }
+            natcasesort($interfaces);
+            $interfaces = array_values($interfaces);
         }
 
         return [

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -428,7 +428,6 @@
                                     <option value="dstport">{{ lang._('dst_port') }}</option>
                                     <option value="protoname">{{ lang._('protoname') }}</option>
                                     <option value="label">{{ lang._('label') }}</option>
-                                    <option value="dst">{{ lang._('dst') }}</option>
                                     <option value="rid">{{ lang._('rule id') }}</option>
                                     <option value="tcpflags">{{ lang._('tcpflags') }}</option>
                                 </select>

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -278,6 +278,10 @@
                         this_condition_match = false;
                     } else if (filter_condition === '~' && !this_data[filter_tag].toLowerCase().match(filter_value)) {
                         this_condition_match = false;
+                    } else if (filter_condition === '!=' && this_data[filter_tag].toLowerCase() == filter_value) {
+                        this_condition_match = false;
+                    } else if (filter_condition === '!~' && this_data[filter_tag].toLowerCase().match(filter_value)) {
+                        this_condition_match = false;
                     }
 
                     if (!this_condition_match && !filter_or_type) {
@@ -436,6 +440,8 @@
                                 <select id="filter_condition" class="condition"  data-width="120px">
                                     <option value="~" selected=selected>{{ lang._('contains') }}</option>
                                     <option value="=">{{ lang._('is') }}</option>
+                                    <option value="!~">{{ lang._('does not contain') }}</option>
+                                    <option value="!=">{{ lang._('is not') }}</option>
                                 </select>
                               </td>
                               <td>

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -430,6 +430,7 @@
                                     <option value="srcport">{{ lang._('src_port') }}</option>
                                     <option value="dst">{{ lang._('dst') }}</option>
                                     <option value="dstport">{{ lang._('dst_port') }}</option>
+                                    <option value="proto">{{ lang._('proto') }}</option>
                                     <option value="protoname">{{ lang._('protoname') }}</option>
                                     <option value="label">{{ lang._('label') }}</option>
                                     <option value="rid">{{ lang._('rule id') }}</option>


### PR DESCRIPTION
Add:
- `does not contain` filter condition
- `is not` filter condition
- `proto` filter

Changed:
- Sorting of `interface_name`

Remove:
- Duplicate `dst` entry in `filter_tag` list

Closes: https://github.com/opnsense/core/issues/4299 and https://github.com/opnsense/core/issues/4365 point 3

**Work in Progress**