### PR TITLE
openvpn: check ipv4 tunnel prefix. v2

### DIFF
--- a/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn/wizard.inc
@@ -440,6 +440,12 @@ function step10_submitphpaction()
 
     if ($result = openvpn_validate_cidr($_POST['tunnelnet'], gettext('IPv4 Tunnel Network'), false, 'ipv4')) {
         $input_errors[] = $result;
+    } elseif (!empty($_POST['tunnelnet'])) {
+        // Check IPv4 tunnelnet pool size. Wizard makes tun mode with net30 server only.
+        list($ipv4tunnel_base, $ipv4tunnel_prefix) = explode('/',trim($_POST['tunnelnet']));
+        if ($ipv4tunnel_prefix > 28) {
+            $input_errors[] = gettext('A prefix longer than 28 cannot be used with a net30 topology.');
+        }
     }
 
     if ($result = openvpn_validate_cidr($_POST['tunnelnetv6'], gettext('IPv6 Tunnel Network'), false, 'ipv6')) {
@@ -770,7 +776,7 @@ function step12_submitphpaction()
         if (strpos($proto, '4') !== false) {
             $rule['protocol'] = substr($proto, 0, -1);
             $rule['ipprotocol'] = "inet";
-        } elseif  (strpos($proto, '6') !== false) {
+        } elseif (strpos($proto, '6') !== false) {
             $rule['protocol'] = substr($proto, 0, -1);
             $rule['ipprotocol'] = "inet6";
         } else {

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -202,6 +202,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         if ($result = openvpn_validate_cidr($pconfig['tunnel_network'], gettext('IPv4 Tunnel Network'), false, 'ipv4')) {
             $input_errors[] = $result;
+        } elseif (!empty($pconfig['tunnel_network'])) {
+            // Check IPv4 tunnel_network pool size
+            list($ipv4tunnel_base, $ipv4tunnel_prefix) = explode('/',trim($pconfig['tunnel_network']));
+            if ($pconfig['dev_mode'] == "tun") {
+                if ($ipv4tunnel_prefix > 28 && empty($pconfig['topology_subnet'])) {
+                    $input_errors[] = gettext('A prefix longer than 28 cannot be used with a net30 topology.');
+                } elseif ($ipv4tunnel_prefix > 29 && !empty($pconfig['topology_subnet'])) {
+                    $input_errors[] = gettext('A prefix longer than 29 cannot be used for tunnel network.');
+                }
+            } elseif ($pconfig['dev_mode'] == "tap" && $ipv4tunnel_prefix > 29) {
+                $input_errors[] = gettext('A prefix longer than 29 cannot be used for tunnel network.');
+            }
         }
 
         if ($result = openvpn_validate_cidr($pconfig['tunnel_networkv6'], gettext('IPv6 Tunnel Network'), false, 'ipv6')) {


### PR DESCRIPTION
Hi!
clear (i hope) version of https://github.com/opnsense/core/pull/5108/
-no more `isset()`
-still check that 'tunnelnet' not empty (`openvpn_validate_cidr` allows empty field) https://github.com/opnsense/core/pull/5108/files#r674182409
-removed the extra space from previous commit in wizard