### PR TITLE
Correct DHCPv6 Custom Options Unsigned Integer field

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1529,7 +1529,11 @@ EOD;
         if (isset($dhcpv6ifconf['numberoptions']['item'])) {
             $dhcpdv6conf .= "\n";
             foreach ($dhcpv6ifconf['numberoptions']['item'] as $itemv6idx => $itemv6) {
-                $dhcpdv6conf .= "  option custom-{$dhcpv6if}-{$itemv6idx} \"{$itemv6['value']}\";\n";
+              if (empty($itemv6['type']) || $itemv6['type'] == "text") {
+                    $dhcpdv6conf .= "  option custom-{$dhcpv6if}-{$itemv6idx} \"{$itemv6['value']}\";\n";
+                } else {
+                    $dhcpdv6conf .= "  option custom-{$dhcpv6if}-{$itemv6idx} {$itemv6['value']};\n";
+                }              
             }
         }
 


### PR DESCRIPTION
Custom Options is incorrectly inserting quotes around the integer value. Issue 4542

Added code to differentiate between numeric or text option, same as v4 Options.