### PR TITLE
add action to dhcpd v6 to restart dhcpd

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_dhcpd.conf
+++ b/src/opnsense/service/conf/actions.d/actions_dhcpd.conf
@@ -9,3 +9,10 @@ command:/usr/local/opnsense/scripts/dhcp/prefixes.php
 parameters:
 type:script
 message:update IPv6 prefixes
+
+[restart6]
+command:/usr/local/sbin/pluginctl -s dhcpd6 restart
+parameters:
+type:script
+description:Restart dhcp6 service
+message:restarting dhcp6


### PR DESCRIPTION
workaround to cope with issue #4691 - allows restarting of dhcpd ipv6 via cron