### PR TITLE
IDPS rule-updater: change syslog severity level

### DIFF
--- a/src/opnsense/scripts/suricata/rule-updater.py
+++ b/src/opnsense/scripts/suricata/rule-updater.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
                         # count number of downloaded files/rules from this metadata package
                         metadata_sources[rule['metadata_source']] += 1
                     else:
-                        syslog.syslog(syslog.LOG_INFO, 'download skipped %s, same version' % rule['filename'])
+                        syslog.syslog(syslog.LOG_NOTICE, 'download skipped %s, same version' % rule['filename'])
 
     # cleanup: match all installed rulesets against the configured ones and remove uninstalled rules
     md_filenames = [x['filename'] for x in md.list_rules(rule_properties)]


### PR DESCRIPTION
Hi!
since syslog-ng grabs only `level(notice..emerg)` for system log maybe it is worth changing the severity level so that messages about skipped downloads go to the log?
thanks!