### PR TITLE
LDAP bugfix: use StartTLS as configured when retrieving authentication containers

### DIFF
--- a/src/www/system_usermanager_settings_ldapacpicker.php
+++ b/src/www/system_usermanager_settings_ldapacpicker.php
@@ -45,6 +45,9 @@ if (isset($_POST['basedn']) && isset($_POST['host'])) {
     }
 
     $ldap_auth = new OPNsense\Auth\LDAP($_POST['basedn'], isset($_POST['proto']) ? $_POST['proto'] : 3);
+    $ldap_auth->setProperties(array(
+        "ldap_urltype" => $_POST['urltype'])
+    ));
     $ldap_is_connected = $ldap_auth->connect(
         $ldap_full_url,
         !empty($_POST['binddn']) ? $_POST['binddn'] : null,


### PR DESCRIPTION
Make StartTLS work when retrieving LDAP authentication containers. The code did not set the LDAP connection properties as configured and thus connected as if `TCP - Standard` was selected.

Fixes #4453 (currently erroneously already closed)