### PR TITLE
DHCP: Fix sorting of leases

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3772,21 +3772,20 @@ function guess_interface_from_ip($ipaddress)
         /* create a route table we can search */
         exec("/usr/bin/netstat -rnWf inet", $output, $ret);
         foreach ($output as $line) {
-            if (preg_match("/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+[ ]+link[#]/", $line)) {
-                $fields = preg_split("/[ ]+/", $line);
+            $fields = preg_split("/[ ]+/", $line);
+            if (is_subnetv4($fields[0])) {
                 if (ip_in_subnet($ipaddress, $fields[0])) {
                     return $fields[5];
-                }
+                }                
             }
         }
     }
-    /* FIXME: This works from cursory testing, regexp might need fine tuning */
     if (is_ipaddrv6($ipaddress)) {
         /* create a route table we can search */
         exec("/usr/bin/netstat -rnWf inet6", $output, $ret);
         foreach ($output as $line) {
-            if (preg_match("/[0-9a-f]+[:]+[0-9a-f]+[:]+[\/][0-9]+/", $line)) {
-                $fields = preg_split("/[ ]+/", $line);
+            $fields = preg_split("/[ ]+/", $line);
+            if (is_subnetv6($fields[0])) {
                 if (ip_in_subnet($ipaddress, $fields[0])) {
                     return $fields[5];
                 }

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -246,19 +246,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
 
-    usort($leases,
-        function ($a, $b) use ($order) {
-            if ($order === 'ip') {
+    if ($order === 'ip') {
+        usort($leases, function ($a, $b) {
+            return ipcmp($a['ip'], $b['ip']);
+        });
+    } else {
+        usort($leases, function ($a, $b) use ($order) {
+            $cmp = strnatcasecmp($a[$order], $b[$order]);
+            if ($cmp === 0) {
                 $cmp = ipcmp($a['ip'], $b['ip']);
-            } else {
-                $cmp = strnatcasecmp($a[$order], $b[$order]);
-                if ($cmp === 0) {
-                    $cmp = ipcmp($a['ip'], $b['ip']);
-                }
             }
             return $cmp;
-        }
-    );
+        });
+    }
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         killbypid('/var/dhcpd/var/run/dhcpd.pid', 'TERM', true);

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -384,7 +384,7 @@ legacy_html_escape_form_data($leases);
             <table class="table table-striped">
               <thead>
                 <tr>
-                    <td><?=gettext("Interface"); ?></td>
+                    <td class="act_sort" data-field="int"><?=gettext("Interface"); ?></td>
                     <td class="act_sort" data-field="ip"><?=gettext("IP address"); ?></td>
                     <td class="act_sort" data-field="mac"><?=gettext("MAC address"); ?></td>
                     <td class="act_sort" data-field="hostname"><?=gettext("Hostname"); ?></td>

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -248,9 +248,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     usort($leases,
         function ($a, $b) use ($order) {
-            $cmp = strnatcasecmp($a[$order], $b[$order]);
-            if ($cmp === 0) {
-                $cmp = strnatcasecmp($a['ip'], $b['ip']);
+            if ($order === 'ip') {
+                $cmp = ipcmp($a['ip'], $b['ip']);
+            } else {
+                $cmp = strnatcasecmp($a[$order], $b[$order]);
+                if ($cmp === 0) {
+                    $cmp = ipcmp($a['ip'], $b['ip']);
+                }
             }
             return $cmp;
         }

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -244,7 +244,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
     }
 
-    $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
+    if (isset($_GET['order'])){
+        if (in_array($_GET['order'], ['int', 'ip', 'mac', 'hostname', 'descr', 'start', 'end', 'online', 'act'])) {
+            $order = $_GET['order'];
+        } else {
+            $order = 'ip';
+        }
+    } else {
+        $order = 'ip';
+    }
 
     if ($order === 'ip') {
         usort($leases, function ($a, $b) {

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -307,11 +307,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
     }
 
-    if ($_GET['order']) {
-        usort($leases, function ($a, $b) {
-            return strcmp($a[$_GET['order']], $b[$_GET['order']]);
-        });
-    }
+    $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
+
+    usort($leases,
+        function ($a, $b) use ($order) {
+            if ($order === 'ip') {
+                $cmp = ipcmp($a['ip'], $b['ip']);
+            } else {
+                $cmp = strnatcasecmp($a[$order], $b[$order]);
+                if ($cmp === 0) {
+                    $cmp = ipcmp($a['ip'], $b['ip']);
+                }
+            }
+            return $cmp;
+        }
+    );
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         killbypid('/var/dhcpd/var/run/dhcpdv6.pid', 'TERM', true);

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -394,6 +394,11 @@ legacy_html_escape_form_data($leases);
               location.reload();
           });
       });
+      // keep sorting in place.
+      $(".act_sort").click(function(){
+          var all = <?=!empty($_GET['all']) ? 1 : 0;?> ;
+          document.location = document.location.origin + window.location.pathname +"?all="+all+"&order="+$(this).data('field');
+      });
   });
   </script>
 <?php include("fbegin.inc"); ?>
@@ -440,16 +445,16 @@ endif;?>
             <table class="table table-striped">
               <thead>
                 <tr>
-                    <th><?=gettext("Interface"); ?></th>
-                    <th><?=gettext("IPv6 address"); ?></th>
-                    <th><?=gettext("IAID"); ?></th>
-                    <th><?=gettext("DUID"); ?></th>
-                    <th><?=gettext("Hostname/MAC"); ?></th>
-                    <th><?=gettext("Description"); ?></th>
-                    <th><?=gettext("Start"); ?></th>
-                    <th><?=gettext("End"); ?></th>
-                    <th><?=gettext("Online"); ?></th>
-                    <th><?=gettext("Lease Type"); ?></th>
+                    <th class="act_sort" data-field="int"><?=gettext("Interface"); ?></th>
+                    <th class="act_sort" data-field="ip"><?=gettext("IPv6 address"); ?></th>
+                    <th class="act_sort" data-field="iaid"><?=gettext("IAID"); ?></th>
+                    <th class="act_sort" data-field="duid"><?=gettext("DUID"); ?></th>
+                    <th class="act_sort" data-field="hostname"><?=gettext("Hostname/MAC"); ?></th>
+                    <th class="act_sort" data-field="descr"><?=gettext("Description"); ?></th>
+                    <th class="act_sort" data-field="start"><?=gettext("Start"); ?></th>
+                    <th class="act_sort" data-field="end"><?=gettext("End"); ?></th>
+                    <th class="act_sort" data-field="online"><?=gettext("Online"); ?></th>
+                    <th class="act_sort" data-field="act"><?=gettext("Lease Type"); ?></th>
                     <th class="text-nowrap"></th>
                 </tr>
               </thead>

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -307,7 +307,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
     }
 
-    $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
+    if (isset($_GET['order'])){
+        if (in_array($_GET['order'], ['int', 'ip', 'iaid', 'duid', 'hostname', 'descr', 'start', 'end', 'online', 'act'])) {
+            $order = $_GET['order'];
+        } else {
+            $order = 'ip';
+        }
+    } else {
+        $order = 'ip';
+    }
 
     if ($order === 'ip') {
         usort($leases, function ($a, $b) {

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -469,7 +469,7 @@ endif;?>
                     foreach ($config['dhcpdv6'] as $dhcpif => $dhcpifconf) {
                         if (isset($dhcpifconf['staticmap'])) {
                             foreach ($dhcpifconf['staticmap'] as $staticent) {
-                                if ($data['ip'] == $staticent['ipaddr']) {
+                                if ($data['ip'] == $staticent['ipaddrv6']) {
                                     $data['int'] = htmlspecialchars($interfaces[$dhcpif]['descr']);
                                     $data['if'] = $dhcpif;
                                     break;

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -309,19 +309,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
 
-    usort($leases,
-        function ($a, $b) use ($order) {
-            if ($order === 'ip') {
+    if ($order === 'ip') {
+        usort($leases, function ($a, $b) {
+            return ipcmp($a['ip'], $b['ip']);
+        });
+    } else {
+        usort($leases, function ($a, $b) use ($order) {
+            $cmp = strnatcasecmp($a[$order], $b[$order]);
+            if ($cmp === 0) {
                 $cmp = ipcmp($a['ip'], $b['ip']);
-            } else {
-                $cmp = strnatcasecmp($a[$order], $b[$order]);
-                if ($cmp === 0) {
-                    $cmp = ipcmp($a['ip'], $b['ip']);
-                }
             }
             return $cmp;
-        }
-    );
+        });
+    }
 } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['deleteip']) && is_ipaddr($_POST['deleteip'])) {
         killbypid('/var/dhcpd/var/run/dhcpdv6.pid', 'TERM', true);

--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -460,7 +460,6 @@ endif;?>
               </thead>
               <tbody>
 <?php
-              $mac_man = json_decode(configd_run("interface list macdb json"), true);
               foreach ($leases as $data):
                 if (!($data['act'] == 'active' || $data['act'] == 'static' || $_GET['all'] == 1)) {
                     continue;


### PR DESCRIPTION
**Issues:**
1. DHCPv6 leases are shown in a wrong order (e.g. ::00d0 above ::0010)
1. DHCPv6 leases cannot be sorted by another column (e.g. hostname)
1. DHCPv6 leases have an empty interface field (all lines)
1. DHCPv6 leases have an empty interface field when IPv6 address belongs to /120 subnet

**Reasons:**
1. DHCPv4/v6 leases pages use strnatcasecmp() and strcmp() for sorting by IP
1. No UI correspoding to this feature
1. $staticent['ipaddrv6'] should be used instead of $staticent['ipaddr'] when searching a static mapping
1. Incomplete preg pattern used to find possible IPv6 subnets

**Solutions:**
1. Use the updated ipcmp() function for sorting by IPv4/v6
1. Add sorting UI to DHCPv6 leases page
1. Fix a typo
1. Apply a consistent approach of using is_subnet{v4,v6} to find possible subnets

**Version:**
OPNsense  20.7.6