### PR TITLE
Add dhcp menu validation, hide interface with subnet mask greater or equal 31

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -233,7 +233,7 @@ class MenuSystem
                 }
                 // "Services: DHCPv[46]" menu tab:
                 if (empty($node->virtual) && isset($node->enable)) {
-                    if (!empty(filter_var($node->ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))) {
+                    if (!empty(filter_var($node->ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) && (!($node->subnet >= "31"))) {
                         $iftargets['dhcp4'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                     }
                     if (!empty(filter_var($node->ipaddrv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) || !empty($node->dhcpd6track6allowoverride)) {


### PR DESCRIPTION
Proposed fix for bug #4762, a simple validation if subnet mask is greater or equal 31, 31 and 32 simply does not have enough addresses to be used by DHCP, we can expand to subnet mask 30, still 30 can be excluded as it technically has 2 hosts that can be used (including the IP assigned to firewall).
This was tested with virtual OPNSense using the latest master.
Note this is the first time ever I contribute code to GitHub so excuse me if I did something wrong, new learner.