### PR TITLE
interfaces.inc: Improve guess_interface_from_ip()

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3768,7 +3768,7 @@ function guess_interface_from_ip($ipaddress)
     if (is_ipaddrv4($ipaddress)) {
         $family = "inet";
     } elseif (is_ipaddrv6($ipaddress)) {
-    	$family = "inet6";
+        $family = "inet6";
     } else {
     	return false;
     }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3765,33 +3765,25 @@ function get_real_interface($interface = 'wan', $family = 'all')
 
 function guess_interface_from_ip($ipaddress)
 {
-    if (!is_ipaddr($ipaddress)) {
-        return false;
-    }
     if (is_ipaddrv4($ipaddress)) {
-        /* create a route table we can search */
-        exec("/usr/bin/netstat -rnWf inet", $output, $ret);
-        foreach ($output as $line) {
-            $fields = preg_split("/[ ]+/", $line);
-            if (is_subnetv4($fields[0])) {
-                if (ip_in_subnet($ipaddress, $fields[0])) {
-                    return $fields[5];
-                }
+        $family = "inet";
+    } elseif (is_ipaddrv6($ipaddress)) {
+    	$family = "inet6";
+    } else {
+    	return false;
+    }
+
+    /* create a route table we can search */
+    exec("/usr/bin/netstat -rnWf ".$family, $output, $ret);
+    foreach ($output as $line) {
+        $fields = preg_split("/\s+/", $line);
+        if (is_subnet($fields[0])) {
+            if (ip_in_subnet($ipaddress, $fields[0])) {
+                return $fields[5];
             }
         }
     }
-    if (is_ipaddrv6($ipaddress)) {
-        /* create a route table we can search */
-        exec("/usr/bin/netstat -rnWf inet6", $output, $ret);
-        foreach ($output as $line) {
-            $fields = preg_split("/[ ]+/", $line);
-            if (is_subnetv6($fields[0])) {
-                if (ip_in_subnet($ipaddress, $fields[0])) {
-                    return $fields[5];
-                }
-            }
-        }
-    }
+
     $ret = exec_command("/sbin/route -n get {$ipaddress} | /usr/bin/awk '/interface/ { print \$2; };'");
     if (empty($ret)) {
         return false;

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3770,7 +3770,7 @@ function guess_interface_from_ip($ipaddress)
     } elseif (is_ipaddrv6($ipaddress)) {
         $family = "inet6";
     } else {
-    	return false;
+        return false;
     }
 
     /* create a route table we can search */

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3776,7 +3776,7 @@ function guess_interface_from_ip($ipaddress)
             if (is_subnetv4($fields[0])) {
                 if (ip_in_subnet($ipaddress, $fields[0])) {
                     return $fields[5];
-                }                
+                }
             }
         }
     }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3772,21 +3772,20 @@ function guess_interface_from_ip($ipaddress)
         /* create a route table we can search */
         exec("/usr/bin/netstat -rnWf inet", $output, $ret);
         foreach ($output as $line) {
-            if (preg_match("/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+[ ]+link[#]/", $line)) {
-                $fields = preg_split("/[ ]+/", $line);
+            $fields = preg_split("/[ ]+/", $line);
+            if (is_subnetv4($fields[0])) {
                 if (ip_in_subnet($ipaddress, $fields[0])) {
                     return $fields[5];
-                }
+                }                
             }
         }
     }
-    /* FIXME: This works from cursory testing, regexp might need fine tuning */
     if (is_ipaddrv6($ipaddress)) {
         /* create a route table we can search */
         exec("/usr/bin/netstat -rnWf inet6", $output, $ret);
         foreach ($output as $line) {
-            if (preg_match("/[0-9a-f]+[:]+[0-9a-f]+[:]+[\/][0-9]+/", $line)) {
-                $fields = preg_split("/[ ]+/", $line);
+            $fields = preg_split("/[ ]+/", $line);
+            if (is_subnetv6($fields[0])) {
                 if (ip_in_subnet($ipaddress, $fields[0])) {
                     return $fields[5];
                 }


### PR DESCRIPTION
**Issue:**
DHCPv6 leases have an empty interface field when IPv6 address belongs to /120 subnet.

**Reason:**
Incomplete preg pattern used to find possible IPv6 subnets in guess_interface_from_ip() function.

**Solution:**
Apply a consistent approach of using is_subnet{v4,v6} to find possible subnets.

**Other:**
This PR is a part of changes proposed by [#4514](https://github.com/opnsense/core/pull/4514).