### PR TITLE
Add GSuite and Youtube filtering in proxy

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -433,6 +433,21 @@
                 <advanced>true</advanced>
             </field>
             <field>
+                <id>proxy.forward.acl.googleapps</id>
+                <label>Google GSuite restricted</label>
+                <type>text</type>
+                <advanced>true</advanced>
+                <help><![CDATA[Insert here the domain that will be allowed to use Google GSuite.
+                All accounts that are not in this domain will be blocked to use it.]]></help>
+            </field>
+            <field>
+                <id>proxy.forward.acl.youtube</id>
+                <label>YouTube Filter</label>
+                <type>dropdown</type>
+                <advanced>true</advanced>
+                <help><![CDATA[Select the Youtube filter level.]]></help>
+            </field>
+            <field>
                 <id>proxy.forward.acl.safePorts</id>
                 <label>Allowed destination TCP port</label>
                 <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -389,6 +389,18 @@
                 <mimeType type="CSVListField">
                     <Required>N</Required>
                 </mimeType>
+                <googleapps type="TextField">
+                    <Required>N</Required>
+                    <mask>/^([a-zA-Z0-9]){0,}\.([a-zA-Z0-9].){0,}/</mask>
+                    <ValidationMessage>Please enter a valid domain name here</ValidationMessage>
+                </googleapps>
+                <youtube type="OptionField">
+                    <Required>N</Required>
+                    <OptionValues>
+                        <strict>Strict</strict>
+                        <moderate>Moderate</moderate>
+                    </OptionValues>
+                </youtube>
                 <safePorts type="CSVListField">
                     <default>80:http,21:ftp,443:https,70:gopher,210:wais,1025-65535:unregistered ports,280:http-mgmt,488:gss-http,591:filemaker,777:multiling http</default>
                     <mask>/^([ \-0-9a-zA-Z:,])*/u</mask>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -389,7 +389,7 @@
                 <mimeType type="CSVListField">
                     <Required>N</Required>
                 </mimeType>
-                <googleapps type="TextField">
+                <googleapps type="HostnameField">
                     <Required>N</Required>
                     <mask>/^([a-zA-Z0-9]){0,}\.([a-zA-Z0-9].){0,}/</mask>
                     <ValidationMessage>Please enter a valid domain name here</ValidationMessage>

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -101,7 +101,6 @@ http_access deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.fo
 
 # Google Suite Filter
 {% if helpers.exists('OPNsense.proxy.forward.acl.googleapps') and OPNsense.proxy.forward.acl.googleapps|default('') != '' %}
-acl gsuite_{{rule.sequence}} src {{source}}
 request_header_add X-GoogApps-Allowed-Domains {{OPNsense.proxy.forward.acl.googleapps}} localnet
 {%    endif %}
 

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -102,12 +102,12 @@ http_access deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.fo
 # Google Suite Filter
 {% if not helpers.empty('OPNsense.proxy.forward.acl.googleapps') %}
 OPNsense.proxy.forward.acl.googleapps|default('') != '' %}
-request_header_add X-GoogApps-Allowed-Domains {{OPNsense.proxy.forward.acl.googleapps}} localnet
+request_header_add X-GoogApps-Allowed-Domains {{OPNsense.proxy.forward.acl.googleapps}}
 {%    endif %}
 
 # YouTube Filter
 {% if helpers.exists('OPNsense.proxy.forward.acl.youtube') and OPNsense.proxy.forward.acl.youtube|default('') != '' %}
-request_header_add YouTube-Restrict {{OPNsense.proxy.forward.acl.youtube}}  localnet
+request_header_add YouTube-Restrict {{OPNsense.proxy.forward.acl.youtube}}
 {%    endif %}
 
 # Deny requests to certain unsafe ports

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -100,7 +100,8 @@ http_access deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.fo
 {% endif %}
 
 # Google Suite Filter
-{% if helpers.exists('OPNsense.proxy.forward.acl.googleapps') and OPNsense.proxy.forward.acl.googleapps|default('') != '' %}
+{% if not helpers.empty('OPNsense.proxy.forward.acl.googleapps') %}
+OPNsense.proxy.forward.acl.googleapps|default('') != '' %}
 request_header_add X-GoogApps-Allowed-Domains {{OPNsense.proxy.forward.acl.googleapps}} localnet
 {%    endif %}
 

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -99,6 +99,17 @@ http_access deny blockmimetypes_requests {% if helpers.exists('OPNsense.proxy.fo
 
 {% endif %}
 
+# Google Suite Filter
+{% if helpers.exists('OPNsense.proxy.forward.acl.googleapps') and OPNsense.proxy.forward.acl.googleapps|default('') != '' %}
+acl gsuite_{{rule.sequence}} src {{source}}
+request_header_add X-GoogApps-Allowed-Domains {{OPNsense.proxy.forward.acl.googleapps}} localnet
+{%    endif %}
+
+# YouTube Filter
+{% if helpers.exists('OPNsense.proxy.forward.acl.youtube') and OPNsense.proxy.forward.acl.youtube|default('') != '' %}
+request_header_add YouTube-Restrict {{OPNsense.proxy.forward.acl.youtube}}  localnet
+{%    endif %}
+
 # Deny requests to certain unsafe ports
 {% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
 {%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}


### PR DESCRIPTION
This adds:

- Google Suite personal accounts blocking: when enabled, block any account outside of the specified domain. Very useful to limit access to Google Drive, Gmail inside corporate networks. (ref.: https://support.google.com/a/answer/1668854?hl=en)
- Youtube: Strict and Moderate modes to avoid young people access some videos with violent or sexual content. Very popular in schools networks. (ref.: https://support.google.com/a/answer/6212415?hl=en) 

**Both requires SSL interception enabled!**
