### PR TITLE
Diagnostics / States: switch dst-src with direction

### DIFF
--- a/src/opnsense/scripts/filter/lib/states.py
+++ b/src/opnsense/scripts/filter/lib/states.py
@@ -136,8 +136,6 @@ def query_states(rule_label, filter_str):
                 'nat_port': None,
                 'iface': parts[0],
                 'proto': parts[1],
-                'src_addr': parse_address(parts[2])['addr'],
-                'src_port': parse_address(parts[2])['port'],
                 'ipproto': parse_address(parts[2])['ipproto']
             }
             if parts[3].find('(') > -1:
@@ -146,13 +144,15 @@ def query_states(rule_label, filter_str):
                 if parts[3].find(':') > -1:
                    record['nat_port'] = parts[3].split(':')[1][:-1]
 
-            record['dst_addr'] = parse_address(parts[-2])['addr']
-            record['dst_port'] = parse_address(parts[-2])['port']
-
             if parts[-3] == '->':
                 record['direction'] = 'out'
             else:
                 record['direction'] = 'in'
+
+            record['dst_addr'] = parse_address(parts[-2])['addr'] if record['direction'] == 'out' else parse_address(parts[2])['addr']
+            record['dst_port'] = parse_address(parts[-2])['port'] if record['direction'] == 'out' else parse_address(parts[2])['port']
+            record['src_addr'] = parse_address(parts[2])['addr'] if record['direction'] == 'out' else parse_address(parts[-2])['addr']
+            record['src_port'] = parse_address(parts[2])['port'] if record['direction'] == 'out' else parse_address(parts[-2])['port']
 
             record['state'] = parts[-1]
 


### PR DESCRIPTION
Hi
it seems that the `states.py` script does not take into account the change in the position of the src and dst addresses depending on the state direction. its clearly visible on a broadcast network. the current behavior can lead to something like (clients applications is searching for sentinel hasp servers):
root@OPN:~ # pfctl -ss | grep .255
```
all udp 172.17.1.255:1947 <- 172.17.1.47:52339       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.65:54326       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.218:63477       NO_TRAFFIC:SINGLE
all udp 239.255.255.250:1900 <- 172.17.1.234:49970       NO_TRAFFIC:SINGLE
all udp 239.255.255.250:1900 <- 172.17.1.215:50739       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.236:60800       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.245:50563       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.61:58181       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.217:57430       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.47:52339       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.129:1030       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.236:60800       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.245:50563       NO_TRAFFIC:SINGLE
all udp 172.17.1.255:1947 <- 172.17.1.129:1030       NO_TRAFFIC:SINGLE
all udp 255.255.255.255:1947 <- 172.17.1.74:51602       NO_TRAFFIC:SINGLE
```
![broadcast_source](https://user-images.githubusercontent.com/36099472/143771305-2747d8e7-713e-4555-aeb0-074836976e5b.PNG)

can we try to take this behavior into account?
thanks!

