### PR TITLE
traffic_graphs.widget: start when widgets is visible

### DIFF
--- a/src/www/index.php
+++ b/src/www/index.php
@@ -281,6 +281,9 @@ include("fbegin.inc");?>
       // show dashboard widgets after initial rendering
       $("#dashboard_container").show();
 
+      // trigger WidgetsReady event
+      $("#dashboard_container").trigger("WidgetsReady");
+
       // sortable widgets
       $(".dashboard_grid_column").sortable({
         handle: '.widget-sort-handle',

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
   /**
    * page setup
    */
-  $(window).on("load", function() {
+  $("#dashboard_container").on("WidgetsReady", function() {
         // XXX: since dashboard widgets may have changed the dom, prevent on load being executed multiple times.
         //      it's not very pretty, but prevents mangled graphs
         if (window.traffic_graph_widget_loaded !== undefined) {

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -64,12 +64,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
    * page setup
    */
   $("#dashboard_container").on("WidgetsReady", function() {
-        // XXX: since dashboard widgets may have changed the dom, prevent on load being executed multiple times.
-        //      it's not very pretty, but prevents mangled graphs
-        if (window.traffic_graph_widget_loaded !== undefined) {
-            return;
-        }
-        window.traffic_graph_widget_loaded = true;
         function format_field(value) {
             if (!isNaN(value) && value > 0) {
                 let fileSizeTypes = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];


### PR DESCRIPTION
Hi!
after a long investigation in the "messages" on the forum, it turned out that the traffic_graph widget is still not quite stable in the Firefox browser. The FF can start requests before the widgets are visible. As a result, the chart plugin assigns the canvas height to 0 (chartjs does not like if the parent element is hidden when the chart is initialized) and it start to look like https://github.com/opnsense/core/issues/4750.
To reproduce the behavior, you can set a breakpoint on the `        $("#traffic_graphs-configure").removeClass("disabled");` in FF and refresh the page. It should be seen that the widgets div are not yet visible before executing the request.
Could you consider adding an event after placing widgets and launching a widget functions on this trigger?
This change tested and gave: "TF loads every time on both my desktop (with all extensions enabled) and mobile FF!"
Thanks!
and that trigger can be used on other client-side widgets to start fetching when whole page is set
ps.
and its looks like this lines not needed any more. since we cut scripts from widgets. works with or without it
https://github.com/opnsense/core/blob/7ac736d46920a4e81c55ee82be304d9b9713d1d7/src/www/widgets/widgets/traffic_graphs.widget.php#L67-L72