### PR TITLE
adding xc0 terminal for opnsense as Xen PVH domU

### DIFF
--- a/src/etc/rc.subr.d/recover
+++ b/src/etc/rc.subr.d/recover
@@ -178,6 +178,7 @@ ttyu2	"/usr/libexec/getty 3wire"	vt100	onifconsole secure
 ttyu3	"/usr/libexec/getty 3wire"	vt100	onifconsole secure
 # Dumb console
 dcons	"/usr/libexec/getty std.9600"	vt100	off secure
+xc0	"/usr/libexec/getty Pc"		xterm	on secure
 
 EOF;
 


### PR DESCRIPTION
Hi

My first pull request so hopefully nothing is screwed up ;-)

Please add in the file /usr/local/etc/rc.subr.d/recover after the line
`dcons	"/usr/libexec/getty std.9600"	vt100	off secure`
the new line
`xc0     "/usr/libexec/getty Pc"         xterm   on  secure`

While running Opnsense as HVM Xen guest the ttys are just fine, with a PVH guest a tty xc0 is needed. Added that myself to /usr/local/etc/rc.subr.d/recover and it works just fine.

[related issue](https://github.com/opnsense/core/issues/4688)

Cheers,
Sebastian