### PR TITLE
DHCPv6 leases status: Fix interface name search

### DIFF
--- a/src/www/status_dhcpv6_leases.php
+++ b/src/www/status_dhcpv6_leases.php
@@ -454,7 +454,7 @@ endif;?>
                     foreach ($config['dhcpdv6'] as $dhcpif => $dhcpifconf) {
                         if (isset($dhcpifconf['staticmap'])) {
                             foreach ($dhcpifconf['staticmap'] as $staticent) {
-                                if ($data['ip'] == $staticent['ipaddr']) {
+                                if ($data['ip'] == $staticent['ipaddrv6']) {
                                     $data['int'] = htmlspecialchars($interfaces[$dhcpif]['descr']);
                                     $data['if'] = $dhcpif;
                                     break;


### PR DESCRIPTION
**Issues in status_dhcpv6_leases.php for which this PR suggests a solution:**
- Incorrect use of $staticent['ipaddr'] instead of $staticent['ipaddrv6'] to match IPv6 of static mappings.

**Other:**
This PR is a part of changes proposed by [#4514](https://github.com/opnsense/core/pull/4514).