### PR TITLE
webgui: https redirect to fqdn

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -465,6 +465,8 @@ EOD;
         !isset($config['system']['webgui']['disablehttpredirect'])
     ) {
         $redirectport = $lighty_port != "443" ? ":{$lighty_port}" : '';
+        $host_name = strtolower($config['system']['hostname']);
+        $domain_name = $config['system']['domain'];
         foreach ($listeners as $listener) {
             if (is_ipaddrv6($listener)) {
                 $listener = "[{$listener}]";
@@ -474,6 +476,9 @@ EOD;
 \$SERVER["socket"] == "{$listener}:80" {
     \$HTTP["host"] =~ "(.*)" {
         url.redirect = ( "^/(.*)" => "https://%1{$redirectport}/$1" )
+    }
+    \$HTTP["host"] =~ "^({$host_name}|wpad)$" {
+        url.redirect = ( "^/(.*)" => "https://%1.{$domain_name}{$redirectport}/$1" )
     }
     ssl.engine = "disable"
 }


### PR DESCRIPTION
The current HTTP->HTTPS redirect results in a certificate error when not using the FQDN. Browsers configured for web proxy auto-discovery (WPAD) connect to `http://wpad/wpad.dat` but fail to download due to this validation error.

```
$ curl -4v http://wpad/wpad.dat
*   Trying 172.16.109.135:80...
* Connected to wpad (172.16.109.135) port 80 (#0)
> GET /wpad.dat HTTP/1.1
> Host: wpad
> User-Agent: curl/7.75.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Location: https://wpad/wpad.dat
< Content-Length: 0
< Date: Thu, 25 Mar 2021 00:00:38 GMT
< Server: OPNsense
< 
* Connection #0 to host wpad left intact
```

This PR appends the domain name to the HTTP redirect. While this fixes the issue, I do not know if it is the proper solution as a webgui restart is now required anytime the domain name changes. Feel free to reject.
