### PR TITLE
Select/Deselect All Mutually Exclusive and Set/Clear

### DIFF
--- a/src/www/system_usermanager_addprivs.php
+++ b/src/www/system_usermanager_addprivs.php
@@ -135,10 +135,32 @@ include("head.inc");
 
                 $("#priv_container").scrollTop(0);
             })
+            all_selections_state();
+        });
+
+        // Set the select all and deselect all checkboxes accordingly.
+        function all_selections_state() {
+            var allselected = true;
+            var noneselected = true;
+            $(".acl_item").each(function(){
+                if ($(this).is(':visible')) {
+                    var selected = ($(this).find('td > label > input').prop('checked'));
+                    allselected = allselected && selected ? allselected : false;
+                    noneselected = noneselected && !selected ? noneselected : false;
+                }
+            });
+            $("#selectall").prop('checked', allselected);
+            $("#deselectall").prop('checked', noneselected);
+        };
+
+        all_selections_state();
+
+        $("input[name^='sysprivs']").click(function(event){
+            all_selections_state();
         });
 
         $("#selectall").click(function(event){
-            event.preventDefault();
+            $("#deselectall").prop('checked', false);
             $(".acl_item").each(function(){
                 if ($(this).is(':visible')) {
                     $(this).find('td > input').prop('checked', true);
@@ -147,7 +169,7 @@ include("head.inc");
         });
 
         $("#deselectall").click(function(event){
-            event.preventDefault();
+            $("#selectall").prop('checked', false);
             $(".acl_item").each(function(){
                 if ($(this).is(':visible')) {
                     $(this).find('td > input').prop('checked', false);


### PR DESCRIPTION
Add mutually exclusive jquery for select/deselect all by replacing event.preventDefault with clearing the other checkbox.
Add jquery selector to set/clear the select and deselect all checkboxes when any of the individual items are clicked.
Provides better feedback re: all selected/deselected checkboxes.