### PR TITLE
Allow DNS resolver to skip entry on EmptyLabel

### DIFF
--- a/src/opnsense/scripts/filter/lib/alias.py
+++ b/src/opnsense/scripts/filter/lib/alias.py
@@ -123,7 +123,7 @@ class Alias(object):
                 for rdata in self._dnsResolver.query(address, record_type):
                     yield str(rdata)
                 could_resolve = True
-            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoNameservers):
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoNameservers, dns.resolver.EmptyLabel):
                 pass
 
         if not could_resolve:

--- a/src/opnsense/scripts/filter/lib/alias.py
+++ b/src/opnsense/scripts/filter/lib/alias.py
@@ -123,7 +123,7 @@ class Alias(object):
                 for rdata in self._dnsResolver.query(address, record_type):
                     yield str(rdata)
                 could_resolve = True
-            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoNameservers, dns.resolver.EmptyLabel):
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoNameservers, dns.name.EmptyLabel):
                 pass
 
         if not could_resolve:


### PR DESCRIPTION
A name like '.example.com' is not a valid name, but should be handled like a non existant name instead of throwing an exception

I was testing using the list from (https://raw.githubusercontent.com/nickspaargaren/no-google/master/categories/youtubeparsed) to attempt to block youtube, but the list would never load.  The first entry is '.youtubeeducation.com', which presumably pihole can deal with but it was causing the following error:

```
Dec 30 13:22:04 OPNsense /update_tables.py: fetch alias url https://raw.githubusercontent.com/nickspaargaren/no-google/master/cat
egories/youtubeparsed (lines: 1823) 
Dec 30 13:22:04 OPNsense /update_tables.py: error fetching alias url https://raw.githubusercontent.com/nickspaargaren/no-google/master/categories/youtubeparsed 
```
