### PR TITLE
Auth/LDAP: Fix reading displayName attribute

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -376,8 +376,8 @@ class LDAP extends Base implements IAuthConnector
                                 'name' => $searchResults[$i][$ldapAttr][0],
                                 'dn' => $searchResults[$i]['dn']
                             );
-                            if (!empty($searchResults[$i]['displayName'][0])) {
-                                $user['fullname'] = $searchResults[$i]['displayName'][0];
+                            if (!empty($searchResults[$i]['displayname'][0])) {
+                                $user['fullname'] = $searchResults[$i]['displayname'][0];
                             } elseif (!empty($searchResults[$i]['cn'][0])) {
                                 $user['fullname'] = $searchResults[$i]['cn'][0];
                             } elseif (!empty($searchResults[$i]['name'][0])) {


### PR DESCRIPTION
In 6f76b5f the displayName attribute was added as the first camel case
attribute being read from the search result. As various[^1] comments[^2]
for `ldap_search` mention the attribute names must be lower case, even
though the LDAP server might return them differently.

Using all lower case to access the returned attribute results in the
value of displayName actually being used as the full name of the user.

[^1]: https://www.php.net/manual/en/function.ldap-search.php#37317
[^2]: https://www.php.net/manual/en/function.ldap-search.php#28991