### PR TITLE
IDPS: handle empty metadata value

### DIFF
--- a/src/opnsense/scripts/suricata/lib/rulecache.py
+++ b/src/opnsense/scripts/suricata/lib/rulecache.py
@@ -195,7 +195,7 @@ class RuleCache(object):
                                         elif parts[0] in record['metadata']:
                                             new_content = parts[1]
                                         else:
-                                            new_content = parts[1] if len(parts) > 1 else None
+                                            new_content = parts[1] if len(parts) > 1 else ""
                                         record['metadata'][parts[0]] = new_content
                             else:
                                 record[prop] = value


### PR DESCRIPTION
Hi
setting `new_content` to `None` on empty metadata value may lead to 
```
Traceback (most recent call last):
  File "/usr/local/opnsense/scripts/suricata/installRules.py", line 105, in <module>
    RuleCache.create()
  File "/usr/local/opnsense/scripts/suricata/lib/rulecache.py", line 284, in create
    for val in rule_info_record['metadata']['metadata'][prop].split("\n"):
AttributeError: 'NoneType' object has no attribute 'split'
```
error on rules install
(worked for https://github.com/opnsense/core/commit/3f73088673973676a4f8d42c1da0134d9c6ac82f#diff-020eca74a1e52ad64394efc524fde61af4845471d4868645ef413ec2ed34ea78 but led to a javascript  error when generating the list of filters (`updateRuleMetadata()` function. `TypeError: Cannot read properties of undefined (reading 'substr')`))

changing to `""` seems to work fine

thanks!
