### PR TITLE
IDS/IPS: disable rules by Policy Action

### DIFF
--- a/src/opnsense/scripts/suricata/installRules.py
+++ b/src/opnsense/scripts/suricata/installRules.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                 # generate altered rule
                 if 'enabled' in rule_updates[rule_info_record['metadata']['sid']]:
                     # enabled / disabled in configuration
-                    if (rule_updates[rule_info_record['metadata']['sid']]['enabled']) == '0':
+                    if (rule_updates[rule_info_record['metadata']['sid']]['enabled']) != '1':
                         rule = ('#%s' % rule[i:])
                     else:
                         rule = rule[i:]


### PR DESCRIPTION
Hi!
rule_updates[rule_info_record['metadata']['sid']]['enabled'] return 0 for` __manual__` disabled rules and False for disabled rules with matched policy.
fixes https://github.com/opnsense/core/issues/4753 on my test vm