### PR TITLE
Unbound: fix domain overrides for private address reverse lookup zones

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -487,7 +487,7 @@ function unbound_add_domain_overrides($pvt = false)
         if ($pvt == true) {
             $domain_entries .= "private-domain: \"$domain\"\n";
             $domain_entries .= "domain-insecure: \"$domain\"\n";
-            if (preg_match('/.+\.in-addr\.arpa\.?$/', $domain)) {
+            if (preg_match('/.+\.(in-addr|ip6)\.arpa\.?$/', $domain)) {
                 $domain_entries .= "local-zone: \"$domain\" typetransparent\n";
             }
         } else {

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -211,7 +211,7 @@ EOF;
     }
 
     // Allow DNS Rebind for forwarded domains
-    if ((isset($config['unbound']['domainoverrides']) && is_array($config['unbound']['domainoverrides'])) && !isset($config['system']['webgui']['nodnsrebindcheck'])) {
+    if (isset($config['unbound']['domainoverrides']) && is_array($config['unbound']['domainoverrides'])) {
         $private_domains = "# Set private domains in case authoritative name server returns a Private IP address\n";
         $private_domains .= unbound_add_domain_overrides(true);
     }
@@ -485,10 +485,11 @@ function unbound_add_domain_overrides($pvt = false)
     $domain_entries = '';
     foreach ($result as $domain => $ips) {
         if ($pvt == true) {
-            $domain_entries .= "private-domain: \"$domain\"\n";
             $domain_entries .= "domain-insecure: \"$domain\"\n";
             if (preg_match('/.+\.(in-addr|ip6)\.arpa\.?$/', $domain)) {
                 $domain_entries .= "local-zone: \"$domain\" typetransparent\n";
+            } elseif (!isset($config['system']['webgui']['nodnsrebindcheck'])) {
+                $domain_entries .= "private-domain: \"$domain\"\n";
             }
         } else {
             $domain_entries .= "forward-zone:\n";

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -466,6 +466,8 @@ function unbound_configure_do($verbose = false, $interface = '')
 
 function unbound_add_domain_overrides($pvt = false)
 {
+    global $config;
+
     $domains = config_read_array('unbound', 'domainoverrides');
 
     usort($domains, function ($a, $b) {


### PR DESCRIPTION
Domain overrides for reverse lookup zones add a typetransparent local-zone to unbound.conf. This allows forwarding of reverse lookups of private IP addresses which would otherwise be blocked by ~~DNS rebinding prevention~~ unbound's default AS112 zones.

These entries were only created for IPv4 reverse lookup zones (.in-addr.arpa.), but not for IPv6 reverse lookup zones (.ip6.arpa.).

Closes #4787.