### PR TITLE
Aliases: show available room in table-entries limit

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -246,6 +246,16 @@ class AliasController extends ApiMutableModelControllerBase
     }
 
     /**
+     * get aliases load stats and table-entries limit
+     */
+    public function getRecordsAction()
+    {
+        $backend = new Backend();
+        $result = $backend->configdRun('filter diag records json');
+        return $result;
+    }
+
+    /**
      * variant on model.getNodes() returning actual field values
      * @param $parent_node BaseField node to reverse
      */

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -99,6 +99,26 @@
         }
 
         /**
+         * show tables limits, counts and alerts
+         **/
+        function get_aliases_stat() {
+            ajaxGet("/api/firewall/alias/getRecords", {}, function(data){
+                overall = data.overall_count;
+                limit = data.table_entries;
+                perc_full = Math.round(100*overall/limit);
+                $('#room_left').attr('aria-valuenow', perc_full + '%').css("width", perc_full + "%");
+                $('#entries_bar > span').text("Records / Limit: "+ perc_full + "% (" + overall + "/" + limit + " records)");
+                bar_color = (perc_full > 50) ? "orangered" : (perc_full < 50 && perc_full > 30) ? "yellowgreen" : "greenyellow";
+                $('#room_left').css("background-color", bar_color);
+                if (data.errors > 0) {
+                    $('#alias_alert').show();
+                } else {
+                    $('#alias_alert').hide();
+                }
+            });
+        }
+
+        /**
          * fetch regions and countries for geoip selection
          */
         ajaxGet("/api/firewall/alias/listCountries", {}, function(data){
@@ -413,6 +433,7 @@
                 }
                 formatTokenizersUI();
                 $('.selectpicker').selectpicker('refresh');
+                get_aliases_stat();
             });
         }
         loadSettings();
@@ -444,8 +465,11 @@
             history.pushState(null, null, e.target.hash);
         });
 
-        // move filter into action header
+        // move filter and progress bar into action header
         $("#type_filter_container").detach().prependTo('#grid-aliases-header > .row > .actionBar > .actions');
+        $("#aliases_stat").detach().prependTo('#grid-aliases-header > .row > .actionBar');
+
+
 
     });
 </script>
@@ -475,7 +499,14 @@
                                 <option value="external">{{ lang._('External (advanced)') }}</option>
                             </select>
                         </div>
-                    </div>
+                        <div id="aliases_stat" style="text-align: center;display: inline-block;width: 25%;margin-right: 25%;">
+                            <div id="entries_bar" class="progress">
+                                <div id="room_left" class="progress-bar" role="progressbar" aria-valuenow="0%" aria-valuemin="0" aria-valuemax="100" style="width: 23%;z-index: 0;"></div>
+                                    <span class="state_text" style="position:absolute;right:0;left:0;">loadind data..</span>
+                                </div>
+                                <span id="alias_alert" style="color: orangered; display:none">There are error(s) loading Alias(es)</span>
+                            </div>
+                        </div>
                     <table id="grid-aliases" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogAlias" data-editAlert="aliasChangeMessage" data-store-selection="true">
                         <thead>
                         <tr>

--- a/src/opnsense/scripts/filter/pfrecords.py
+++ b/src/opnsense/scripts/filter/pfrecords.py
@@ -1,0 +1,66 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2021 Deciso B.V.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+    --------------------------------------------------------------------------------------
+    returns the stats for pf table load and errors (optional as a json container)
+    usage : pfrecords.py [optional|json]
+"""
+import collections
+import subprocess
+import sys
+import os
+import ujson
+
+if __name__ == '__main__':
+    result = {'status': 'ok'}
+    sp = subprocess.run(['/sbin/pfctl', '-vvsT'], capture_output=True, text=True)
+    tables_count = 0
+    for line in sp.stdout.strip().split('\n'):
+        if "Addresses:" in line:
+            table_count = int("".join(filter(str.isdigit, line)))
+            tables_count += table_count
+    result['overall_count'] = tables_count
+
+    sp = subprocess.run(['/sbin/pfctl', '-sm'], capture_output=True, text=True)
+    for line in sp.stdout.strip().split('\n'):
+        if "table-entries" in line:
+            entries_limit = int("".join(filter(str.isdigit, line)))
+    result['table_entries'] = entries_limit
+    result['errors'] = len(open('/var/db/aliastables/alias_errs.log').readlines(  ));
+    if os.stat('/var/db/aliastables/alias_errs.log').st_size != 0:
+        extra_count = 0
+        err_file = open('/var/db/aliastables/alias_errs.log', 'r')
+        for err_line in err_file:
+            extra_count += int(err_line.split(',')[2])
+        result['overall_count'] += extra_count 
+
+    # handle command line argument (type selection)
+    if len(sys.argv) > 1 and sys.argv[1] == 'json':
+        print(ujson.dumps(result))
+    else:
+        # output plain
+        print (result['overall_count'], entries_limit, result['errors'])

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -107,6 +107,12 @@ parameters: %s
 type:script_output
 message:request pf diagnostic information
 
+[diag.records]
+command:/usr/local/opnsense/scripts/filter/pfrecords.py
+parameters: %s
+type:script_output
+message:request pf current overall tablet records count and table-entries limit
+
 [flush.states]
 command:/sbin/pfctl
 parameters: -F state


### PR DESCRIPTION
Hi!
in continuation of the https://github.com/opnsense/core/issues/5127#issuecomment-892399166 discussion
-show progress bar with overall count (including failed tables length) vs. `table-entries` limit
-send error msg to syslog on table (re)load error
-write stats file ((so api call executes faster)) to aliases db dir with alias name, alias size, alias extra size, pfctl errror message