### PR TITLE
firewall_nat_edit.php display bug fix

### DIFF
--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -539,7 +539,7 @@ $( document ).ready(function() {
                       <select name="interface[]" class="selectpicker" data-width="auto" data-live-search="true" multiple="multiple">
 <?php
                         foreach (legacy_config_get_interfaces(array("enable" => true)) as $iface => $ifdetail): ?>
-                        <option value="<?=$iface;?>" <?= in_array($iface, $pconfig['interface']) ? "selected=\"selected\"" : ""; ?>>
+                        <option value="<?=$iface;?>" <?= in_array($iface, $pconfig['interface']?:[]) ? "selected=\"selected\"" : ""; ?>>
                           <?=htmlspecialchars($ifdetail['descr']);?>
                         </option>
                         <?php endforeach; ?>

--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -539,7 +539,7 @@ $( document ).ready(function() {
                       <select name="interface[]" class="selectpicker" data-width="auto" data-live-search="true" multiple="multiple">
 <?php
                         foreach (legacy_config_get_interfaces(array("enable" => true)) as $iface => $ifdetail): ?>
-                        <option value="<?=$iface;?>" <?= in_array($iface, $pconfig['interface']?:[]) ? "selected=\"selected\"" : ""; ?>>
+                        <option value="<?=$iface;?>" <?= in_array($iface, $pconfig['interface'] ? : []) ? "selected=\"selected\"" : ""; ?>>
                           <?=htmlspecialchars($ifdetail['descr']);?>
                         </option>
                         <?php endforeach; ?>


### PR DESCRIPTION
If interface is not set, it will throw warning in POST page, because $pconfig['ipprotocol'] is not predefined as array like GET.
PHP Warning:  in_array() expects parameter 2 to be array, null given in /usr/local/www/firewall_nat_edit.php on line 542