### PR TITLE
Add Option for Vendor-Class-ID by pool

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -643,10 +643,24 @@ EOD;
      * loop through and determine if we need
      * to setup failover peer "bleh" entries
      */
+    $classlist = array();       
+    $all_pools = array(); 
     foreach ($config['dhcpd'] as $dhcpif => $dhcpifconf) {
         if (!isset($dhcpifconf['enable'])) {
             continue;
         }
+
+        $all_pools[] = $dhcpifconf;
+        if (!empty($dhcpifconf['pool'])) {
+            $all_pools = array_merge($all_pools, $dhcpifconf['pool']);
+        }
+        foreach ($all_pools as $poolconf) {
+          if (!empty($poolconf['dhcp_class'])) {
+            array_push($classlist, $poolconf['dhcp_class'] );
+          }
+        }
+        unset($all_pools);
+
         if (!empty($config['dhcpd'][$dhcpif]['staticmap'])) {
             interfaces_staticarp_configure($dhcpif);
         }
@@ -708,6 +722,13 @@ EOPP;
     $iflist = get_configured_interface_with_descr();
     $gwObject = new \OPNsense\Routing\Gateways($ifconfig_details);
 
+    if( count($classlist) > 0) {
+      foreach ($classlist as $class ){
+        $dhcpdconf .= "\nclass \"".str_replace(' ','',$class)."\""." {\n";
+        $dhcpdconf .= " match if option vendor-class-identifier = "."\"".$class."\"".";\n";
+        $dhcpdconf .= "}\n";
+      }
+    } 
     foreach ($config['dhcpd'] as $dhcpif => $dhcpifconf) {
         if (!isset($dhcpifconf['enable']) || !isset($iflist[$dhcpif])) {
             continue;
@@ -781,6 +802,7 @@ EOPP;
          * Join them into one big comma-separated string then split
          * them all up.
          */
+        $dhcp_class_list = array();
         $all_mac_strings = array();
         foreach ($all_pools as $poolconf) {
             if (!empty($poolconf['mac_allow'])) {
@@ -788,8 +810,10 @@ EOPP;
             }
             if (!empty($poolconf['mac_deny'])) {
                 $all_mac_strings[] = $poolconf['mac_deny'];
-            }
+            }           
+            array_push($dhcp_class_list,$poolconf['dhcp_class']);
         }
+
         $all_mac_list = array_unique(explode(',', implode(',', $all_mac_strings)));
         foreach ($all_mac_list as $mac) {
             if (!empty($mac)) {
@@ -812,6 +836,30 @@ EOPP;
                     $dhcpdconf .= ",{$poolconf['dnsserver'][1]}";
                 }
                 $dhcpdconf .= ";\n";
+            }
+            /* allow class option  */
+
+            
+            if (!empty($poolconf['dhcp_class'])) {
+              foreach($dhcp_class_list as $class) {
+                if($class == $poolconf['dhcp_class']){
+                  $dhcpdconf .= "    allow members of \"" . str_replace(' ','',$poolconf['dhcp_class']). "\";\n" ;                  
+                }
+              }
+            } else {
+              /* Iterate the pools again as this is the default pool */
+              foreach ($all_pools as $denypools) {
+                if (!empty($denypools['dhcp_class'])) {
+                  foreach($dhcp_class_list as $class) {
+                    if($class == $denypools['dhcp_class']){
+                      $deny_list .= "    deny members of \"" . str_replace(' ','',$denypools['dhcp_class']). "\";\n";
+                    }
+                  }
+                }
+              }
+              if ($deny_list != "") {
+                $dhcpdconf .= $deny_list;
+              }
             }
 
             /* allow/deny MACs */

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -151,6 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     // list items
     $pconfig['range_from'] = !empty($dhcpdconf['range']['from']) ? $dhcpdconf['range']['from'] : "";
     $pconfig['range_to'] = !empty($dhcpdconf['range']['to']) ? $dhcpdconf['range']['to'] : "";
+    $pconfig['dhcp_class'] = !empty($dhcpdconf['dhcp_class']) ? $dhcpdconf['dhcp_class'] : "";
     $pconfig['wins1'] = !empty($dhcpdconf['winsserver'][0]) ? $dhcpdconf['winsserver'][0] : "";
     $pconfig['wins2'] = !empty($dhcpdconf['winsserver'][1]) ? $dhcpdconf['winsserver'][1] : "";
     $pconfig['dns1'] = !empty($dhcpdconf['dnsserver'][0]) ? $dhcpdconf['dnsserver'][0] : "";
@@ -418,6 +419,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $dhcpdconf['range']['from'] = $pconfig['range_from'];
             $dhcpdconf['range']['to'] = $pconfig['range_to'];
 
+            $dhcpdconf['dhcp_class'] = $pconfig['dhcp_class'];
             // array types
             $dhcpdconf['winsserver'] = [];
             if (!empty($pconfig['wins1'])) {
@@ -782,6 +784,17 @@ include("head.inc");
                     </tr>
 <?php
                     endif; ?>
+                    <tr>
+                      <td><a id="help_for_class" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>  <?=gettext("Vendor class identifier string");?></td>
+                      <td>
+                        <input name="dhcp_class" type="text" value="<?=$pconfig['dhcp_class'];?>" />
+                        <div class="hidden" data-for="help_for_class">
+                          <?= gettext('The class field allows you to enter an option 61 text field. When a client specifies a string that matches this entry then it will get an address from this pool.') ?>
+                          <?= gettext('When no identifier string is entered then any client will get an address from this pool. With multiple pools there must only be one with') ?>
+                          <?= gettext('no identifier.') ?>
+                        </div>
+                      </td>
+                    </tr>
                     <tr>
                       <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("WINS servers");?></td>
                       <td>


### PR DESCRIPTION
You can do pool dhcp using MAC addresses, but doing it by Vendor-Class is another option, very useful for phones or any devices where the vendor class Id is sent.