### PR TITLE
Prevent Browser Auto Fill Username/Password

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -84,7 +84,7 @@
             &nbsp;&nbsp;<a href="#" class="text-danger" id="paste-options_{{ id }}" style="display:none"><i class="fa fa-paste"></i> <small>{{ lang._('Paste') }}</small></a>
             {% endif %}
         {% elseif type == "password" %}
-            <input type="password" class="form-control {{style|default('')}}" size="{{size|default("50")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} >
+            <input type="password" autocomplete="new-password" class="form-control {{style|default('')}}" size="{{size|default("50")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} >
         {% elseif type == "textbox" %}
             <textarea class="{{style|default('')}}" rows="{{height|default("5")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }}></textarea>
         {% elseif type == "info" %}

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
@@ -175,7 +175,7 @@
                   <label for="inputUsername" class="sr-only">Username</label>
                   <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus autocomplete="none" autocapitalize="none" autocorrect="off">
                   <label for="inputPassword" class="sr-only">Password</label>
-                  <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
+                  <input type="password" autocomplete="new-password" id="inputPassword" class="form-control" placeholder="Password" required>
                   <button class="btn btn-primary btn-block" id="signin" type="button">Sign in</button>
               </form>
           </div>

--- a/src/www/diag_authentication.php
+++ b/src/www/diag_authentication.php
@@ -120,7 +120,7 @@ include("head.inc");
                 </tr>
                 <tr>
                   <td style="width:22%"><?=gettext("Password"); ?></td>
