### PR TITLE
pftop: fix all state value

### DIFF
--- a/src/www/diag_system_pftop.php
+++ b/src/www/diag_system_pftop.php
@@ -151,7 +151,7 @@ $( document ).ready(function() {
                       <option value='200' selected="selected">200</option>
                       <option value='500'>500</option>
                       <option value='1000'>1000</option>
-                      <option value='9999999999'><?= gettext('all') ?></option>
+                      <option value='99999999999'><?= gettext('all') ?></option>
                     </select>
                   </div>
                 </td>


### PR DESCRIPTION
The html element of the "all" value in the pftop diagnostics view currently does not match the array value. For this reason, the option has no effect. The number of states is always set to the default value of 200.