### PR TITLE
Firewall/Live View: dont search rid for nat

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -325,13 +325,14 @@
                                 row.append($("<td/>").text(sorted_keys[i]));
                                 if (sorted_keys[i] == 'rid') {
                                   // rid field, links to rule origin
-                                  var rid_td = $("<td/>").addClass("act_info_fld_"+sorted_keys[i]);
                                   var rid = sender_details[sorted_keys[i]];
-
-                                  var rid_link = $("<a target='_blank' href='/firewall_rule_lookup.php?rid=" + rid + "'/>");
-                                  rid_link.text(rid);
-                                  rid_td.append($("<i/>").addClass('fa fa-fw fa-search'));
-                                  rid_td.append(rid_link);
+                                  var rid_td = $("<td/>").addClass("act_info_fld_"+sorted_keys[i]);
+                                  if (rid.length == 32) {
+                                      var rid_link = $("<a target='_blank' href='/firewall_rule_lookup.php?rid=" + rid + "'/>");
+                                      rid_link.text(rid);
+                                      rid_td.append($("<i/>").addClass('fa fa-fw fa-search'));
+                                      rid_td.append(rid_link);
+                                  }
                                   row.append(rid_td);
                                 } else if (icon === null) {
                                   row.append($("<td/>").addClass("act_info_fld_"+sorted_keys[i]).text(

--- a/src/opnsense/scripts/filter/read_log.py
+++ b/src/opnsense/scripts/filter/read_log.py
@@ -177,6 +177,9 @@ if __name__ == '__main__':
                     # obsolete md5 in log record
                     else:
                         rule['label'] = ''
+                elif rule['action'] not in ['pass', 'block']:
+                    # no id for translation rules
+                    rule['label'] = "%s rule" % rule['action']
                 elif len(rulep) > 0 and len(rulep[-1]) == 32 and set(rulep[-1]).issubset(HEX_DIGITS):
                     # rule id apended in record format, don't use rule sequence number in that case either
                     rule['rid'] = rulep[-1]
@@ -186,11 +189,8 @@ if __name__ == '__main__':
                     else:
                         rule['label'] = ''
                 elif 'rulenr' in rule and rule['rulenr'] in running_conf_descr['line_ids']:
-                    if rule['action'] in ['pass', 'block']:
-                        rule['label'] = running_conf_descr['line_ids'][rule['rulenr']]['label']
-                        rule['rid'] = running_conf_descr['line_ids'][rule['rulenr']]['rid']
-                elif rule['action'] not in ['pass', 'block']:
-                    rule['label'] = "%s rule" % rule['action']
+                    rule['label'] = running_conf_descr['line_ids'][rule['rulenr']]['label']
+                    rule['rid'] = running_conf_descr['line_ids'][rule['rulenr']]['rid']
 
                 result.append(rule)
 


### PR DESCRIPTION
Hi!
For "live view" part of  https://github.com/opnsense/core/issues/5412
-dont check rule number in `running_conf_descr` for nat/rdr rules
-dont show rule lookup link if `rid`  is not rid

thanks!