### PR TITLE
util: add support for terabytes, and petabytes to format_bytes

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1106,7 +1106,11 @@ function is_private_ip($iptocheck)
 
 function format_bytes($bytes)
 {
-    if ($bytes >= (1024 * 1024 * 1024)) {
+    if ($bytes >= (1024 * 1024 * 1024 * 1024 * 1024)) {
+        return sprintf("%.2f PB", $bytes / (1024 * 1024 * 1024 * 1024 * 1024));
+    } elseif ($bytes >= (1024 * 1024 * 1024 * 1024)) {
+        return sprintf("%.2f TB", $bytes / (1024 * 1024 * 1024 * 1024));
+    } elseif ($bytes >= (1024 * 1024 * 1024)) {
         return sprintf("%.2f GB", $bytes / (1024 * 1024 * 1024));
     } elseif ($bytes >= 1024 * 1024) {
         return sprintf("%.2f MB", $bytes / (1024 * 1024));

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1106,14 +1106,14 @@ function is_private_ip($iptocheck)
 
 function format_bytes($bytes)
 {
-    if ($bytes >= (1024 * 1024 * 1024 * 1024 * 1024)) {
-        return sprintf("%.2f PB", $bytes / (1024 * 1024 * 1024 * 1024 * 1024));
-    } elseif ($bytes >= (1024 * 1024 * 1024 * 1024)) {
-        return sprintf("%.2f TB", $bytes / (1024 * 1024 * 1024 * 1024));
-    } elseif ($bytes >= (1024 * 1024 * 1024)) {
-        return sprintf("%.2f GB", $bytes / (1024 * 1024 * 1024));
-    } elseif ($bytes >= 1024 * 1024) {
-        return sprintf("%.2f MB", $bytes / (1024 * 1024));
+    if ($bytes >= 1024 ** 5) {
+        return sprintf("%.2f PB", $bytes / (1024 ** 5));
+    } elseif ($bytes >= 1024 ** 4) {
+        return sprintf("%.2f TB", $bytes / (1024 ** 4));
+    } elseif ($bytes >= 1024 ** 3) {
+        return sprintf("%.2f GB", $bytes / (1024 ** 3));
+    } elseif ($bytes >= 1024 ** 2) {
+        return sprintf("%.2f MB", $bytes / (1024 ** 2));
     } elseif ($bytes >= 1024) {
         return sprintf("%.0f KB", $bytes / 1024);
     } else {


### PR DESCRIPTION
This just expands the supported range of the formatting to support tera-, and petabytes.

It utilizes the same method as megabytes, and gigabytes, only adding an extra 1024 for the larger sizes.

* This formatted number is used by the Interface Statistics widget,
  and makes the columns go wider than necessary when going above a
  terabyte of data. Add petabytes for good measure.