### PR TITLE
Bugfix: Prevent PHP output buffer rewriting from corrupting downloaded packet capture files

### DIFF
--- a/src/www/csrf.inc
+++ b/src/www/csrf.inc
@@ -32,6 +32,8 @@ class LegacyCSRF
     private $security = null;
     private $session = null;
     private $is_html_output = false;
+    private $is_rewrite_enabled = true;
+
     public function __construct()
     {
         global $config;
@@ -80,8 +82,23 @@ class LegacyCSRF
         return array('token' => $_SESSION['$PHALCON/CSRF$'], 'key' => $_SESSION['$PHALCON/CSRF/KEY$']);
     }
 
+    public function get_rewrite_enabled_status()
+    {
+      return $this->is_rewrite_enabled;
+    }
+
+    public function configure_rewrite_enabled($set_enabled)
+    {
+      $this->is_rewrite_enabled = $set_enabled;
+    }
+
     public function csrfRewriteHandler($buffer)
     {
+        // Don't rewrite anything if rewriting is manually disabled
+        if (!$this->is_rewrite_enabled) {
+            return $buffer;
+        }
+       
         // quick check if output looks like html, don't rewrite other document types
         if (stripos($buffer, '<html') !== false) {
             $this->is_html_output = true;

--- a/src/www/diag_packet_capture.php
+++ b/src/www/diag_packet_capture.php
@@ -161,12 +161,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 header("Content-Disposition: attachment; filename={$bfilename}");
                 header("Content-Length: ".filesize($filename));
                 header('Content-Transfer-Encoding: binary');
+
+                // Temporarily disable output buffer rewriting during the
+                // download, as it is not needed for the packet capture file
+                // and would even corrupt certain capture files
+                $prev_is_rewrite_enabled = $LegacyCSRFObject->get_rewrite_enabled_status();
+                $LegacyCSRFObject->configure_rewrite_enabled(false);                
+
                 $file = fopen($filename, 'rb');
                 while(!feof($file)) {
                     print(fread($file, 32 * 1024));
                     ob_flush();
                 }
                 fclose($file);
+
+                // Restore original output buffer rewriting state
+                $LegacyCSRFObject->configure_rewrite_enabled($prev_is_rewrite_enabled);
+
                 break;
             }
         }


### PR DESCRIPTION
**Issue/how to reproduce:** When creating certain packet capture files via the OPNsense GUI and trying to download them, these files files get corrupted during the download. The corruption happens for packet capture files that contain unencrypted HTML file transfers, e.g., captures of HTTP (not HTTPS) website accesses. The packet capture files can be downloaded without corruption via SSH.

**Root cause:** The CSRF functionality of OPNsense's GUI modifies the PHP output buffer before sending it out to the client. It uses a very simply heuristic to decide whether or not the buffer should be modified (looking for "<html"). This heuristic gives a false positive result for any capture files that contain "<html", which is quite a common case.

**Proposed fix:** Added a new internal state to class LegacyCSRF, which allows to manually control if the output buffer rewriting is enabled. This is then manually disabled before the file download starts and re-stored afterwards.