### PR TITLE
DHCP: Update DNS with hostname only static entries

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1104,6 +1104,7 @@ EOD;
                     $dhhostname = str_replace(" ", "_", $sm['hostname']);
                     $dhhostname = str_replace(".", "_", $dhhostname);
                     $dhcpdconf .= "  option host-name \"{$dhhostname}\";\n";
+                    $dhcpdconf .= "  set hostname-override = config-option host-name;\n";
                 }
                 if (!empty($sm['filename'])) {
                     $dhcpdconf .= "  filename \"{$sm['filename']}\";\n";
@@ -1573,6 +1574,7 @@ EOD;
                     $dhhostname = str_replace(" ", "_", $sm['hostname']);
                     $dhhostname = str_replace(".", "_", $dhhostname);
                     $dhcpdv6conf .= "  option host-name {$dhhostname};\n";
+                    $dhcpdv6conf .= "  set hostname-override = config-option host-name;\n";
                 }
                 if (!empty($sm['filename'])) {
                     $dhcpdv6conf .= "  filename \"{$sm['filename']}\";\n";

--- a/src/opnsense/site-python/watchers/dhcpd.py
+++ b/src/opnsense/site-python/watchers/dhcpd.py
@@ -57,6 +57,7 @@ class DHCPDLease(object):
         :param lines: lease section as list item
         :return: dictionary
         """
+        hostname_override = None
         lease = dict()
         lease['address'] = lines[0].split()[1]
         for line in lines:
@@ -73,9 +74,14 @@ class DHCPDLease(object):
                 field_value = {'hardware-type': parts[1], 'mac-address': parts[2].split(';')[0]}
             elif field_name in('uid', 'client-hostname') and len(parts) >= 2 and parts[1].find('"') > -1:
                 field_value = parts[1].split('"')[1]
+            elif field_name == 'set' and len(parts) >= 4 and parts[1] == 'hostname-override' and parts[3].find('"') > -1:
+                hostname_override = parts[3].split('"')[1]
 
             if field_value is not None:
                 lease[field_name] = field_value
+
+        if hostname_override is not None:
+            lease['client-hostname'] = hostname_override
 
         return lease
 

--- a/src/www/services_dhcp_edit.php
+++ b/src/www/services_dhcp_edit.php
@@ -354,7 +354,6 @@ include("head.inc");
                     <input name="hostname" type="text" value="<?=$pconfig['hostname'];?>" />
                     <div class="hidden" data-for="help_for_hostname">
                       <?=gettext("Name of the host, without domain part.");?>
-                      <?=gettext("If no IP address is given above, hostname will not be visible to DNS services with lease registration enabled.");?>
                     </div>
                   </td>
                 </tr>

--- a/src/www/services_dhcpv6_edit.php
+++ b/src/www/services_dhcpv6_edit.php
@@ -207,7 +207,6 @@ include("head.inc");
                       <input name="hostname" type="text" value="<?=$pconfig['hostname'];?>" />
                       <div class="hidden" data-for="help_for_hostname">
                         <?=gettext("Name of the host, without domain part.");?>
-                        <?=gettext("If no IP address is given above, hostname will not be visible to DNS services with lease registration enabled.");?>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
When a DHCP static entry is created with a hostname but no IP address, Unbound DNS is not update when an IP address from the DHCP pool is assigned to the client.

As discussed in #2946 the issue is that the hostname reported in the `client-hostname` field in dhcpd.leases is the hostname reported by the client.  This change adds the configured hostname to a _set_ variable, `hostname-override`, that gets recorded in dhcpd.leases, then use this value if preset to update the DNS server record.

This only works with the Unbound DNS server, but it could be extended to work with dnsmasq by updating sbin/dhcpleases to parse `hostname-override`