### PR TITLE
Hopeful fix for #4423 - Incorrect parsing of DUID in dhcpd6.leases.

### DIFF
--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -67,6 +67,7 @@ function parse_duid($duid_string)
             $n = substr($duid_string, $i+1, 1);
             if (($n == '\\') || ($n == '"')) {
                 $parsed_duid[] = sprintf("%02x", ord($n));
+                $i += 1;
             } elseif (is_numeric($n)) {
                 $parsed_duid[] = sprintf("%02x", octdec(substr($duid_string, $i+1, 3)));
                 $i += 3;


### PR DESCRIPTION
This is a *hopeful* fix for Issue #4423. I've only tested the code in isolation (not in opnsense itself!), but I hopefully it should fix the issue. Please make sure to test before merging.