### PR TITLE
Unbound: Add description for [reload] action

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -45,6 +45,7 @@ command:/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf reload
 parameters:
 type:script
 message:Reloading Unbound
+description: Reload Unbound configuration
 
 [start]
 command:/usr/local/bin/flock -n -E 0 -o /tmp/unbound_start.lock /usr/local/opnsense/scripts/unbound/unbound_start.sh


### PR DESCRIPTION
Adds description for unbound's configd [reload] action

This causes the reload option to show up as a predefined action in cron and Let's Encrypt UI pages.[1] This is desirable if you want to use your Let's Encrypt certificate to offer DNS-over-TLS via unbound on port 853, so that the LE plugin can reload the unbound config whenever it renews the relevant certificate

[1] https://forum.opnsense.org/index.php?topic=6177.msg25956#msg25956