### PR TITLE
Allow to configure SSH setting PubkeyAcceptedAlgorithms via GUI

### DIFF
--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -87,6 +87,21 @@ function openssh_stop()
     mwexecf('/bin/pkill -af %s', '/usr/local/sbin/sshd', true);
 }
 
+function openssh_check_querylist($list, $config) {
+    $supported = json_decode(configd_run("openssh query {$list}"));
+    $selected = [];
+    foreach (explode(',', $config) as $elem) {
+        if (in_array($elem, $supported)) {
+            $selected[] = $elem;
+        }
+    }
+
+    if (count($selected) == 0) {
+        syslog(LOG_WARNING, "OpenSSH: No configured {$list} ({$config}) supported - using defaults.");
+    }
+    return implode(',', $selected);
+}
+
 function openssh_configure_do($verbose = false, $interface = '')
 {
     global $config;
@@ -192,20 +207,36 @@ function openssh_configure_do($verbose = false, $interface = '')
         $sshconf .= "PasswordAuthentication no\n";
     }
     if (!empty($sshcfg['kex'])) {
-        $sshconf .= "KexAlgorithms {$sshcfg['kex']}\n";
+        $kexs = openssh_check_querylist('kex', $sshcfg['kex']);
+        if (strlen($kexs) > 0) {
+            $sshconf .= "KexAlgorithms {$kexs}\n";
+        }
     }
     if (!empty($sshcfg['ciphers'])) {
-        $sshconf .= "Ciphers {$sshcfg['ciphers']}\n";
+        $ciphers = openssh_check_querylist('cipher', $sshcfg['ciphers']);
+        if (strlen($ciphers) > 0) {
+            $sshconf .= "Ciphers {$ciphers}\n";
+        }
     }
     if (!empty($sshcfg['macs'])) {
-        $sshconf .= "MACs {$sshcfg['macs']}\n";
+        $macs = openssh_check_querylist('mac', $sshcfg['macs']);
+        if (strlen($macs) > 0) {
+            $sshconf .= "MACs {$macs}\n";
+        }
     }
     if (!empty($sshcfg['keys'])) {
-        $sshconf .= "HostKeyAlgorithms {$sshcfg['keys']}\n";
+        $keys = openssh_check_querylist('key', $sshcfg['keys']);
+        if (strlen($keys) > 0) {
+            $sshconf .= "HostKeyAlgorithms {$keys}\n";
+        }
     }
     if (!empty($sshcfg['keysig'])) {
-        $sshconf .= "PubkeyAcceptedAlgorithms {$sshcfg['keysig']}\n";
+        $keysigs = openssh_check_querylist('key-sig', $sshcfg['keysig']);
+        if (strlen($keysigs) > 0) {
+            $sshconf .= "PubkeyAcceptedAlgorithms {$keysigs}\n";
+        }
     }