-                  <td style="width:78%"><input type="password" name="password" value="<?=htmlspecialchars($pconfig['password']);?>"></td>
+                  <td style="width:78%"><input type="password" autocomplete="new-password" name="password" value="<?=htmlspecialchars($pconfig['password']);?>"></td>
                 </tr>
                 <tr>
                   <td style="width:22%">&nbsp;</td>

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -359,11 +359,11 @@ $( document ).ready(function() {
                       <table class="table table-condensed">
                         <tr>
                           <td><?= gettext('Password') ?></td>
-                          <td><input name="encrypt_password" type="password"/></td>
+                          <td><input name="encrypt_password" type="password" autocomplete="new-password"/></td>
                         </tr>
                         <tr>
                           <td><?= gettext('Confirmation') ?></td>
-                          <td><input name="encrypt_passconf" type="password"/> </td>
+                          <td><input name="encrypt_passconf" type="password" autocomplete="new-password"/> </td>
                         </tr>
                       </table>
                     </div>
@@ -408,7 +408,7 @@ $( document ).ready(function() {
                       <table class="table table-condensed">
                         <tr>
                           <td><?= gettext('Password') ?></td>
-                          <td><input name="decrypt_password" type="password"/></td>
+                          <td><input name="decrypt_password" type="password" autocomplete="new-password"/></td>
                         </tr>
                       </table>
                     </div>
@@ -460,7 +460,7 @@ $( document ).ready(function() {
 <?php
                         elseif ($field['type'] == 'password'):?>
 
-                        <input name="<?=$fieldId;?>" type="password" value="<?=$pconfig[$fieldId];?>" />
+                        <input name="<?=$fieldId;?>" type="password" autocomplete="new-password" value="<?=$pconfig[$fieldId];?>" />
 <?php
                         elseif ($field['type'] == 'textarea'):?>
                         <textarea name="<?=$fieldId;?>" rows="10"><?=$pconfig[$fieldId];?></textarea>

--- a/src/www/firewall_virtual_ip_edit.php
+++ b/src/www/firewall_virtual_ip_edit.php
@@ -434,7 +434,7 @@ $( document ).ready(function() {
                   <tr>
                     <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Virtual IP Password");?></td>
                     <td>
-                      <input type='password'  name='password' id="password" value="<?=$pconfig['password'];?>" />
+                      <input type='password' autocomplete='new-password' name='password' id="password" value="<?=$pconfig['password'];?>" />
                       <div class="hidden" data-for="help_for_password">
                         <?=gettext("Enter the VHID group password.");?>
                       </div>

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -128,7 +128,8 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     //<![CDATA[
     $( document ).ready(function() {
       $('[data-toggle="tooltip"]').tooltip();
-      $("input").attr("autocomplete","off");
+      $("input").not("[autocomplete]").attr("autocomplete","off");
+
       // hide empty menu items
       $('#mainmenu > div > .collapse').each(function(){
         // cleanup empty second level menu containers

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -2350,7 +2350,7 @@ include("head.inc");
                         <tr>
                           <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Password"); ?></td>
                           <td>
-                            <input name="password" type="password" id="password" value="<?=$pconfig['password'];?>" />
+                            <input name="password" type="password" autocomplete="new-password" id="password" value="<?=$pconfig['password'];?>" />
                           </td>
                         </tr>
                         <tr>
@@ -2418,7 +2418,7 @@ include("head.inc");
                         <tr>
                           <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Password"); ?></td>
                           <td>
-                            <input name="pppoe_password" type="password" id="pppoe_password" value="<?=htmlspecialchars($pconfig['pppoe_password']);?>" />
+                            <input name="pppoe_password" type="password" autocomplete="new-password" id="pppoe_password" value="<?=htmlspecialchars($pconfig['pppoe_password']);?>" />
                           </td>
                         </tr>
                         <tr>
@@ -2493,7 +2493,7 @@ include("head.inc");
                         <tr>
                           <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Password"); ?></td>
                           <td>
-                            <input name="pptp_password" type="password" id="pptp_password" value="<?=$pconfig['pptp_password'];?>" />
+                            <input name="pptp_password" type="password" autocomplete="new-password" id="pptp_password" value="<?=$pconfig['pptp_password'];?>" />
                           </td>
                         </tr>
                         <tr>

--- a/src/www/interfaces_ppps_edit.php
+++ b/src/www/interfaces_ppps_edit.php
@@ -552,7 +552,7 @@ include("head.inc");
                       <tr>
                         <td><i class="fa fa-info-circle text-muted"></i> <?= gettext("Password"); ?></td>
                         <td>
-                          <input name="password" type="password" id="password" value="<?=$pconfig['password'];?>" />
+                          <input name="password" type="password" autocomplete="new-password" id="password" value="<?=$pconfig['password'];?>" />
                         </td>
                       </tr>
                       <tr style="display:none" id="phone_num">

--- a/src/www/services_opendns.php
+++ b/src/www/services_opendns.php
@@ -181,7 +181,7 @@ include 'head.inc';
                 <tr>
                   <td><i class="fa fa-info-circle text-muted"></i> <?=gettext('Password'); ?></td>
                   <td>
-                    <input name="password" type="password" id="password" size="20" value="<?=$pconfig['password'];?>" />
+                    <input name="password" type="password" autocomplete="new-password" id="password" size="20" value="<?=$pconfig['password'];?>" />
                   </td>
                 </tr>
                 <tr>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -661,7 +661,7 @@ endif; ?>
                     <?=gettext("User DN:");?><br/>
                     <input name="ldap_binddn" type="text" id="ldap_binddn" size="40" value="<?=$pconfig['ldap_binddn'];?>"/>
                     <?=gettext("Password:");?><br/>
-                    <input name="ldap_bindpw" type="password" id="ldap_bindpw" size="20" value="<?=$pconfig['ldap_bindpw'];?>"/><br />
+                    <input name="ldap_bindpw" type="password" autocomplete="new-password" id="ldap_bindpw" size="20" value="<?=$pconfig['ldap_bindpw'];?>"/><br />
                     <div class="hidden" data-for="help_for_ldap_binddn">
                       <?=gettext("Leave empty to use anonymous binds to resolve distinguished names");?>
                     </div>
@@ -793,7 +793,7 @@ endif; ?>
                 <tr class="auth_radius auth_options hidden">
                   <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Shared Secret");?></td>
                   <td>
-                    <input name="radius_secret" type="password" id="radius_secret" size="20" value="<?=$pconfig['radius_secret'];?>"/>
+                    <input name="radius_secret" type="password" autocomplete="new-password" id="radius_secret" size="20" value="<?=$pconfig['radius_secret'];?>"/>
                   </td>
                 </tr>
                 <tr class="auth_radius auth_options hidden">

--- a/src/www/system_certmanager.php
+++ b/src/www/system_certmanager.php
@@ -863,8 +863,8 @@ include("head.inc");
         event.preventDefault();
         var id = $(this).data('id');
 
-        let password_input = $('<input type="password" class="form-control password_field" placeholder="<?=html_safe(gettext("Password"));?>">');
-        let confirm_input = $('<input type="password" class="form-control password_field" placeholder="<?=html_safe(gettext("Confirm"));?>">');
+        let password_input = $('<input type="password" autocomplete="new-password" class="form-control password_field" placeholder="<?=html_safe(gettext("Password"));?>">');
+        let confirm_input = $('<input type="password" autocomplete="new-password" class="form-control password_field" placeholder="<?=html_safe(gettext("Confirm"));?>">');
         let dialog_items = $('<div class = "form-group">');
         dialog_items.append(
           $("<span>").text("<?=html_safe(gettext('Optionally use a password to protect your export'));?>"),

--- a/src/www/system_hasync.php
+++ b/src/www/system_hasync.php
@@ -231,7 +231,7 @@ include("head.inc");
                 <tr>
                   <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Remote System Password') ?></td>
                   <td>
-                    <input  type="password" name="password" value="<?=$pconfig['password']; ?>" />
+                    <input  type="password" autocomplete="new-password" name="password" value="<?=$pconfig['password']; ?>" />
                     <div class="hidden" data-for="help_for_password">
                       <?=gettext('Enter the web GUI password of the system entered above for synchronizing your configuration.') ?><br />
                       <div class="well well-sm">

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -617,8 +617,8 @@ $( document ).ready(function() {
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Password");?></td>
                     <td>
-                      <input name="passwordfld1" type="password" id="passwordfld1" size="20" value="" /><br/>
-                      <input name="passwordfld2" type="password" id="passwordfld2" size="20" value="" />
+                      <input name="passwordfld1" type="password" autocomplete="new-password" id="passwordfld1" size="20" value="" /><br/>
+                      <input name="passwordfld2" type="password" autocomplete="new-password" id="passwordfld2" size="20" value="" />
                       <small><?= gettext("(confirmation)"); ?></small><br/><br/>
                       <input type="checkbox" name="gen_new_password" <?= !empty($pconfig['gen_new_password']) ? 'checked="checked"' : '' ?>/>
                       <small><?=gettext('Generate a scrambled password to prevent local database logins for this user.') ?></small>

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -204,19 +204,19 @@ $( document ).ready(function() {
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Old password"); ?></td>
                     <td>
-                      <input name="passwordfld0" type="password" id="passwordfld0" size="20" />
+                      <input name="passwordfld0" type="password" autocomplete="new-password" id="passwordfld0" size="20" />
                     </td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("New password"); ?></td>
                     <td>
-                      <input name="passwordfld1" type="password" id="passwordfld1" size="20" />
+                      <input name="passwordfld1" type="password" autocomplete="new-password" id="passwordfld1" size="20" />
                     </td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Confirmation");?></td>
                     <td>
-                      <input name="passwordfld2" type="password" id="passwordfld2" size="20" />
+                      <input name="passwordfld2" type="password" autocomplete="new-password" id="passwordfld2" size="20" />
                     </td>
                   </tr>
                   <tr>

--- a/src/www/vpn_openvpn_client.php
+++ b/src/www/vpn_openvpn_client.php
@@ -747,7 +747,7 @@ $( document ).ready(function() {
                 <div><?=gettext("Username"); ?> <br/></div>
                 <div><input name="proxy_user" id="proxy_user" class="form-control unknown" type="text" size="20" value="<?=$pconfig['proxy_user'];?>" /></div>
                 <div><?=gettext("Password"); ?> </div>
-                <div><input name="proxy_passwd" id="proxy_passwd" type="password" class="form-control pwd" size="20" value="<?=$pconfig['proxy_passwd'];?>" /></div>
+                <div><input name="proxy_passwd" id="proxy_passwd" type="password" autocomplete="new-password" class="form-control pwd" size="20" value="<?=$pconfig['proxy_passwd'];?>" /></div>
               </div>
             </td>
           </tr>
@@ -777,7 +777,7 @@ $( document ).ready(function() {
               <div><?=gettext("Username"); ?></div>
               <div><input name="auth_user" id="auth_user" class="form-control unknown" type="text" size="20" value="<?=$pconfig['auth_user'];?>" /></div>
               <div><?=gettext("Password"); ?></div>
-              <div><input name="auth_pass" id="auth_pass" type="password" class="form-control pwd" size="20" value="<?=$pconfig['auth_pass'];?>" /></div>
+              <div><input name="auth_pass" id="auth_pass" type="password" autocomplete="new-password" class="form-control pwd" size="20" value="<?=$pconfig['auth_pass'];?>" /></div>
               <div class="hidden" data-for="help_for_auth_user_pass">
                 <?=gettext("Leave empty when no user name and password are needed."); ?>
               </div>


### PR DESCRIPTION
Prevent browser from auto filling certain username/password fields with the system login credentials in new forms or if left blank.
 * Don't globally override existing autocomplete attribute on input elements.
 * Apply the attribute autocomplete="new-password" to password input elements.

Examples:

System:
 Access:
  User +
  Servers +
  Tester

 Configuration:
  Backups - Google Drive

 High Availability:
  Settings

Interfaces:
 Point-to-point:
  Devices +

VPN:
 OpenVPN:
  Clients +

Services:
 Dynamic DNS +
 OpenDNS

See also corresponding commit in plugins for DynDNS.