### PR TITLE
Fix missing ')'

### DIFF
--- a/src/opnsense/scripts/unbound/download_blacklists.py
+++ b/src/opnsense/scripts/unbound/download_blacklists.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 
                 syslog.syslog(
                     syslog.LOG_NOTICE,
-                    'blacklist download %(uri)s (lines: %(lines)d exclude: %(skip)d black: %(blacklist)d' % file_stats
+                    'blacklist download %(uri)s (lines: %(lines)d exclude: %(skip)d black: %(blacklist)d)' % file_stats
                 )
 
     # write out results


### PR DESCRIPTION
Fix missing ')' at the end of log line:

before fix: blacklist download https://block.energized.pro/bluGo/formats/hosts (lines: 125888 exclude: 5 black: 125814
after fix: blacklist download https://block.energized.pro/bluGo/formats/hosts (lines: 125888 exclude: 5 black: 125814)