### PR TITLE
vpn_openvpn_server.php: netbios options prettify

### DIFF
--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1466,7 +1466,7 @@ endif; ?>
                         <div id="netbios_data">
                           <span>
                             <?=gettext("Node Type"); ?>:&nbsp;
-                          </span>
+                          </span><br>
                           <select name='netbios_ntype' class="selectpicker">
 <?php
                           foreach ($netbios_nodetypes as $type => $name) :
@@ -1484,7 +1484,7 @@ endif; ?>
                                                         "(point-to-point name queries to a WINS server), " .
                                                         "m-node (broadcast then query name server), and " .
                                                         "h-node (query name server, then broadcast)."); ?>
-                          </div>
+                          </div><br>
                           <span>
                             <?=gettext("Scope ID"); ?>:&nbsp;
                           </span>


### PR DESCRIPTION
Hi!
NetBIOS options in server config looks a bit ugly (especially in dark themes).
Can we add a couple of breaks to prettify it?
before:
![ovpn_nb1](https://user-images.githubusercontent.com/36099472/104837047-26567780-58c3-11eb-876a-5de09f75b491.PNG)

after:
![ovpn_nb2](https://user-images.githubusercontent.com/36099472/104837051-2eaeb280-58c3-11eb-9488-0c1cbaef0c10.PNG)

Thanks!