### PR TITLE
Dashboard: cut scripts from widgets before move

### DIFF
--- a/src/www/index.php
+++ b/src/www/index.php
@@ -263,6 +263,9 @@ include("fbegin.inc");?>
       // rearrange widgets to stored column
       $(".widgetdiv").each(function(){
           var widget = $(this);
+          widget.find('script').each(function(){
+              $(this).remove();
+          });
           var container = $(this).parent();
           var target_col = widget.data('sortkey').split('-')[1];
           if (target_col != undefined) {


### PR DESCRIPTION
Hi.
This can help to get rid of double event bindings in widgets when manipulating DOMs.
Also fixes https://github.com/opnsense/core/issues/4750 on my test vm without changing to $( document ).ready


