### PR TITLE
GUI: speedup forms load a bit

### DIFF
--- a/src/opnsense/www/js/opnsense.js
+++ b/src/opnsense/www/js/opnsense.js
@@ -178,7 +178,7 @@ function setFormData(parent,data) {
  * @param validationErrors
  */
 function handleFormValidation(parent,validationErrors) {
-    $( "#"+parent).find("*").each(function() {
+    $( "#"+parent).find("[id]").each(function() {
         if (validationErrors !== undefined && $(this).prop('id') in validationErrors) {
             $("*[id*='" + $(this).prop('id') + "']").addClass("has-error");
             $("span[id='help_block_" + $(this).prop('id') + "']").text(validationErrors[$(this).prop('id')]);


### PR DESCRIPTION
Hi!
noticed when checking the observers performance
I hope not missing anything, if we are looking for element `id` in `validationErrors`, maybe it makes sense to limit `find` only to elements with `id`? (this gave me about 0.4s when loading forms with a lot of elements, like Aliases forms)
Thanks!