### PR TITLE
DHCPv4 leases status: Fix sorting

### DIFF
--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -248,9 +248,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     usort($leases,
         function ($a, $b) use ($order) {
-            $cmp = strnatcasecmp($a[$order], $b[$order]);
+            $cmp = ($order === 'ip') ? 0 : strnatcasecmp($a[$order], $b[$order]);
             if ($cmp === 0) {
-                $cmp = strnatcasecmp($a['ip'], $b['ip']);
+                $cmp = ipcmp($a['ip'], $b['ip']);
             }
             return $cmp;
         }

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -372,7 +372,7 @@ legacy_html_escape_form_data($leases);
             <table class="table table-striped">
               <thead>
                 <tr>
-                    <td><?=gettext("Interface"); ?></td>
+                    <td class="act_sort" data-field="int"><?=gettext("Interface"); ?></td>
                     <td class="act_sort" data-field="ip"><?=gettext("IP address"); ?></td>
                     <td class="act_sort" data-field="mac"><?=gettext("MAC address"); ?></td>
                     <td class="act_sort" data-field="hostname"><?=gettext("Hostname"); ?></td>

--- a/src/www/status_dhcp_leases.php
+++ b/src/www/status_dhcp_leases.php
@@ -244,7 +244,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
     }
 
-    $order = ( $_GET['order'] ) ? $_GET['order'] : 'ip';
+    if (isset($_GET['order']) && 
+      in_array($_GET['order'], ['int', 'ip', 'mac', 'hostname', 'descr', 'start', 'end', 'online', 'act'])) {
+        $order = $_GET['order'];
+    } else {
+        $order = 'ip';
+    }
 
     usort($leases,
         function ($a, $b) use ($order) {


### PR DESCRIPTION
**Issues in status_dhcp_leases.php for which this PR suggests a solution:**
- Insecure handling of the order argument
- Use of strnatcasecmp() instead of ipcmp() for sorting by ip
- Impossible to sort by interface name

**Other:**
This PR is a part of changes proposed by [#4514](https://github.com/opnsense/core/pull/4514).