### PR TITLE
webgui: clarify help text for firewall rules traffic direction

### DIFF
--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -836,7 +836,7 @@ include("head.inc");
                                    "filter inbound traffic, which means the policy applies to the interface on which ".
                                    "the traffic is originally received by the firewall from the source. This is more ".
                                    "efficient from a traffic processing perspective. In most cases, the default ".
-                                   "policy will the most appropriate.") ?>
+                                   "policy will be the most appropriate.") ?>
                       </div>
                     </td>
                   <tr>

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -830,8 +830,13 @@ include("head.inc");
                       endforeach; ?>
                       </select>
                       <div class="hidden" data-for="help_for_direction">
-                        <?=gettext("Direction of the traffic. The default policy is to filter inbound traffic, ".
-                                   "which sets the policy to the interface originally receiving the traffic.") ?>
+                        <?=gettext("Direction of the traffic. Traffic IN is coming into the firewall interface, ".
+                                   "while traffic OUT is going out of the firewall interface. In visual terms: ".
+                                   "[Source] -> IN -> [Firewall] -> OUT -> [Destination]. The default policy is to ".
+                                   "filter inbound traffic, which means the policy applies to the interface on which ".
+                                   "the traffic is originally received by the firewall from the source. This is more ".
+                                   "efficient from a traffic processing perspective. In most cases, the default ".
+                                   "policy will the most appropriate.") ?>
                       </div>
                     </td>
                   <tr>


### PR DESCRIPTION
A lot of OPNsense users become confused by the concept of traffic direction in firewall rules (despite this being covered in the official documentation). This change is to expand the help text that is shown in the webgui for the Direction option in the firewall rules, along the lines of the official documentation, to hopefully to provide more clarity for users. Feel free to accept or decline in your discretion!