### PR TITLE
Enable group sync for LDAP servers, that do not return memberOf

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -578,7 +578,7 @@ class LDAP extends Base implements IAuthConnector
         if ($ldap_is_connected) {
             $this->lastAuthProperties['dn'] = $user_dn;
             if ($this->ldapReadProperties) {
-                $sr = @ldap_read($this->ldapHandle, $user_dn, '(objectclass=*)');
+                $sr = @ldap_read($this->ldapHandle, $user_dn, '(objectclass=*)', array("*", "memberOf"));
                 $info = @ldap_get_entries($this->ldapHandle, $sr);
                 if ($info['count'] != 0) {
                     foreach ($info[0] as $ldap_key => $ldap_value) {

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -578,7 +578,7 @@ class LDAP extends Base implements IAuthConnector
         if ($ldap_is_connected) {
             $this->lastAuthProperties['dn'] = $user_dn;
             if ($this->ldapReadProperties) {
-                $sr = @ldap_read($this->ldapHandle, $user_dn, '(objectclass=*)', array("*", "memberOf"));
+                $sr = @ldap_read($this->ldapHandle, $user_dn, '(objectclass=*)', ['*', 'memberOf']);
                 $info = @ldap_get_entries($this->ldapHandle, $sr);
                 if ($info['count'] != 0) {
                     foreach ($info[0] as $ldap_key => $ldap_value) {


### PR DESCRIPTION
The OpenLDAP setup we use does not return functional attributes by default. I understand this behaviour is quite common. One has to query for memberOf separately. So to enable allocating users to groups, I have added an extra ldap_read() that adds memberOf attributes to the lastAuthProperties array. 

This is relevant to issue #4454.
