### PR TITLE
Unbound: Handle DHCP client expiring and returning

### DIFF
--- a/src/opnsense/scripts/dns/unbound_dhcpd.py
+++ b/src/opnsense/scripts/dns/unbound_dhcpd.py
@@ -67,7 +67,7 @@ class UnboundLocalData:
             unbound_control(['list_local_data'], output_stream)
             for line in output_stream:
                 parts = line.decode().split()
-                if len(parts) > 4 and parts[3] == 'A':
+                if len(parts) > 4 and parts[3] == 'A' and parts[4] != '0.0.0.0':
                     self.add_address(parts[4], parts[0][:-1])
 
     def add_address(self, address, fqdn):
@@ -131,6 +131,9 @@ def run_watcher(target_filename, domain):
                     )
                     unbound_control(['local_data_remove',  cached_leases[address]['client-hostname']])
                     del cached_leases[address]
+                    fqdn = '%s.%s' % (cached_leases[address]['client-hostname'], domain)
+                    if unbound_local_data.is_equal(address, fqdn):
+                        unbound_local_data.cleanup(address, fqdn)
                     dhcpd_changed = True
 
         if dhcpd_changed:


### PR DESCRIPTION
Cleanup local data cache when a DHCP endpoint expires, so that it is
kept in sync with dynamic changes.  This ensures that if an expired DHCP
endpoint returns and is assigned the same IP address the local cache is
correct and doesn't block the entry being dynamically re-added to Unbound.

Also don't cache the blacklist entries, which aren't needed to manage
the DHCP DNS entries. There can easily be 1M+ blacklist entries, so
ignoring these improves startup speed and reduces memory footprint

Fixes #4714