### PR TITLE
fix dnsmasq strict-order

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -166,6 +166,8 @@ function dnsmasq_configure_do($verbose = false)
 
     if (isset($config['dnsmasq']['strict_order'])) {
         $args .= ' --strict-order ';
+    } else {
+        $args .= ' --all-servers ';
     }
 
     if (isset($config['dnsmasq']['domain_needed'])) {
@@ -189,7 +191,7 @@ function dnsmasq_configure_do($verbose = false)
 
     _dnsmasq_add_host_entries();
 
-    mwexec("/usr/local/sbin/dnsmasq --all-servers {$args}");
+    mwexec("/usr/local/sbin/dnsmasq {$args}");
 
     _dnsmasq_dhcpleases_start();
 


### PR DESCRIPTION
Currently, when configured, "strict-order" adds the necessary "strict-order" argument. However, the hardcoded "all-servers" argument overrides this, making "strict-order" pointless.

With this change, "all-servers" and "strict-order" are mutually exclusive.