### PR TITLE
Allow hyphen '-' in aliases

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasNameField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasNameField.php
@@ -87,8 +87,8 @@ class AliasNameField extends BaseField
             $validators[] = new Regex(array(
                 'message' => sprintf(gettext(
                     'The name must be less than 32 characters long and may only consist of the following characters: %s'
-                ), 'a-z, A-Z, 0-9, _'),
-                'pattern' => '/[_0-9a-zA-z]{1,31}/'));
+                ), 'a-z, A-Z, 0-9, _, -'),
+                'pattern' => '/[_0-9a-zA-z-]{1,31}/'));
             $validators[] = new CallbackValidator(
                 [
                     "callback" => function ($value) {


### PR DESCRIPTION
Allow the hyphen '-' in aliases. This has been tested in aliases and nested aliases in firewall rules. This is adding the hyphen and not using HostnameField validation for backwards compatibility with existing aliases.

This feature was requested in forum post below:
https://forum.opnsense.org/index.php?topic=6468.msg27746#msg27746