### PR TITLE
Adding additional memory cache options for squid webproxy

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -185,7 +185,7 @@
                 <advanced>true</advanced>
             </field>
             <field>
-                <id>memory_cache_mode</id>
+                <id>proxy.general.cache.local.memory_cache_mode</id>
                 <label>Memory cache mode</label>
                 <type>dropdown</type>
                 <help>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -178,6 +178,25 @@
                 <advanced>true</advanced>
             </field>
             <field>
+                <id>proxy.general.cache.local.maximum_object_size_in_memory</id>
+                <label>Maximum object size in memory (KB)</label>
+                <type>text</type>
+                <help>Set the maximum object size in memory (default 512KB when left empty).</help>
+                <advanced>true</advanced>
+            </field>
+            <field>
+                <id>memory_cache_mode</id>
+                <label>Memory cache mode</label>
+                <type>dropdown</type>
+                <help>
+                    Controls which objects to keep in the memory cache (cache_mem)
+                    always:	Keep most recently fetched objects in memory (default)
+                    disk: Only disk cache hits are kept in memory, which means an object must first be cached on disk and then hit a second time before cached in memory.
+                    network: Only objects fetched from network is kept in memory
+                </help>
+                <advanced>true</advanced>
+            </field>
+            <field>
                 <id>proxy.general.cache.local.cache_linux_packages</id>
                 <label>Enable Linux Package Cache</label>
                 <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/proxy</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>
         (squid) proxy settings
     </description>
@@ -131,6 +131,22 @@
                       <ValidationMessage>Specify a maximum object size. (number of MB's)</ValidationMessage>
                       <Required>N</Required>
                     </maximum_object_size>
+                    <maximum_object_size_in_memory type="IntegerField">
+                      <MinimumValue>1</MinimumValue>
+                      <MaximumValue>99999</MaximumValue>
+                      <ValidationMessage>Specify a maximum object size in memory. (number of KB's)</ValidationMessage>
+                      <Required>N</Required>
+                    </maximum_object_size_in_memory>
+                    <memory_cache_mode type="OptionField">
+                        <default>always</default>
+                        <Required>N</Required>
+                        <BlankDesc>Default</BlankDesc>
+                        <OptionValues>
+                            <always>Keep all most recent files (always)</always>
+                            <disk>Keep most recent HIT files(disk)</disk>
+                            <network>Keep only files fetched from network (network)</network>
+                        </OptionValues>
+                    </memory_cache_mode>
                     <size type="IntegerField">
                         <default>100</default>
                         <MinimumValue>1</MinimumValue>

--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -313,6 +313,12 @@ maximum_object_size {{OPNsense.proxy.general.cache.local.maximum_object_size}} M
 cache_replacement_policy heap LFUDA
 {%    endif %}
 {%   endif %}
+{%  if OPNsense.proxy.general.cache.local.maximum_object_size_in_memory|default('') != '' %}
+maximum_object_size_in_memory {{OPNsense.proxy.general.cache.local.maximum_object_size_in_memory}} KB
+{%  endif %}
+{%  if OPNsense.proxy.general.cache.local.memory_cache_mode|default('always') != 'always' %}
+memory_cache_mode {{OPNsense.proxy.general.cache.local.memory_cache_mode}}
+{%  endif %}
 {%   if OPNsense.proxy.general.cache.local.enabled == '1' %}
 cache_dir ufs {{OPNsense.proxy.general.cache.local.directory}} {{OPNsense.proxy.general.cache.local.size}} {{OPNsense.proxy.general.cache.local.l1}} {{OPNsense.proxy.general.cache.local.l2}}
 {%   endif %}


### PR DESCRIPTION
memory_cache_mode: 	Controls which objects to keep in the memory cache (cache_mem)

default = always. If always is set, value will not saved to config.

Maximum object size in memory: Objects greater than this size will not be attempted to kept in the memory cache. This should be set high enough to keep objects accessed frequently in memory to improve performance whilst low enough to keep larger objects from hoarding cache_mem.

default = 512KB. If value not set default applies.


Only visible with advanced config. Help text formated and adapted form squid documentation.