### PR TITLE
mvc: Add BlankDesc to ModelRelationField

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
@@ -35,37 +35,12 @@ use OPNsense\Base\Validators\CsvListValidator;
  * Class ModelRelationField defines a relation to another entity within the model, acts like a select item.
  * @package OPNsense\Base\FieldTypes
  */
-class ModelRelationField extends BaseField
+class ModelRelationField extends BaseListField
 {
-    /**
-     * @var bool marks if this is a data node or a container
-     */
-    protected $internalIsContainer = false;
-
-    /**
-     * @var bool field may contain multiple data nodes at once
-     */
-    private $internalMultiSelect = false;
-
     /**
      * @var bool field content should remain sort order
      */
     private $internalIsSorted = false;
-
-    /**
-     * @var string default validation message string
-     */
-    protected $internalValidationMessage = "option not in list";
-
-    /**
-     * @var array collected options
-     */
-    private static $internalOptionList = array();
-
-    /**
-     * @var string default description for empty item
-     */
-    private $internalEmptyDescription = null;
 
     /**
      * @var array|null model settings to use for validation
@@ -83,6 +58,11 @@ class ModelRelationField extends BaseField
     private $internalCacheKey = "";
 
     /**
+     * @var array collected options
+     */
+    private static $internalCacheOptionList = array();
+
+    /**
      * load model option list
      * @param boolean $force force option load if we already seen this model before
      */
@@ -90,8 +70,8 @@ class ModelRelationField extends BaseField
     {
         // only collect options once per source/filter combination, we use a static to save our unique option
         // combinations over the running application.
-        if (!isset(self::$internalOptionList[$this->internalCacheKey]) || $force) {
-            self::$internalOptionList[$this->internalCacheKey] = array();
+        if (!isset(self::$internalCacheOptionList[$this->internalCacheKey]) || $force) {
+            self::$internalCacheOptionList[$this->internalCacheKey] = array();
             foreach ($this->mdlStructure as $modelData) {
                 // only handle valid model sources
                 if (!isset($modelData['source']) || !isset($modelData['items']) || !isset($modelData['display'])) {
@@ -146,7 +126,7 @@ class ModelRelationField extends BaseField
                         }
 
                         $uuid = $node->getAttributes()['uuid'];
-                        self::$internalOptionList[$this->internalCacheKey][$uuid] =
+                        self::$internalCacheOptionList[$this->internalCacheKey][$uuid] =
                             (string)$node->$displayKey;
                     }
                 }
@@ -154,9 +134,11 @@ class ModelRelationField extends BaseField
             }
 
             if (!$this->internalIsSorted) {
-                natcasesort(self::$internalOptionList[$this->internalCacheKey]);
+                natcasesort(self::$internalCacheOptionList[$this->internalCacheKey]);
             }
         }
+        // Set for use in BaseListField->getNodeData()
+        $this->internalOptionList = self::$internalCacheOptionList[$this->internalCacheKey];
     }
 
     /**
@@ -184,16 +166,6 @@ class ModelRelationField extends BaseField
     }
 
     /**
-     * select if multiple data nodes may be selected at once
-     * @param $value boolean value Y/N
-     */
-    public function setMultiple($value)
-    {
-        $this->internalMultiSelect = trim(strtoupper($value)) == "Y";
-    }
-
-
-    /**
      * select if sort order should be maintained
      * @param $value boolean value Y/N
      */
