### PR TITLE
unbound: add configurable dnsbl response

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
@@ -12,6 +12,33 @@
         <help>Select which kind of DNSBL you want to use.</help>
     </field>
     <field>
+        <id>unbound.dnsbl.localzone</id>
+        <label>DNSBL Response Type</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Select the desired DNSBL response type for blocklist matches. See 'local-zone' in unbound.conf(5) for full details.
+          "Always" types always return the indicated response.
+          "Inform" types generate additional logging that can be used to monitor blocklist matches.
+          "Redirect" types will return NXDOMAIN or local data (if configured).
+          Types that match subdomains can improve DNSBL coverage but may require whitelisting some subdomains.
+          NXDOMAIN responses may produce improved behavior versus null records with some web sites and mobile apps.
+        ]]></help>
+    </field>
+    <field>
+        <id>unbound.dnsbl.redirect_a</id>
+        <label>Redirect A record (optional)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Return this IPv4 address (typically 0.0.0.0) for redirected A records or NXDOMAIN if blank.</help>
+    </field>
+    <field>
+        <id>unbound.dnsbl.redirect_aaaa</id>
+        <label>Redirect AAAA record (optional)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Return this IPv6 address (typically ::) for redirected AAAA records or NXDOMAIN if blank.</help>
+    </field>
+    <field>
         <id>unbound.dnsbl.lists</id>
         <label>URLs of Blocklists</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/unboundplus</mount>
     <description>Unbound configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <service_enabled type="LegacyLinkField">
             <Source>unbound.enable</Source>
@@ -49,6 +49,30 @@
                     <yy>YoYo List</yy>
                 </OptionValues>
             </type>
+            <localzone type="OptionField">
+                <Required>Y</Required>
+                <default>__default__</default>
+                <OptionValues>
+                    <__default__>Return null (0.0.0.0) A record (default)</__default__>
+                    <always_nxdomain>Always return NXDOMAIN</always_nxdomain>
+                    <always_null>Always return null A/AAAA response (matches subdomains)</always_null>
+                    <redirect>Return NXDOMAIN or redirect record (matches subdomains)</redirect>
+                    <inform_redirect>Log and return NXDOMAIN or redirect record (matches subdomains)</inform_redirect>
+                    <inform>Log and resolve normally or return redirect record</inform>
+                </OptionValues>
+            </localzone>
+            <redirect_a type="NetworkField">
+                <Required>N</Required>
+                <netMaskAllowed>N</netMaskAllowed>
+                <version>ipv4</version>
+                <default></default>
+            </redirect_a>
+            <redirect_aaaa type="NetworkField">
+                <Required>N</Required>
+                <netMaskAllowed>N</netMaskAllowed>
+                <version>ipv6</version>
+                <default></default>
+            </redirect_aaaa>
             <lists type="CSVListField">
                 <Required>N</Required>
             </lists>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
@@ -52,6 +52,11 @@ custom_{{loop.index}}={{uri}}
 {%      endfor %}
 {%    endif %}
 
+[response]
+localzone={{ OPNsense.unboundplus.dnsbl.localzone }}
+redirect_a={{ OPNsense.unboundplus.dnsbl.redirect_a }}
+redirect_aaaa={{ OPNsense.unboundplus.dnsbl.redirect_aaaa }}
+
 [exclude]
 # exclude localhost entries
 default_pattern_1=.*localhost$


### PR DESCRIPTION
The default DNSBL response of a static NULL A record causes some poorly written sites and mobile apps to spin needlessly on connection failures to 0.0.0.0.  Further, the DNSBL does not block IPv6 requests which utilize different record types.

This PR adds the ability to configure different response types including NXDOMAIN, full IPv4/IPv6 null response and request logging.  It includes the same "log only" functionality as PR https://github.com/opnsense/core/pull/4715 but is more generalized.  The configuration is marked as 'advanced' and retains current OPNsense behavior by default.

Response types added by this PR are 'always_nxdomain', 'always_null', 'redirect', 'inform_redirect', and 'inform'.   Additional types may be easily added should the need arise, although few of the other types are useful in a DNSBL context.