### PR TITLE
OpenVPN: Enhance configuration - Compression

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -133,16 +133,19 @@ function openvpn_verbosity_level()
     );
 }
 
-function openvpn_compression_algos()
+function openvpn_compression_modes()
 {
     return array(
-        '' => gettext('Disabled - No Compression & Framing'),
-        'pfc' => gettext('Partial - Packet Framing for Compression'),
-        'lz4' => gettext('Enabled - LZ4 Algorithm'),
-        'lz4-v2' => gettext('Enabled - LZ4 v2 Algorithm'),
-        'lzo' => gettext('Enabled - LZO Algorithm'),
-        'stub' => gettext('Enabled - Stub Algorithm'),
-        'stub-v2' => gettext('Enabled - Stub v2 Algorithm'),
+        '' => gettext('No Preference'),
+        'pfc' => gettext('Partial - Packet Framing for Compression (--compress)'),
+        'lz4' => gettext('Enabled - LZ4 Algorithm (--compress lz4)'),
+        'lz4-v2' => gettext('Enabled - LZ4 v2 Algorithm (--compress lz4-v2)'),
+        'lzo' => gettext('Enabled - LZO Algorithm (--compress lzo, equivalent to --comp-lzo yes)'),
+        'stub' => gettext('Enabled - Stub Algorithm (--compress stub)'),
+        'stub-v2' => gettext('Enabled - Stub v2 Algorithm (--compress stub-v2)'),
+        'no' => gettext('Legacy - Disabled LZO Algorithm (--comp-lzo no)'),
+        'adaptive' => gettext('Legacy - Enabled LZO Algorithm with Adaptive Compression (--comp-lzo adaptive)'),
+        'yes' => gettext('Legacy - Enabled LZO Algorithm without Adaptive Compression (--comp-lzo yes)'),
     );
 }
 
@@ -911,10 +914,17 @@ function openvpn_reconfigure($mode, $settings, $device_only = false)
     }
 
     if (!empty($settings['compression'])) {
-        if ($settings['compression'] === 'pfc') {
-            $conf .= "compress\n";
-        } else {
-            $conf .= "compress {$settings['compression']}\n";
+        switch($settings['compression']){
+            case 'no':
+            case 'adaptive':
+            case 'yes':
+                $conf .= "comp-lzo {$settings['compression']}\n";
+                break;
+            case 'pfc':
+                $conf .= "compress\n";
+                break;
+            default:
+                $conf .= "compress {$settings['compression']}\n";
         }
     }
 

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -133,13 +133,16 @@ function openvpn_verbosity_level()
     );
 }
 
-function openvpn_compression_modes()
+function openvpn_compression_algos()
 {
     return array(
-        '' => gettext('No Preference'),
-        'no' => gettext('Disabled - No Compression'),
-        'adaptive' => gettext('Enabled with Adaptive Compression'),
-        'yes' => gettext('Enabled without Adaptive Compression'),
+        '' => gettext('Disabled - No Compression & Framing'),
+        'pfc' => gettext('Partial - Packet Framing for Compression'),
+        'lz4' => gettext('Enabled - LZ4 Algorithm'),
+        'lz4-v2' => gettext('Enabled - LZ4 v2 Algorithm'),
+        'lzo' => gettext('Enabled - LZO Algorithm'),
+        'stub' => gettext('Enabled - Stub Algorithm'),
+        'stub-v2' => gettext('Enabled - Stub v2 Algorithm'),
     );
 }
 
