### PR TITLE
read_log.py: set label for obsolete hash in log

### DIFF
--- a/src/opnsense/scripts/filter/read_log.py
+++ b/src/opnsense/scripts/filter/read_log.py
@@ -164,13 +164,15 @@ if __name__ == '__main__':
                     rule['rid'] = rulep[-1]
                     if rulep[-1] in running_conf_descr['rule_map']:
                         rule['label'] = running_conf_descr['rule_map'][rulep[-1]]
+                    # obsolete md5 in log record
+                    else:
+                        rule['label'] = rulep[-1]
                 elif 'rulenr' in rule and rule['rulenr'] in running_conf_descr['line_ids']:
                     if rule['action'] in ['pass', 'block']:
                         rule['label'] = running_conf_descr['line_ids'][rule['rulenr']]['label']
                         rule['rid'] = running_conf_descr['line_ids'][rule['rulenr']]['rid']
-                elif rule['action'] not in ['pass', 'block']:
-                    rule['label'] = "%s rule" % rule['action']
-
+                    elif rule['action'] not in ['pass', 'block']:
+                        rule['label'] = "%s rule" % rule['action']
                 result.append(rule)
 
                 # handle exit criteria, row limit or last digest


### PR DESCRIPTION
Hi!
after https://github.com/opnsense/core/commit/01031b4e546300e09a26598fbb011da78f05ed5f there is no more erroneous label assignment but read_log.py does not return 'label' at all for an entry with an obsolete hash.
ref: https://forum.opnsense.org/index.php?topic=23690.0
may be we can assign md5 as a label for this records?
or should I just add handling for a missing label in log.widget?
https://github.com/opnsense/core/blob/9e1582ced1689a24a7c934a1a5de3518f350ed6d/src/www/widgets/widgets/log.widget.php#L132-L133

I'm not sure about the second change, but it seems to me that `elif rule['action'] not in ['pass', 'block']` refers to the `if rule['action'] in ['pass', 'block']:` statement

thanks!