### PR TITLE
Allow to specify port ranges for outgoing NAT.

### DIFF
--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -162,7 +162,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if(!empty($pconfig['dstport']) && !is_portrange($pconfig['dstport']) && !is_portoralias($pconfig['dstport'])) {
             $input_errors[] = gettext("You must supply either a valid port or port alias for the destination port entry.");
         }
-        if (!empty($pconfig['natport']) && !is_port($pconfig['natport']) && empty($pconfig['nonat'])) {
+        if (!empty($pconfig['natport']) && !(is_port($pconfig['natport']) || is_portrange($pconfig['natport'])) && empty($pconfig['nonat'])) {
             $input_errors[] = gettext("You must supply a valid port for the NAT port entry.");
         }
     }


### PR DESCRIPTION
This allows to specify port ranges for NAT which is a valid pf configuration. With this change I can add 3000:3100 in the UI and see this in the ruleset:
```
pfctl -sn
no nat proto carp all
nat on pppoe0 inet proto tcp from any to <API_Endpoints> -> (pppoe0:0) port 3000:3100
nat on pppoe0 inet from (bridge0:network) to any port = isakmp -> (pppoe0:0) static-port
nat on pppoe0 inet from (lo0:network) to any port = isakmp -> (pppoe0:0) static-port
nat on pppoe0 inet from 127.0.0.0/8 to any port = isakmp -> (pppoe0:0) static-port
nat on pppoe0 inet from (bridge0:network) to any -> (pppoe0:0) port 1024:65535
nat on pppoe0 inet from (lo0:network) to any -> (pppoe0:0) port 1024:65535
nat on pppoe0 inet from 127.0.0.0/8 to any -> (pppoe0:0) port 1024:65535
no rdr proto carp all
no rdr on bridge0 proto tcp from any to (bridge0) port = ssh
no rdr on bridge0 proto tcp from any to (bridge0) port = http
no rdr on bridge0 proto tcp from any to (bridge0) port = https
rdr-anchor "miniupnpd" all
```