### PR TITLE
lighttpd: set HSTS max-age to 1 year

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -412,7 +412,7 @@ EOD;
 
         if (!empty($config['system']['webgui']['ssl-hsts'])) {
             $lighty_config .= "\$HTTP[\"scheme\"] == \"https\" {\n";
-            $lighty_config .= "    setenv.add-response-header = (\"Strict-Transport-Security\" => \"max-age=15768000\" )\n";
+            $lighty_config .= "    setenv.add-response-header = (\"Strict-Transport-Security\" => \"max-age=31536000\" )\n";
             $lighty_config .= "}\n";
         }
 


### PR DESCRIPTION
An HSTS cache validity period of less than 1 year is no longer considered to be sufficiently secure and might fail various audits.

References:
https://internet.nl/article/new-release-with-improved-tests-for-TLS-and-CSP/
https://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/http-strict-transport-security-hsts-max-age-value-too-low/
https://hstspreload.org/