### PR TITLE
VLANs: add warning not to use tagged + untagged on the same interface

### DIFF
--- a/src/www/interfaces_vlan.php
+++ b/src/www/interfaces_vlan.php
@@ -149,6 +149,9 @@ $main_buttons = array(
                   <tfoot>
                     <tr>
                       <td colspan="5">
+                        <strong><?= gettext("When using VLANs, avoid using their parent interfaces! Firewall rules added to a parent interface may interfere with VLANs and result in unpredictable behaviour.");?></strong>
+                        <br />
+                        <br />
                         <?= gettext("Not all drivers/NICs support 802.1Q VLAN tagging properly. On cards that do not explicitly support it, VLAN tagging will still work, but the reduced MTU may cause problems.");?>
                       </td>
                     </tr>


### PR DESCRIPTION
As recently mentioned by @fichtner [1], you should avoid using a parent interface if it has VLANs. Many users are probably unaware of this limitation (I certainly was), especially since having tagged and untagged frames on the same interface is a very common configuration on other devices.

[1] https://forum.opnsense.org/index.php?topic=22571.msg107332#msg107332