+
     foreach ($keys_all as $name) {
         $file = "/conf/sshd/{$name}";
         if (!file_exists($file)) {

--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -93,6 +93,8 @@ function openssh_check_querylist($list, $config) {
     foreach (explode(',', $config) as $elem) {
         if (in_array($elem, $supported)) {
             $selected[] = $elem;
+        } else {
+            syslog(LOG_NOTICE, "OpenSSH: Configured value '{$elem}' of {$list} setting not suppored.");
         }
     }
 

--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -203,6 +203,9 @@ function openssh_configure_do($verbose = false, $interface = '')
     if (!empty($sshcfg['keys'])) {
         $sshconf .= "HostKeyAlgorithms {$sshcfg['keys']}\n";
     }
+    if (!empty($sshcfg['keysig'])) {
+        $sshconf .= "PubkeyAcceptedAlgorithms {$sshcfg['keysig']}\n";
+    }
     foreach ($keys_all as $name) {
         $file = "/conf/sshd/{$name}";
         if (!file_exists($file)) {

--- a/src/opnsense/scripts/openssh/ssh_query.py
+++ b/src/opnsense/scripts/openssh/ssh_query.py
@@ -32,7 +32,7 @@ import argparse
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('option', help='query option',  choices=['kex', 'mac', 'cipher' ,'key'])
+    parser.add_argument('option', help='query option',  choices=['kex', 'mac', 'cipher' ,'key', 'key-sig'])
     args = parser.parse_args()
 
     result = list()

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -72,6 +72,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['ssh-ciphers'] = !empty($config['system']['ssh']['ciphers']) ? explode(',', $config['system']['ssh']['ciphers']) : array();
     $pconfig['ssh-macs'] = !empty($config['system']['ssh']['macs']) ? explode(',', $config['system']['ssh']['macs']) : array();
     $pconfig['ssh-keys'] = !empty($config['system']['ssh']['keys']) ? explode(',', $config['system']['ssh']['keys']) : array();
+    $pconfig['ssh-keysig'] = !empty($config['system']['ssh']['keysig']) ? explode(',', $config['system']['ssh']['keysig']) : array();
 
     /* XXX listtag "fun" */
     $pconfig['sshlogingroup'] = !empty($config['system']['ssh']['group'][0]) ? $config['system']['ssh']['group'][0] : null;
@@ -268,6 +269,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $config['system']['ssh']['ciphers'] = !empty($pconfig['ssh-ciphers']) ? implode(',', $pconfig['ssh-ciphers']) : null;
         $config['system']['ssh']['macs'] = !empty($pconfig['ssh-macs']) ? implode(',', $pconfig['ssh-macs']) : null;
         $config['system']['ssh']['keys'] = !empty($pconfig['ssh-keys']) ? implode(',', $pconfig['ssh-keys']) : null;
+        $config['system']['ssh']['keysig'] = !empty($pconfig['ssh-keysig']) ? implode(',', $pconfig['ssh-keysig']) : null;
 
         if (!empty($pconfig['enablesshd'])) {
             $config['system']['ssh']['enabled'] = 'enabled';
@@ -818,6 +820,24 @@ $(document).ready(function() {
                     </select>
                     <div class="hidden" data-for="help_for_sshkeys">
                       <?=gettext("Specifies the host	key algorithms that the	server offers");?>
+                    </div>
+                </td>
+              </tr>
+              <tr>
+                <td><a id="help_for_sshkeysig" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Public key signature algorithms"); ?></td>
+                <td>
+                    <select name="ssh-keysig[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+<?php
+                    $options = json_decode(configd_run("openssh query key-sig"), true);
+                    foreach ($options = empty($options) ? array() : $options as $option):?>
+                      <option value="<?=$option;?>" <?= !empty($pconfig['ssh-keysig']) && in_array($option, $pconfig['ssh-keysig']) ? 'selected="selected"' : '' ?>>
+                        <?=$option;?>
+                      </option>
+<?php
+                    endforeach;?>
+                    </select>
+                    <div class="hidden" data-for="help_for_sshkeysig">
+                      <?=gettext("The signature algorithms that are used for public key authentication");?>
                     </div>
                 </td>
               </tr>

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -373,6 +373,22 @@ include("head.inc");
 
 ?>
 <body>
+<script>
+    $( document ).ready(function() {
+        $("#show-advanced-cryptocryptobtn").click(function (event) {
+            event.preventDefault();
+            $(this).parent().parent().hide();
+            $(".show-advanced-crypto").show();
+            $(window).trigger('resize');
+        });
+        // show advanced when at least one option is set
+        $(".advanced-crypto").each(function () {
+            if ($(this).val() != '') {
+                $("#show-advanced-cryptocryptobtn").click();
+            }
+        });
+    });
+</script>
 <?php include("fbegin.inc"); ?>
 <script>
 
@@ -752,9 +768,15 @@ $(document).ready(function() {
                 </td>
               </tr>
               <tr>
+                <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Advanced");?></td>
+                <td>
+                  <button id="show-advanced-cryptocryptobtn" class="btn btn-xs btn-default" value="yes"><?= gettext('Show cryptographic option') ?></button>
+                </td>
+              </tr>
+              <tr class="show-advanced-crypto" style="display:none">
                 <td><a id="help_for_sshkex" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Key exchange algorithms"); ?></td>
                 <td>
-                    <select name="ssh-kex[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+                    <select name="ssh-kex[]" class="selectpicker advanced-crypto" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
 <?php
                     $options = json_decode(configd_run("openssh query kex"), true);
                     foreach ($options = empty($options) ? array() : $options as $option):?>
@@ -769,10 +791,10 @@ $(document).ready(function() {
                     </div>
                 </td>
               </tr>
-              <tr>
+              <tr class="show-advanced-crypto" style="display:none">
                 <td><a id="help_for_sshciphers" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Ciphers"); ?></td>
                 <td>
-                    <select name="ssh-ciphers[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+                    <select name="ssh-ciphers[]" class="selectpicker advanced-crypto" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
 <?php
                     $options = json_decode(configd_run("openssh query cipher"), true);
                     foreach ($options = empty($options) ? array() : $options as $option):?>
@@ -787,10 +809,10 @@ $(document).ready(function() {
                     </div>
                 </td>
               </tr>
-              <tr>
+              <tr class="show-advanced-crypto" style="display:none">
                 <td><a id="help_for_sshmacs" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("MACs"); ?></td>
                 <td>
-                    <select name="ssh-macs[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+                    <select name="ssh-macs[]" class="selectpicker advanced-crypto" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
 <?php
                     $options = json_decode(configd_run("openssh query mac"), true);
                     foreach ($options = empty($options) ? array() : $options as $option):?>
@@ -805,10 +827,10 @@ $(document).ready(function() {
                     </div>
                 </td>
               </tr>
-              <tr>
+              <tr class="show-advanced-crypto" style="display:none">
                 <td><a id="help_for_sshkeys" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Host key algorithms"); ?></td>
                 <td>
-                    <select name="ssh-keys[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+                    <select name="ssh-keys[]" class="selectpicker advanced-crypto" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
 <?php
                     $options = json_decode(configd_run("openssh query key"), true);
                     foreach ($options = empty($options) ? array() : $options as $option):?>
@@ -823,10 +845,10 @@ $(document).ready(function() {
                     </div>
                 </td>
               </tr>
-              <tr>
+              <tr class="show-advanced-crypto" style="display:none">
                 <td><a id="help_for_sshkeysig" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Public key signature algorithms"); ?></td>
                 <td>
-                    <select name="ssh-keysig[]" class="selectpicker" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
+                    <select name="ssh-keysig[]" class="selectpicker advanced-crypto" multiple="multiple" data-live-search="true" title="<?=gettext("System defaults");?>">
 <?php
                     $options = json_decode(configd_run("openssh query key-sig"), true);
                     foreach ($options = empty($options) ? array() : $options as $option):?>


### PR DESCRIPTION
As OpenSSH 8.8 disables RSA signatures using the SHA-1 hash algorithm
by default some older SSH clients might not be able to connect to
OPNsense anymore. Therefore, it might be needed to manually modify the
PubkeyAucceptedAlgorithms sshd config option.