### PR TITLE
Backend.php: syslog-ng migration

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/Backend.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Backend.php
@@ -30,6 +30,7 @@ namespace OPNsense\Core;
 
 use Phalcon\Logger;
 use Phalcon\Logger\Adapter\Syslog;
+use Phalcon\Logger\Formatter\Line;
 
 /**
  * Class Backend
@@ -54,15 +55,20 @@ class Backend
      * @param string $ident syslog identifier
      * @return Syslog log handler
      */
-    protected function getLogger($ident = 'configd')
+    protected function getLogger($ident = 'configd.py')
     {
+        $formatter = new Line('%message%');
+        $adapter = new Syslog($ident,
+            [
+                'option'   => LOG_PID,
+                'facility' => LOG_LOCAL4,
+            ]
+        );
+        $adapter->setFormatter($formatter);
         $logger = new Logger(
             'messages',
             [
-                'main' => new Syslog($ident, array(
-                    'option' => LOG_PID,
-                    'facility' => LOG_LOCAL4
-                ))
+                'main' => $adapter
             ]
         );
 


### PR DESCRIPTION
Hi!
ref. https://github.com/opnsense/core/issues/5382
it seems that error messages from the `configdRun()` function (https://github.com/opnsense/core/blob/b6ffe6fa17b8ec7838128027b9955697330bacab/src/opnsense/mvc/app/library/OPNsense/Core/Backend.php#L81) do not get into the `syslog-ng` backend log.
changes worked for me:
- `$ident = 'configd.py'` for `f_local_configd` syslog-ng filter matching
- remove `[%date%][%type%] ` from default phalcon message format to avoid duplication in log line

thanks!


