### PR TITLE
unbound dnsbl: yet another change in regex

### DIFF
--- a/src/opnsense/scripts/unbound/download_blacklists.py
+++ b/src/opnsense/scripts/unbound/download_blacklists.py
@@ -82,8 +82,8 @@ if __name__ == '__main__':
         sys.exit(99)
 
     domain_pattern = re.compile(
-        r'(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
-        r'?([\da-zA-Z]\.((xn\-\-[a-zA-Z\d]+)|([a-zA-Z\d]{2,})))'
+        r'^(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
+        r'?([\da-zA-Z]\.((xn\-\-[a-zA-Z\d]+)|([a-zA-Z\d]{2,})))$'
     )
 
     startup_time = time.time()
@@ -133,6 +133,8 @@ if __name__ == '__main__':
                             if domain_pattern.match(domain):
                                 file_stats['blacklist'] += 1
                                 blacklist_items.add(entry)
+                            else:
+                                file_stats['skip'] += 1
 
                 syslog.syslog(
                     syslog.LOG_NOTICE,


### PR DESCRIPTION
Hi!
started testing unbound with a new regex-check and it looks like we forgot to escape the string for a complete match - allows entries with url on first match. 

-match the entire string to prevent garbage after valid fqdn
-add to skip stat if not match