### PR TITLE
Syslog: Adding support for enabling destination flags

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/Api/SettingsController.php
@@ -53,7 +53,7 @@ class SettingsController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             "destinations.destination",
-            array("enabled", "description", "transport", "program", "level", "facility", "hostname", "port"),
+            array("enabled", "description", "transport", "program", "level", "facility", "flags", "hostname", "port"),
             "description"
         );
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
@@ -30,6 +30,12 @@
     <help>Choose which facilities to include, omit to select all.</help>
   </field>
   <field>
+    <id>destination.flags</id>
+    <label>Flags</label>
+    <type>select_multiple</type>
+    <help>Choose which flags to enable.</help>
+  </field>
+  <field>
     <id>destination.hostname</id>
     <label>Hostname</label>
     <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
@@ -77,6 +77,24 @@
                       <local7>locally used (7)</local7>
                   </OptionValues>
                 </facility>
+                <flags type="OptionField">
+                  <Required>N</Required>
+                  <Multiple>Y</Multiple>
+                  <OptionValues>
+                      <assume-utf8>assume-utf8</assume-utf8>
+                      <empty-lines>empty-lines</empty-lines>
+                      <expect-hostname>expect-hostname</expect-hostname>
+                      <kernel>kernel</kernel>
+                      <no-hostname>no-hostname</no-hostname>
+                      <no-multi-line>no-multi-line</no-multi-line>
+                      <no-parse>no-parse</no-parse>
+                      <dont-store-legacy-msghdr>dont-store-legacy-msghdr</dont-store-legacy-msghdr>
+                      <sanitize-utf8>sanitize-utf8</sanitize-utf8>
+                      <store-raw-message>store-raw-message</store-raw-message>
+                      <syslog-protocol>syslog-protocol</syslog-protocol>
+                      <validate-utf8>validate-utf8</validate-utf8>
+                  </OptionValues>
+                </flags>
                 <hostname type="HostnameField">
                     <Required>Y</Required>
                 </hostname>

--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
@@ -28,6 +28,9 @@ destination d_{{dest_key}} {
         transport("{{destination.transport[:3]}}")
         port({{destination.port}})
         ip-protocol({{destination.transport[3]}})
+        {% if destination.flags %}
+        flags({% for flag in destination.flags %}{{ flag }}{% if not loop.last %}, {% endif %}{% endfor %})
+        {% endif %}
         persist-name("{{dest_key}}")
     );
 {%            endif %}


### PR DESCRIPTION
Disclaimer: I currently don't have a development environment setup for OPNsense so I have not tested the contents of the PR. I had one free hour so I thought this would be better that opening an issue asking for someone to implement the support. 

The goal of this PR is to be able to select the flags available on the syslog-ng destination. My use case specifically is to enable the syslog-format flag. I'm currently spending 2 minutes after every upgrade adding this manually so I thought 1 hour now would pay off in a few years time :P 