### PR TITLE
openvpn: use plugin for deferred authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ CORE_DEPENDS?=		${CORE_DEPENDS_${CORE_ARCH}} \
 			ntp \
 			openssh-portable \
 			openvpn \
+			openvpn-auth-script \
 			opnsense-lang \
 			opnsense-update \
 			pam_opnsense \

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -726,8 +726,9 @@ function openvpn_reconfigure($mode, $settings, $device_only = false)
                     if ($settings['strictusercn']) {
                         $strictusercn = "true";
                     }
-                    $conf .= "auth-user-pass-verify \"/usr/local/etc/inc/plugins.inc.d/openvpn/ovpn_auth_verify " .
-                        "user '{$settings['authmode']}' '{$strictusercn}' '{$mode_id}'\" via-env\n";
+                    $conf .= "plugin /usr/local/lib/openvpn/plugins/openvpn-plugin-auth-script.so " .
+                        "/usr/local/etc/inc/plugins.inc.d/openvpn/ovpn_auth_verify " .
+                        "user '{$settings['authmode']}' '{$strictusercn}' '{$mode_id}'\n";
                 }
                 break;
         }

--- a/src/etc/inc/plugins.inc.d/openvpn/ovpn_auth_verify
+++ b/src/etc/inc/plugins.inc.d/openvpn/ovpn_auth_verify
@@ -2,13 +2,28 @@
 
 if [ "$1" = "tls" ]; then
 	/usr/local/bin/php /usr/local/etc/inc/plugins.inc.d/openvpn/tls-verify.php -d "$2" "$3"
+	exit $?
 else
 	# Single quoting $password breaks getting the value from the variable.
 	# XXX I really don't like going through openssl for this...
 	password=$(echo -n "${password}" | /usr/local/bin/openssl enc -base64 | sed -e 's/=/%3D/g')
 	username=$(echo -n "${username}" | /usr/local/bin/openssl enc -base64 | sed -e 's/=/%3D/g')
 
-	/usr/local/bin/php /usr/local/etc/inc/plugins.inc.d/openvpn/auth-user.php "$username" "$password" "$common_name" "$3" "$2" "$4"
-fi
+	# has to be done before the script call. otherwise $? will be the result of the assignment,
+	# instead of the return value of the auth script
+	auth_success="0"
 
-exit $?
+	# do the actual authentication
+	/usr/local/bin/php /usr/local/etc/inc/plugins.inc.d/openvpn/auth-user.php "$username" "$password" "$common_name" "$3" "$2" "$4"
+
+	if [ $? = 0 ]; then
+		auth_success="1"
+	fi
+
+	# auth_control_file is provided by the plugin
+	printf "%s" "${auth_success}" > "${auth_control_file}"
+
+	# the authentication result is passed on to the plugin via the file,
+	# but the script itself should always return successfully here
+	exit 0
+fi


### PR DESCRIPTION
fixes #3992

The blocking behaviour of OpenVPN is problematic, especially in larger environments. Authentication stalls traffic for all connected users, every time somebody connects. The impact may be negligible with a small number of users or when local authentication is used, but when OPNsense relies on another server for authentication, the impact becomes worse. Depending on multiple factors, the authentication server may at times be slow to respond or not respond at all. That should not have any negative impact on already-connected users.

This PR introduces the `openvpn-auth-script` plugin to handle user authentication in a non-blocking manner. For reference, this plugin was introduced to pfSense in 2018 and has proven to work well (that's based on my personal experience and the fact that it was basically never touched since then). https://redmine.pfsense.org/issues/7905

Below is a comparison with an artificial 5-second authentication delay.

Before:
![before](https://user-images.githubusercontent.com/23556080/104110026-f19b5c80-52d3-11eb-8529-6e6306c0325f.gif)

After:
![after](https://user-images.githubusercontent.com/23556080/104110028-f6f8a700-52d3-11eb-9ca1-c69d7c3727dc.gif)