### PR TITLE
rulecache.py: skip empty metadata

### DIFF
--- a/src/opnsense/scripts/suricata/lib/rulecache.py
+++ b/src/opnsense/scripts/suricata/lib/rulecache.py
@@ -189,7 +189,8 @@ class RuleCache(object):
                             if prop == 'metadata':
                                 for mdtag in list(csv.reader([value], delimiter=","))[0]:
                                     parts = mdtag.split(maxsplit=1)
-                                    record['metadata'][parts[0]] = parts[1] if len(parts) > 1 else None
+                                    if parts:
+                                        record['metadata'][parts[0]] = parts[1] if len(parts) > 1 else None
                             else:
                                 record[prop] = value
 


### PR DESCRIPTION
Hi!
again strange metadata in the ptresearch ruleset
`metadata: autosign, id_0,;`
ref: https://github.com/ptresearch/AttackDetection/blob/9bb547bd8411e2398ea6d4972af979d1ee64504e/Telegram/telegram.rules#L2
so mdtag[2] leads to 'index out of range' error for `record['metadata'][parts[0]]`
can we add one more check please?
thanks!