### PR TITLE
syslog-ng: add empty line to template

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng.conf.in
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng.conf.in
@@ -20,6 +20,7 @@ source s_all {
 {%  for sfilename in helpers.glob("OPNsense/Syslog/sources/*.conf") %}{%
         include sfilename without context
 %}
+
 {%  endfor %}
 
 };


### PR DESCRIPTION
Hi!
add trailing new line after each file included so as not to control its presence in each inclusion
ref: https://github.com/opnsense/plugins/issues/2587#issuecomment-954873093
(example: `001-local.conf` does not contain trailing new line. so next file will be appended to the last line from it)
thanks!