### PR TITLE
Clear stale SIP UDP states when WAN IP changes.

### DIFF
--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -155,9 +155,10 @@ if (!is_ipaddr($cacheip) || $ip != $cacheip || !is_ipaddr($configip)) {
     plugins_configure('monitor');
     filter_configure_sync(false, isset($config['system']['ip_change_kill_states']));
 
-    // Remove states with previous IP address as source, that were not cleared correctly (particularly UDP SIP connections), when ip_change_kill_states is disabled
-    if (is_ipaddr($cacheip) && !isset($config['system']['ip_change_kill_states'])) {
-	$retval = mwexecf('/sbin/pfctl -k ' . $cacheip);
+    // Clear states on ip change
+    if (is_ipaddr($cacheip) && ($ip != $cacheip) && !isset($config['system']['ip_change_kill_states'])) {
+	log_error("IP address change detected, killing states of old ip $cacheip");
+	mwexec('/sbin/pfctl -k ' . $cacheip);
     }
 
     if (is_ipaddr($ip)) {
@@ -167,6 +168,4 @@ if (!is_ipaddr($cacheip) || $ip != $cacheip || !is_ipaddr($configip)) {
     plugins_configure('vpn', false, array($interface));
     plugins_configure('newwanip', false, array($interface));
     rrd_configure();
-
-
 }

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -155,20 +155,11 @@ if (!is_ipaddr($cacheip) || $ip != $cacheip || !is_ipaddr($configip)) {
     plugins_configure('monitor');
     filter_configure_sync(false, isset($config['system']['ip_change_kill_states']));
 
-    /*
-    Remove states with previous IP address as source, that were not cleared correctly (particularly UDP SIP connections), when ip_change_kill_states is disabled
-    */
+    // Remove states with previous IP address as source, that were not cleared correctly (particularly UDP SIP connections), when ip_change_kill_states is disabled
     if (is_ipaddr($cacheip) && !isset($config['system']['ip_change_kill_states'])) {
-        $stale_states = json_decode(configdp_run('filter list states', array($cacheip, 10000)), true);
-        if (!empty($stale_states['details'])) {
-            foreach ($stale_states['details'] as $state) {
-                if ($state['src_addr'] == $cacheip) {
-                    $retval = mwexecf('/sbin/pfctl -k %s/32 -k %s/32', $cacheip, $state['dst_addr']));
-                }
-            }
-        }
+	$retval = mwexecf('/sbin/pfctl -k ' . $cacheip);
     }
-    
+
     if (is_ipaddr($ip)) {
         @file_put_contents($cacheip_file, $ip);
     }
@@ -176,4 +167,6 @@ if (!is_ipaddr($cacheip) || $ip != $cacheip || !is_ipaddr($configip)) {
     plugins_configure('vpn', false, array($interface));
     plugins_configure('newwanip', false, array($interface));
     rrd_configure();
+
+
 }

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -155,6 +155,20 @@ if (!is_ipaddr($cacheip) || $ip != $cacheip || !is_ipaddr($configip)) {
     plugins_configure('monitor');
     filter_configure_sync(false, isset($config['system']['ip_change_kill_states']));
 
+    /*
+    Remove states with previous IP address as source, that were not cleared correctly (particularly UDP SIP connections), when ip_change_kill_states is disabled
+    */
+    if (is_ipaddr($cacheip) && !isset($config['system']['ip_change_kill_states'])) {
+        $stale_states = json_decode(configdp_run('filter list states', array($cacheip, 10000)), true);
+        if (!empty($stale_states['details'])) {
+            foreach ($stale_states['details'] as $state) {
+                if ($state['src_addr'] == $cacheip) {
+                    $retval = mwexecf('/sbin/pfctl -k %s/32 -k %s/32', $cacheip, $state['dst_addr']));
+                }
+            }
+        }
+    }
+    
     if (is_ipaddr($ip)) {
         @file_put_contents($cacheip_file, $ip);
     }

--- a/src/opnsense/scripts/interfaces/dhclient-script
+++ b/src/opnsense/scripts/interfaces/dhclient-script
@@ -53,6 +53,8 @@ arp_flush() {
 		sh >/dev/null 2>&1
 }
 
+/* Disabled: taken care of by rc.newwanip
+
 delete_old_states() {
 	$LOGGER "Starting delete_old_states()"
 	_FLUSHED=0
@@ -82,6 +84,7 @@ delete_old_states() {
 		fi
 	fi
 }
+*/
 
 delete_old_address() {
 	rm -f /var/db/${interface}_ip
@@ -335,7 +338,7 @@ MEDIUM)
 PREINIT)
 	delete_old_alias
 	$IFCONFIG $interface inet alias 0.0.0.0 netmask 255.0.0.0 broadcast 255.255.255.255 up
-	delete_old_states
+	// delete_old_states
 	rm -f /tmp/${interface}_router
 	;;
 
@@ -345,9 +348,13 @@ ARPCHECK|ARPSEND)
 BOUND|RENEW|REBIND|REBOOT)
 	check_hostname
 	changes="no"
+
+	/*
 	if [ "$old_ip_address" != "$new_ip_address" ]; then
 		delete_old_states
 	fi
+	*/
+
 	if [ -n "$old_ip_address" ]; then
 		if [ -n "$alias_ip_address" -a "$old_ip_address" != "$alias_ip_address" ]; then
 			delete_old_alias
@@ -381,7 +388,7 @@ BOUND|RENEW|REBIND|REBOOT)
 
 EXPIRE|FAIL)
 	delete_old_alias
-	delete_old_states
+	// delete_old_states
 	if [ -n "$old_ip_address" ]; then
 		delete_old_address
 		delete_old_routes
@@ -429,7 +436,7 @@ TIMEOUT)
 		fi
 	fi
 	eval "$IFCONFIG $interface inet -alias $new_ip_address $medium"
-	delete_old_states
+	// delete_old_states
 	delete_old_routes
 	exit_with_hooks 1
 	;;

--- a/src/www/diag_dump_states.php
+++ b/src/www/diag_dump_states.php
@@ -54,6 +54,7 @@ if (isset($_POST['filter']) && isset($_POST['killfilter'])) {
     if (!empty($tokill)) {
         mwexec("/sbin/pfctl -k {$tokill} -k 0/0");
         mwexec("/sbin/pfctl -k 0.0.0.0/0 -k {$tokill}");
+        mwexec("/sbin/pfctl -k {$tokill}");
     }
 }
 


### PR DESCRIPTION
This is a suggestion to fix VOIP/SIP connection problems after WAN IP change.
See issue #4652
It should be an alternative to #4594 and also to #2414 (both similar or even identical problems).

The purpose is to kill all remaining states referring to the previous IP (typically UDP MULTIPLE:MULTIPLE connections for voice-over-ip-communication on port 5060). No cheap hardware router does have these issues. From my point of view, this is a critical issue for any business use of OPNsense, particularly if many phones, PBXs, fax servers are connected to the router.

Unfortunately I do not have a build environment set up and the code provided **IS NOT TESTED**. This is supposed to be a replacement for awful workarounds with external scripts to monitor IP change and kill remaining states.

This is my first pull request ever, so please forgive me, if there is anything wrong.



Best regards,
  Walter