### PR TITLE
firmware/status: Update to support terabytes

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/FirmwareController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/FirmwareController.php
@@ -50,7 +50,9 @@ class FirmwareController extends ApiControllerBase
             /* already processed */
             return $bytes;
         }
-        if ($bytes >= (1024 * 1024 * 1024)) {
+        if ($bytes >= (1024 * 1024 * 1024 * 1024)) {
+            return sprintf('%.1F%s', $bytes / (1024 * 1024 * 1024 * 1024), 'TiB');
+        } elseif ($bytes >= (1024 * 1024 * 1024)) {
             return sprintf('%.1F%s', $bytes / (1024 * 1024 * 1024), 'GiB');
         } elseif ($bytes >= 1024 * 1024) {
             return sprintf('%.1F%s', $bytes / (1024 * 1024), 'MiB');

--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/FirmwareController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/FirmwareController.php
@@ -50,12 +50,14 @@ class FirmwareController extends ApiControllerBase
             /* already processed */
             return $bytes;
         }
-        if ($bytes >= (1024 * 1024 * 1024 * 1024)) {
-            return sprintf('%.1F%s', $bytes / (1024 * 1024 * 1024 * 1024), 'TiB');
-        } elseif ($bytes >= (1024 * 1024 * 1024)) {
-            return sprintf('%.1F%s', $bytes / (1024 * 1024 * 1024), 'GiB');
-        } elseif ($bytes >= 1024 * 1024) {
-            return sprintf('%.1F%s', $bytes / (1024 * 1024), 'MiB');
+        if ($bytes >= 1024 ** 5) {
+            return sprintf('%.1F%s', $bytes / (1024 ** 5), 'PiB');
+        } elseif ($bytes >= 1024 ** 4) {
+            return sprintf('%.1F%s', $bytes / (1024 ** 4), 'TiB');
+        } elseif ($bytes >= 1024 ** 3) {
+            return sprintf('%.1F%s', $bytes / (1024 ** 3), 'GiB');
+        } elseif ($bytes >= 1024 ** 2) {
+            return sprintf('%.1F%s', $bytes / (1024 ** 2), 'MiB');
         } elseif ($bytes >= 1024) {
             return sprintf('%.1F%s', $bytes / 1024, 'KiB');
         } else {
@@ -135,6 +137,9 @@ class FirmwareController extends ApiControllerBase
                 if (preg_match('/\s*(\d+)\s*([a-z])/i', $size, $matches)) {
                     $factor = 1;
                     switch (isset($matches[2]) ? strtolower($matches[2]) : 'b') {
+                        case 't':
+                            $factor *= 1024;
+                            /* FALLTROUGH */
                         case 'g':
                             $factor *= 1024;
                             /* FALLTROUGH */


### PR DESCRIPTION
Update `formatBytes()` to support terabytes. 

* Add support for terabyte sizes, used in calculating update sizes

I am not aware of a clean way to test this, so I just overrode the values of `$active_count = 1;` and `$active_size = 723918942673774;` to force the API to return the message.

Looks like:
![image](https://user-images.githubusercontent.com/7823088/146654279-ade65a56-0c2e-4493-801f-f1d136885931.png)

Other sizes tested:
```
| Tested Value      | output size |
| ----------------  | ----------- |
| 42705383466540728 |     37.9PiB |
| 1125899906842624  |      1.0PiB |
| 723918942673774   |    658.4TiB |
| 58274116272128    |     53.0TiB |
| 1099511627776     |      1.0TiB |
| 72391673774       |     67.4GiB |
| 1073741824        |      1.0GiB |
| 37633392          |     35.9MiB |
| 1048576           |      1.0MiB |
| 1024              |      1.0KiB |
| 424               |        424B |
| 0                 |          0B |
```