### PR TITLE
feat: add ipxe configuration to dhcp netboot options

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1079,6 +1079,7 @@ EOD;
                 $dhcpdconf .= "  next-server {$dhcpifconf['nextserver']};\n";
             }
 <<<<<<< HEAD
+<<<<<<< HEAD
             $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
             $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
             if (!empty($dhcpifconf['ipxeaddress'])) {
@@ -1100,6 +1101,8 @@ EOD;
                 $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
                 $dhcpdconf .= "  }\n\n";
 =======
+=======
+>>>>>>> 4758cbdd4 (feat: add ipxe configuration to dhcp netboot options)
 
             $conditional = false;
             $filemap = [
@@ -1129,7 +1132,32 @@ EOD;
                     $dhcpdconf .= "  }";
                 }
                 $dhcpdconf .= "\n";
+<<<<<<< HEAD
 >>>>>>> cc443a706 (dhcp: rewrite conditionals to adapt to configured reality)
+=======
+=======
+            $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
+            $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
+            if (!empty($dhcpdconf['ipxeaddress'])) {
+                $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
+                $dhcpdconf .= "  }\n\n";
+            } elseif (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
+                $dhcpdconf .= "  if option arch = 00:06 {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['filename32']}\";\n";
+                $dhcpdconf .= "  } else if option arch = 00:07 {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
+                $dhcpdconf .= "  } else if option arch = 00:09 {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
+                $dhcpdconf .= "  } else if option arch = 00:0a {\n";
+                $dhcpdconf .= "    filename \"{$arm32}\";\n";
+                $dhcpdconf .= "  } else if option arch = 00:0b {\n";
+                $dhcpdconf .= "    filename \"{$arm64}\";\n";
+                $dhcpdconf .= "  } else {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
+                $dhcpdconf .= "  }\n\n";
+>>>>>>> 15e4076bd (feat: add ipxe configuration to dhcp netboot options)
+>>>>>>> 4758cbdd4 (feat: add ipxe configuration to dhcp netboot options)
             } elseif (!empty($dhcpifconf['filename'])) {
                 $dhcpdconf .= "  filename \"{$dhcpifconf['filename']}\";\n";
             }

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1138,7 +1138,7 @@ EOD;
 =======
             $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
             $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
-            if (!empty($dhcpdconf['ipxeaddress'])) {
+            if (!empty($dhcpifconf['ipxeaddress'])) {
                 $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
                 $dhcpdconf .= "  }\n\n";

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1080,7 +1080,7 @@ EOD;
             }
             $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
             $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
-            if (!empty($dhcpdconf['ipxeaddress'])) {
+            if (!empty($dhcpifconf['ipxeaddress'])) {
                 $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
                 $dhcpdconf .= "  }\n\n";

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1078,6 +1078,7 @@ EOD;
             if (!empty($dhcpifconf['nextserver'])) {
                 $dhcpdconf .= "  next-server {$dhcpifconf['nextserver']};\n";
             }
+<<<<<<< HEAD
             $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
             $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
             if (!empty($dhcpifconf['ipxeaddress'])) {
@@ -1098,9 +1099,41 @@ EOD;
                 $dhcpdconf .= "  } else {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
                 $dhcpdconf .= "  }\n\n";
+=======
+
+            $conditional = false;
+            $filemap = [
+                '00:06' => 'filename32',
+                '00:07' => 'filename64',
+                '00:09' => 'filename64',
+                '00:0a' => 'filename32arm',
+                '00:0b' => 'filename64arm',
+            ];
+
+            foreach ($filemap as $arch => $file) {
+                if (empty($dhcpifconf[$file])) {
+                    continue;
+                }
+
+                $dhcpdconf .= $conditional ? ' else ' : '  ';
+                $dhcpdconf .= "if option arch = {$arch} {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf[$file]}\";\n";
+                $dhcpdconf .= "  }";
+
+                $conditional = true;
+            }
+            if ($conditional) {
+                if (!empty($dhcpifconf['filename'])) {
+                    $dhcpdconf .= "  else {\n";
+                    $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
+                    $dhcpdconf .= "  }";
+                }
+                $dhcpdconf .= "\n";
+>>>>>>> cc443a706 (dhcp: rewrite conditionals to adapt to configured reality)
             } elseif (!empty($dhcpifconf['filename'])) {
                 $dhcpdconf .= "  filename \"{$dhcpifconf['filename']}\";\n";
             }
+
             if (!empty($dhcpifconf['rootpath'])) {
                 $dhcpdconf .= "  option root-path \"{$dhcpifconf['rootpath']}\";\n";
             }

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1080,7 +1080,11 @@ EOD;
             }
             $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
             $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
-            if (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
+            if (!empty($dhcpdconf['ipxeaddress'])) {
+                $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
+                $dhcpdconf .= "  }\n\n";
+            } elseif (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
                 $dhcpdconf .= "  if option arch = 00:06 {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['filename32']}\";\n";
                 $dhcpdconf .= "  } else if option arch = 00:07 {\n";

--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1078,88 +1078,42 @@ EOD;
             if (!empty($dhcpifconf['nextserver'])) {
                 $dhcpdconf .= "  next-server {$dhcpifconf['nextserver']};\n";
             }
-<<<<<<< HEAD
-<<<<<<< HEAD
-            $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
-            $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
             if (!empty($dhcpifconf['ipxeaddress'])) {
                 $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
-                $dhcpdconf .= "  }\n\n";
-            } elseif (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
-                $dhcpdconf .= "  if option arch = 00:06 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename32']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:07 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:09 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:0a {\n";
-                $dhcpdconf .= "    filename \"{$arm32}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:0b {\n";
-                $dhcpdconf .= "    filename \"{$arm64}\";\n";
-                $dhcpdconf .= "  } else {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
-                $dhcpdconf .= "  }\n\n";
-=======
-=======
->>>>>>> 4758cbdd4 (feat: add ipxe configuration to dhcp netboot options)
+                $dhcpdconf .= "  }\n";
+            } else {
+                $conditional = false;
+                $filemap = [
+                    '00:06' => 'filename32',
+                    '00:07' => 'filename64',
+                    '00:09' => 'filename64',
+                    '00:0a' => 'filename32arm',
+                    '00:0b' => 'filename64arm',
+                ];
 
-            $conditional = false;
-            $filemap = [
-                '00:06' => 'filename32',
-                '00:07' => 'filename64',
-                '00:09' => 'filename64',
-                '00:0a' => 'filename32arm',
-                '00:0b' => 'filename64arm',
-            ];
+                foreach ($filemap as $arch => $file) {
+                    if (empty($dhcpifconf[$file])) {
+                        continue;
+                    }
 
-            foreach ($filemap as $arch => $file) {
-                if (empty($dhcpifconf[$file])) {
-                    continue;
-                }
-
-                $dhcpdconf .= $conditional ? ' else ' : '  ';
-                $dhcpdconf .= "if option arch = {$arch} {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf[$file]}\";\n";
-                $dhcpdconf .= "  }";
-
-                $conditional = true;
-            }
-            if ($conditional) {
-                if (!empty($dhcpifconf['filename'])) {
-                    $dhcpdconf .= "  else {\n";
-                    $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
+                    $dhcpdconf .= $conditional ? ' else ' : '  ';
+                    $dhcpdconf .= "if option arch = {$arch} {\n";
+                    $dhcpdconf .= "    filename \"{$dhcpifconf[$file]}\";\n";
                     $dhcpdconf .= "  }";
+
+                    $conditional = true;
                 }
-                $dhcpdconf .= "\n";
-<<<<<<< HEAD
->>>>>>> cc443a706 (dhcp: rewrite conditionals to adapt to configured reality)
-=======
-=======
-            $arm64 = $dhcpifconf['filename64arm'] ?? $dhcpifconf['filename'];
-            $arm32 = $dhcpifconf['filename32arm'] ?? $dhcpifconf['filename'];
-            if (!empty($dhcpifconf['ipxeaddress'])) {
-                $dhcpdconf .= "  if exists user-class and option user-class = \"iPXE\" {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['ipxeaddress']}\";\n";
-                $dhcpdconf .= "  }\n\n";
-            } elseif (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
-                $dhcpdconf .= "  if option arch = 00:06 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename32']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:07 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:09 {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:0a {\n";
-                $dhcpdconf .= "    filename \"{$arm32}\";\n";
-                $dhcpdconf .= "  } else if option arch = 00:0b {\n";
-                $dhcpdconf .= "    filename \"{$arm64}\";\n";
-                $dhcpdconf .= "  } else {\n";
-                $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
-                $dhcpdconf .= "  }\n\n";
->>>>>>> 15e4076bd (feat: add ipxe configuration to dhcp netboot options)
->>>>>>> 4758cbdd4 (feat: add ipxe configuration to dhcp netboot options)
-            } elseif (!empty($dhcpifconf['filename'])) {
-                $dhcpdconf .= "  filename \"{$dhcpifconf['filename']}\";\n";
+                if ($conditional) {
+                    if (!empty($dhcpifconf['filename'])) {
+                        $dhcpdconf .= "  else {\n";
+                        $dhcpdconf .= "    filename \"{$dhcpifconf['filename']}\";\n";
+                        $dhcpdconf .= "  }";
+                    }
+                    $dhcpdconf .= "\n";
+                } elseif (!empty($dhcpifconf['filename'])) {
+                    $dhcpdconf .= "  filename \"{$dhcpifconf['filename']}\";\n";
+                }
             }
 
             if (!empty($dhcpifconf['rootpath'])) {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
@@ -145,6 +145,8 @@ abstract class BaseModel
                     }
                     $check_derived = $check_derived->getParentClass();
                 }
+            } else {
+                throw new ModelException("class " . $classname . " missing");
             }
             if (!$is_derived_from_basefield) {
                 // class found, but of wrong type. raise an exception.

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -57,7 +57,7 @@ function reconfigure_dhcpd()
 $config_copy_fieldsnames = array('enable', 'staticarp', 'failover_peerip', 'failover_split', 'dhcpleaseinlocaltime','descr',
   'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'denyunknown','ignoreuids', 'ddnsdomain',
   'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsupdate', 'mac_allow',
-  'mac_deny', 'tftp', 'bootfilename', 'ldap', 'netboot', 'nextserver', 'filename', 'filename32', 'filename64',
+  'mac_deny', 'tftp', 'bootfilename', 'ldap', 'netboot', 'nextserver', 'ipxeaddress', 'filename', 'filename32', 'filename64',
   'filename32arm', 'filename64arm', 'rootpath', 'netmask', 'numberoptions', 'interface_mtu', 'wpad', 'omapi', 'omapiport',
   'omapialgorithm', 'omapikey', 'minsecs');
 
@@ -978,6 +978,10 @@ include("head.inc");
                           <br/><br/>
                           <?=gettext('Set next-server IP');?>
                           <input name="nextserver" type="text" id="nextserver" value="<?=$pconfig['nextserver'];?>" /><br />
+                          <?=gettext('Set iPXE address');?>
+                          <input name="ipxeaddress" type="text" id="ipxeaddress" value="<?=$pconfig['ipxeaddress'];?>" /><br />
+                          <?=gettext("Note: Setting an iPXE address will ignore the filename fields below!");?>
+                          <br/><br/>
                           <?=gettext('Set default bios filename');?>
                           <input name="filename" type="text" id="filename" value="<?=$pconfig['filename'];?>" /><br />
                           <?=gettext('Set UEFI 32bit filename');?>

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -967,14 +967,14 @@ include("head.inc");
                       </td>
                     </tr>
                     <tr>
-                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable network booting");?></td>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?= gettext('Network booting') ?></td>
                       <td>
                         <div id="shownetbootbox">
                           <input type="button" onclick="show_netboot_config()" class="btn btn-default btn-xs" value="<?= html_safe(gettext('Advanced')) ?>" /> - <?=gettext("Show Network booting");?>
                         </div>
                         <div id="shownetboot" style="display:none">
                           <input type="checkbox" value="yes" name="netboot" id="netboot" <?=!empty($pconfig['netboot']) ? " checked=\"checked\"" : ""; ?> />
-                          <strong><?=gettext("Enables network booting.");?></strong>
+                          <?= gettext('Enable network booting') ?>
                           <br/><br/>
                           <?=gettext('Set next-server IP');?>
                           <input name="nextserver" type="text" id="nextserver" value="<?=$pconfig['nextserver'];?>" /><br />
@@ -984,16 +984,15 @@ include("head.inc");
                           <br/><br/>
                           <?=gettext('Set default bios filename');?>
                           <input name="filename" type="text" id="filename" value="<?=$pconfig['filename'];?>" /><br />
-                          <?=gettext('Set UEFI 32bit filename');?>
+                          <?=gettext('Set x86 UEFI (32-bit) filename');?>
                           <input name="filename32" type="text" id="filename32" value="<?=$pconfig['filename32'];?>" /><br />
-                          <?=gettext('Set UEFI 64bit filename');?>
+                          <?=gettext('Set x64 UEFI/EBC (64-bit) filename');?>
                           <input name="filename64" type="text" id="filename64" value="<?=$pconfig['filename64'];?>" /><br />
-                          <?=gettext('Set UEFI ARM 32bit filename');?>
+                          <?=gettext('Set ARM UEFI (32-bit) filename');?>
                           <input name="filename32arm" type="text" id="filename32arm" value="<?=$pconfig['filename32arm'];?>" /><br />
-                          <?=gettext('Set UEFI ARM 64bit filename');?>
+                          <?=gettext('Set ARM UEFI (64-bit) filename');?>
                           <input name="filename64arm" type="text" id="filename64arm" value="<?=$pconfig['filename64arm'];?>" /><br />
-                          <?=gettext("Note: You need both a filename and a boot server configured for this to work!");?><br/>
-                          <?=gettext("You will need all three filenames and a boot server configured for UEFI to work!");?>
+                          <?= gettext('You need both a filename and a boot server configured for this to work.') ?><br/>
                           <br/><br/>
                           <?=gettext('Set root-path string');?>
                           <input name="rootpath" type="text" id="rootpath" size="90" value="<?=$pconfig['rootpath'];?>" /><br />


### PR DESCRIPTION
This PR adds the ability to set a iPXE address for netbooting, which previously is only possible to do by editing the files directly.  I added a new field `ipxeaddress` that when set will ignore all the `filename*` fields and allow people to boot off an iPXE address.

There is definitely a few different ways of tackling this issue, so please let me know if you want it done another way. I chose the most logical method to me.

Fixes: https://github.com/opnsense/core/issues/5162 
Related: https://github.com/opnsense/core/issues/3557

Thanks!

Signed-off-by: Devin Buhl <devin@buhl.casa>