### PR TITLE
allow peer id for mobile phase1 & xauth_psk_server

### DIFF
--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -848,7 +848,7 @@ endforeach; ?>
                     </td>
                   </tr>
 <?php
-                  if (empty($pconfig['mobile'])):?>
+                  if ($pconfig['authentication_method'] == "xauth_psk_server" || empty($pconfig['mobile'])):?>
                   <tr class="auth_opt auth_eap_tls auth_psk auth_pubkey">
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Peer identifier"); ?></td>
                     <td>
@@ -874,7 +874,7 @@ endforeach; ?>
 ?>
                       </select>
                       <input name="peerid_data" type="text" id="peerid_data" size="30" value="<?=$pconfig['peerid_data'];?>" />
-<?php if (!empty($pconfig['mobile'])) {
+<?php if ($pconfig['authentication_method'] == "xauth_psk_server" || !empty($pconfig['mobile'])) {
 ?>
                       <small><?=gettext("NOTE: This is known as the \"group\" setting on some VPN client implementations."); ?></small>
                     <?php


### PR DESCRIPTION
Hi,

I've migrated my old pfsense ipsec road warrior config to opnsense and was missing the peer id configuration, which is needed for some ios devices as a group name.

There was already a discussion about it in the forum https://forum.opnsense.org/index.php?topic=6194.0 and in #2070.

I was thinking about reverting 0dd120ff1aac446f0df9a3f82051b95b64eecf27, but dont want to cause issues in some other configurations and instead i've only added an exception for the authentication method "xauth_psk_server", since its definitly needed there and the configuration wont work without it. 

This fix is especially needed, since the official documentation also mentions a peer id here: 
https://docs.opnsense.org/manual/how-tos/ipsec-road.html#phase-1-proposal-authentication