### PR TITLE
Correct the melody database directory in manpage

### DIFF
--- a/src/man/man8/opnsense-beep.8
+++ b/src/man/man8/opnsense-beep.8
@@ -63,7 +63,7 @@ as understood by
 .Xr beep 1 .
 .Sh FILES
 .Bl -tag -width Ds
-.It Pa /usr/local/etc/opnsene-beep.d
+.It Pa /usr/local/etc/opnsense-beep.d
 The melody database directory.
 .El
 .Sh EXIT STATUS


### PR DESCRIPTION
Blindly copied the path, added my own musical score and wondering why it doesn't work.