### PR TITLE
Update dhcpd.inc plugin for manage custom parameter.

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1214,6 +1214,11 @@ EOD;
         $dhcpdconf .= dhcpd_zones($ddns_zones);
     }
 
+    /* check if exists a custom file to include */
+    if (file_exists("/var/dhcpd/etc/dhcpd.conf.custom")) {
+        $dhcpdconf .= "\ninclude "/etc/dhcpd.conf.custom";\n";
+    }
+
     @file_put_contents('/var/dhcpd/etc/dhcpd.conf', $dhcpdconf);
     @touch('/var/dhcpd/var/db/dhcpd.leases');
     @unlink('/var/dhcpd/var/run/dhcpd.pid');


### PR DESCRIPTION
Hi, I hope this is the right way to propose a pull request, sorry for my precedent malformed comunication :-)

I would propose to modify /usr/local/etc/inc/plugins.inc.d/dhcpd.inc to allow the include of an external file in /var/dhcpd/etc/dhcpd.conf that can be edited directly from the shell.

I have the necessity to add personalized parameter to isc-dhcp configuration file that is not managed by opnsense web interface.

I can't manually modify dhcpd.conf because the dhcpd plugin, normally, overwrite the dhcpd.conf file and than restart dhcp service every time something chance on configuration file or after a opnsense reboot.

With the code I proposed, I will add customized parameter to an external file without touch anithing else on the core or web interface.
