### PR TITLE
DHCPv6: Fix sorting of IPv6 static mappings

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1187,20 +1187,8 @@ function check_subnets_overlap($subnet1, $bits1, $subnet2, $bits2)
     return ($sn1 == $sn2);
 }
 
-/* compare two IPv4 addresses */
+/* compare two IP addresses */
 function ipcmp($a, $b)
-{
-    if (ip_less_than($a, $b)) {
-        return -1;
-    } elseif (ip_greater_than($a, $b)) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
-/* compare two IPv6 addresses */
-function ip6cmp($a, $b)
 {
     $na = inet_pton($a);
     $nb = inet_pton($b);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1187,12 +1187,26 @@ function check_subnets_overlap($subnet1, $bits1, $subnet2, $bits2)
     return ($sn1 == $sn2);
 }
 
-/* compare two IP addresses */
+/* compare two IPv4 addresses */
 function ipcmp($a, $b)
 {
     if (ip_less_than($a, $b)) {
         return -1;
     } elseif (ip_greater_than($a, $b)) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+/* compare two IPv6 addresses */
+function ip6cmp($a, $b)
+{
+    $na = inet_pton($a);
+    $nb = inet_pton($b);
+    if ($na < $nb) {
+        return -1;
+    } elseif ($na > $b) {
         return 1;
     } else {
         return 0;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1194,7 +1194,7 @@ function ipcmp($a, $b)
     $nb = inet_pton($b);
     if ($na < $nb) {
         return -1;
-    } elseif ($na > $b) {
+    } elseif ($na > $nb) {
         return 1;
     } else {
         return 0;

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -135,7 +135,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
 
         usort($config['dhcpdv6'][$if]['staticmap'], function ($a, $b) {
-            return ip6cmp($a['ipaddrv6'], $b['ipaddrv6']);
+            return ipcmp($a['ipaddrv6'], $b['ipaddrv6']);
         });
 
         write_config();

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -135,7 +135,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
 
         usort($config['dhcpdv6'][$if]['staticmap'], function ($a, $b) {
-            return ipcmp($a['ipaddrv6'], $b['ipaddrv6']);
+            return ip6cmp($a['ipaddrv6'], $b['ipaddrv6']);
         });
 
         write_config();


### PR DESCRIPTION
**Issue:**
The DHCPv6 static mappings are shown in the order they were added. Sorting code exists but won't work. 

**Reason:**
The ipcmp() function doesn't seem to return a correct result for IPv6 addresses. 

**Solution:**
Introduce ip6cmp() function and fix sorting of IPv6 static mappings.

**Version:**
OPNsense 20.7.6