### PR TITLE
jquery.bootgrid.js:  convert on append

### DIFF
--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -1446,9 +1446,14 @@ Grid.prototype.append = function(rows)
         var appendedRows = [];
         for (var i = 0; i < rows.length; i++)
         {
-            if (appendRow.call(this, rows[i]))
+            var row = rows[i];
+            for (var j = 0; j < this.columns.length; j++) {
+                var column = this.columns[j];
+                row[column.id] = column.converter.from(row[column.id]);
+            }
+            if (appendRow.call(this, row))
             {
-                appendedRows.push(rows[i]);
+                appendedRows.push(row);
             }
         }
         sortRows.call(this);


### PR DESCRIPTION
Hi!
since https://github.com/opnsense/core/commit/d641c00528e95e44bd74f7ed232ec2858f6358bf SIZE and RES values in System: Diagnostics: Activity are displayed incorrectly and sorting stopped working
`jquery.bootgrid` forgets to apply conversion on `append`
code is taken from https://github.com/MoveInc/jquery-bootgrid/pull/4
thanks!