### PR TITLE
Logs: quick severity filter with "Warning" default

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/LogController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/LogController.php
@@ -103,7 +103,7 @@ class LogController extends ApiControllerBase
                 $this->response->setRawHeader("Content-Type: text/csv");
                 $this->response->setRawHeader("Content-Disposition: attachment; filename=" . $scope . ".log");
                 foreach (json_decode($response, true)['rows'] as $row) {
-                    printf("%s\t%s\t%s\n", $row['timestamp'], $row['process_name'], $row['line']);
+                    printf("%s\t%s\t%s\t%s\n", $row['timestamp'], $row['severity'], $row['process_name'], $row['line']);
                 }
                 return;
             }

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -158,8 +158,9 @@
           select.selectpicker({ header: header_val });
 
           // attach event handler each time header created
-          $("#exact_severity").on("click", function() {
-              filter_exact = !filter_exact
+          $("#exact_severity").on("click", function(event) {
+              event.stopPropagation();
+              filter_exact = !filter_exact;
               let select = $("#severity_filter");
 
               // set new select value to current value or highest value of multiselect

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -176,6 +176,8 @@
                   localStorage.setItem('log_severity_{{module}}_{{scope}}', new_val);
               }
               switch_mode(new_val);
+              // keep it open
+              select.selectpicker('toggle');
           });
 
           select.val(value);

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -26,6 +26,11 @@
 
 <script>
     $( document ).ready(function() {
+      // map available severity values to array
+      severities = $('#severity_filter option').map(function(){
+          return (this.value ? this.value : null);
+      }).get();
+
       if (window.localStorage && localStorage.getItem('log_max_severity_{{module}}_{{scope}}')) {
           $('#severity_filter').val(localStorage.getItem('log_max_severity_{{module}}_{{scope}}')).change();
       }
@@ -47,7 +52,6 @@
               },
               requestHandler: function(request){
                   if ( $('#severity_filter').val().length > 0) {
-                      let severities = ["Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug"];
                       let selectedSeverity = $('#severity_filter').val();
                       request['severity'] = severities.slice(0,severities.indexOf(selectedSeverity) + 1);
                   }

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -28,6 +28,8 @@
     $( document ).ready(function() {
       var filter_exact = false;
       let s_filter_val = "Warning";
+      s_header = '<a href="#"><i class="fa fa-toggle-off text-danger" id="exact_severity" title="{{ lang._('Toggle between range (max level) and exact severity filter') }}"></i> {{ lang._('Multiselect') }}</a>';
+      m_header = '<a href="#"><i class="fa fa-toggle-on text-success" id="exact_severity" title="{{ lang._('Toggle between range (max level) and exact severity filter') }}"></i> {{ lang._('Multiselect') }}</a>';
       var page = 0;
       // map available severity values to array
       severities = $('#severity_filter option').map(function(){
@@ -38,13 +40,11 @@
           if (localStorage.getItem('log_filter_exact_{{module}}_{{scope}}')) {
               s_filter_val = localStorage.getItem('log_severity_{{module}}_{{scope}}') ? localStorage.getItem('log_severity_{{module}}_{{scope}}').split(',') : [];
               filter_exact = true;
-              $("#exact_severity").toggleClass("fa-toggle-on fa-toggle-off").toggleClass("text-success text-danger");
-              switch_mode(s_filter_val);
           } else {
-              s_filter_val = localStorage.getItem('log_severity_{{module}}_{{scope}}') ? localStorage.getItem('log_severity_{{module}}_{{scope}}').split(',') : "Warning";
-              $('#severity_filter').val(s_filter_val).change();
+              s_filter_val = localStorage.getItem('log_severity_{{module}}_{{scope}}') ? localStorage.getItem('log_severity_{{module}}_{{scope}}').split(',') : s_filter_val;
           }
       }
+      switch_mode(s_filter_val);
 
       let grid_log = $("#grid-log").UIBootgrid({
           options:{
@@ -138,77 +138,62 @@
           $('<a></a>').attr('href',download_link).get(0).click();
       });
 
-      $("#exact_severity").on("click", function() {
-          $(this).toggleClass("fa-toggle-on fa-toggle-off");
-          $(this).toggleClass("text-success text-danger");
-          if ($(this).hasClass("fa-toggle-on")) {
-              filter_exact = true;
-              if (window.localStorage) {
-                  localStorage.setItem('log_filter_exact_{{module}}_{{scope}}', 1);
-              }
-          } else {
-              filter_exact = false;
-              if (window.localStorage) {
-                  localStorage.removeItem('log_filter_exact_{{module}}_{{scope}}');
-              }
-          }
-          let select = $("#severity_filter");
-
-          // set new select value to current value or highest value of multiselect
-          let new_val = Array.isArray(select.val()) ? select.val().pop() : select.val();
-
-          // store user choice
-          localStorage.setItem('log_severity_{{module}}_{{scope}}', new_val);
-
-          switch_mode(new_val);
-      });
-
       updateServiceControlUI('{{service}}');
 
       // move filter into action header
       $("#severity_filter_container").detach().prependTo('#grid-log-header > .row > .actionBar > .actions');
+
+
+      function switch_mode(value) {
+          let select = $("#severity_filter");
+
+          // switch select mode and destroy selectpicker
+          select.prop("multiple", filter_exact);
+          select.selectpicker('destroy');
+
+          // remove title option. bug in bs-select. fixed in v1.13.18 https://github.com/snapappointments/bootstrap-select/issues/2491
+          select.find('option.bs-title-option').remove();
+
+          let header_val = filter_exact ? m_header : s_header;
+          select.selectpicker({ header: header_val });
+
+          // attach event handler each time header created
+          $("#exact_severity").on("click", function() {
+              filter_exact = !filter_exact
+              let select = $("#severity_filter");
+
+              // set new select value to current value or highest value of multiselect
+              let new_val = Array.isArray(select.val()) ? select.val().pop() : select.val();
+
+              if (window.localStorage) {
+                  if (filter_exact) {
+                      localStorage.setItem('log_filter_exact_{{module}}_{{scope}}', 1);
+                  } else {
+                      localStorage.removeItem('log_filter_exact_{{module}}_{{scope}}');
+                  }
+                  // store user choice
+                  localStorage.setItem('log_severity_{{module}}_{{scope}}', new_val);
+              }
+              switch_mode(new_val);
+          });
+
+          select.val(value);
+          // fetch data
+          select.change();
+      }
+
     });
 
-    function switch_mode(value) {
-        let select = $("#severity_filter");
-
-        // switch select mode and destroy selectpicker
-        select.prop("multiple", !select.prop("multiple"));
-        select.selectpicker('destroy');
-
-        // remove title option. bug in bs-select. fixed in v1.13.18 https://github.com/snapappointments/bootstrap-select/issues/2491
-        select.find('option.bs-title-option').remove();
-
-        select.selectpicker();
-        select.val(value);
-        // fetch data
-        select.change();
-    }
 </script>
 
 <div class="content-box">
     <div class="content-box-main">
         <div class="table-responsive">
-            <table class="table table-striped table-condensed">
-                <tbody>
-                    <tr>
-                        <td style="text-align:left">
-                            <a href="#"><i class="fa fa-toggle-off text-danger" id="exact_severity"></i></a><small> {{ lang._('exact severity selection') }}</small>
-                            <div class="hidden" data-for="help_for_exact_severity">
-                                <small>{{ lang._('Filter by exact severity level(s) specified. When disabled, include messages with a lower level (more severe).') }}</small>
-                            </div>
-                        </td>
-                        <td style="text-align:right">
-                            <small>full help</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help"></i></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
             <div  class="col-sm-12">
                 <div class="hidden">
                     <!-- filter per type container -->
                     <div id="severity_filter_container" class="btn-group">
-                        <select id="severity_filter"  data-title="{{ lang._('Severity') }}" class="selectpicker" data-width="200px">
+                        <select id="severity_filter" data-title="{{ lang._('Severity') }}" class="selectpicker" data-width="200px">
                             <option value="Emergency">{{ lang._('Emergency') }}</option>
                             <option value="Alert">{{ lang._('Alert') }}</option>
                             <option value="Critical">{{ lang._('Critical') }}</option>

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -28,6 +28,7 @@
     $( document ).ready(function() {
       var filter_exact = false;
       let s_filter_val = "Warning";
+      var page = 0;
       // map available severity values to array
       severities = $('#severity_filter option').map(function(){
           return (this.value ? this.value : null);
@@ -80,16 +81,21 @@
       });
 
       grid_log.on("loaded.rs.jquery.bootgrid", function(){
+          if (page > 0) {
+              $("ul.pagination > li:last > a").data('page', page).click();
+              page = 0;
+          }
+
           $(".action-page").click(function(event){
               event.preventDefault();
               $("#grid-log").bootgrid("search",  "");
-              let new_page = parseInt((parseInt($(this).data('row-id')) / $("#grid-log").bootgrid("getRowCount")))+1;
+              page = parseInt((parseInt($(this).data('row-id')) / $("#grid-log").bootgrid("getRowCount")))+1;
               $("input.search-field").val("");
-              $("#severity_filter").selectpicker('deselectAll');
-              // XXX: a bit ugly, but clearing the filter triggers a load event.
-              setTimeout(function(){
-                  $("ul.pagination > li:last > a").data('page', new_page).click();
-              }, 100);
+              if ($("#exact_severity").hasClass("fa-toggle-on")) {
+                  $("#severity_filter").selectpicker('deselectAll');
+              } else {
+                  $("#severity_filter").val("Debug").change();
+              }
           });
       });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -123,7 +123,8 @@
               params.push("searchPhrase=" + encodeURIComponent($("input.search-field").val()));
           }
           if ( $('#severity_filter').val().length > 0) {
-              params.push("severity=" + encodeURIComponent($('#severity_filter').val().join(",")));
+              let r_severity = filter_exact ? $('#severity_filter').val() : severities.slice(0,severities.indexOf($('#severity_filter').val()) + 1);
+              params.push("severity=" + encodeURIComponent(r_severity.join(",")));
           }
           if (params.length > 0) {
               download_link = download_link + "?" + params.join("&");

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -26,6 +26,9 @@
 
 <script>
     $( document ).ready(function() {
+      if (window.localStorage && localStorage.getItem('log_max_severity_{{module}}_{{scope}}')) {
+          $('#severity_filter').val(localStorage.getItem('log_max_severity_{{module}}_{{scope}}')).change();
+      }
       let grid_log = $("#grid-log").UIBootgrid({
           options:{
               sorting:false,
@@ -44,7 +47,9 @@
               },
               requestHandler: function(request){
                   if ( $('#severity_filter').val().length > 0) {
-                      request['severity'] = $('#severity_filter').val();
+                      let severities = ["Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug"];
+                      let selectedSeverity = $('#severity_filter').val();
+                      request['severity'] = severities.slice(0,severities.indexOf(selectedSeverity) + 1);
                   }
                   return request;
               },
@@ -52,6 +57,9 @@
           search:'/api/diagnostics/log/{{module}}/{{scope}}'
       });
       $("#severity_filter").change(function(){
+          if (window.localStorage) {
+              localStorage.setItem('log_max_severity_{{module}}_{{scope}}', $("#severity_filter").val());
+          }
           $('#grid-log').bootgrid('reload');
       });
 
@@ -120,12 +128,12 @@
                 <div class="hidden">
                     <!-- filter per type container -->
                     <div id="severity_filter_container" class="btn-group">
-                        <select id="severity_filter"  data-title="{{ lang._('Severity') }}" class="selectpicker" multiple="multiple" data-width="200px">
+                        <select id="severity_filter"  data-title="{{ lang._('Maximum severity level') }}" class="selectpicker" data-width="200px">
                             <option value="Emergency">{{ lang._('Emergency') }}</option>
                             <option value="Alert">{{ lang._('Alert') }}</option>
                             <option value="Critical">{{ lang._('Critical') }}</option>
                             <option value="Error">{{ lang._('Error') }}</option>
-                            <option value="Warning">{{ lang._('Warning') }}</option>
+                            <option value="Warning" selected>{{ lang._('Warning') }}</option>
                             <option value="Notice">{{ lang._('Notice') }}</option>
                             <option value="Informational">{{ lang._('Informational') }}</option>
                             <option value="Debug">{{ lang._('Debug') }}</option>

--- a/src/opnsense/scripts/systemhealth/queryLog.py
+++ b/src/opnsense/scripts/systemhealth/queryLog.py
@@ -97,40 +97,40 @@ if __name__ == '__main__':
                 for rec in reverse_log_reader(filename):
                     row_number += 1
                     if rec['line'] != "" and filter_regexp.match(('%s' % rec['line']).lower()):
-                        result['total_rows'] += 1
-                        if (len(result['rows']) < limit or limit == 0) and result['total_rows'] >= offset:
-                            record = {
-                                'timestamp': None,
-                                'parser': None,
-                                'facility': 1,
-                                'severity': 3,
-                                'process_name': '',
-                                'pid': None,
-                                'rnum': row_number
-                            }
-                            frmt = format_container.get_format(rec['line'])
-                            if frmt:
-                                if issubclass(frmt.__class__, BaseLogFormat):
-                                    # backwards compatibility, old style log handler
-                                    record['timestamp'] = frmt.timestamp(rec['line'])
-                                    record['process_name'] = frmt.process_name(rec['line'])
-                                    record['line'] = frmt.line(rec['line'])
-                                    record['parser'] = frmt.name
-                                else:
-                                    record['timestamp'] = frmt.timestamp
-                                    record['process_name'] = frmt.process_name
-                                    record['pid'] = frmt.pid
-                                    record['facility'] = frmt.facility
-                                    record['severity'] = frmt.severity_str
-                                    record['line'] = frmt.line
-                                    record['parser'] = frmt.name
+                        frmt = format_container.get_format(rec['line'])
+                        record = {
+                            'timestamp': None,
+                            'parser': None,
+                            'facility': 1,
+                            'severity': 3,
+                            'process_name': '',
+                            'pid': None,
+                            'rnum': row_number
+                        }
+                        if frmt:
+                            if issubclass(frmt.__class__, BaseLogFormat):
+                                # backwards compatibility, old style log handler
+                                record['timestamp'] = frmt.timestamp(rec['line'])
+                                record['process_name'] = frmt.process_name(rec['line'])
+                                record['line'] = frmt.line(rec['line'])
+                                record['parser'] = frmt.name
                             else:
-                                record['line'] = rec['line']
-                            if len(severity) == 0 or record['severity'] in severity:
+                                record['timestamp'] = frmt.timestamp
+                                record['process_name'] = frmt.process_name
+                                record['pid'] = frmt.pid
+                                record['facility'] = frmt.facility
+                                record['severity'] = frmt.severity_str
+                                record['line'] = frmt.line
+                                record['parser'] = frmt.name
+                        else:
+                            record['line'] = rec['line']
+                        if len(severity) == 0 or record['severity'] in severity:
+                            result['total_rows'] += 1
+                            if (len(result['rows']) < limit or limit == 0) and result['total_rows'] >= offset:
                                 result['rows'].append(record)
-                        elif limit > 0 and result['total_rows'] > offset + limit:
-                            # do not fetch data until end of file...
-                            break
+                            elif limit > 0 and result['total_rows'] > offset + limit:
+                                # do not fetch data until end of file...
+                                break
             if limit > 0 and result['total_rows'] > offset + limit:
                 break
 


### PR DESCRIPTION
Hi!
just for possible discussion of  https://github.com/opnsense/core/issues/5337#issuecomment-974886511

Clarifications: Under certain circumstances, some processes and services can create quite a lot of noise in the logs. This is great for debugging, but can be annoying for the administrator during normal operation.

Initial idea: since the OPNSense finally completely switches to syslog-ng, RFC5424 support has been added, and even a severity filter has already been added (!  :thumbsup:), it may be worth considering to make the default log representation of the "warning logs" type (do not show by default lines reflecting normal behavior)?

Details: pr by default displays the logs filtered with "Warning" severity (UPD. badly put it: filtered with a level **below or equal to** "Warning"), the severity filter allows to specify the maximum severity level to fetch and saves the user's choice to localStorage.

thanks!
