### PR TITLE
Format packet count with toLocaleString in dashboard widget

### DIFF
--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -80,8 +80,8 @@ $ifvalues = array(
           // fill in stats, use column index to determine td location
           var item_index = $("#interface_statistics_widget_intf_" + interface_data['descr']).index();
           if (item_index != -1) {
-              $("#interface_statistics_widget_val_pkg_in > td:eq("+item_index+")").html(interface_data['inpkts']);
-              $("#interface_statistics_widget_val_pkg_out > td:eq("+item_index+")").html(interface_data['outpkts']);
+              $("#interface_statistics_widget_val_pkg_in > td:eq("+item_index+")").html(parseInt(interface_data['inpkts']).toLocaleString());
+              $("#interface_statistics_widget_val_pkg_out > td:eq("+item_index+")").html(parseInt(interface_data['outpkts']).toLocaleString());
               $("#interface_statistics_widget_val_bytes_in > td:eq("+item_index+")").html(interface_data['inbytes_frmt']);
               $("#interface_statistics_widget_val_bytes_out > td:eq("+item_index+")").html(interface_data['outbytes_frmt']);
               $("#interface_statistics_widget_val_errors_in > td:eq("+item_index+")").html(interface_data['inerrs']);


### PR DESCRIPTION
This adjusts to the user's preference: in an English browser, 1234567890 will be shown as 1,234,567,890. JavaScript is already required for widgets to work, adding these toLocaleString calls is not an issue in that regard, and the function is supported in all browsers as far as I can see https://caniuse.com/mdn-javascript_builtins_number_tolocalestring

The current packet count column is very hard to read at a glance. Since one may want to see whether packets are going through the interface at all, and you already can't tell that from the data column (as that is shown in MB/GB/...), I figured we wouldn't want to hide the last few digits by making it shown 5k/5M/5G or something. Formatting the number with the user's local settings seemed like the best option to me.