### PR TITLE
Change dpinger syslog message to reflect correct RTT and RTTd unit

### DIFF
--- a/src/etc/rc.syshook.d/monitor/10-dpinger
+++ b/src/etc/rc.syshook.d/monitor/10-dpinger
@@ -32,7 +32,7 @@ if [ -z "${GATEWAY}" ]; then
 	exit 1
 fi
 
-/usr/bin/logger -t dpinger "GATEWAY ALARM: ${GATEWAY} (Addr: ${2} Alarm: ${3} RTT: ${4}ms RTTd: ${5}ms Loss: ${6}%)"
+/usr/bin/logger -t dpinger "GATEWAY ALARM: ${GATEWAY} (Addr: ${2} Alarm: ${3} RTT: ${4}us RTTd: ${5}us Loss: ${6}%)"
 
 echo -n "Reloading filter: "
 configctl filter reload gateway


### PR DESCRIPTION
Dpinger actually reports RTT and RTTd in µs.