### PR TITLE
radvd: don't advertise ::/0 route

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -355,12 +355,6 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
             $radvdconf .= "\t};\n";
         }
 
-        if (!empty($dhcpv6ifconf['rainterface'])) {
-            $radvdconf .= "\troute ::/0 {\n";
-            $radvdconf .= "\t\tRemoveRoute off;\n";
-            $radvdconf .= "\t};\n";
-        }
-
         if (!empty($dhcpv6ifconf['raroutes'])) {
             foreach (explode(',', $dhcpv6ifconf['raroutes']) as $raroute) {
                 $radvdconf .= "\troute {$raroute} {\n";


### PR DESCRIPTION
As discussed back in #3343: Router Advertisements should never contain a ::/0 route. A default route is indicated by setting the Router Lifetime to > 0. This was originally fixed by @fichtner in e67dade991d631d7edba5b750a87396b38bac2e1, but the ::/0 route is still added for CARP interfaces and "static mode" interfaces (introduced in 66dc0e9b29ec3d7fbe2446faf057116e6a9b6337).

I only noticed this after recently switching to static interface mode.