### PR TITLE
firewall: categories improvements

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
@@ -55,6 +55,18 @@ class CategoryController extends ApiMutableModelControllerBase
     }
 
     /**
+     * search categories with an empty (no category) at the beginning
+     * @return array search results
+     * @throws \ReflectionException
+     */
+    public function searchNoCategoryItemAction()
+    {
+        $result = $this->searchBase("categories.category", array('name', 'auto', 'color'), "name");
+        array_unshift($result['rows'], array('uuid' => "", 'name' => gettext("(No Category)"), 'auto' => "", 'color' => ""));
+        return $result;
+    }
+
+    /**
      * Update category with given properties
      * @param string $uuid internal id
      * @return array save result + validation output

--- a/src/www/javascript/opnsense_legacy.js
+++ b/src/www/javascript/opnsense_legacy.js
@@ -180,7 +180,7 @@ function window_highlight_table_option()
  */
 function hook_firewall_categories() {
     let cat_select = $("#fw_category");
-    ajaxCall('/api/firewall/category/searchItem', {}, function(data){
+    ajaxCall('/api/firewall/category/searchNoCategoryItem', {}, function(data){
         if (data.rows !== undefined && data.rows.length > 0) {
             let color_map = {};
             for (let i=0; i < data.rows.length ; ++i) {
@@ -205,8 +205,8 @@ function hook_firewall_categories() {
                     }
                 });
             });
-            let no_opt = $('<div/>').html("(No Category)").text();
-            cat_select.append($('<option/>').val(no_opt).html("(No Category)"));
+            //let no_opt = $('<div/>').html("(No Category)").text();
+            //cat_select.append($('<option/>').val(no_opt).html("(No Category)"));
             for (let i=0; i < data.rows.length ; ++i) {
                 let opt_val = $('<div/>').html(data.rows[i].name).text();
                 let option = $("<option/>");
@@ -244,7 +244,6 @@ function hook_firewall_categories() {
             $(".rule").each(function(){
                 let is_selected = false;
                 $(this).data('category').split(',').forEach(function(item){
-                    console.log(selected_values);
                     if (selected_values.indexOf("(No Category)") > -1 && item === "") {
                         // No category for this rule
                         is_selected = true;

--- a/src/www/javascript/opnsense_legacy.js
+++ b/src/www/javascript/opnsense_legacy.js
@@ -200,11 +200,13 @@ function hook_firewall_categories() {
                         // suffix category color in the description td
                         let td = row.find('td.rule-description');
                         if (td.length > 0) {
-                            td.append($("<i class='fa fa-circle'/>").css('color', '#'+color_map[item]));
+                            td.append($("<i class='fa fa-circle' title='"+item+"'/>").css('color', '#'+color_map[item]));
                         }
                     }
                 });
             });
+            let no_opt = $('<div/>').html("(No Category)").text();
+            cat_select.append($('<option/>').val(no_opt).html("(No Category)"));
             for (let i=0; i < data.rows.length ; ++i) {
                 let opt_val = $('<div/>').html(data.rows[i].name).text();
                 let option = $("<option/>");
@@ -242,6 +244,11 @@ function hook_firewall_categories() {
             $(".rule").each(function(){
                 let is_selected = false;
                 $(this).data('category').split(',').forEach(function(item){
+                    console.log(selected_values);
+                    if (selected_values.indexOf("(No Category)") > -1 && item === "") {
+                        // No category for this rule
+                        is_selected = true;
+                    }
                     if (selected_values.indexOf(item) > -1) {
                         is_selected = true;
                     }


### PR DESCRIPTION
This commit adds the option of filtering on (No Category) in the firewall rules. A tooltip for visual aid is also added. In order to run static text through gettext(), a separate API endpoint has been created.