### PR TITLE
Correct dhcp6c.conf issue on pppoe link down

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1033,6 +1033,25 @@ function interface_bring_down($interface = "wan", $ifacecfg = false)
         kill_hostapd($realif);
     }
 
+    $track6 = link_interface_to_track6($interface);
+    if (count($track6)) {
+        /* bring down radvd and dhcp6 on these interfaces */
+        plugins_configure('dhcp', false, array('inet6', $track6));
+    }
+
+    switch ($ifcfg['ipaddrv6']) {
+        case 'slaac':
+        case 'dhcp6':
+            interface_dhcpv6_prepare($interface, $ifcfg, true);
+            killbypid('/var/run/dhcp6c.pid', 'HUP');
+            break;
+        case 'track6':
+            interface_track6_configure($interface, $ifcfg, false, true);
+            break;
+        default:
+            break;
+    }
+
     switch ($ifcfg['ipaddr']) {
         case 'ppp':
         case 'pppoe':
@@ -1055,25 +1074,6 @@ function interface_bring_down($interface = "wan", $ifacecfg = false)
             break;
         case 'dhcp':
             killbypid("/var/run/dhclient.{$realif}.pid", 'TERM', true);
-            break;
-        default:
-            break;
-    }
-
-    $track6 = link_interface_to_track6($interface);
-    if (count($track6)) {
-        /* bring down radvd and dhcp6 on these interfaces */
-        plugins_configure('dhcp', false, array('inet6', $track6));
-    }
-
-    switch ($ifcfg['ipaddrv6']) {
-        case 'slaac':
-        case 'dhcp6':
-            interface_dhcpv6_prepare($interface, $ifcfg, true);
-            killbypid('/var/run/dhcp6c.pid', 'HUP');
-            break;
-        case 'track6':
-            interface_track6_configure($interface, $ifcfg, false, true);
             break;
         default:
             break;


### PR DESCRIPTION
When a PPPoE down event happens the dhcp6c.conf file does not get re-written thus leaving the config section for that link. This results in errors from dhcp6c and possibly delays when the link is re-established,
It happens because the interface_bring_down returns when it's a PPPoE link without calling an update using interface_dhcpv6_prepare() and a HUP to dhcp6c.