### PR TITLE
Reporting / Traffic (+dashboard widget): 24H format alternative

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
@@ -196,6 +196,7 @@ POSSIBILITY OF SUCH DAMAGE.
                                   minUnit: 'second',
                                   displayFormats: {
                                       second: 'HH:mm:ss',
+                                      minute: 'HH:mm:ss'
                                   }
                               },
                               type: 'realtime',

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
@@ -104,6 +104,7 @@ POSSIBILITY OF SUCH DAMAGE.
                                   minUnit: 'second',
                                   displayFormats: {
                                       second: 'HH:mm:ss',
+                                      minute: 'HH:mm:ss'
                                   }
                               },
                               type: 'realtime',

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
@@ -98,15 +98,15 @@ POSSIBILITY OF SUCH DAMAGE.
                       maintainAspectRatio: false,
                       scales: {
                           xAxes: [{
-                              type: 'realtime',
                               time: {
+                                  tooltipFormat:'HH:mm:ss',
                                   unit: 'second',
-                                  minUnit: 'seconds',
+                                  minUnit: 'second',
                                   displayFormats: {
                                       second: 'HH:mm:ss',
-                                      minute: 'HH:mm:ss'
                                   }
                               },
+                              type: 'realtime',
                               realtime: {
                                   duration: 20000,
                                   refresh: 2000,
@@ -127,13 +127,7 @@ POSSIBILITY OF SUCH DAMAGE.
                           callbacks: {
                               label: function(tooltipItem, data) {
                                   let ds = data.datasets[tooltipItem.datasetIndex];
-                                  if (ds.data[tooltipItem.index].y) {
-                                      return moment.unix(ds.data[tooltipItem.index].x/1000).format('HH:mm:ss') + " : " +
-                                             format_field(ds.data[tooltipItem.index].y).toString();
-                                  }
-                              },
-                              title: function(tooltipItem, data) {
-                                  return "";
+                                  return ds.label + " : " + format_field(ds.data[tooltipItem.index].y).toString();
                               }
                           }
                       },
@@ -195,15 +189,15 @@ POSSIBILITY OF SUCH DAMAGE.
                       maintainAspectRatio: false,
                       scales: {
                           xAxes: [{
-                              type: 'realtime',
                               time: {
+                                  tooltipFormat:'HH:mm:ss',
                                   unit: 'second',
-                                  minUnit: 'seconds',
+                                  minUnit: 'second',
                                   displayFormats: {
                                       second: 'HH:mm:ss',
-                                      minute: 'HH:mm:ss'
                                   }
                               },
+                              type: 'realtime',
                               realtime: {
                                   duration: 40000,
                                   refresh: 3000,
@@ -224,13 +218,11 @@ POSSIBILITY OF SUCH DAMAGE.
                           callbacks: {
                               label: function(tooltipItem, data) {
                                   let ds = data.datasets[tooltipItem.datasetIndex];
-                                  if (ds.data[tooltipItem.index].y) {
-                                      return [
-                                        moment.unix(ds.data[tooltipItem.index].x/1000).format('HH:mm:ss'),
-                                        ds.label + " : " + ds.data[tooltipItem.index].address,
-                                        "@ " + format_field(ds.data[tooltipItem.index].y).toString()
-                                      ];
-                                  }
+                                  return [
+                                    tooltipItem.xLabel,
+                                    ds.label + " : " + ds.data[tooltipItem.index].address,
+                                    "@ " + format_field(ds.data[tooltipItem.index].y).toString()
+                                  ];
                               }
                           }
                       },

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -117,15 +117,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                       maintainAspectRatio: false,
                       scales: {
                           xAxes: [{
-                              type: 'realtime',
                               time: {
+                                  tooltipFormat:'HH:mm:ss',
                                   unit: 'second',
-                                  minUnit: 'seconds',
+                                  minUnit: 'second',
                                   displayFormats: {
                                       second: 'HH:mm:ss',
-                                      minute: 'HH:mm:ss'
                                   }
                               },
+                              type: 'realtime',
                               realtime: {
                                   duration: 50000,
                                   refresh: 5000,
@@ -146,14 +146,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                           callbacks: {
                               label: function(tooltipItem, data) {
                                   let ds = data.datasets[tooltipItem.datasetIndex];
-                                  if (ds.data[tooltipItem.index].y) {
-                                      return moment.unix(ds.data[tooltipItem.index].x/1000).format('HH:mm:ss') + " : " +
-                                             format_field(ds.data[tooltipItem.index].y).toString();
-                                  }
-                              },
-                              title: function(tooltipItem, data) {
-                                  return "";
-                              },
+                                  return ds.label + " : " + format_field(ds.data[tooltipItem.index].y).toString();
+                              }
                           }
                       },
                       hover: {


### PR DESCRIPTION
Hi
just https://github.com/opnsense/core/commit/3d3810b42d1664087594ecc8fadc43568056220c alternative
uses internal time formatting instead of additional `moment` use
don't think it's faster - just fewer lines of code
thanks!