### PR TITLE
unbound: add option to validate server certificate

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/miscellaneous.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/miscellaneous.xml
@@ -13,6 +13,6 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help>List of nameservers to use for DoT. Use syntax ip@port like 9.9.9.9@853</help>
+        <help>List of nameservers to use for DoT. Use syntax ip@port like 9.9.9.9@853 or ip@port#fqdn like 9.9.9.9@853#dns.quad9.net to validate the server certificate.</help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
@@ -8,7 +8,7 @@
         </privatedomain>
         <dotservers type="CSVListField">
             <Required>N</Required>
-            <mask>/^[a-fA-F0-9\.\,\:\@]{1,512}$/</mask>
+            <mask>/^([a-fA-F0-9\.\:]{1,39}(@[0-9]{1,5})?(#[a-zA-Z0-9\.\-]{1,253})?\b\,?){1,64}$/</mask>
         </dotservers>
     </items>
 </model>


### PR DESCRIPTION
This PR adds an option for unbound to validate the certificates of DNS-over-TLS servers. Here is the relevant section from `man unbound.conf`:

```
If tls is enabled, then you can append a '#' and a
name, then it'll check the tls authentication certificates with
that name.  If you combine the '@' and '#', the '@' comes first.
```

I also took the opportunity to split the mask regex into IP, port, and name sections - and set a max of 64 entries for the field.