### PR TITLE
firewall: Fix Icon Toggle for Block

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -437,7 +437,7 @@ $( document ).ready(function() {
   $(".act_toggle").click(function(event){
       event.preventDefault();
       let target = $(this);
-      target.removeClass('fa-play').addClass('fa-spinner fa-pulse');
+      target.addClass('fa-spinner fa-pulse');
       let id = target.attr("id").split('_').pop(-1);
       $.ajax("firewall_rules.php",{
           type: 'post',
@@ -446,7 +446,7 @@ $( document ).ready(function() {
           data: {'act': 'toggle', 'id': id},
           success: function(response) {
               target.prop('title', response['new_label']).tooltip('fixTitle').tooltip('hide');
-              target.removeClass('fa-spinner fa-pulse').addClass('fa-play');
+              target.removeClass('fa-spinner fa-pulse');
               if (response['new_state']) {
                   target.removeClass('text-muted').addClass('text-success');
               } else {
@@ -457,7 +457,7 @@ $( document ).ready(function() {
               $("#fw-alert-changes").removeClass("hidden");
           },
           error: function () {
-              target.removeClass('fa-spinner fa-pulse').addClass('fa-play');
+              target.removeClass('fa-spinner fa-pulse');
           }
       });
   });


### PR DESCRIPTION
When a rule is set to Allow, Block or Reject, the icon is `fa-play`, `fa-times` and `fa-times-circle` respectively.  When you toggle a rule to disable it, the code in `firewall_rules.php` changes the icon to `fa-play` (Allow Icon) regardless of it being Block or Reject, which is confusing.  

Due to the order of how things are defined in the CSS, Reject and Allow work fine, but Block does not.  Since `fa-spinner fa-pulse` appears to be defined later in CSS than the indicators, it takes priority for the icon.  When removed, it restores the proper icon with the appropriate `text-muted` or `text-success`.  I think we can safely remove the `fa-play` from the toggle, which will fix the Block icon.

Example of issue by clicking it a couple times..
![Screen Shot 2021-01-26 at 12 05 34 AM](https://user-images.githubusercontent.com/161904/105805020-21529180-5f6f-11eb-9e1f-20ed0737305b.png)
