### PR TITLE
proxy fetchACLs: Change close() semantics

### DIFF
--- a/src/opnsense/scripts/proxy/fetchACLs.py
+++ b/src/opnsense/scripts/proxy/fetchACLs.py
@@ -229,7 +229,7 @@ class DomainSorter(object):
                     break
                 else:
                     set_content[line.split('|')[0]] = '|'.join(line.split('|')[1:])
-            for itemkey in sorted(set_content, reverse=True):
+            for itemkey in sorted(set_content, reverse=False):
                 yield set_content[itemkey]
 
     @staticmethod
@@ -262,9 +262,12 @@ class DomainSorter(object):
                         # duplicate, skip
                         continue
                     if self.is_domain(line):
-                        # prefix domain, if this domain is different then the previous one
-                        if prev_line is None or '.%s' % line not in prev_line:
+                        # write prefix for domain, but only if it is not a
+                        # subdomain of the previous entry - if so, skip
+                        if prev_line is None or '.%s' % prev_line not in line:
                             f_out.write(b'.')
+                        else:
+                            continue
                     f_out.write(line.encode())
                     prev_line = line
 


### PR DESCRIPTION
Under current close() semantics for a DomainSorter() object, more general (e.g. higher level) domains are evaluated after subdomains.  This resulted in a curious situation in which if ads.foo.bar was in a blacklist under one category and foo.bar was in the same blacklist under a different category, the resulting ACL file would have:

```
.ads.foo.bar
foo.bar
```

Which would result in any subdomain other than ads being accessible.  Change the semantics so that higher level domains are considered first and prefixed with `.`, and if any subdomains are subsequently encountered they are just skipped.