### PR TITLE
syslog-ng, switch our default logging format on disk to rfc5424

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
@@ -50,6 +50,12 @@
     </help>
   </field>
   <field>
+    <id>destination.rfc5424</id>
+    <label>rfc5424</label>
+    <type>checkbox</type>
+    <help>Use rfc5424 formated messages for this destination.</help>
+  </field>
+  <field>
     <id>destination.description</id>
     <label>Description</label>
     <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Syslog</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -90,6 +90,10 @@
                     <Required>Y</Required>
                     <default>514</default>
                 </port>
+                <rfc5424 type="BooleanField">
+                  <default>0</default>
+                  <Required>Y</Required>
+                </rfc5424>
                 <description type="TextField">
                   <Required>N</Required>
                 </description>

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -100,7 +100,10 @@
                     <thead>
                     <tr>
                         <th data-column-id="timestamp" data-width="11em" data-type="string">{{ lang._('Date') }}</th>
+                        <th data-column-id="facility" data-type="string" data-visible="false">{{ lang._('Facility') }}</th>
+                        <th data-column-id="severity" data-type="string" data-width="2em">{{ lang._('Severity') }}</th>
                         <th data-column-id="process_name" data-width="2em" data-type="string">{{ lang._('Process') }}</th>
+                        <th data-column-id="pid" data-width="2em" data-type="numeric" data-visible="false">{{ lang._('PID') }}</th>
                         <th data-column-id="line" data-type="string">{{ lang._('Line') }}</th>
                         <th data-column-id="rnum" data-type="numeric" data-formatter="page"  data-width="2em"></th>
                     </tr>

--- a/src/opnsense/scripts/systemhealth/logformats/__init__.py
+++ b/src/opnsense/scripts/systemhealth/logformats/__init__.py
@@ -34,6 +34,10 @@ class BaseLogFormat:
     def __init__(self, filename):
         self._filename = filename
         self._priority = 255
+        self._line = ""
+
+    def set_line(self, line):
+        self._line = line
 
     @property
     def name(self):
@@ -51,23 +55,58 @@ class BaseLogFormat:
         """
         return False
 
-    @staticmethod
-    def timestamp(line):
+    @property
+    def timestamp(self):
         """ Extract timestamp from line
         """
         pass
 
-    @staticmethod
-    def line(line):
+    @property
+    def line(self):
         """ Return line (without timestamp)
         """
         return line
 
-    @staticmethod
-    def process_name(line):
+    @property
+    def process_name(self):
         """ Return process name
         """
         return ""
+
+    @property
+    def pid(self):
+        """ Return pid
+        """
+        return None
+
+    @property
+    def facility(self):
+        """ syslog facility
+        """
+        return None
+
+    @property
+    def severity(self):
+        """ syslog severity
+        """
+        return None
+
+    @property
+    def severity_str(self):
+        severity = self.severity
+        options = {
+            0: 'Emergency',
+            1: 'Alert',
+            2: 'Critical',
+            3: 'Error',
+            4: 'Warning',
+            5: 'Notice',
+            6: 'Informational',
+            7: 'Debug'
+        }
+        if severity in options:
+            return options[severity]
+        return None
 
 
 class FormatContainer:
@@ -92,4 +131,5 @@ class FormatContainer:
     def get_format(self, line):
         for handler in self._handlers:
             if handler.match(line):
+                handler.set_line(line)
                 return handler

--- a/src/opnsense/scripts/systemhealth/logformats/__init__.py
+++ b/src/opnsense/scripts/systemhealth/logformats/__init__.py
@@ -28,7 +28,7 @@ import glob
 import importlib
 import sys
 
-class BaseLogFormat:
+class LogFormat:
     """ Log format handler
     """
     def __init__(self, filename):
@@ -55,6 +55,38 @@ class BaseLogFormat:
         """
         return False
 
