### PR TITLE
VIP address being used as the primary address in RADVD.CONF.

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4627,12 +4627,13 @@ function interfaces_primary_address6($interface, $realif = null, $ifconfig_detai
         }
 
         $addrparts = explode('/', $tmpaddr);
-
+        $temp_address = Net_Ipv6::uncompress($addrparts[0],true);
         foreach (config_read_array('virtualip', 'vip') as $vip) {
-            if ($vip['interface'] == $interface && $vip['mode'] == 'ipalias' && $vip['subnet'] == $addrparts[0]) {
-                /* do not care about alias */
-                continue 2;
-            }
+          $temp_vip = Net_Ipv6::uncompress( $vip['subnet'],true);
+          if ($vip['interface'] == $interface && $vip['mode'] == 'ipalias' && $temp_address == $temp_vip) {                
+            /* do not care about alias */
+            continue 2;
+          }
         }
 
         $networkv6 = gen_subnetv6($addrparts[0], $addrparts[1]) . "/{$addrparts[1]}";


### PR DESCRIPTION
When adding a VIP address RADVD should continue to use the primary GUA address and add the LUA ( VIP ) address as an extra net. The comparison function to check that the address being checked is not a VIP did not take into account the possibility of zeros in the address, Solution = Expand IPv6 addresses to full length before doing a compare.