### PR TITLE
Firewall/Alias: Add striping fix

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -204,6 +204,7 @@
          * Type selector, show correct type input.
          */
         $("#alias\\.type").change(function(){
+            $(".dummy_row").remove();
             $(".alias_type").hide();
             $("#row_alias\\.updatefreq").hide();
             $("#row_alias\\.interface").hide();
@@ -238,6 +239,10 @@
             } else {
                 $("#row_alias\\.counters").show();
             }
+            // add a dummy row to keep even \ odd
+            $(this).closest('table').find('tr[id][style*="display: none"]').each(function () {
+                $(this).after('<tr class="dummy_row" style="display: none"></tr>');
+            });
         });
 
         /**


### PR DESCRIPTION
This is a workaround to fix the color striping of the rows in the dialog box since the hidden rows cause the visible rows to skip the expected alternating colors when the visible rows are at an odd number of rows away. It basically adds one hidden dummy row for each hidden real row so that the rows will always be even, so that the next visible row will be the alternate color.

* Add/Remove dummy rows whenever alias type changes