### PR TITLE
openvpn: check ipv4 tunnel prefix

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -440,6 +440,12 @@ function step10_submitphpaction()
 
     if ($result = openvpn_validate_cidr($_POST['tunnelnet'], gettext('IPv4 Tunnel Network'), false, 'ipv4')) {
         $input_errors[] = $result;
+    } elseif (isset($_POST['tunnelnet'])) {
+        // Check IPv4 tunnelnet pool size. Wizard makes tun mode with net30 server only.
+        list($ipv4tunnel_base, $ipv4tunnel_prefix) = explode('/',trim($_POST['tunnelnet']));
+        if ($ipv4tunnel_prefix > 28) {
+            $input_errors[] = gettext('A prefix longer than 28 cannot be used with a net30 topology.');
+        }
     }
 
     if ($result = openvpn_validate_cidr($_POST['tunnelnetv6'], gettext('IPv6 Tunnel Network'), false, 'ipv6')) {

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -202,6 +202,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         if ($result = openvpn_validate_cidr($pconfig['tunnel_network'], gettext('IPv4 Tunnel Network'), false, 'ipv4')) {
             $input_errors[] = $result;
+        } elseif (isset($pconfig['tunnel_network'])) {
+            // Check IPv4 tunnel_network pool size
+            list($ipv4tunnel_base, $ipv4tunnel_prefix) = explode('/',trim($pconfig['tunnel_network']));
+            if ($pconfig['dev_mode'] != "tap") {
+                if ($ipv4tunnel_prefix > 28 && empty($pconfig['topology_subnet'])) {
+                    $input_errors[] = gettext('A prefix longer than 28 cannot be used with a net30 topology.');
+                }
+                if ($ipv4tunnel_prefix > 29 && !empty($pconfig['topology_subnet'])) {
+                    $input_errors[] = gettext('A prefix longer than 29 cannot be used for tunnel network.');
+                }
+            } else {
+                if ($ipv4tunnel_prefix > 29) {
+                    $input_errors[] = gettext('A prefix longer than 29 cannot be used for tunnel network.');
+                }
+            }
         }
 
         if ($result = openvpn_validate_cidr($pconfig['tunnel_networkv6'], gettext('IPv6 Tunnel Network'), false, 'ipv6')) {


### PR DESCRIPTION
Hi!
openvpn 2.5 now requires the pool size to be at least 2 (https://github.com/OpenVPN/openvpn/pull/153)
maybe we can verify ipv4 tunnel prefix at server creation/editing?
ref: https://forum.opnsense.org/index.php?topic=23934.0
