### PR TITLE
radvd advanced options: remove AdvRDNSSLifetime / AdvDNSSLLifetime bounds

### DIFF
--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -127,21 +127,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $input_errors[] = sprintf(gettext('AdvValidLifetime must be between %s and %s seconds.'),  1, 4294967295);
         }
         if (!empty($pconfig['AdvPreferredLifetime']) && !val_int_in_range($pconfig['AdvPreferredLifetime'], 1, 4294967295)) {
-            $input_errors[] = sprintf(gettext('AdvPreferredLifetime must be between %s and %s seconds.'),  1, 4294967295);
+            $input_errors[] = sprintf(gettext('AdvPreferredLifetime must be between %s and %s seconds.'), 1, 4294967295);
         }
-        if (!empty($pconfig['AdvRDNSSLifetime']) && !val_int_in_range($pconfig['AdvRDNSSLifetime'], $pconfig['ramaxinterval'], $pconfig['ramaxinterval'] * 2)) {
-            $input_errors[] = sprintf(gettext('AdvRDNSSLifetime must be between %s and %s seconds.'),  $pconfig['ramaxinterval'], $pconfig['ramaxinterval'] * 2);
+        if (!empty($pconfig['AdvRDNSSLifetime']) && !val_int_in_range($pconfig['AdvRDNSSLifetime'], 1, 4294967295)) {
+            $input_errors[] = sprintf(gettext('AdvRDNSSLifetime must be between %s and %s seconds.'), 1, 4294967295);
         }
-        if (!empty($pconfig['AdvDNSSLLifetime']) && !val_int_in_range($pconfig['AdvDNSSLLifetime'], $pconfig['ramaxinterval'], $pconfig['ramaxinterval'] * 2)) {
-            $input_errors[] = sprintf(gettext('AdvDNSSLLifetime must be between %s and %s seconds.'),  $pconfig['ramaxinterval'], $pconfig['ramaxinterval'] * 2);
+        if (!empty($pconfig['AdvDNSSLLifetime']) && !val_int_in_range($pconfig['AdvDNSSLLifetime'], 1, 4294967295)) {
+            $input_errors[] = sprintf(gettext('AdvDNSSLLifetime must be between %s and %s seconds.'), 1, 4294967295);
         }
         if (!empty($pconfig['AdvRouteLifetime']) && !val_int_in_range($pconfig['AdvRouteLifetime'], 1, 4294967295)) {
-            $input_errors[] = sprintf(gettext('AdvRouteLifetime must be between %s and %s seconds.'),  1, 4294967295);
+            $input_errors[] = sprintf(gettext('AdvRouteLifetime must be between %s and %s seconds.'), 1, 4294967295);
         }
         $mtu_low = 1280;
         $mtu_high = 65535;
         if (!empty($pconfig['AdvLinkMTU']) && !val_int_in_range($pconfig['AdvLinkMTU'], $mtu_low, $mtu_high)) {
-            $input_errors[] = sprintf(gettext('AdvLinkMTU must be between %s and %s bytes.'),  $mtu_low, $mtu_high);
+            $input_errors[] = sprintf(gettext('AdvLinkMTU must be between %s and %s bytes.'), $mtu_low, $mtu_high);
         }
     }
 


### PR DESCRIPTION
RFC 8106 removes the bound of acceptable values:
https://tools.ietf.org/html/rfc8106#section-5.1
https://tools.ietf.org/html/rfc8106#section-5.2

radvd does not enforce a maximum. 2.19 enforces a minimum (MaxRtrAdvInterval), but does not fail if a lower value is configured. All bounds have been removed in master: radvd-project/radvd@17c43bff200bbc1d4786eb917860a79db4f95c2e

Context: #4867