### PR TITLE
CARP: Fix fetching VIP status

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4515,7 +4515,7 @@ function get_carp_interface_status($carpinterface)
     /* XXX: Need to find a better way for this! */
     list ($interface, $vhid) = explode("_vip", $carpinterface);
     $interface = get_real_interface($interface);
-    exec("/sbin/ifconfig $interface | /usr/bin/grep -v grep | /usr/bin/grep carp: | /usr/bin/grep 'vhid {$vhid}'", $carp_query);
+    exec("/sbin/ifconfig $interface | /usr/bin/grep -v grep | /usr/bin/grep carp: | /usr/bin/grep 'vhid {$vhid} '", $carp_query);
     foreach ($carp_query as $int) {
         if (stristr($int, "MASTER")) {
             return gettext("MASTER");

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -31,7 +31,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-require_once("interfaces.lib.inc");
 
 function openvpn_configure()
 {

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -903,7 +903,7 @@ function openvpn_restart($mode, $settings, $carp_event = false)
         list ($interface, $vhid) = explode("_vip", $settings['interface']);
         $carp_statuses = legacy_interface_details(get_real_interface($interface))['carp'];
         if (
-            $carp_statuses[array_search($vhid, array_column($carp_statuses, 'vhid'))]['status'] == 'BACKUP'
+            $carp_statuses[$vhid]['status'] == 'BACKUP'
         ) {
             /* do not restart a client if we are a CARP backup instance */
             return;

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -901,9 +901,10 @@ function openvpn_restart($mode, $settings, $carp_event = false)
         strstr($settings['interface'], '_vip') && $mode == 'client'
     ) {
         list ($interface, $vhid) = explode("_vip", $settings['interface']);
-        $carp_statuses = legacy_interface_details(get_real_interface($interface))['carp'];
+        $interface_details = legacy_interface_details(get_real_interface($interface));
         if (
-            $carp_statuses[$vhid]['status'] == 'BACKUP'
+            !empty($interface_details) && !empty($interface_details['carp'][$vhid]) && 
+            $interface_details['carp'][$vhid]['status'] == 'BACKUP'
         ) {
             /* do not restart a client if we are a CARP backup instance */
             return;

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -31,7 +31,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 function openvpn_configure()
 {
     return array(

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+require_once("interfaces.lib.inc");
+
 function openvpn_configure()
 {
     return array(
@@ -898,11 +900,16 @@ function openvpn_restart($mode, $settings, $carp_event = false)
     }
 
     if (
-        strstr($settings['interface'], '_vip') && $mode == 'client' &&
-        get_carp_interface_status($settings['interface']) == gettext('BACKUP')
+        strstr($settings['interface'], '_vip') && $mode == 'client'
     ) {
-        /* do not restart a client if we are a CARP backup instance */
-        return;
+        list ($interface, $vhid) = explode("_vip", $settings['interface']);
+        $carp_statuses = legacy_interface_details(get_real_interface($interface))['carp'];
+        if (
+            $carp_statuses[array_search($vhid, array_column($carp_statuses, 'vhid'))]['status'] == 'BACKUP'
+        ) {
+            /* do not restart a client if we are a CARP backup instance */
+            return;
+        }
     }
 
     @unlink("/var/etc/openvpn/{$mode_id}.sock");

--- a/src/www/carp_status.php
+++ b/src/www/carp_status.php
@@ -169,22 +169,26 @@ include("head.inc");
                         continue;
                     }
                     $icon = '';
-                    $intf_carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
-                    $intf_status = $intf_carp_statuses[array_search($carp['vhid'], array_column($intf_carp_statuses, 'vhid'))]['status'];
+                    $carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
+                    $intf_status = $carp_statuses[array_search($carp['vhid'], array_column($carp_statuses, 'vhid'))]['status'];
                     if (($carpcount > 0 && !$status)) {
                         $icon = "fa fa-remove fa-fw text-danger";
                         $intf_status = 'DISABLED';
+                        $intf_status_i18n = gettext('DISABLED');
                     } elseif ($intf_status == 'MASTER') {
                         $icon = "fa fa-play fa-fw text-success";
+                        $intf_status_i18n = gettext('MASTER');
                     } elseif ($intf_status == 'BACKUP') {
                         $icon = "fa fa-play fa-fw text-muted";
+                        $intf_status_i18n = gettext('BACKUP');
                     } elseif ($intf_status == 'INIT') {
                         $icon = "fa fa-info-circle fa-fw";
+                        $intf_status_i18n = gettext('INIT');
                     }?>
                 <tr>
                   <td><?=convert_friendly_interface_to_friendly_descr($carp['interface']) . "@{$carp['vhid']}" ;?></td>
                   <td><?=$carp['subnet'];?></td>
-                  <td><span class="<?=$icon;?>"></span> <?=gettext($intf_status);?></td>
+                  <td><span class="<?=$icon;?>"></span> <?=$intf_status_i18n;?></td>
                 </tr>
 <?php
                   endforeach;

--- a/src/www/carp_status.php
+++ b/src/www/carp_status.php
@@ -29,7 +29,6 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
-require_once("interfaces.lib.inc");
 
 $a_vip = &config_read_array('virtualip', 'vip');
 

--- a/src/www/carp_status.php
+++ b/src/www/carp_status.php
@@ -29,6 +29,7 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
+require_once("interfaces.lib.inc");
 
 $a_vip = &config_read_array('virtualip', 'vip');
 
@@ -163,26 +164,28 @@ include("head.inc");
                 </tr>
 <?php
                 else:
+                  $interfaces_details = legacy_interfaces_details();
                   foreach ($a_vip as $carp):
                     if ($carp['mode'] != "carp") {
                         continue;
                     }
                     $icon = '';
-                    $intf_status = get_carp_interface_status("{$carp['interface']}_vip{$carp['vhid']}");
+                    $intf_carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
+                    $intf_status = $intf_carp_statuses[array_search($carp['vhid'], array_column($intf_carp_statuses, 'vhid'))]['status'];
                     if (($carpcount > 0 && !$status)) {
                         $icon = "fa fa-remove fa-fw text-danger";
-                        $intf_status = gettext('DISABLED');
-                    } elseif ($intf_status == gettext('MASTER')) {
+                        $intf_status = 'DISABLED';
+                    } elseif ($intf_status == 'MASTER') {
                         $icon = "fa fa-play fa-fw text-success";
-                    } elseif ($intf_status == gettext('BACKUP')) {
+                    } elseif ($intf_status == 'BACKUP') {
                         $icon = "fa fa-play fa-fw text-muted";
-                    } elseif ($intf_status == gettext('INIT')) {
+                    } elseif ($intf_status == 'INIT') {
                         $icon = "fa fa-info-circle fa-fw";
                     }?>
                 <tr>
                   <td><?=convert_friendly_interface_to_friendly_descr($carp['interface']) . "@{$carp['vhid']}" ;?></td>
                   <td><?=$carp['subnet'];?></td>
-                  <td><span class="<?=$icon;?>"></span> <?=$intf_status;?></td>
+                  <td><span class="<?=$icon;?>"></span> <?=gettext($intf_status);?></td>
                 </tr>
 <?php
                   endforeach;

--- a/src/www/carp_status.php
+++ b/src/www/carp_status.php
@@ -169,8 +169,14 @@ include("head.inc");
                         continue;
                     }
                     $icon = '';
-                    $carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
-                    $intf_status = $carp_statuses[array_search($carp['vhid'], array_column($carp_statuses, 'vhid'))]['status'];
+                    $intf = get_real_interface($carp['interface']);
+                    if (
+                        !empty($interfaces_details[$intf]) && !empty($interfaces_details[$intf]['carp'][$carp['vhid']])
+                    ) {
+                        $intf_status = $interfaces_details[$intf]['carp'][$carp['vhid']]['status'];
+                    } else {
+                        $intf_status = null;
+                    }
                     if (($carpcount > 0 && !$status)) {
                         $icon = "fa fa-remove fa-fw text-danger";
                         $intf_status = 'DISABLED';

--- a/src/www/widgets/widgets/carp_status.widget.php
+++ b/src/www/widgets/widgets/carp_status.widget.php
@@ -29,17 +29,20 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
+require_once("interfaces.lib.inc");
 
 config_read_array('virtualip', 'vip');
 
 ?>
 <table class="table table-striped table-condensed">
 <?php
+    $interfaces_details = legacy_interfaces_details();
     foreach ($config['virtualip']['vip'] as $carp):
         if ($carp['mode'] != "carp") {
             continue;
         }
-        $status = get_carp_interface_status("{$carp['interface']}_vip{$carp['vhid']}");?>
+        $carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
+        $status = $carp_statuses[array_search($carp['vhid'], array_column($carp_statuses, 'vhid'))]['status'];?>
     <tr>
       <td>
           <i class="fa fa-exchange fa-fw text-success"></i>
@@ -52,18 +55,18 @@ config_read_array('virtualip', 'vip');
       <td>
 <?php
       if (get_single_sysctl('net.inet.carp.allow') <= 0 ) {
-          $status = gettext("DISABLED");
+          $status = "DISABLED";
           echo "<span class=\"fa fa-remove fa-fw text-danger\" title=\"$status\" ></span>";
-      } elseif ($status == gettext("MASTER")) {
+      } elseif ($status == "MASTER") {
           echo "<span class=\"fa fa-play fa-fw text-success\" title=\"$status\" ></span>";
-      } elseif ($status == gettext("BACKUP")) {
+      } elseif ($status == "BACKUP") {
           echo "<span class=\"fa fa-play fa-fw text-muted\" title=\"$status\" ></span>";
-      } elseif ($status == gettext("INIT")) {
+      } elseif ($status == "INIT") {
           echo "<span class=\"fa fa-info-circle fa-fw\" title=\"$status\" ></span>";
       }
       if (!empty($carp['subnet'])):?>
         &nbsp;
-        <?=htmlspecialchars($status);?> &nbsp;
+        <?=htmlspecialchars(gettext($status));?> &nbsp;
         <?=htmlspecialchars($carp['subnet']);?>
 <?php
       endif;?>

--- a/src/www/widgets/widgets/carp_status.widget.php
+++ b/src/www/widgets/widgets/carp_status.widget.php
@@ -40,8 +40,15 @@ config_read_array('virtualip', 'vip');
         if ($carp['mode'] != "carp") {
             continue;
         }
-        $carp_statuses = $interfaces_details[get_real_interface($carp['interface'])]['carp'];
-        $status = $carp_statuses[array_search($carp['vhid'], array_column($carp_statuses, 'vhid'))]['status'];?>
+        $intf = get_real_interface($carp['interface']);
+        if (
+            !empty($interfaces_details[$intf]) && !empty($interfaces_details[$intf]['carp'][$carp['vhid']])
+        ) {
+            $status = $interfaces_details[$intf]['carp'][$carp['vhid']]['status'];
+        } else {
+            $status = null;
+        }
+?>
     <tr>
       <td>
           <i class="fa fa-exchange fa-fw text-success"></i>

--- a/src/www/widgets/widgets/carp_status.widget.php
+++ b/src/www/widgets/widgets/carp_status.widget.php
@@ -29,7 +29,6 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
-require_once("interfaces.lib.inc");
 
 config_read_array('virtualip', 'vip');
 

--- a/src/www/widgets/widgets/carp_status.widget.php
+++ b/src/www/widgets/widgets/carp_status.widget.php
@@ -55,17 +55,21 @@ config_read_array('virtualip', 'vip');
 <?php
       if (get_single_sysctl('net.inet.carp.allow') <= 0 ) {
           $status = "DISABLED";
+          $status_i18n = gettext("DISABLED");
           echo "<span class=\"fa fa-remove fa-fw text-danger\" title=\"$status\" ></span>";
       } elseif ($status == "MASTER") {
+          $status_i18n = gettext("MASTER");
           echo "<span class=\"fa fa-play fa-fw text-success\" title=\"$status\" ></span>";
       } elseif ($status == "BACKUP") {
+          $status_i18n = gettext("BACKUP");
           echo "<span class=\"fa fa-play fa-fw text-muted\" title=\"$status\" ></span>";
       } elseif ($status == "INIT") {
+          $status_i18n = gettext("INIT");
           echo "<span class=\"fa fa-info-circle fa-fw\" title=\"$status\" ></span>";
       }
       if (!empty($carp['subnet'])):?>
         &nbsp;
-        <?=htmlspecialchars(gettext($status));?> &nbsp;
+        <?=htmlspecialchars($status_i18n);?> &nbsp;
         <?=htmlspecialchars($carp['subnet']);?>
 <?php
       endif;?>


### PR DESCRIPTION
Issue:
- Sometimes OPNsense WebUI shows CARP VIP status improperly, i.e. it may report MASTER on [/carp_status.php](https://github.com/opnsense/core/blob/af587e812a7b8d96cf3fd84869dc7e00bbfe09b3/src/www/carp_status.php#L171) while ifconfig reports BACKUP and vice versa.

Reason:
- The grep expression used to fetch CARP VIP status in [etc/inc/interfaces.inc](https://github.com/opnsense/core/blob/af587e812a7b8d96cf3fd84869dc7e00bbfe09b3/src/etc/inc/interfaces.inc#L4503) is not precise enough. When you have CARP VHID 255 in MASTER and CARP VHID 2 in BACKUP, the function may return MASTER for VHID 2 in case ifconfig prints VHID 255 line before VHID 2 line.

Solution:
- Add a space to the grep expression after VHID.