### PR TITLE
VPN / IPsec / Advanced settings - add sha256_96 flag

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1511,6 +1511,12 @@ function ipsec_configure_do($verbose = false, $interface = '')
                     $ealgosp1 = 'ike = ' . implode(',', array_reverse($list)) . '!';
                 }
 
+                if (!empty($ph1ent['sha256_96'])) {
+                    $sha256_96_line = "sha256_96 = {$ph1ent['sha256_96']}";
+                } else {
+                    $sha256_96_line = '';
+                }
+
                 if (!empty($ph1ent['closeaction'])) {
                     $closeaction_line = "closeaction = {$ph1ent['closeaction']}";
                 } else {
@@ -1675,6 +1681,7 @@ conn con<<connectionId>>
   installpolicy = {$installpolicy}
   type = {$parsed_phase2['type']}
   {$closeaction_line}
+  {$sha256_96_line}
   {$dpdline}
   {$inactivityline}
   {$keyingtriesline}

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1511,8 +1511,8 @@ function ipsec_configure_do($verbose = false, $interface = '')
                     $ealgosp1 = 'ike = ' . implode(',', array_reverse($list)) . '!';
                 }
 
-                if (!empty($ph1ent['sha256_96'])) {
-                    $sha256_96_line = "sha256_96 = {$ph1ent['sha256_96']}";
+                if (isset($ph1ent['sha256_96'])) {
+                    $sha256_96_line = "sha256_96 = yes";
                 } else {
                     $sha256_96_line = '';
                 }

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -89,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     ,encryption-algorithm,lifetime,authentication_method,descr,nat_traversal,rightallowany,inactivity_timeout
     ,interface,iketype,dpd_delay,dpd_maxfail,dpd_action,remote-gateway,pre-shared-key,certref,margintime,rekeyfuzz
     ,caref,local-kpref,peer-kpref,reauth_enable,rekey_enable,auto,tunnel_isolation,authservers,mobike,keyingtries
-    ,closeaction";
+    ,closeaction,sha256_96";
     if (isset($p1index) && isset($config['ipsec']['phase1'][$p1index])) {
         // 1-on-1 copy
         foreach (explode(",", $phase1_fields) as $fieldname) {
@@ -403,7 +403,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $copy_fields = "ikeid,iketype,interface,mode,protocol,myid_type,myid_data
         ,peerid_type,peerid_data,encryption-algorithm,margintime,rekeyfuzz,inactivity_timeout,keyingtries
         ,lifetime,pre-shared-key,certref,caref,authentication_method,descr,local-kpref,peer-kpref
-        ,nat_traversal,auto,mobike,closeaction";
+        ,nat_traversal,auto,mobike,closeaction,sha256_96";
 
         foreach (explode(",",$copy_fields) as $fieldname) {
             $fieldname = trim($fieldname);
@@ -1137,6 +1137,19 @@ endforeach; ?>
                       <input name="tunnel_isolation" type="checkbox" id="tunnel_isolation" value="yes" <?= !empty($pconfig['tunnel_isolation']) ? 'checked="checked"' : '' ?>/>
                       <div class="hidden" data-for="help_for_tunnel_isolation">
                         <?= gettext('This option will create a tunnel for each phase 2 entry for IKEv2 interoperability with e.g. FortiGate devices.') ?>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><a id="help_for_sha256_96" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('SHA256 96 Bit Truncation') ?></td>
+                    <td>
+                      <input name="sha256_96" type="checkbox" id="sha256_96" value="yes" <?= !empty($pconfig['sha256_96']) ? 'checked="checked"' : '' ?>/>
+                      <div class="hidden" data-for="help_for_sha256_96">
+                        <?= gettext(
+                          "For compatibility with implementations that incorrectly use 96-bit (instead of 128-bit) truncation this ".
+                          "option may be enabled to configure the shorter truncation length. This is not negotiated, so this only works ".
+                          "with peers that use the incorrect truncation length (or have this option enabled), e.g. Forcepoint Sidewinder."
+                        ) ?>
                       </div>
                     </td>
                   </tr>

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -347,6 +347,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $input_errors[] = gettext('Invalid argument for close action.');
     }
 
+    if (!empty($pconfig['sha256_96'])) {
+        $ph1ent['sha256_96'] = true;
+    }
+
     if (!empty($pconfig['dpd_enable'])) {
         if (!is_numeric($pconfig['dpd_delay'])) {
             $input_errors[] = gettext("A numeric value must be specified for DPD delay.");


### PR DESCRIPTION
Hi folks,

another minor enhancement to the IPsec options. Some legacy devices like Forcepoint Sidewinder incorrectly implement HMAC_SHA256 for phase 2.

With the same reasoning as for the "closeaction" parameter I added the field to the phase 1 form, because it applies to all phase 2 entries of a particular peer or not at all.

In general style I followed @AdSchellevis implementation of the "closeaction".

Kind regards,
Patrick