### PR TITLE
QueryFilter.php: allow underscore in filter string

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Base/Filters/QueryFilter.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/Filters/QueryFilter.php
@@ -45,6 +45,6 @@ class QueryFilter
      */
     public function filter($value)
     {
-        return preg_replace("/[^0-9,a-z,A-Z, ,*,\-,.,\#]/", "", $value);
+        return preg_replace("/[^0-9,a-z,A-Z, ,*,\-,_,.,\#]/", "", $value);
     }
 }


### PR DESCRIPTION
Hi!
it is not forbidden to use the underscore sign in the filter string?
(want to use it in the search in the system log widget and system->log files)
Thanks!