### PR TITLE
system: add option to reload templates after restore

### DIFF
--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -231,6 +231,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     if (!empty($pconfig['rebootafterrestore'])) {
                         $do_reboot = true;
                     }
+                    if (!empty($pconfig['templatereloadafterrestore'])) {
+                        $do_templatereload = true;
+                    }
                     $savemsg = gettext("The configuration area has been restored.");
                 }
             } else {
@@ -241,6 +244,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 if ($cnf->restoreBackup($filename)) {
                     if (!empty($pconfig['rebootafterrestore'])) {
                         $do_reboot = true;
+                    }
+                    if (!empty($pconfig['templatereloadafterrestore'])) {
+                        $do_templatereload = true;
                     }
                     $config = parse_config();
                     /* extract out rrd items, unset from $config when done */
@@ -402,6 +408,8 @@ $( document ).ready(function() {
                     <input name="conffile" type="file" id="conffile" /><br/>
                     <input name="rebootafterrestore" type="checkbox" id="rebootafterrestore" checked="checked" />
                     <?=gettext("Reboot after a successful restore."); ?><br/>
+                    <input name="templatereloadafterrestore" type="checkbox" id="templatereloadafterrestore" />
+                    <?=gettext("Reload all templates after a successful restore."); ?><br/>
                     <input name="decrypt" type="checkbox" id="decryptconf"/>
                     <?=gettext("Configuration file is encrypted."); ?>
                     <div class="hidden table-responsive __mt" id="decrypt_opts">
@@ -495,6 +503,10 @@ $( document ).ready(function() {
 <?php
 
 include("foot.inc");
+
+if ($do_templatereload) {
+    configd_run('template reload *');
+}
 
 if ($do_reboot) {
     configd_run('system reboot', true);


### PR DESCRIPTION
In https://github.com/opnsense/plugins/issues/2474 it was reported that the HAProxy configuration file was missing after restoring the configuration. It looks like a valid complain to me, because the template reload needs to be triggered to generate the configuration file.

This patch adds an option to trigger a template reload after restoring a config backup. What do you think?

(Side note: this does not yet solve the HAProxy startup issue, I'll have to make a small adjustment to `setup.sh` for this to work. But this depends on this PR.)

(Disclaimer: I haven't tested this patch yet, I first like to know whether this approach is good or bad.)