### PR TITLE
firmware/health.sh: refine missing/invalid signature message

### DIFF
--- a/src/opnsense/scripts/firmware/health.sh
+++ b/src/opnsense/scripts/firmware/health.sh
@@ -86,8 +86,10 @@ set_check()
 
 	if [ ! -f ${FILE}.sig ]; then
 		echo "Cannot verify ${SET}: missing ${FILE}.sig" | ${TEE} ${LOCKFILE}
+		return
 	elif ! opnsense-verify -q ${FILE}; then
 		echo "Cannot verify ${SET}: invalid ${FILE}.sig" | ${TEE} ${LOCKFILE}
+		return
 	fi
 
 	echo ">>> Check for missing or altered ${SET} files" | ${TEE} ${LOCKFILE}

--- a/src/opnsense/scripts/firmware/health.sh
+++ b/src/opnsense/scripts/firmware/health.sh
@@ -85,9 +85,9 @@ set_check()
 	fi
 
 	if [ ! -f ${FILE}.sig ]; then
-		echo "Unverified hashes for ${SET}: missing ${FILE}.sig" | ${TEE} ${LOCKFILE}
+		echo "Unverified consistency check for ${SET}: missing ${FILE}.sig" | ${TEE} ${LOCKFILE}
 	elif ! opnsense-verify -q ${FILE}; then
-		echo "Unverified hashes for ${SET}: invalid ${FILE}.sig" | ${TEE} ${LOCKFILE}
+		echo "Unverified consistency check for ${SET}: invalid ${FILE}.sig" | ${TEE} ${LOCKFILE}
 	fi
 
 	echo ">>> Check for missing or altered ${SET} files" | ${TEE} ${LOCKFILE}

--- a/src/opnsense/scripts/firmware/health.sh
+++ b/src/opnsense/scripts/firmware/health.sh
@@ -85,11 +85,9 @@ set_check()
 	fi
 
 	if [ ! -f ${FILE}.sig ]; then
-		echo "Cannot verify ${SET}: missing ${FILE}.sig" | ${TEE} ${LOCKFILE}
-		return
+		echo "Unverified hashes for ${SET}: missing ${FILE}.sig" | ${TEE} ${LOCKFILE}
 	elif ! opnsense-verify -q ${FILE}; then
-		echo "Cannot verify ${SET}: invalid ${FILE}.sig" | ${TEE} ${LOCKFILE}
-		return
+		echo "Unverified hashes for ${SET}: invalid ${FILE}.sig" | ${TEE} ${LOCKFILE}
 	fi
 
 	echo ">>> Check for missing or altered ${SET} files" | ${TEE} ${LOCKFILE}


### PR DESCRIPTION
To avoid self-contradictory output:

>>> Check installed kernel version
Version 21.1.3 is correct.
Cannot verify kernel: missing /usr/local/opnsense/version/kernel.mtree.sig
>>> Check for missing or altered kernel files
No problems detected.

Now we will instead get:

>>> Check installed kernel version
Version 21.1.3 is correct.
Cannot verify kernel: missing /usr/local/opnsense/version/kernel.mtree.sig