### PR TITLE
radvd/virtual IPs: Implement prefix advertisement switch

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -316,7 +316,7 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = array())
         }
 
         foreach (config_read_array('virtualip', 'vip') as $vip) {
-            if ($vip['interface'] == $dhcpv6if && is_ipaddrv6($vip['subnet'])) {
+            if ($vip['interface'] == $dhcpv6if && is_ipaddrv6($vip['subnet']) && empty($vip['noipv6ra'])) {
                 $subnetv6 = gen_subnetv6($vip['subnet'], $vip['subnet_bits']);
                 $stanzas[] = "{$subnetv6}/{$vip['subnet_bits']}";
             }


### PR DESCRIPTION
**Issue:**

If router advertisement is enable on the interface, now the radvd configuration includes all the prefixes calculated from the addresses assigned to this interface. While it's ok for most users, in some circumstances one may opt for not advertising some of the prefixes.

**Solution:**
Add an IPv6 RA checkbox (on by default for compatibility) to the VIPs edit page and take it into account in the radvd configuration management script.

**To do list (in my tests the solution works fine, but help/advice is appreciated to make it even better):**
1) Radvd configuration isn't updated after applying VIP changes. Thus you must manually restart radvd to take into account the newly added checkboxes (and other changes, to be more precise).
2) The checkbox is shown and its value saved for any interface which you can assign an IPv6 alias / CARP to. But router advertisements configuration is possible for a few "real" interfaces only. E.g. we show the checkbox for an IPv6 alias assigned to a loopback, but it is useless, since such an interface isn't included into radvd configuration. So far I have failed to find the attribute of the interface based on which we can hide/show the checkbox.