### PR TITLE
unbound dnsbl suggestiones

### DIFF
--- a/src/opnsense/scripts/unbound/start.sh
+++ b/src/opnsense/scripts/unbound/start.sh
@@ -46,5 +46,5 @@ done
 
 chown -R unbound:unbound /var/unbound
 
-/usr/local/sbin/unbound -c /var/unbound/unbound.conf
+/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1 | logger -t unbound
 /usr/local/opnsense/scripts/unbound/cache.sh load

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -70,7 +70,7 @@ message:Checking Unbound configuration
 [dnsbl]
 command:
     /usr/local/opnsense/scripts/unbound/blocklists.py &&
-    cp /usr/local/etc/unbound.opnsense.d/dnsbl.conf /var/unbound/etc/ &&
+    /usr/local/opnsense/scripts/unbound/cache.sh dump &&
     /usr/local/sbin/unbound-control -c /var/unbound/unbound.conf stop &&
     /usr/local/bin/flock -n -E 0 -o /tmp/unbound_start.lock /usr/local/opnsense/scripts/unbound/start.sh
 parameters:


### PR DESCRIPTION
Hi!
2 suggestiones:
1.replace copy of dnsbl records to /var/unbound/etc (`start.sh` will overwrite it anyway) with cache dumping
2.redirect stderr to syslog when starting unbound via `start.sh`. in this case, information about the reasons for the unsuccessful start may appear in the log (for example, executing the `start.sh` while the instance is running will generate"error: can't bind socket: Address already in use for 127.0.0.1 port 953" lines in the log) (ref: https://forum.opnsense.org/index.php?topic=24924.0 the reason why the unbound refused to start is not clear)

and the question:
shouldn't the unbound take into account the `cacheflush` config value when restarts after updating the dnsbl?
or is it assumed that the `cacheflush` value only makes sense when the service is restarted?

thanks!