### PR TITLE
configd_ctl.py: catch broken pipe on event handler

### DIFF
--- a/src/opnsense/service/configd_ctl.py
+++ b/src/opnsense/service/configd_ctl.py
@@ -125,7 +125,11 @@ if args.e:
         rlist, _, _ = select([sys.stdin], [], [], args.t)
         if rlist:
             last_message_stamp = time.time()
-            stashed_lines.append(sys.stdin.readline())
+            r_line = sys.stdin.readline()
+            if len(r_line) == 0:
+                #EOFError. pipe broken?
+                sys.exit(-1)
+            stashed_lines.append(r_line)
 
         if len(stashed_lines) >= 1 and (args.t is None or time.time() - last_message_stamp > args.t):
             # emit event trigger(s) to syslog


### PR DESCRIPTION
Hi!
can we discuss `configd_ctl.py` behavior when a pipe breaks? (ref. https://forum.opnsense.org/index.php?topic=24868.0) ?
afaik `readline()` not catching EOFError and just returns empty string. maybe it is worth adding a check for such a condition?

and could you please explain why the `list` is used if only one line is read?

thanks!!