### PR TITLE
Firewall / Diagnostics / Sessions - typo

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
@@ -120,7 +120,7 @@
       <thead>
       <tr>
           <th data-column-id="id" data-type="string" data-sortable="false" data-identifier="true" data-visible="false" >{{ lang._('state id') }}</th>
-          <th data-column-id="direction" data-type="string" data-width="4em" data-formatter="direction">{{ lang._('Dir') }}</th>
+          <th data-column-id="dir" data-type="string" data-width="4em" data-formatter="direction">{{ lang._('Dir') }}</th>
           <th data-column-id="proto" data-type="string" data-width="6em">{{ lang._('Proto') }}</th>
           <th data-column-id="src" data-type="string" data-formatter="address" data-sortable="false">{{ lang._('Source') }}</th>
           <th data-column-id="gw" data-type="string" data-formatter="address" data-sortable="false">{{ lang._('Gateway') }}</th>


### PR DESCRIPTION
Hi!
I apologize, did not notice earlier and did not add to the previous pr :worried: .
looks like a typo on the pf_top page. as a result, all sessions are marked as incoming (api returns direction as a `dir`. formatter uses `column.id` to get value ).

thanks!