### PR TITLE
Properly and forcibly compress IPv6 addresses

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4631,7 +4631,7 @@ function interfaces_primary_address6($interface, $realif = null, $ifconfig_detai
         foreach (config_read_array('virtualip', 'vip') as $vip) {
             if (
                 $vip['interface'] == $interface && $vip['mode'] == 'ipalias' &&
-                Net_IPv6::compress($vip['subnet']) == $addrparts[0]
+                Net_IPv6::compress($vip['subnet'], true) == Net_IPv6::compress($addrparts[0], true)
             ) {
                 /* do not care about alias */
                 continue 2;


### PR DESCRIPTION
Properly and forcibly compress ipv6 addresses that we get from the interface and the ones from the VIP.

Fixes issue #5008.
Is a variant of PR #4932

test log:
```
[06-Jun-2021 13:10:42 Etc/UTC] vip[subnet] == fda4:4fab:7fec:0::1
[06-Jun-2021 13:10:42 Etc/UTC] IPV6::compress(vip[subnet]) == fda4:4fab:7fec:0::1
[06-Jun-2021 13:10:42 Etc/UTC] Forced: IPV6::compress(vip[subnet]) == fda4:4fab:7fec::1

[06-Jun-2021 13:10:42 Etc/UTC] addrparts[0] == fda4:4fab:7fec::1
[06-Jun-2021 13:10:42 Etc/UTC] IPV6::compress(addrparts[0]) == fda4:4fab:7fec::1
[06-Jun-2021 13:10:42 Etc/UTC] Forced: IPV6::compress(addrparts[0]) == fda4:4fab:7fec::1
```

without the forced compression the 0 in one of the parts of the ipv6 address remained, causing the test to fail.
I don't know if it's optimal to do it on both ends?