### PR TITLE
trim carp password. without this the untrimmed password will be used …

### DIFF
--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -140,6 +140,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                    $input_errors[] = sprintf(gettext("VHID %s is already in use on interface %s. Pick a unique number on this interface."),$pconfig['vhid'], convert_friendly_interface_to_friendly_descr($pconfig['interface']));
                }
             }
+            // prevent leading/trailing whitespace in carp password
+            $pconfig['password'] = trim($pconfig['password']);
             if (empty($pconfig['password'])) {
                 $input_errors[] = gettext("You must specify a CARP password that is shared between the two VHID members.");
             }


### PR DESCRIPTION
…on master firewall and the trimmed password on secondary firewall after config sync - resulting in dual master due to password mismatch.