### PR TITLE
system log widget: add filter

### DIFF
--- a/src/www/widgets/widgets/system_log.widget.php
+++ b/src/www/widgets/widgets/system_log.widget.php
@@ -30,19 +30,44 @@
 require_once("guiconfig.inc");
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input_errors = array();
     if (is_numeric($_POST['systemlogfiltercount'])) {
         $config['widgets']['systemlogfiltercount'] = $_POST['systemlogfiltercount'];
     }
     if (is_numeric($_POST['systemlogentriesupdateinterval'])) {
         $config['widgets']['systemlogupdateinterval'] = $_POST['systemlogentriesupdateinterval'];
     }
-    write_config("Saved Widget System Log Filter Setting");
+
+    if (!empty($_POST['systemlogentriesfilter'])) {
+        if (!preg_match('/^[0-9,a-z,A-Z *\-_.\#]*$/', $_POST['systemlogentriesfilter'])) {
+        $input_errors[] = gettext("Query filter string is invalid");
+        }
+    }
+
+    if (count($input_errors) == 0) {
+      $config['widgets']['systemlogentriesfilter'] = $_POST['systemlogentriesfilter'];
+      write_config("System Log Widget settings saved");
+      header(url_safe('Location: /index.php'));
+      exit;
+    }
+
+    for ($i = 0; $i < count($input_errors); $i++) {
+      setcookie("inputerrors[$i]", $input_errors[$i], 0, '/');
+    }
+
     header(url_safe('Location: /index.php'));
     exit;
 }
 
 $systemlogEntriesToFetch = isset($config['widgets']['systemlogfiltercount']) ? $config['widgets']['systemlogfiltercount'] : 20;
 $systemlogupdateinterval = isset($config['widgets']['systemlogupdateinterval']) ? $config['widgets']['systemlogupdateinterval'] : 10;
+$systemlogentriesfilter = isset($config['widgets']['systemlogentriesfilter']) ? $config['widgets']['systemlogentriesfilter'] : "";
+if (isset($_COOKIE['inputerrors'])) {
+    foreach ($_COOKIE['inputerrors'] as $i => $value) {
+        $input_errors[] = $value;
+        setcookie("inputerrors[$i]", "", time() - 3600);
+    }
+}
 
 ?>
 
@@ -74,8 +99,21 @@ $systemlogupdateinterval = isset($config['widgets']['systemlogupdateinterval']) 
         </td>
         <td></td>
       </tr>
+      <tr>
+        <td><?= gettext('Log query filter:') ?><t/d>
+        <td colspan="2">
+         <input id="systemlogentriesfilter" name="systemlogentriesfilter" type="text" value="<?=$systemlogentriesfilter?>" placeholder="<?=$systemlogentriesfilter?>" />
+        </td>
+      </tr>
     </table>
   </form>
+</div>
+<div style="overflow: overlay;">
+<?php
+    if (isset($input_errors) && count($input_errors) > 0) {
+        print_input_errors($input_errors);
+    }
+?>
 </div>
 <div id="system_log-widgets" class="content-box" style="overflow:scroll;">
 <table id="system_log_table" class="table table-striped">
@@ -86,9 +124,14 @@ $systemlogupdateinterval = isset($config['widgets']['systemlogupdateinterval']) 
 <script>
 
             function fetch_system_log(rowCount, refresh_interval_ms) {
+                //it is more correct to pass the filter value to the function (without searching the value every time). but this method allows to "live" test the filter value before saving
+                let filterstring = "";
+                if ($("#systemlogentriesfilter").val()) {
+                    filterstring = $("#systemlogentriesfilter").val();
+                }
                 $.ajax({
                     url: 'api/diagnostics/log/core/system',
-                    data: 'current=1&rowCount=' + rowCount,
+                    data: 'current=1&rowCount=' + rowCount + '&searchPhrase=' + filterstring,
                     type: 'POST'
                 })
                     .done(function (data, status) {
@@ -96,11 +139,15 @@ $systemlogupdateinterval = isset($config['widgets']['systemlogupdateinterval']) 
                         let entry;
                         let system_log_tr = "";
                         if (typeof data.rows !== "undefined") {
-                            while ((entry = data.rows.shift())) {
+                            if (data.rows.length == 0 && data.filters.length > 0 ) {
+                                system_log_tr += '<tr class="system_log_entry"><td style="text-align: center;"><?=html_safe(gettext("No matching results!")); ?></td></tr>';
+                            } else {
+                                while ((entry = data.rows.shift())) {
                                 system_log_tr += '<tr class="system_log_entry"><td style="white-space: nowrap;">' + entry['timestamp'] + '<br>' + entry['process_name'].split('[')[0] + '</td><td>' + entry['line'] + '</td></tr>';
+                                }
                             }
                         } else {
-                            system_log_tr += '<tr class="system_log_entry"><td style="white-space: nowrap;"></td><td><?=gettext("An empty response from the server."); ?></td></tr>';
+                            system_log_tr += '<tr class="system_log_entry"><td style="text-align: center;"><?=html_safe(gettext("An empty response from the server.")); ?></td></tr>';
                         }
                         $("#system_log_table tbody").append(system_log_tr);
                         setTimeout(fetch_system_log, refresh_interval_ms, rowCount, refresh_interval_ms);
@@ -117,6 +164,11 @@ $systemlogupdateinterval = isset($config['widgets']['systemlogupdateinterval']) 
                 var rowCount = $("#systemlogfiltercount").val();
                 var refresh_interval_ms = parseInt($("#systemlogentriesupdateinterval").val()) * 1000;
                 refresh_interval_ms = (isNaN(refresh_interval_ms) || refresh_interval_ms < 5000 || refresh_interval_ms > 60000) ? 10000 : refresh_interval_ms;
+                let filterstring = "";
+                if ($("#systemlogentriesfilter").val()) {
+                    filterstring = $("#systemlogentriesfilter").val();
+                    $('section#system_log').find('h3').append('&nbsp;&nbsp;filtered with "' + filterstring + '"');
+                }
                 fetch_system_log(rowCount, refresh_interval_ms);
             })
 


### PR DESCRIPTION
Hi!
Can we discuss adding a filter to the widget?
Answering the question posed earlier: yes, it seems to me that being able to save the filter in config might add a bit of convenience. Life scenario: user can setup the monit to monitor events\logs important to him, just save the filter with the "monit" value and always see a filtered log in lobby

and can you please explain why using cookies to pass validation results is not a good idea in this case?
by the way I can try to do this by changing the form submit behavior if it is more correct )

thanks!