### PR TITLE
Update alias.py to add User-Agent

### DIFF
--- a/src/opnsense/scripts/filter/lib/alias.py
+++ b/src/opnsense/scripts/filter/lib/alias.py
@@ -140,6 +140,9 @@ class Alias(object):
         req_opts['url'] = url
         req_opts['stream'] = True
         req_opts['timeout'] = self._timeout
+        req_opts['headers'] = {
+            'User-Agent': 'OPNsense/20.7.8_4',
+        }
         if self._ssl_no_verify:
             req_opts['verify'] = False
         # fetch data


### PR DESCRIPTION
This is needed since some web servers (including `os-nginx` in its default configuration) reject requests without a User-Agent specified.

Not sure how to dynamically get the current OPNsense version, or whether that's even a good User-Agent. Feel free to modify to fix that.