### PR TITLE
Properly halt instead of poweroff

### DIFF
--- a/src/etc/rc.halt
+++ b/src/etc/rc.halt
@@ -2,4 +2,4 @@
 
 /usr/local/etc/rc.syshook stop
 
-exec /sbin/shutdown -op now
+exec /sbin/shutdown -oh now


### PR DESCRIPTION
When using UPS it is better to halt (as the name suggests) in case of powerloss instead of poweroff. This way the appliance will halt when the power is low, but will be able to restart when power returns. (If it is powered off it will not reboot by itself when power returns.)