### PR TITLE
Edit Alias fix

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -210,6 +210,7 @@
                     break;
                 case 'dynipv6host':
                     $("#row_alias\\.interface").show();
+                    $("#alias\\.proto").selectpicker('hide');                                                             
                     $("#alias_type_default").show();
                     break;
                 case 'urltable':


### PR DESCRIPTION
When the Edit panel is opened to edit an existing Dynamic IPv6 Alias, the proto type is visible. If you select another type of Alias and then return to the Dynamic IPv6 type the proto has gone. This PR just adds a hide proto selectpicker.