### PR TITLE
download_blacklists.py: fix broken lines in large files

### DIFF
--- a/src/opnsense/scripts/unbound/download_blacklists.py
+++ b/src/opnsense/scripts/unbound/download_blacklists.py
@@ -58,10 +58,11 @@ def uri_reader(uri):
                 break
             else:
                 parts = (prev_chop + chop).split('\n')
-                if len(parts) > chop.find('\n'):
-                     prev_chop = parts.pop()
+                if parts[-1] != "\n":
+                    prev_chop = parts.pop()
                 else:
                     prev_chop = ''
+                    parts.pop()
                 for part in parts:
                     yield part
     else:

--- a/src/opnsense/scripts/unbound/download_blacklists.py
+++ b/src/opnsense/scripts/unbound/download_blacklists.py
@@ -62,7 +62,6 @@ def uri_reader(uri):
                     prev_chop = parts.pop()
                 else:
                     prev_chop = ''
-                    parts.pop()
                 for part in parts:
                     yield part
     else:


### PR DESCRIPTION
proposed fix for https://github.com/opnsense/core/issues/4595
also changed "if chop[-1]" to "if parts[-1] != "\n":" (checking an array is more correct than checking an incoming string?)
second "parts.pop()" in line65 just for array  cleanup (so as not to yield "\n" only).
checked on https://raw.githubusercontent.com/lightswitch05/hosts/master/docs/lists/ads-and-tracking-extended.txt and
https://blocklistproject.github.io/Lists/fraud.txt (without ending "\n")