### PR TITLE
System / Trust / Authorities get authority keyid from authorityKeyIdentifier extension

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -833,7 +833,7 @@ function system_trust_configure($verbose = false)
                         $certext = !empty($certinfo['extensions']) ? $certinfo['extensions'] : [];
                         $authoritykey = "";
                         if (!empty($certext['authorityKeyIdentifier'])) {
-                            $authoritykey = trim(str_replace('keyid:', '', $certext['authorityKeyIdentifier']));
+                            $authoritykey = trim(str_replace('keyid:', '', preg_split("/\r\n|\n|\r/", $certext['authorityKeyIdentifier'])[0]));
                         }
                         $subjectkey = $certext['subjectKeyIdentifier'];
                         $is_self_signed = empty($authoritykey) || $subjectkey == $authoritykey;


### PR DESCRIPTION
Hi!
sorry, it looks like we missed one point when we discussed excluding intermediate certificates from the store
authorityKeyIdentifier extension may  have several params
https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
if the root CA's certificate extension contains them, then the condition will not be met and the certificate will not be flushed to the store
ref. https://forum.opnsense.org/index.php?topic=25361.0

thanks!
