### PR TITLE
unbound dnsbl: allow to create inform local-zones

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
@@ -12,6 +12,12 @@
         <help>Select which kind of DNSBL you want to use.</help>
     </field>
     <field>
+        <id>dnsbl.inform</id>
+        <label>Inform zone type</label>
+        <type>checkbox</type>
+        <help>For debugging purposes. Create inform-type local-zone's for blacklisted hosts. Allows to use a 'inform ' keyword to find blacklisted hosts lookups.</help>
+    </field>
+    <field>
         <id>dnsbl.lists</id>
         <label>URLs of Blacklists</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Dnsbl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Dnsbl.xml
@@ -50,6 +50,10 @@
         <lists type="CSVListField">
             <Required>N</Required>
         </lists>
+        <inform type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </inform>
         <whitelists type="CSVListField">
             <Required>N</Required>
         </whitelists>

--- a/src/opnsense/scripts/unbound/download_blacklists.py
+++ b/src/opnsense/scripts/unbound/download_blacklists.py
@@ -129,14 +129,20 @@ if __name__ == '__main__':
 
                 syslog.syslog(
                     syslog.LOG_NOTICE,
-                    'blacklist download %(uri)s (lines: %(lines)d exclude: %(skip)d black: %(blacklist)d' % file_stats
+                    'blacklist download %(uri)s (lines: %(lines)d exclude: %(skip)d black: %(blacklist)d)' % file_stats
                 )
+        
+        inform = False
+        if cnf.has_section('inform'): 
+            inform = True
 
     # write out results
     with open("/var/unbound/etc/dnsbl.conf", 'w') as unbound_outf:
         if blacklist_items:
             unbound_outf.write('server:\n')
             for entry in blacklist_items:
+                if inform:
+                   unbound_outf.write("local-zone: \"%s\" inform\n" % entry)    
                 unbound_outf.write("local-data: \"%s A 0.0.0.0\"\n" % entry)
 
     syslog.syslog(syslog.LOG_NOTICE, "blacklist download done in %0.2f seconds (%d records)" % (

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blacklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blacklists.conf
@@ -55,7 +55,7 @@ custom_{{loop.index}}={{uri}}
 # exclude localhost entries
 default_pattern_1=.*localhost$
 # exclude non domain entries
-default_pattern_2=^(?![a-zA-Z\d]).*
+default_pattern_2=^(?![a-zA-Z_\d]).*
 {%    if not helpers.empty('OPNsense.unboundplus.dnsbl.whitelists')%}
 # user defined
 {%      for pattern in OPNsense.unboundplus.dnsbl.whitelists.split(',') %}

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blacklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blacklists.conf
@@ -62,5 +62,9 @@ default_pattern_2=^(?![a-zA-Z\d]).*
 custom_pattern_{{loop.index}}={{ pattern }}
 {%      endfor %}
 {%    endif %}
+{%    if not helpers.empty('OPNsense.unboundplus.dnsbl.inform')%}
+[inform]
+inform=yes
+{%    endif %}
 
 {%  endif %}


### PR DESCRIPTION
Hi!
for https://github.com/opnsense/core/issues/4557#issuecomment-780304743
the idea is to add the ability to create inform-type local zones for blacklisted hosts (by default unbound creates transparent zones implicitly in this case). as a result, requests for such hosts are displayed in the log with a record like:
` info: bad.host.com. inform 192.168.0.215@60748 bad.host.com. A IN`
and can be filtered by ' inform ' keyword.
may close https://github.com/opnsense/core/issues/4557
thanks!

