### PR TITLE
Traffic: Fix long comment preventing ipfw reload

### DIFF
--- a/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
+++ b/src/opnsense/service/templates/OPNsense/IPFW/ipfw.conf
@@ -175,7 +175,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     xmit {{physical_interface(rule.interface2)
-    }} // {{ rule['@uuid'] }} {{rule.interface}} -> {{rule.interface2}}: {{helpers.getUUID(rule.target).description}}
+    }} // {{ (rule['@uuid'] + " " + rule.interface + " -> " + rule.interface2 + ": " + helpers.getUUID(rule.target).description)[0:78] }}
 {%                         endif %}
 {%                         if rule.direction == 'out' or not rule.direction %}
 add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
@@ -188,7 +188,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %}
     recv {{physical_interface(rule.interface2)
-    }} // {{ rule['@uuid'] }} {{rule.interface2}} -> {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
+    }} // {{ (rule['@uuid'] + " " + rule.interface2 + " -> " + rule.interface + ": " + helpers.getUUID(rule.target).description)[0:78] }}
 {%                         endif %}
 {%                       else %}
 {#  normal, single interface situation  #}
@@ -201,7 +201,7 @@ add {{loop.index + 60000}} {{ helpers.getUUIDtag(rule.target) }} {{
     if rule.iplen|default('') != '' %} iplen 1-{{ rule.iplen }}{% endif %}{%
     if rule.dscp|default('') != '' %} dscp {{ rule.dscp }}{% endif %} via {{
     physical_interface(rule.interface)
-    }} // {{ rule['@uuid'] }} {{rule.interface}}: {{helpers.getUUID(rule.target).description}}
+    }} // {{ (rule['@uuid'] + " " + rule.interface + ": " + helpers.getUUID(rule.target).description)[0:78] }}
 {%                       endif %}
 {%                   endif %}
 {%            endif %}


### PR DESCRIPTION
It seems that comments are limited in ipfw to 80 chars which is not documented (at least not in the manpage `ipfw(8)`). If users accidentally use long traffic shaper rule descriptions this limit could be reached causing updates via the GUI apply button to be silently ignored which will cause confusion.

`ipfw /usr/local/etc/ipfw.rules` shows the following error:

    Line 77: comment too long (max 80 chars)

and exists with edit code 65.

Interestingly, a slice of up to `0:83` still works. As this is undocumented and the error says max 80 chars I go with something slightly below this max to account for the whitespace.
