### PR TITLE
firewall: categories improvements

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
@@ -55,6 +55,18 @@ class CategoryController extends ApiMutableModelControllerBase
     }
 
     /**
+     * search categories with an empty (no category) at the beginning
+     * @return array search results
+     * @throws \ReflectionException
+     */
+    public function searchNoCategoryItemAction()
+    {
+        $result = $this->searchBase("categories.category", array('name', 'auto', 'color'), "name");
+        array_unshift($result['rows'], array('uuid' => "", 'name' => gettext("(No Category)"), 'auto' => "", 'color' => ""));
+        return $result;
+    }
+
+    /**
      * Update category with given properties
      * @param string $uuid internal id
      * @return array save result + validation output

--- a/src/www/javascript/opnsense_legacy.js
+++ b/src/www/javascript/opnsense_legacy.js
@@ -180,7 +180,7 @@ function window_highlight_table_option()
  */
 function hook_firewall_categories() {
     let cat_select = $("#fw_category");
-    ajaxCall('/api/firewall/category/searchItem', {}, function(data){
+    ajaxCall('/api/firewall/category/searchNoCategoryItem', {}, function(data){
         if (data.rows !== undefined && data.rows.length > 0) {
             let color_map = {};
             for (let i=0; i < data.rows.length ; ++i) {
@@ -200,7 +200,7 @@ function hook_firewall_categories() {
                         // suffix category color in the description td
                         let td = row.find('td.rule-description');
                         if (td.length > 0) {
-                            td.append($("<i class='fa fa-circle'/>").css('color', '#'+color_map[item]));
+                            td.append($("<i class='fa fa-circle' data-toggle='tooltip' title='"+item+"'/>").css('color', '#'+color_map[item]));
                         }
                     }
                 });
@@ -242,6 +242,10 @@ function hook_firewall_categories() {
             $(".rule").each(function(){
                 let is_selected = false;
                 $(this).data('category').split(',').forEach(function(item){
+                    if (selected_values.indexOf("(No Category)") > -1 && item === "") {
+                        // No category for this rule
+                        is_selected = true;
+                    }
                     if (selected_values.indexOf(item) > -1) {
                         is_selected = true;
                     }
@@ -257,5 +261,6 @@ function hook_firewall_categories() {
             $(".opnsense-rules").change();
         });
         cat_select.change();
+        $('[data-toggle="tooltip"]').tooltip();
     });
 }

--- a/src/www/javascript/opnsense_legacy.js
+++ b/src/www/javascript/opnsense_legacy.js
@@ -200,7 +200,7 @@ function hook_firewall_categories() {
                         // suffix category color in the description td
                         let td = row.find('td.rule-description');
                         if (td.length > 0) {
-                            td.append($("<i class='fa fa-circle' data-toggle='tooltip' title='"+item+"'/>").css('color', '#'+color_map[item]));
+                            td.append($("<i class='fa fa-circle selector-item'  title='"+item+"'/>").css('color', '#'+color_map[item]));
                         }
                     }
                 });
@@ -239,10 +239,11 @@ function hook_firewall_categories() {
                 window.sessionStorage.setItem("firewall.selected.categories", cat_select.val().join(','));
             }
             let selected_values = cat_select.val();
+            let no_cat = cat_select.find("option")[0].value;
             $(".rule").each(function(){
                 let is_selected = false;
                 $(this).data('category').split(',').forEach(function(item){
-                    if (selected_values.indexOf("(No Category)") > -1 && item === "") {
+                    if (selected_values.indexOf(no_cat) > -1 && item === "") {
                         // No category for this rule
                         is_selected = true;
                     }
@@ -261,6 +262,6 @@ function hook_firewall_categories() {
             $(".opnsense-rules").change();
         });
         cat_select.change();
-        $('[data-toggle="tooltip"]').tooltip();
+        $('.selector-item').tooltip();
     });
 }


### PR DESCRIPTION
This commit adds the option of filtering on (No Category) in the firewall rules. A tooltip for visual aid is also added. In order to run static text through gettext(), a separate API endpoint has been created. This is a clean PR and invalidates the old one (https://github.com/opnsense/core/pull/4775) since it was pretty messy.