### PR TITLE
Firewall Rules: show loopback auto-rules

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -211,7 +211,7 @@ function filter_core_rules_system($fw, $defaults)
     // block All IPv6 except loopback traffic
     $fw->registerFilterRule(
         1,
-        array('interface' => 'loopback', 'ipprotocol' => 'inet6', 'disabled' => isset($config['system']['ipv6allow']),
+        array('interface' => 'lo0', 'ipprotocol' => 'inet6', 'disabled' => isset($config['system']['ipv6allow']),
           'descr' => 'Pass all loopback IPv6', '#ref' => 'system_advanced_firewall.php#ipv6allow'),
         $defaults['pass']
     );
@@ -535,7 +535,7 @@ function filter_core_rules_system($fw, $defaults)
         }
     }
     // loopback
-    $fw->registerFilterRule(5, array('interface' => 'loopback', 'descr' => 'pass loopback'), $defaults['pass']);
+    $fw->registerFilterRule(5, array('interface' => 'lo0', 'descr' => 'pass loopback'), $defaults['pass']);
     // out from this Firewall
     $fw->registerFilterRule(
         5,


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=22278.0
Probably more of a question than a request and definitely not urgent.
Now the "Automatically generated rules" 'pass loopback' and 'Pass all loopback IPv6' for the Loopback interface are not displayed in Firewall: Rules: Loopback.
confusing a little..
and it seems that this is due to that this rules is registered with the `loopback` interface, and the GET request goes with the value `if=lo0`.
if, for these rules, only `lo0->loopback` is mapped (not `lo` group)
https://github.com/opnsense/core/blob/ac8bb09c6b912275490aee2720e59009eda9dd8f/src/opnsense/mvc/app/library/OPNsense/Firewall/Plugin.php#L77-L82
then perhaps we can register rules directly with the lo0 interface? then these rules are displayed in the GUI for Loopback if.
rule management is too complex and I'm probably missing something

thanks!
