### PR TITLE
Alias.php: typo in dst type

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -60,7 +60,7 @@ class Alias extends BaseModel
         $sources[] = array(array('nat', 'onetoone'), array('destination', 'address'));
         $sources[] = array(array('nat', 'outbound', 'rule'), array('source', 'network'));
         $sources[] = array(array('nat', 'outbound', 'rule'), array('sourceport'));
-        $sources[] = array(array('nat', 'outbound', 'rule'), array('destination', 'address'));
+        $sources[] = array(array('nat', 'outbound', 'rule'), array('destination', 'network'));
         $sources[] = array(array('nat', 'outbound', 'rule'), array('dstport'));
         $sources[] = array(array('nat', 'outbound', 'rule'), array('target'));
         $sources[] = array(array('load_balancer', 'lbpool'), array('port'));


### PR DESCRIPTION
Hi!
looks like a typo (outbound nat rules uses 'network' for aliases. not 'address').
https://github.com/opnsense/core/blob/3277c0beb6f3ecb957fef0e95ae0562cea43eb99/src/www/firewall_nat_out_edit.php#L286-L297
closes https://github.com/opnsense/core/issues/4778 imho (tested on vm)
thanks!