### PR TITLE
IPSec Management - Added new identifier type Raw to allow passing My identifier as is without changes.

### DIFF
--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -286,6 +286,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $input_errors[] = gettext("Please enter an address for 'My Identifier'");
     } elseif ($pconfig['myid_type'] == "keyid tag" && $pconfig['myid_data'] == "") {
         $input_errors[] = gettext("Please enter a keyid tag for 'My Identifier'");
+    } elseif ($pconfig['myid_type'] == "raw tag" && $pconfig['myid_data'] == "") {
+        $input_errors[] = gettext("Please enter a raw tag for 'My Identifier'");
     } elseif ($pconfig['myid_type'] == "fqdn" && $pconfig['myid_data'] == "") {
         $input_errors[] = gettext("Please enter a fully qualified domain name for 'My Identifier'");
     } elseif ($pconfig['myid_type'] == "user_fqdn" && $pconfig['myid_data'] == "") {
@@ -316,6 +318,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
         if ($pconfig['peerid_type'] == "keyid tag" and $pconfig['peerid_data'] == "") {
             $input_errors[] = gettext("Please enter a keyid tag for 'Peer Identifier'");
+        }
+        if ($pconfig['peerid_type'] == "raw tag" and $pconfig['peerid_data'] == "") {
+            $input_errors[] = gettext("Please enter a raw tag for 'Peer Identifier'");
         }
         if ($pconfig['peerid_type'] == "fqdn" and $pconfig['peerid_data'] == "") {
             $input_errors[] = gettext("Please enter a fully qualified domain name for 'Peer Identifier'");
@@ -825,6 +830,7 @@ include("head.inc");
                         'user_fqdn' => array( 'desc' => gettext('User distinguished name'), 'mobile' => true ),
                         'asn1dn' => array( 'desc' => gettext('ASN.1 distinguished Name'), 'mobile' => true ),
                         'keyid tag' => array( 'desc' => gettext('KeyID tag'), 'mobile' => true ),
+                        'raw tag' => array( 'desc' => gettext('Raw tag'), 'mobile' => true ),
                         'dyn_dns' => array( 'desc' => gettext('Dynamic DNS'), 'mobile' => true ));
                       foreach ($my_identifier_list as $id_type => $id_params) :
 ?>
@@ -854,7 +860,8 @@ endforeach; ?>
                         'fqdn' => array( 'desc' => gettext('Distinguished name'), 'mobile' => true ),
                         'user_fqdn' => array( 'desc' => gettext('User distinguished name'), 'mobile' => true ),
                         'asn1dn' => array( 'desc' => gettext('ASN.1 distinguished Name'), 'mobile' => true ),
-                        'keyid tag' => array( 'desc' =>gettext('KeyID tag'), 'mobile' => true ));
+                        'keyid tag' => array( 'desc' =>gettext('KeyID tag'), 'mobile' => true ),
+                        'raw tag' => array( 'desc' =>gettext('Raw tag'), 'mobile' => true ));
                       foreach ($peer_identifier_list as $id_type => $id_params) :
                         if (!empty($pconfig['mobile']) && !$id_params['mobile']) {
                           continue;


### PR DESCRIPTION
Setup:
My end: OPNSense
Other End: Sophos Hardware Router

Preface:
After upgrade of OPNSense from 21.1.9_1 to 21.7(And then 21.7.1) my P1 authentication no longer works:

I started to receive those in the log:
14[IKE] <con1|17> received AUTHENTICATION_FAILED notify error
14[ENC] <con1|17> parsed IKE_AUTH response 1 [ N(AUTH_FAILED) ]

After digging around a little I came into this:
https://forum.opnsense.org/index.php?topic=22197.0

While the change there is fine, it has a big drawback: while keyid was changed, nothing provided to allow previous behaviour(tag w/o type prefix) and I found quickly by checking ipsec.conf that it was indeed cause of regression on my setup.

I've attached my patch which ads new type 'Raw tag' to the types list, which passes the tag as is, w/o modifications, and yet doesn't break the keyid changes you made before.

The patch is for 21.7/stable and unfortunately doesn't apply to master, due to seemingly refactors done there.
