### PR TITLE
Firewall ACLs: Add readonly actions to "Aliases" permission

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
@@ -205,9 +205,10 @@
         <name>Firewall: Aliases</name>
         <patterns>
             <pattern>ui/firewall/alias/*</pattern>
+            <pattern>api/firewall/alias/export</pattern>
             <pattern>api/firewall/alias/search*</pattern>
             <pattern>api/firewall/alias/list*</pattern>
-            <pattern>api/firewall/alias/getItem*</pattern>
+            <pattern>api/firewall/alias/get*</pattern>
         </patterns>
     </page-firewall-aliases>
     <page-firewall-nat-1-1>


### PR DESCRIPTION
Add readonly actions to page-firewall-aliases permission:

* api/firewall/alias/export
* api/firewall/alias/getAliasUUID
* api/firewall/alias/getGeoIP