@@ -203,61 +175,45 @@ class ModelRelationField extends BaseField
     }
 
     /**
-     * set descriptive text for empty value
-     * @param $value string description
-     */
-    public function setBlankDesc($value)
-    {
-        $this->internalEmptyDescription = gettext($value);
-    }
-
-    /**
      * get valid options, descriptions and selected value
+     * performs sorting on internalOptionsList
+     * Doing this here instead of in loadModelOptions()
+     * otherwise internalIsSorted would have to be set
+     * the first time loadModelOptions() runs. This allows
+     * it to change later.
      * @return array
      */
     public function getNodeData()
     {
-        $result = array ();
         if (
-            isset(self::$internalOptionList[$this->internalCacheKey]) &&
-            is_array(self::$internalOptionList[$this->internalCacheKey])
+            isset($this->internalOptionList) &&
+            is_array($this->internalOptionList)
         ) {
-            if (empty($this->internalEmptyDescription)) {
-                $this->internalEmptyDescription = gettext("none");
-            }
-
-            // if relation is not required, add empty option
-            if (!$this->internalIsRequired && !$this->internalMultiSelect) {
-                $result[""] = array("value" => $this->internalEmptyDescription, "selected" => empty($this->internalValue));
-            }
-
+            // Get selected items into an array.
             $datanodes = explode(',', $this->internalValue);
             if ($this->internalIsSorted) {
+                // Establish an array of keys with the selected keys as the first entires.
                 $optKeys = $datanodes;
-                foreach (array_keys(self::$internalOptionList[$this->internalCacheKey]) as $key) {
+                foreach (array_keys($this->internalOptionList) as $key) {
+                    // Append each non-selected key to the array one-by-one.
                     if (!in_array($key, $optKeys)) {
                         $optKeys[] = $key;
                     }
                 }
-            } else {
-                $optKeys = array_keys(self::$internalOptionList[$this->internalCacheKey]);
-            }
-            foreach ($optKeys as $optKey) {
-                if (isset(self::$internalOptionList[$this->internalCacheKey][$optKey])) {
-                    if (in_array($optKey, $datanodes)) {
-                        $selected = 1;
-                    } else {
-                        $selected = 0;
+                // Perform reordering of the option list based on the newly ordered keys array.
+                $ordered_option_list = array();
+                // Iterate through each key and inject the key:value pair from internalOptionList.
+                foreach ($optKeys as $key) {
+                    // Prevent arbitrary $key values, check that $key is in internalOptionList.
+                    if (in_array($key, array_keys($this->internalOptionList))) {
+                        $ordered_option_list[$key] = $this->internalOptionList[$key];
                     }
-                    $result[$optKey] = array(
-                        "value" => self::$internalOptionList[$this->internalCacheKey][$optKey],
-                        "selected" => $selected
-                    );
                 }
+                $this->internalOptionList = $ordered_option_list;
             }
         }
 
-        return $result;
+        return parent::getNodeData();
     }
 
     /**
@@ -266,22 +222,11 @@ class ModelRelationField extends BaseField
      */
     public function getValidators()
     {
-        $validators = parent::getValidators();
         if ($this->internalValue != null) {
             // if our options come from the same model, make sure to reload the options before validating them
             $this->loadModelOptions($this->internalOptionsFromThisModel);
-            if ($this->internalMultiSelect) {
-                // field may contain more than one entries
-                $validators[] = new CsvListValidator(array(
-                    'message' => $this->internalValidationMessage,
-                    'domain' => array_keys(self::$internalOptionList[$this->internalCacheKey])
-                ));
-            } else {
-                // single value selection
-                $validators[] = new InclusionIn(array('message' => $this->internalValidationMessage,
-                    'domain' => array_keys(self::$internalOptionList[$this->internalCacheKey])));
-            }
         }
-        return $validators;
+        // Use validators from BaseListField, includes validations for multi-select, and single-select.
+        return parent::getValidators();
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
@@ -63,6 +63,11 @@ class ModelRelationField extends BaseField
     private static $internalOptionList = array();
 
     /**
+     * @var string default description for empty item
+     */
+    private $internalEmptyDescription = null;
+
+    /**
      * @var array|null model settings to use for validation
      */
     private $mdlStructure = null;
@@ -198,6 +203,15 @@ class ModelRelationField extends BaseField
     }
 
     /**
+     * set descriptive text for empty value
+     * @param $value string description
+     */
+    public function setBlankDesc($value)
+    {
+        $this->internalEmptyDescription = gettext($value);
+    }
+
+    /**
      * get valid options, descriptions and selected value
      * @return array
      */
@@ -208,9 +222,13 @@ class ModelRelationField extends BaseField
             isset(self::$internalOptionList[$this->internalCacheKey]) &&
             is_array(self::$internalOptionList[$this->internalCacheKey])
         ) {
+            if (empty($this->internalEmptyDescription)) {
+                $this->internalEmptyDescription = gettext("none");
+            }
+
             // if relation is not required, add empty option
             if (!$this->internalIsRequired && !$this->internalMultiSelect) {
-                $result[""] = array("value" => "none", "selected" => 0);
+                $result[""] = array("value" => $this->internalEmptyDescription, "selected" => empty($this->internalValue));
             }
 
             $datanodes = explode(',', $this->internalValue);

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/ModelRelationFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/ModelRelationFieldTest.php
@@ -72,6 +72,9 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertInstanceOf('\OPNsense\Base\FieldTypes\ModelRelationField', new ModelRelationField());
     }
 
+    /**
+     * Select single valid, defaults.
+     */
     public function testSetSingleOk()
     {
         $field = new ModelRelationField();
@@ -87,6 +90,192 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertEmpty($this->validate($field));
     }
 
+    /**
+     * Select multiple valid, required false (default), multiple false (default).
+     */
+    public function testSetMultipleNok()
+    {
+        $field = new ModelRelationField();
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("5ea2a35c-b02b-485a-912b-d077e639bf9f,60e1bc02-6817-4940-bbd3-61d0cf439a8a");
+        $this->assertEquals($this->validate($field), ['Phalcon\Validation\Validator\InclusionIn']);
+    }
+
+    /**
+     * Selecting "none" option, required false (default), multiple false (default).
+     */
+    public function testSetNoneOk()
+    {
+        $field = new ModelRelationField();
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * Selecting "none" option, field required.
+     */
+    public function testSetNoneNok()
+    {
+        $field = new ModelRelationField();
+        $field->setRequired("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+        $this->assertEquals($this->validate($field), ['Phalcon\Validation\Validator\PresenceOf']);
+    }
+
+    /**
+     * Selecting "none" option, with multiple.
+     */
+    public function testSetNoneMultiNok()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("'',5ea2a35c-b02b-485a-912b-d077e639bf9f");
+        $this->assertEquals($this->validate($field), ['CsvListValidator']);
+    }
+
+    /**
+     * Selecting "none" option, using the blank description (BlankDesc) override.
+     * Needs not required, and multiple.
+     */
+    public function testSetNoneBlankDescOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setBlankDesc("No selection.");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * Selecting a non-option, using the blank description (BlankDesc) override.
+     * Needs not required, and multiple.
+     */
+    public function testSetNoneBlankDescNok()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setBlankDesc("No selection.");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("Not an option");
+        $this->assertEquals($this->validate($field), ['CsvListValidator']);
+    }
+
+    /**
+     * Selecting another option, using the blank description (BlankDesc) override.
+     * Needs not required, and multiple.
+     */
+    public function testSetNoneBlankDescSingleOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setBlankDesc("No selection.");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("d1e7eda3-f940-42d9-8dfa-db7b1264b6e1");
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * Selecting none option, while blank desciption override.
+     * Defined blank description should pass through to value, and show selected.
+     * Needs not required (default), and multiple false (default)
+     */
+    public function testSetNoneBlankDescValueOk()
+    {
+        $field = new ModelRelationField();
+        $field->setBlankDesc("No selection.");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+        $node_data = $field->getNodeData();
+        $this->assertEquals($node_data[""], array("value" => "No selection.","selected" => true));
+
+    }
+
+    /**
+     * Selecting none option, while blank desciption override.
+     * Empty Blank description should get override with word "none"
+     * Needs not required (default), and multiple false (default)
+     */
+    public function testSetNoneBlankDescBlankValueOk()
+    {
+        $field = new ModelRelationField();
+        $field->setBlankDesc("");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+        $node_data = $field->getNodeData();
+        $this->assertEquals($node_data[""], array("value" => "none","selected" => true));
+
+    }
+
+    /**
+     * Selecting single invalid option, not required.
+     */
     public function testSetSingleNok()
     {
         $field = new ModelRelationField();
@@ -102,6 +291,9 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertEquals($this->validate($field), ['Phalcon\Validation\Validator\InclusionIn']);
     }
 
+    /**
+     * Selecting multiple, with multiple enabled.
+     */
     public function testSetMultiOk()
     {
         $field = new ModelRelationField();
@@ -118,6 +310,9 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertEmpty($this->validate($field));
     }
 
+    /**
+     * Selecting one invalid in multiple, with multiple enabled.
+     */
     public function testSetMultiNok()
     {
         $field = new ModelRelationField();
@@ -134,7 +329,29 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertEquals($this->validate($field), ['CsvListValidator']);
     }
 
-    public function testSorted()
+    /**
+     * Selecting valid multiple with multiple disabled.
+     */
+    public function testSetMultiNoNok()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("N");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("4d0e2835-7a19-4a19-8c23-e12383827594,5ea2a35c-b02b-485a-912b-d077e639bf9f");
+        $this->assertEquals($this->validate($field), ['Phalcon\Validation\Validator\InclusionIn']);
+    }
+
+    /**
+     * Selecting multiple, with multiple enabled, and sorting enabled.
+     */
+    public function testSortedOk()
     {
         $field = new ModelRelationField();
         $field->setMultiple("Y");
@@ -149,7 +366,6 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $field->setValue("4d0e2835-7a19-4a19-8c23-e12383827594,5ea2a35c-b02b-485a-912b-d077e639bf9f");
 
         $node_data = $field->getNodeData();
-        // sorted by source model
         $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
         $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
 
@@ -160,6 +376,218 @@ class ModelRelationFieldTest extends Field_Framework_TestCase
         $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 1);
     }
 
