### PR TITLE
Potential fix for shutdown order of services

### DIFF
--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -117,6 +117,11 @@ if [ "${1}" == "start" ]; then
 	done
 fi
 
+if [ "${1}" == "stop" ]; then
+	rc_filenames=$(echo "${rc_filenames}" | tail -r)
+	rc_filenames_defer=$(echo "${rc_filenames_defer}" | tail -r)
+fi
+
 # pass all commands to script now
 for rc_filename in ${rc_filenames} ${rc_filenames_defer}; do
 	eval "$(grep "^name[[:blank:]]*=" ${rc_filename})"


### PR DESCRIPTION
**Problem:**
It appears that, depending on what services are being utilized, a reboot may hang due to a dependent service being shut down prior to the depending service. The example here is redis and ntopng.

Note - this problem also affects upgrades that require a reboot. It also affects the reboot page within the opnsense GUI.

**Proposed Fix:**
I'm unsure if this fix would have any ill effects. However, when calling rc.freebsd with "stop", if we flip the order of services gathered by rcorder and shutdown services per the new list, it appears that reboots performs cleanly.

**Other details:**

- The current OPNsense version where the bug first appeared
     - Unknown - appears to affect latest release
-  The last OPNsense version where the bug did not exist
    -  Unknown
-  The exact URL of the GUI page involved (if any)
    - N/A
-  A list of steps to replicate the bug
    -  Install redis and ntopng on an opnsense install. Reboots will hang on stopping ntopng due to redis being shut down first

