### PR TITLE
Unbound: Update Miscellaneous.xml

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
@@ -8,7 +8,7 @@
         </privatedomain>
         <dotservers type="CSVListField">
             <Required>N</Required>
-            <mask>/^[a-fA-F0-9\.\,\:\@]{1,512}$/</mask>
+            <mask>/^[a-zA-Z0-9\.\,\:\@\#]{1,512}$/</mask>
         </dotservers>
     </items>
 </model>


### PR DESCRIPTION
Allow cert verification in transition. 

I know we agreed to move to grid, but maybe for interim we just allow hash sign. We already dont to a validation for private domain field above (which is not an excuse) but at this point, maybe its better to allow this now while still have the option to migrate to grid view in later version