### PR TITLE
Add option for webgui and ssh to configure management IP

### DIFF
--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -195,11 +195,17 @@ function openssh_configure_do($verbose = false, $interface = '')
 
     $listeners = array();
 
-    foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
-        if ($info['scope']) {
-            /* link-local does not seem to be supported */
-            continue;
-        }
+    /* bind on (all/selected) interfaces or use specified IP */
+    if (isset($config['system']['ssh']['managementaccess']) &&
+        $config['system']['ssh']['managementaccess'] === 'ip' &&
+        isset($config['system']['ssh']['ip'])) {
+        $listeners[] = $config['system']['ssh']['ip'];
+    } else {
+        foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
+            if ($info['scope']) {
+                /* link-local does not seem to be supported */
+                continue;
+            }
 
         if (count($listeners) < 16) {
             $listeners[] = $tmpaddr;

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -70,7 +70,7 @@ function webgui_configure_do($verbose = false, $interface = '')
     if (isset($config['system']['webgui']['managementaccess']) &&
         $config['system']['webgui']['managementaccess'] === 'ip' &&
         isset($config['system']['webgui']['ip'])) {
-        $listeners[] = $config['system']['webgui']['ip'];
+        $listeners = array($config['system']['webgui']['ip']);
     } else {
         foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
             if ($info['scope']) {

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -66,13 +66,20 @@ function webgui_configure_do($verbose = false, $interface = '')
 
     $listeners = count($interfaces) ? array() : array('0.0.0.0', '::');
 
-    foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
-        if ($info['scope']) {
-            /* link-local does not seem to be supported */
-            continue;
-        }
+    /* bind on (all/selected) interfaces or use specified IP */
+    if (isset($config['system']['webgui']['managementaccess']) &&
+        $config['system']['webgui']['managementaccess'] === 'ip' &&
+        isset($config['system']['webgui']['ip'])) {
+        $listeners[] = $config['system']['webgui']['ip'];
+    } else {
+        foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
+            if ($info['scope']) {
+                /* link-local does not seem to be supported */
+                continue;
+            }
 
-        $listeners[] = $tmpaddr;
+            $listeners[] = $tmpaddr;
+        }
     }
 
     chdir('/usr/local/www');

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -719,7 +719,7 @@ $(document).ready(function() {
                 <td><a id="help_for_webguiip" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Management IP") ?></td>
                 <td>
                   <input name="webguiip" type="text" value="<?= $pconfig['webguiip'] ?>"/>
-                  <?=gettext("Only accept connections from the specified IP. Use with care."); ?>
+                  <?=gettext("Web GUI only listen on specified IP address. Use with care."); ?>
                   <div class="hidden" data-for="help_for_webguiip">
                     <?= gettext('The WebGUI only listens on the selected IP address. You may need to manually add required firewall rules first. Use with care.') ?>
                   </div>

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -834,7 +834,7 @@ $(document).ready(function() {
                 <td><a id="help_for_sship" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Management IP") ?></td>
                 <td>
                   <input name="sship" type="text" value="<?= $pconfig['sship'] ?>"/>
-                  <?=gettext("Only accept connections from the specified IP. Use with care."); ?>
+                  <?=gettext("Only accept connections on the specified IP address. Use with care."); ?>
                   <div class="hidden" data-for="help_for_sship">
                     <?= gettext('The SSH service only listens on the selected IP address. You may need to manually add required firewall rules first. Use with care.') ?>
                   </div>

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -836,7 +836,7 @@ $(document).ready(function() {
                   <input name="sship" type="text" value="<?= $pconfig['sship'] ?>"/>
                   <?=gettext("Only accept connections on the specified IP address. Use with care."); ?>
                   <div class="hidden" data-for="help_for_sship">
-                    <?= gettext('The SSH service only listens on the selected IP address. You may need to manually add required firewall rules first. Use with care.') ?>
+                    <?= gettext('The SSH service only listens on the specified IP address. You may need to manually add required firewall rules first. Use with care.') ?>
                   </div>
                 </td>
               </tr>

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -806,10 +806,10 @@ $(document).ready(function() {
                 <td>
                   <select id="ssh_managementaccess" name="ssh_managementaccess" class="selectpicker">
                       <option value="interfaces" <?= empty($pconfig['ssh_managementaccess']) || $pconfig['ssh_managementaccess'] === 'interfaces' ? 'selected="selected"' : '';?>>
-                        <?=gettext("Choose Listen Interfaces");?>
+                        <?=gettext("Listen on specified interfaces (recommended)");?>
                       </option>
                       <option value="ip" <?=$pconfig['ssh_managementaccess'] === 'ip' ? 'selected="selected"' : '';?>>
-                        <?=gettext("Specify Management IP");?>
+                        <?=gettext("Listen on specified IP address");?>
                       </option>
                   </select>
                   <div class="hidden" data-for="help_for_ssh_managementaccess">

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -408,6 +408,7 @@ $(document).ready(function() {
                      if (!result) {
                          $('#webgui_managementaccess option:selected').prop('selected', false);
                          $('#webgui_managementaccess').selectpicker('refresh');
+                         $("#webgui_managementaccess").change();
                          $.webgui_managementaccess_warned = 0;
                      }
                  }

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -691,10 +691,10 @@ $(document).ready(function() {
                 <td>
                   <select id="webgui_managementaccess" name="webgui_managementaccess" class="selectpicker">
                       <option value="interfaces" <?= empty($pconfig['webgui_managementaccess']) || $pconfig['webgui_managementaccess'] === 'interfaces' ? 'selected="selected"' : '';?>>
-                        <?=gettext("Choose Listen Interfaces");?>
+                        <?=gettext("Listen on specified interfaces (recommended)");?>
                       </option>
                       <option value="ip" <?=$pconfig['webgui_managementaccess'] === 'ip' ? 'selected="selected"' : '';?>>
-                        <?=gettext("Specify Management IP");?>
+                        <?=gettext("Listen on specified IP address");?>
                       </option>
                   </select>
                   <div class="hidden" data-for="help_for_webgui_managementaccess">


### PR DESCRIPTION
### Preface

Howdy. In #4541 I've suggested to implement a _workaround_ for a problem. The discussion made me realize that this was not the best approach.

### Description
This PR contains a new solution that finally adresses the underlying issue and adds a simple option to make the management IP configurable. Let me know what you think.

Compared to #4541 this approach...

* is easily understood: users can simply switch between both behaviours
* does not increase code complexity (because it no longer manipulates the behaviour of another option/function)
* is failsafe: it is not visible by default and a clear warning is shown when selected

In case you agree to merge this new option, then I'll happily update [the documentation](https://github.com/opnsense/docs/blob/master/source/manual/settingsmenu.rst) to include a description for the new option.

### Screenshots

##### Default: listen on specified interfaces

![opn_1](https://user-images.githubusercontent.com/909706/105644715-568bb080-5e97-11eb-903d-04b714dc2d35.png)

#####  Optional: listen on specified IP

![opn_2](https://user-images.githubusercontent.com/909706/105644721-5be8fb00-5e97-11eb-85f8-e6b81ed84799.png)


(The option was added to both WebGUI and SSH, but they look the same so I've only added screenshots for the WebGUI option.)