### PR TITLE
 LAGG hashing configurability improvements

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -614,8 +614,20 @@ function interface_lagg_configure(&$lagg)
     }
 
     mwexec("/sbin/ifconfig {$laggif} laggproto " . escapeshellarg($lagg['proto']));
+    if ($lagg['proto'] == 'lacp' || $lagg['proto'] == 'loadbalance') {
+        if (!empty($lagg['hash_layers'])) {
+            mwexec("/sbin/ifconfig {$laggif} lagghash " . escapeshellarg($lagg['hash_layers']));
+        }
+        if (isset($lagg['use_flowid'])) {
+            if (!empty($lagg['use_flowid'])) {
+                mwexec("/sbin/ifconfig {$laggif} use_flowid");
+            } else {
+                mwexec("/sbin/ifconfig {$laggif} -use_flowid");
+            }
+        }
+    }
     if ($lagg['proto'] == 'lacp') {
-        foreach (['lacp_fast_timeout', 'use_flowid', 'lacp_strict'] as $attr) {
+        foreach (['lacp_fast_timeout', 'lacp_strict'] as $attr) {
             if (isset($lagg[$attr])) {
                 if (!empty($lagg[$attr])) {
                     mwexec("/sbin/ifconfig {$laggif} {$attr}");

--- a/src/etc/inc/interfaces.lib.inc
+++ b/src/etc/inc/interfaces.lib.inc
@@ -322,6 +322,9 @@ function legacy_interfaces_details($intf = null)
             $result[$current_interface]['channel'] = $matches[1];
         } elseif (preg_match("/ssid (\".*?\"|\S*)/", $line, $matches)) {
             $result[$current_interface]['ssid'] = $matches[1];
+        } elseif (preg_match("/laggproto (\S+) lagghash (\S+)$/", $line, $matches)) {
+            $result[$current_interface]['laggproto'] = $matches[1];
+            $result[$current_interface]['lagghash'] = $matches[2];
         } elseif (preg_match("/laggproto (.*)$/", $line, $matches)) {
             $result[$current_interface]['laggproto'] = $matches[1];
         } elseif (preg_match("/lagg options:(.*)$/", $line, $matches)) {

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -395,6 +395,11 @@ include("head.inc");
                     <tr>
                       <td><?= gettext("LAGG Options") ?></td>
                       <td>
+<?php
+                          if (!empty($ifinfo['lagghash'])):?>
+                          <?= gettext("lagghash") ?>=<?=$ifinfo['lagghash'] ?><br/>
+<?php
+                          endif;?>
                           <?= gettext("flags") ?>=<?= implode(",", $ifinfo['laggoptions']['flags']) ?><br/>
                           <?= gettext("flowid_shift") ?>:<?=$ifinfo['laggoptions']['flowid_shift'] ?>
 <?php


### PR DESCRIPTION
Allow LAGG layers to be configured for LACP and loadbalance LAGGs.
Allow "use flowid" option to also be used for loadbalance LAGGs.

Addresses feature request issue https://github.com/opnsense/core/issues/5208