### PR TITLE
Add option to ignore virtual IPs for WebGUI and SSH

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4539,7 +4539,7 @@ function make_ipv6_64_address($prefix, $suffix)
     return implode(':', $prefix_array);
 }
 
-function interfaces_addresses($interfaces, $as_subnet = false, $ifconfig_details = null)
+function interfaces_addresses($interfaces, $as_subnet = false, $ifconfig_details = null, $include_vips = true)
 {
     global $config;
 
@@ -4581,6 +4581,14 @@ function interfaces_addresses($interfaces, $as_subnet = false, $ifconfig_details
             foreach ($intf_details[$realif][$proto] as $address) {
                 if (!empty($address['tunnel']) || empty($address['ipaddr'])) {
                     continue;
+                }
+                if (!$include_vips) {
+                    $vip_types = array('carp', 'ipalias');
+                    foreach (config_read_array('virtualip', 'vip') as $vip) {
+                        if ($vip['subnet'] == $address['ipaddr'] && in_array($vip['mode'], $vip_types)) {
+                            continue 2;
+                        }
+                    }
                 }
                 $scope = '';
                 if (!empty($address['link-local'])) {

--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -195,7 +195,13 @@ function openssh_configure_do($verbose = false, $interface = '')
 
     $listeners = array();
 
-    foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
+    if (isset($sshcfg['strictbind']) && $sshcfg['strictbind'] != '') {
+        $include_vips = false;
+    } else {
+        $include_vips = true;
+    }
+
+    foreach (interfaces_addresses($interfaces,null,null,$include_vips) as $tmpaddr => $info) {
         if ($info['scope']) {
             /* link-local does not seem to be supported */
             continue;

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -66,7 +66,13 @@ function webgui_configure_do($verbose = false, $interface = '')
 
     $listeners = count($interfaces) ? array() : array('0.0.0.0', '::');
 
-    foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
+    if (isset($config['system']['webgui']['strictbind']) && $config['system']['webgui']['strictbind'] != '') {
+        $include_vips = false;
+    } else {
+        $include_vips = true;
+    }
+
+    foreach (interfaces_addresses($interfaces,null,null,$include_vips) as $tmpaddr => $info) {
         if ($info['scope']) {
             /* link-local does not seem to be supported */
             continue;


### PR DESCRIPTION
The WebGUI and the SSH service on any OPNsense firewall listens either on all interfaces or only on the specified interfaces. However, in both cases it will listen on *all* interface IP addresses, including all _virtual_ IP addresses (IP aliases, CARP).

On large deployments with many virtual IP addresses this behaviour has several drawbacks

* It wastes three ports (i.e. 22, 80, 443) on any virtual IP (for the selected interfaces). They cannot be used for any other service or application.
* It makes it easy to introduce a security risk. Just by adding another new virtual IP the firewall WebGUI/SSH may be exposed to insecure networks.

While this may sound like a negligible issue at first glance, it causes headaches when working with 40+ CARP VIPs. I've already implemented so many workarounds for this limitation that the configuratin is starting to get really messy.

Granted, one may be able to prevent this issue if the network is designed with this OPNsense-specific limitation in mind. However, the reality is that most networks are designed for other network equipment and are only later migrated to OPNsense. The OPNsense firewall should be able to work in any environment. This limitation looks very artificial to me.

**I do not propose to change the default setting.** The default setting ensures that the WebGUI is reachable and that users don't easily lock themselves out. That's a good thing.

However, **expert users** really should be able to configure this behaviour. My proposal adds a new option "Enable Strict Binding", which will ignore all virtual IP addresses. I've also added a warning box to inform novice users about potential damage.