@@ -908,7 +911,11 @@ function openvpn_reconfigure($mode, $settings, $device_only = false)
     }
 
     if (!empty($settings['compression'])) {
-        $conf .= "comp-lzo {$settings['compression']}\n";
+        if ($settings['compression'] === 'pfc') {
+            $conf .= "compress\n";
+        } else {
+            $conf .= "compress {$settings['compression']}\n";
+        }
     }
 
     if ($settings['passtos']) {

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -408,7 +408,7 @@ function step10_stepbeforeformdisplay()
             }
         } elseif ($field['name'] == "compression") {
             $pkg['step'][$stepid]['fields']['field'][$idx]['options']['option'] = array();
-            foreach (openvpn_compression_modes() as $name => $desc) {
+            foreach (openvpn_compression_algos() as $name => $desc) {
                 $opt = array();
                 $opt['name'] = $desc;
                 $opt['value'] = $name;

--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -408,7 +408,7 @@ function step10_stepbeforeformdisplay()
             }
         } elseif ($field['name'] == "compression") {
             $pkg['step'][$stepid]['fields']['field'][$idx]['options']['option'] = array();
-            foreach (openvpn_compression_algos() as $name => $desc) {
+            foreach (openvpn_compression_modes() as $name => $desc) {
                 $opt = array();
                 $opt['name'] = $desc;
                 $opt['value'] = $name;

--- a/src/opnsense/mvc/app/library/OPNsense/OpenVPN/PlainOpenVPN.php
+++ b/src/opnsense/mvc/app/library/OPNsense/OpenVPN/PlainOpenVPN.php
@@ -141,10 +141,17 @@ class PlainOpenVPN extends BaseExporter implements IExportProvider
         }
 
         if (!empty($this->config['compression'])) {
-            if($this->config['compression'] === 'pfc') {
-                $conf[] = "compress";
-            } else {
-                $conf[] = "compress " . $this->config['compression'];
+            switch($this->config['compression']){
+                case 'no':
+                case 'adaptive':
+                case 'yes':
+                    $conf[] = "comp-lzo " . $this->config['compression'];
+                    break;
+                case 'pfc':
+                    $conf[] = "compress";
+                    break;
+                default:
+                    $conf[] = "compress " . $this->config['compression'];
             }
         }
 

--- a/src/opnsense/mvc/app/library/OPNsense/OpenVPN/PlainOpenVPN.php
+++ b/src/opnsense/mvc/app/library/OPNsense/OpenVPN/PlainOpenVPN.php
@@ -141,7 +141,11 @@ class PlainOpenVPN extends BaseExporter implements IExportProvider
         }
 
         if (!empty($this->config['compression'])) {
-            $conf[] = "comp-lzo " . $this->config['compression'];
+            if($this->config['compression'] === 'pfc') {
+                $conf[] = "compress";
+            } else {
+                $conf[] = "compress " . $this->config['compression'];
+            }
         }
 
         if (!empty($this->config['plain_config'])) {

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -1038,18 +1038,18 @@ $( document ).ready(function() {
             <td>
               <select name="compression" class="form-control">
                 <?php
-                                foreach (openvpn_compression_modes() as $cmode => $cmodedesc):
+                                foreach (openvpn_compression_algos() as $calgo => $calgodesc):
                                     $selected = "";
-                                    if ($cmode == $pconfig['compression']) {
+                                    if ($calgo == $pconfig['compression']) {
                                         $selected = " selected=\"selected\"";
                                     }
                                 ?>
-                <option value="<?= $cmode ?>" <?= $selected ?>><?= $cmodedesc ?></option>
+                <option value="<?= $calgo ?>" <?= $selected ?>><?= $calgodesc ?></option>
                 <?php
                                 endforeach; ?>
               </select>
               <div class="hidden" data-for="help_for_compression">
-                <?=gettext("Compress tunnel packets using the LZO algorithm. Adaptive compression will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
+                <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later."); ?>
               </div>
             </td>
           </tr>

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -1038,18 +1038,18 @@ $( document ).ready(function() {
             <td>
               <select name="compression" class="form-control">
                 <?php
-                                foreach (openvpn_compression_algos() as $calgo => $calgodesc):
+                                foreach (openvpn_compression_modes() as $cmode => $cmodedesc):
                                     $selected = "";
-                                    if ($calgo == $pconfig['compression']) {
+                                    if ($cmode == $pconfig['compression']) {
                                         $selected = " selected=\"selected\"";
                                     }
                                 ?>
-                <option value="<?= $calgo ?>" <?= $selected ?>><?= $calgodesc ?></option>
+                <option value="<?= $cmode ?>" <?= $selected ?>><?= $cmodedesc ?></option>
                 <?php
                                 endforeach; ?>
               </select>
               <div class="hidden" data-for="help_for_compression">
-                <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later."); ?>
+                <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later. The legacy LZO algorithm with adaptive compression mode will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
               </div>
             </td>
           </tr>

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1262,18 +1262,18 @@ endif; ?>
                       <td>
                         <select name="compression" class="selectpicker">
 <?php
-                        foreach (openvpn_compression_algos() as $calgo => $calgodesc):
+                        foreach (openvpn_compression_modes() as $cmode => $cmodedesc):
                             $selected = "";
-                            if ($calgo == $pconfig['compression']) {
+                            if ($cmode == $pconfig['compression']) {
                                 $selected = " selected=\"selected\"";
                             }
                           ?>
-                            <option value="<?= $calgo ?>" <?= $selected ?>><?= $calgodesc ?></option>
+                            <option value="<?= $cmode ?>" <?= $selected ?>><?= $cmodedesc ?></option>
 <?php
                         endforeach; ?>
                         </select>
                         <div class="hidden" data-for="help_for_compression">
-                            <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later."); ?>
+                            <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later. The legacy LZO algorithm with adaptive compression mode will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
                         </div>
                       </td>
                     </tr>

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1262,18 +1262,18 @@ endif; ?>
                       <td>
                         <select name="compression" class="selectpicker">
 <?php
-                        foreach (openvpn_compression_modes() as $cmode => $cmodedesc):
+                        foreach (openvpn_compression_algos() as $calgo => $calgodesc):
                             $selected = "";
-                            if ($cmode == $pconfig['compression']) {
+                            if ($calgo == $pconfig['compression']) {
                                 $selected = " selected=\"selected\"";
                             }
                           ?>
-                            <option value="<?= $cmode ?>" <?= $selected ?>><?= $cmodedesc ?></option>
+                            <option value="<?= $calgo ?>" <?= $selected ?>><?= $calgodesc ?></option>
 <?php
                         endforeach; ?>
                         </select>
                         <div class="hidden" data-for="help_for_compression">
-                            <?=gettext("Compress tunnel packets using the LZO algorithm. Adaptive compression will dynamically disable compression for a period of time if OpenVPN detects that the data in the packets is not being compressed efficiently."); ?>
+                            <?=gettext("Compress tunnel packets using the LZ4/LZO algorithm. The LZ4 generally offers the best preformance with least CPU usage. For backwards compatibility use the LZO (which is identical to the older option --comp-lzo yes). In the partial mode (the option --compress with an empty algorithm) compression is turned off, but the packet framing for compression is still enabled, allowing a different setting to be pushed later."); ?>
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
This PR deals with OpenVPN compression configurations for both servers and clients. The [official documentation](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/) suggests using the option --compress instead of the deprecated --comp-lzo. It allows to use the LZ4/LZ4 v2 algorithms in addition to the LZO. Besides, in view of the [VORACLE attack](https://community.openvpn.net/openvpn/wiki/VORACLE), the stub/stub v2 algorithms are made available.

Before:
<img width="632" alt="openvpn_compression_before" src="https://user-images.githubusercontent.com/46669194/104274453-eef65e00-54b1-11eb-91c4-8def2e03b89f.png">

After:
<img width="632" alt="openvpn_compression_after" src="https://user-images.githubusercontent.com/46669194/104274755-a0958f00-54b2-11eb-8635-20a8ae985067.png">

This is a part of the changes requested in #2048.