### PR TITLE
DHCPv4: Removed the need for a static IP being outside of the pool

### DIFF
--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -140,27 +140,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     $parent_net = find_interface_network(get_real_interface($if));
 
-    /* make sure it's not within the dynamic subnet */
-    if (!empty($pconfig['ipaddr'])) {
-        $dynsubnet_start = ip2ulong($config['dhcpd'][$if]['range']['from']);
-        $dynsubnet_end = ip2ulong($config['dhcpd'][$if]['range']['to']);
-        if (ip2ulong($pconfig['ipaddr']) >= $dynsubnet_start && ip2ulong($pconfig['ipaddr']) <= $dynsubnet_end) {
-            $input_errors[] = sprintf(gettext("The IP address must not be within the DHCP range for this interface."));
-        }
-
-        if (!empty($config['dhcpd'][$if]['pool'])) {
-            foreach ($config['dhcpd'][$if]['pool'] as $pidx => $p) {
-                if (is_inrange_v4($pconfig['ipaddr'], $p['range']['from'], $p['range']['to'])) {
-                    $input_errors[] = gettext("The IP address must not be within the range configured on a DHCP pool for this interface.");
-                    break;
-                }
-            }
-        }
-
-        if (!ip_in_subnet($pconfig['ipaddr'], $parent_net)) {
-            $ifcfgdescr = convert_friendly_interface_to_friendly_descr($if);
-            $input_errors[] = sprintf(gettext('The IP address must lie in the %s subnet.'), $ifcfgdescr);
-        }
+    if (!ip_in_subnet($pconfig['ipaddr'], $parent_net)) {
+        $ifcfgdescr = convert_friendly_interface_to_friendly_descr($if);
+        $input_errors[] = sprintf(gettext('The IP address must lie in the %s subnet.'), $ifcfgdescr);
     }
 
     if (!empty($pconfig['gateway']) && !is_ipaddrv4($pconfig['gateway'])) {
@@ -341,7 +323,7 @@ include("head.inc");
                   <td>
                     <input name="ipaddr" type="text" value="<?=$pconfig['ipaddr'];?>" />
                     <div class="hidden" data-for="help_for_ipaddr">
-                      <?=gettext("If an IPv4 address is entered, the address must be outside of the pool.");?>
+                      <?=gettext("If an IPv4 address is entered, the address must be within the interface subnet.");?>
                       <br />
                       <?=gettext("If no IPv4 address is given, one will be dynamically allocated from the pool.");?>
                     </div>

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -140,9 +140,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     $parent_net = find_interface_network(get_real_interface($if));
 
-    if (!ip_in_subnet($pconfig['ipaddr'], $parent_net)) {
-        $ifcfgdescr = convert_friendly_interface_to_friendly_descr($if);
-        $input_errors[] = sprintf(gettext('The IP address must lie in the %s subnet.'), $ifcfgdescr);
+    if (!empty($pconfig['ipaddr'])) {
+      if (!ip_in_subnet($pconfig['ipaddr'], $parent_net)) {
+          $ifcfgdescr = convert_friendly_interface_to_friendly_descr($if);
+          $input_errors[] = sprintf(gettext('The IP address must lie in the %s subnet.'), $ifcfgdescr);
+      }
     }
 
     if (!empty($pconfig['gateway']) && !is_ipaddrv4($pconfig['gateway'])) {


### PR DESCRIPTION
As we had the discussion on the forum in the last days, I had a look at the software OPNsense is using as DHCP server. As it turns out it is ISC DHCP, so there is no need to keep the static leases outside of the pool.
Just removed the check from the PHP file and changed one description in line 326 (do I need to do something about translations here?).

Copied the file to my test OPNsense and I was able to set a static lease within the pool. Client was receiving the correct IP.

Old line 144 was not needed anymore as we're already checking this in line 117.