### PR TITLE
Enable Alerts and stats events to UNIX-socket

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -24,6 +24,16 @@
         <help><![CDATA[Send alerts to system log in fast log format. This will not change the alert logging used by the product itself.]]></help>
     </field>
     <field>
+        <id>ids.general.unix_sock</id>
+        <label>Enable alerts and stats events to UNIX-socket</label>
+        <type>checkbox</type>
+        <help><![CDATA[
+          Report triggered IDS/IPS alerts, internal performance counters of the Suricata IDS/IPS engine, 
+          such as captured traffic volume, memory usage, uptime, flow counters, and much more to UNIX-socket /tmp/suricata-stats.sock.
+          Suricata Data Sink must be enabled in Telegraf first.
+          ]]></help>
+    </field>
+    <field>
         <id>ids.general.syslog_eve</id>
         <label>Enable eve syslog output</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -251,6 +251,10 @@
                 <default>0</default>
                 <Required>Y</Required>
             </syslog_eve>
+            <unix_sock type="BooleanField">
+                <default>0</default>
+                <Required>Y</Required>
+            </unix_sock>
             <LogPayload type="BooleanField">
                 <default>0</default>
                 <Required>Y</Required>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -70,6 +70,29 @@ stats:
 
 # Configure the type of alert (and other) logging you would like.
 outputs:
+{% if helpers.exists('OPNsense.IDS.general.unix_sock') and OPNsense.IDS.general.unix_sock == '1' %}
+
+  # Extensible Event Format (nicknamed EVE) to UNIX-socket
+  - eve-log:
+      enabled: yes
+      filetype: unix_stream
+      filename: /tmp/suricata-stats.sock
+      types:
+        - stats:
+           threads: yes
+        - alert:
+             # packet: yes              # enable dumping of packet (without stream segments)
+             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
+             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
+             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
+
+             # Enable the logging of tagged packets for rules using the
+             # "tag" keyword.
+             tagged-packets: yes
+
+             http: yes
+             tls: yes
+{% endif %}
 
   # a line based alerts log similar to Snort's fast.log
   - fast:

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -81,6 +81,11 @@ outputs:
         - stats:
            threads: yes
         - alert:
+{% if not helpers.empty('OPNsense.IDS.general.LogPayload') %}
+             payload: yes
+             payload-buffer-size: 100kb
+             payload-printable: yes
+{% endif %}
              # packet: yes              # enable dumping of packet (without stream segments)
              # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
              # http-body: yes           # Requires metadata; enable dumping of http body in Base64


### PR DESCRIPTION
Report triggered IDS/IPS alerts, internal performance counters of the Suricata IDS/IPS engine, such as captured traffic volume, memory usage, uptime, flow counters, and much more to a UNIX-socket.

This is to be used in conjunction with [[inputs.suricata]] which is a plugin for Suricata metrics in Telegraf. 