### PR TITLE
Allow more characters in the "Distinguished name - Organisation" field

### DIFF
--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -321,11 +321,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig["dn_commonname"])) {
                         $input_errors[] = gettext("The field 'Distinguished name Common Name' contains invalid characters.");
                     }
-                } elseif ($reqdfields[$i] == "csr_dn_organization") {
-                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig["csr_dn_organization"])) {
+                } elseif ($reqdfields[$i] == "dn_organization") {
+                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig["dn_organization"])) {
                         $input_errors[] = gettext("The field 'Distinguished name Organization' contains invalid characters.");
                     }
-                } elseif (($reqdfields[$i] != "descr") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig["$reqdfields[$i]"])) {
+                } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "dn_organization") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig["$reqdfields[$i]"])) {
                     $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                 }
             }

--- a/src/www/system_camanager.php
+++ b/src/www/system_camanager.php
@@ -321,6 +321,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig["dn_commonname"])) {
                         $input_errors[] = gettext("The field 'Distinguished name Common Name' contains invalid characters.");
                     }
+                } elseif ($reqdfields[$i] == "csr_dn_organization") {
+                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig["csr_dn_organization"])) {
+                        $input_errors[] = gettext("The field 'Distinguished name Organization' contains invalid characters.");
+                    }
                 } elseif (($reqdfields[$i] != "descr") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig["$reqdfields[$i]"])) {
                     $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                 }

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -581,7 +581,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig[$reqdfields[$i]])) {
                         $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                     }
-                } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "csr" && $reqdfields[$i] != "csr_dn_organization") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
+                } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "csr" && $reqdfields[$i] != "csr_dn_organization" && $reqdfields[$i] != "dn_organization") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
                     $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                 }
             }

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -577,7 +577,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
                         $input_errors[] = gettext("The field 'Distinguished name Common Name' contains invalid characters.");
                     }
-                } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "csr") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
+                } elseif ($reqdfields[$i] == "csr_dn_organization") {
+                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig["csr_dn_organization"])) {
+                        $input_errors[] = gettext("The field 'Distinguished name Organization' contains invalid characters.");
+                    }
+                } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "csr" && $reqdfields[$i] != "csr_dn_organization") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
                     $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                 }
             }

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -577,9 +577,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
                         $input_errors[] = gettext("The field 'Distinguished name Common Name' contains invalid characters.");
                     }
-                } elseif ($reqdfields[$i] == "csr_dn_organization") {
-                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig["csr_dn_organization"])) {
-                        $input_errors[] = gettext("The field 'Distinguished name Organization' contains invalid characters.");
+                } elseif ($reqdfields[$i] == "csr_dn_organization" || $reqdfields[$i] == "dn_organization") {
+                    if (preg_match("/[\!\#\$\%\^\(\)\~\?\>\<\&\/\\\"\']/", $pconfig[$reqdfields[$i]])) {
+                        $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);
                     }
                 } elseif (($reqdfields[$i] != "descr" && $reqdfields[$i] != "csr" && $reqdfields[$i] != "csr_dn_organization") && preg_match("/[\!\@\#\$\%\^\(\)\~\?\>\<\&\/\\\,\"\']/", $pconfig[$reqdfields[$i]])) {
                     $input_errors[] = sprintf(gettext("The field '%s' contains invalid characters."), $reqdfieldsn[$i]);


### PR DESCRIPTION
The "Distinguished name - organisation" field is quite limited in what is allowed in it. Even just having a comma or fullstop was prohibited.

Searching through the docs of openssl I could not find a reason to block those, so here's a PR to allow those characters specifically in the organisation fields.