+    /**
+     * Selecting none, with sorting, required false (default).
+     */
+    public function testSortedNoneOk()
+    {
+        $field = new ModelRelationField();
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, ''), 0);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 4);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, ''), 0);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 4);
+    }
+
+    /**
+     * Selecting none and valid, with multiple, with sorting, required false (default).
+     */
+    public function testSortedNoneWithMulitpleOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("4d0e2835-7a19-4a19-8c23-e12383827594,''");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 0);
+    }
+
+    /**
+     * Selecting all, with multiple, with sorting, required false (default).
+     */
+    public function testSortedSelectAllOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("5ea2a35c-b02b-485a-912b-d077e639bf9f," .
+                         "48bea3c9-c563-4885-a593-dea0a6af2e1e," .
+                         "d1e7eda3-f940-42d9-8dfa-db7b1264b6e1," .
+                         "4d0e2835-7a19-4a19-8c23-e12383827594," .
+                         "60e1bc02-6817-4940-bbd3-61d0cf439a8a," .
+                         "3bf8fc9c-6f36-4821-9944-ed7dfed50ad6");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+    }
+
+    /**
+     * Selecting some, in order, with multiple, with sorting, required false (default).
+     */
+    public function testSortedSelectSomeOrderedOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("d1e7eda3-f940-42d9-8dfa-db7b1264b6e1," .
+                         "4d0e2835-7a19-4a19-8c23-e12383827594," .
+                         "60e1bc02-6817-4940-bbd3-61d0cf439a8a,");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 4);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 1);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+    }
+
+    /**
+     * Selecting some unordered, with multiple, with sorting, required false (default).
+     */
+    public function testSortedSelectSomeUnorderedOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("60e1bc02-6817-4940-bbd3-61d0cf439a8a," .
+                         "48bea3c9-c563-4885-a593-dea0a6af2e1e," .
+                         "4d0e2835-7a19-4a19-8c23-e12383827594,");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+    }
+
+    /**
+     * Selecting some unordered, with multiple, with invalid, with sorting, required false (default).
+     * Invalid entry is ignored.
+     */
+    public function testSortedSelectSomeInvalidOk()
+    {
+        $field = new ModelRelationField();
+        $field->setMultiple("Y");
+        $field->setModel(array(
+            "item" => array(
+                "source" => "tests.OPNsense.Base.BaseModel.TestModel",
+                "items" => "simpleList.items",
+                "display" => "number"
+            )
+        ));
+        $field->eventPostLoading();
+        $field->setValue("60e1bc02-6817-4940-bbd3-61d0cf439a8a," .
+                         "d3adb33f-c563-4885-a593-dea0a6af2e1e," .
+                         "4d0e2835-7a19-4a19-8c23-e12383827594,");
+
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 1);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 3);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+
+        // set sorted by input and check again
+        $field->setSorted('Y');
+        $node_data = $field->getNodeData();
+        $this->assertEquals($this->arraySequence($node_data, '5ea2a35c-b02b-485a-912b-d077e639bf9f'), 2);
+        $this->assertEquals($this->arraySequence($node_data, '48bea3c9-c563-4885-a593-dea0a6af2e1e'), 3);
+        $this->assertEquals($this->arraySequence($node_data, 'd1e7eda3-f940-42d9-8dfa-db7b1264b6e1'), 4);
+        $this->assertEquals($this->arraySequence($node_data, '4d0e2835-7a19-4a19-8c23-e12383827594'), 1);
+        $this->assertEquals($this->arraySequence($node_data, '60e1bc02-6817-4940-bbd3-61d0cf439a8a'), 0);
+        $this->assertEquals($this->arraySequence($node_data, '3bf8fc9c-6f36-4821-9944-ed7dfed50ad6'), 5);
+    }
 
     /**
      * type is not a container


### PR DESCRIPTION
I came across this in my exploration, and thought it was weird that this field didn't support the BlankDesc option with it building a very similar thing to what OptionFields do. I tried it out and it seems to work the same way as OptionFields' BlankDesc. Needs an expert eye though. I just copied the same structures over from the `BaseListField` type and change the code to use the `internalEmptyDescription` instead of the hard coded `none`.

* Add BlankDesc options for ModelRelationField types.
* Copied from BaseListField type.