+
+class BaseLogFormat(LogFormat):
+    """ Legacy log format handler
+    """
+    @staticmethod
+    def match(line):
+        """ Does this formatter fit for the provided line
+        """
+        return False
+
+    @staticmethod
+    def timestamp(line):
+        """ Extract timestamp from line
+        """
+        pass
+
+    @staticmethod
+    def line(line):
+        """ Return line (without timestamp)
+        """
+        return line
+
+    @staticmethod
+    def process_name(line):
+        """ Return process name
+        """
+        return ""
+
+
+class NewBaseLogFormat(LogFormat):
+    """ log format handler
+    """
     @property
     def timestamp(self):
         """ Extract timestamp from line
@@ -123,7 +155,8 @@ class FormatContainer:
         for module_name in dir(sys.modules[__name__]):
             for attribute_name in dir(getattr(sys.modules[__name__], module_name)):
                 cls = getattr(getattr(sys.modules[__name__], module_name), attribute_name)
-                if isinstance(cls, type) and issubclass(cls, BaseLogFormat) and cls != BaseLogFormat:
+                if isinstance(cls, type) and issubclass(cls, LogFormat)\
+                        and cls not in (LogFormat, BaseLogFormat, NewBaseLogFormat):
                     all_handlers.append(cls(self._filename))
 
         self._handlers = sorted(all_handlers, key=lambda k: k.prio)

--- a/src/opnsense/scripts/systemhealth/logformats/squid.py
+++ b/src/opnsense/scripts/systemhealth/logformats/squid.py
@@ -38,19 +38,19 @@ class SquidLogFormat(BaseLogFormat):
     def match(self, line):
         return self._filename.find('squid') > -1 and re.match(squid_timeformat, line) is not  None
 
-    @staticmethod
-    def timestamp(line):
-        tmp = re.match(squid_timeformat, line)
+    @property
+    def timestamp(self):
+        tmp = re.match(squid_timeformat, self._line)
         grp = tmp.group(1)
         return datetime.datetime.strptime(grp, "%Y/%m/%d %H:%M:%S").isoformat()
 
-    @staticmethod
-    def process_name(line):
+    @property
+    def process_name(self):
         return "squid"
 
-    @staticmethod
-    def line(line):
-        return line[19:].strip()
+    @property
+    def line(self):
+        return self._line[19:].strip()
 
 
 class SquidExtLogFormat(BaseLogFormat):
@@ -61,19 +61,19 @@ class SquidExtLogFormat(BaseLogFormat):
     def match(self, line):
         return self._filename.find('squid') > -1 and re.match(squid_ext_timeformat, line) is not  None
 
-    @staticmethod
-    def timestamp(line):
-        tmp = re.match(squid_ext_timeformat, line)
+    @property
+    def timestamp(self):
+        tmp = re.match(squid_ext_timeformat, self._line)
         grp = tmp.group(1)
         return datetime.datetime.strptime(grp[1:].split()[0], "%d/%b/%Y:%H:%M:%S").isoformat()
 
-    @staticmethod
-    def process_name(line):
+    @property
+    def process_name(self):
         return "squid"
 
-    @staticmethod
-    def line(line):
-        tmp = re.match(squid_ext_timeformat, line)
+    @property
+    def line(self):
+        tmp = re.match(squid_ext_timeformat, self._line)
         grp = tmp.group(1)
         return line.replace(grp, '')
 
@@ -89,6 +89,7 @@ class SquidJsonLogFormat(BaseLogFormat):
     def match(self, line):
         return self._filename.find('squid') > -1 and line.find('"@timestamp"') > -1
 
+    @property
     def timestamp(self, line):
         tmp = line[line.find('"@timestamp"')+13:].split(',')[0].strip().strip('"')
         try:
@@ -97,10 +98,10 @@ class SquidJsonLogFormat(BaseLogFormat):
         except ValueError:
             return None
 
-    @staticmethod
-    def process_name(line):
+    @property
+    def process_name(self):
         return "squid"
 
-    @staticmethod
-    def line(line):
-        return line
+    @property
+    def line(self):
+        return self._line

--- a/src/opnsense/scripts/systemhealth/logformats/squid.py
+++ b/src/opnsense/scripts/systemhealth/logformats/squid.py
@@ -25,12 +25,12 @@
 """
 import re
 import datetime
