### PR TITLE
firewall log widget: multiple interface choice, popovers, link to Live View

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -393,6 +393,17 @@
             });
         });
 
+        // get and apply url params. ie11 compat
+        let urlvars = window.location.search.substring(1).split("&");
+        if (urlvars.length >= 1 && urlvars[0] !== "") {
+            urlvars.forEach(function(value) {
+                $("#filter_tag").val(value.split("=")[0]);
+                $("#filter_condition").val("=");
+                $("#filter_value").val(value.split("=")[1]);
+                $("#add_filter_condition").click();
+            });
+        }
+
         // startup poller
         poller();
     });

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -75,7 +75,7 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
 
 ?>
 <script>
-    $(window).on("load", function() {
+    $("#dashboard_container").on("WidgetsReady", function() {
         // needed to display the widget settings menu
         $("#log-configure").removeClass("disabled");
         // icons

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -128,13 +128,17 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
                                     case 'icon':
                                         var icon = field_type_icons[record[column_name]];
                                         if (icon != undefined) {
-                                            log_td.html('<i class="fa '+icon+'" aria-hidden="true"></i>');
+                                            // prepare popover content
+                                            let popContent = "@" + record.rulenr;
+                                            popContent += record.label.length > 0 ? " Label: " + record.label : '';
+                                            popContent += "<br><sub><?= gettext('click the Act icon to track this rule in Live View') ?></sub>"
+                                            log_td.html('<a target="_blank" href="/ui/diagnostics/firewall/log?rid=' + record.rid + '" type="button" data-toggle="popover" data-trigger="hover" \
+                                                        data-html="true" data-title="<?= gettext('Matched rule') ?>" data-content="' + popContent + '"><i class="fa ' + icon + '" aria-hidden="true"></i></a>');
                                             if (record[column_name] == 'pass') {
-                                                log_td.addClass('text-success');
+                                                log_td.find('a').addClass('text-success');
                                             } else {
-                                                log_td.addClass('text-danger');
+                                                log_td.find('a').addClass('text-danger');
                                             }
-
                                         }
                                         break;
                                     case 'time':
@@ -169,8 +173,16 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
                         }
                     }
                 }
+                //hide popover before elem remove
+                $('[data-toggle="popover"]').popover('hide');
                 $("#filter-log-entries > tbody > tr:gt("+(parseInt($("#filterlogentries").val() - 1))+")").remove();
                 $("#filter-log-entries > tbody > tr").show();
+                //enable popover with full width for long descriptions
+                $('[data-toggle="popover"]').popover({
+                    container: 'body'
+                }).on('show.bs.popover', function() {
+                    $(this).data("bs.popover").tip().css("max-width", "100%")
+                });
             });
 
             // schedule next fetch


### PR DESCRIPTION
Hi!
replaces https://github.com/opnsense/core/pull/4817 and possibly closes https://github.com/opnsense/core/issues/4815
- no `legacy_config_get_interfaces`
- multiple choice of interfaces
- no `toLowerCase()`
- not reading DOM attrs for each log entry
- starts on "WidgetsReady" for Firefox consistency on page refresh (bootstrap not applied on 'load' after F5. so FF generates second `<button>`)
widget works on driver-names and is indifferent to upper\lowercases from the API
thanks!

UPD
- added changes for https://github.com/opnsense/core/issues/4836 

bootstrap popover on Action icon hover with rule number and description (if any) display.
open ruleID-prefiltered Live View on Action icon click
ie11,chrome,FF tested )
thanks!