### PR TITLE
Fix OpenVPN dynamic gateway detection

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn/ovpn-linkup
+++ b/src/etc/inc/plugins.inc.d/openvpn/ovpn-linkup
@@ -8,7 +8,8 @@ if [ -n "${route_vpn_gateway}" ]; then
 elif [ -n "${ifconfig_remote}" ]; then
 	/bin/echo ${ifconfig_remote} > /tmp/$1_router
 elif [ -n "${ifconfig_local}" ]; then
-	/bin/echo ${ifconfig_local} > /tmp/$1_router
+	vpn_subnet=`/bin/echo ${ifconfig_local} | /usr/bin/cut -d'.' -f 1-3`
+	/bin/echo $vpn_subnet".1" > /tmp/$1_router
 elif [ "${dev_type}" = "tun" ]; then
 	/bin/echo ${5} > /tmp/${1}_router
 fi


### PR DESCRIPTION
This is a quick hack to fix OpenVPN dynamic gateway detection for 99% of the cases. It is highly unlikely someone has a VPN gateway on their own local tunnel IP / loopback. The gateway usually is the .1 address on the same subnet as the client, this fix will help in that case. If this is not the case, a proper parser should be written (which could be overkill for simple use cases).