-from . import BaseLogFormat
+from . import NewBaseLogFormat
 squid_ext_timeformat = r'.*(\[\d{1,2}/[A-Za-z]{3}/\d{4}:\d{1,2}:\d{1,2}:\d{1,2} \+\d{4}\]).*'
 squid_timeformat = r'^(\d{4}/\d{1,2}/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}).*'
 
 
-class SquidLogFormat(BaseLogFormat):
+class SquidLogFormat(NewBaseLogFormat):
     def __init__(self, filename):
         super().__init__(filename)
         self._priority = 100
@@ -53,7 +53,7 @@ class SquidLogFormat(BaseLogFormat):
         return self._line[19:].strip()
 
 
-class SquidExtLogFormat(BaseLogFormat):
+class SquidExtLogFormat(NewBaseLogFormat):
     def __init__(self, filename):
         super().__init__(filename)
         self._priority = 120
@@ -78,7 +78,7 @@ class SquidExtLogFormat(BaseLogFormat):
         return line.replace(grp, '')
 
 
-class SquidJsonLogFormat(BaseLogFormat):
+class SquidJsonLogFormat(NewBaseLogFormat):
     def __init__(self, filename):
         super().__init__(filename)
         self._priority = 140

--- a/src/opnsense/scripts/systemhealth/logformats/syslog.py
+++ b/src/opnsense/scripts/systemhealth/logformats/syslog.py
@@ -25,9 +25,9 @@
 """
 import re
 import datetime
-from . import BaseLogFormat
+from . import NewBaseLogFormat
 
-class SysLogFormat(BaseLogFormat):
+class SysLogFormat(NewBaseLogFormat):
     def __init__(self, filename):
         super(SysLogFormat, self).__init__(filename)
         self._priority = 2
@@ -61,7 +61,7 @@ class SysLogFormat(BaseLogFormat):
         return response[:tmp].strip().split()[-1] if tmp > -1 else ""
 
 
-class SysLogFormatEpoch(BaseLogFormat):
+class SysLogFormatEpoch(NewBaseLogFormat):
     def __init__(self, filename):
         super(SysLogFormatEpoch, self).__init__(filename)
         self._priority = 3
@@ -80,7 +80,7 @@ class SysLogFormatEpoch(BaseLogFormat):
         return self._line[14:].strip()
 
 
-class SysLogFormatRFC5424(BaseLogFormat):
+class SysLogFormatRFC5424(NewBaseLogFormat):
     def __init__(self, filename):
         super().__init__(filename)
         self._priority = 1

--- a/src/opnsense/scripts/systemhealth/logformats/syslog.py
+++ b/src/opnsense/scripts/systemhealth/logformats/syslog.py
@@ -30,32 +30,33 @@ from . import BaseLogFormat
 class SysLogFormat(BaseLogFormat):
     def __init__(self, filename):
         super(SysLogFormat, self).__init__(filename)
-        self._priority = 1
+        self._priority = 2
         self._startup_timestamp = datetime.datetime.now()
 
     @staticmethod
     def match(line):
         return len(line) > 15 and re.match(r'(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)', line[7:15])
 
-    def timestamp(self, line):
+    @property
+    def timestamp(self):
         # syslog format, strip timestamp and return actual log data
-        ts = datetime.datetime.strptime("%s %s" % (self._startup_timestamp.year, line[0:15]), "%Y %b %d %H:%M:%S")
+        ts = datetime.datetime.strptime("%s %s" % (self._startup_timestamp.year, self._line[0:15]), "%Y %b %d %H:%M:%S")
         ts = ts.replace(year=self._startup_timestamp.year)
         if (self._startup_timestamp - ts).days < 0:
             # likely previous year, (month for this year not reached yet)
             ts = ts.replace(year=ts.year - 1)
         return ts.isoformat()
 
-    @staticmethod
-    def line(line):
+    @property
+    def line(self):
         # parse [date] [hostname] [process_name] [line] format
-        response = line[16:]
+        response = self._line[16:]
         tmp = response.find(':')
         return response[tmp+1:].strip() if tmp > -1 else response[response.find(' ')+1:].strip()
 
-    @staticmethod
-    def process_name(line):
-        response = line[16:]
+    @property
+    def process_name(self):
+        response = self._line[16:]
         tmp = response.find(':')
         return response[:tmp].strip().split()[-1] if tmp > -1 else ""
 
@@ -63,17 +64,57 @@ class SysLogFormat(BaseLogFormat):
 class SysLogFormatEpoch(BaseLogFormat):
     def __init__(self, filename):
         super(SysLogFormatEpoch, self).__init__(filename)
-        self._priority = 2
+        self._priority = 3
 
     @staticmethod
     def match(line):
         # looks like an epoch
         return len(line) > 15 and line[0:10].isdigit() and line[10] == '.' and line[11:13].isdigit()
 
-    @staticmethod
-    def timestamp(line):
-        return datetime.datetime.fromtimestamp(float(line[0:13])).isoformat()
+    @property
+    def timestamp(self):
+        return datetime.datetime.fromtimestamp(float(self._line[0:13])).isoformat()
+
+    @property
+    def line(self):
+        return self._line[14:].strip()
+
+
+class SysLogFormatRFC5424(BaseLogFormat):
+    def __init__(self, filename):
+        super().__init__(filename)
+        self._priority = 1
+        self._parts = list()
 
     @staticmethod
-    def line(line):
-        return line[14:].strip()
+    def match(line):
+        return len(line) > 15 and line[0] == '<' and '>' in line[1:5] and line.find(']') > 0
+
+    def set_line(self, line):
+        super().set_line(line)
+        self._parts = self._line.split(maxsplit=5)
+
+    @property
+    def line(self):
+        return self._line.split(']', 1)[-1]
+
+    @property
+    def timestamp(self):
+        return self._parts[1].split('+', maxsplit=1)[0]
+
+    @property
+    def process_name(self):
+        return self._parts[3]
+
+    @property
+    def pid(self):
+        return self._parts[4]
+
+    @property
+    def facility(self):
+        return int(int(self._line[1:].split('>', 1)[0]) / 8)
+
+    @property
+    def severity(self):
+        tmp = int(self._line[1:].split('>', 1)[0])
+        return tmp - (int((tmp / 8)) * 8)

--- a/src/opnsense/scripts/systemhealth/queryLog.py
+++ b/src/opnsense/scripts/systemhealth/queryLog.py
@@ -37,7 +37,7 @@ import sre_constants
 import ujson
 import datetime
 import glob
-from logformats import FormatContainer
+from logformats import FormatContainer, BaseLogFormat
 sys.path.insert(0, "/usr/local/opnsense/site-python")
 from log_helper import reverse_log_reader, fetch_clog
 import argparse
@@ -107,13 +107,20 @@ if __name__ == '__main__':
                             }
                             frmt = format_container.get_format(rec['line'])
                             if frmt:
-                                record['timestamp'] = frmt.timestamp
-                                record['process_name'] = frmt.process_name
-                                record['pid'] = frmt.pid
-                                record['facility'] = frmt.facility
-                                record['severity'] = frmt.severity_str
-                                record['line'] = frmt.line
-                                record['parser'] = frmt.name
+                                if issubclass(frmt.__class__, BaseLogFormat):
+                                    # backwards compatibility, old style log handler
+                                    record['timestamp'] = frmt.timestamp(rec['line'])
+                                    record['process_name'] = frmt.process_name(rec['line'])
+                                    record['line'] = frmt.line(rec['line'])
+                                    record['parser'] = frmt.name
+                                else:
+                                    record['timestamp'] = frmt.timestamp
+                                    record['process_name'] = frmt.process_name
+                                    record['pid'] = frmt.pid
+                                    record['facility'] = frmt.facility
+                                    record['severity'] = frmt.severity_str
+                                    record['line'] = frmt.line
+                                    record['parser'] = frmt.name
                             else:
                                 record['line'] = rec['line']
                             result['rows'].append(record)

--- a/src/opnsense/scripts/systemhealth/queryLog.py
+++ b/src/opnsense/scripts/systemhealth/queryLog.py
@@ -99,14 +99,20 @@ if __name__ == '__main__':
                             record = {
                                 'timestamp': None,
                                 'parser': None,
+                                'facility': 1,
+                                'severity': 3,
                                 'process_name': '',
+                                'pid': None,
                                 'rnum': row_number
                             }
                             frmt = format_container.get_format(rec['line'])
                             if frmt:
-                                record['timestamp'] = frmt.timestamp(rec['line'])
-                                record['process_name'] = frmt.process_name(rec['line'])
-                                record['line'] = frmt.line(rec['line'])
+                                record['timestamp'] = frmt.timestamp
+                                record['process_name'] = frmt.process_name
+                                record['pid'] = frmt.pid
+                                record['facility'] = frmt.facility
+                                record['severity'] = frmt.severity_str
+                                record['line'] = frmt.line
                                 record['parser'] = frmt.name
                             else:
                                 record['line'] = rec['line']

--- a/src/opnsense/service/conf/actions.d/actions_system.conf
+++ b/src/opnsense/service/conf/actions.d/actions_system.conf
@@ -6,7 +6,7 @@ message:Show system activity
 
 [diag.log]
 command:/usr/local/opnsense/scripts/systemhealth/queryLog.py
-parameters:--limit %s --offset %s --filter %s  --module %s --filename %s
+parameters:--limit %s --offset %s --filter %s  --module %s --filename %s --severity %s
 type:script_output
 message:Show log
 

--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
@@ -28,6 +28,9 @@ destination d_{{dest_key}} {
         transport("{{destination.transport[:3]}}")
         port({{destination.port}})
         ip-protocol({{destination.transport[3]}})
+{%             if destination.rfc5424|default('0') == '1' %}
+        flags(syslog-protocol)
+{%             endif %}
         persist-name("{{dest_key}}")
     );
 {%           elif destination.transport in ['tls4', 'tls6'] %}

--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-local.conf
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-local.conf
@@ -14,6 +14,7 @@ destination d_local_{{ local_config }} {
     file(
         "/var/log/{{local_config.replace('_', '/')}}/{{local_config.split('_')[-1]}}_${YEAR}${MONTH}${DAY}.log"
         create-dirs(yes)
+        flags(syslog-protocol)
     );
 };
 log {
@@ -36,6 +37,7 @@ destination d_local_system {
     file(
         "/var/log/system/system_${YEAR}${MONTH}${DAY}.log"
         create-dirs(yes)
+        flags(syslog-protocol)
     );
 };
 


### PR DESCRIPTION
**Important notices**

Before you add a new report, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I am convinced that my issue is new after having checked both open and closed issues at https://github.com/opnsense/core/issues?q=is%3Aissue

**Is your feature request related to a problem? Please describe.**

Currently some information is missing in local log files, mainly the severity which would help during debugging. Another problem with the current stored files is that dates don't contain the year in rfc3164 format, which means we do need to calculate them when converting to iso 8601.

**Describe the solution you like**

Switch local stored format to rfc5424, we don't really need backwards compatibility it we're able to parse both formats. Other non local consumers should use the configurable syslog destinations or our api.

**Describe alternatives you considered**

none

**Additional context**

while here, best add optional rfc5424 for external consumers as well (https://github.com/opnsense/core/issues/4911)
