### PR TITLE
Firewall/Scrub: Display interface descriptions

### DIFF
--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -313,6 +313,7 @@ $( document ).ready(function() {
 <?php
                 $special_nets = get_specialnets();
                 legacy_html_escape_form_data($special_nets);
+                $configured_interfaces = legacy_config_get_interfaces();
                 foreach ($a_scrub as $i => $scrubEntry):?>
                   <tr>
                     <td>
@@ -321,7 +322,16 @@ $( document ).ready(function() {
                           <span class="fa fa-play fa-fw <?=(empty($scrubEntry['disabled'])) ? "text-success" : "text-muted";?>"></span>
                         </a>
                     </td>
-                    <td><?=strtoupper($scrubEntry['interface']);?></td>
+<?php
+                    $scrubEntryInterfaceNames = explode(',', $scrubEntry['interface']);
+                    $scrubEntryInterfaceDescrs = [];
+                    foreach ($scrubEntryInterfaceNames as $scrubEntryInterfaceName) {
+                        if (array_key_exists($scrubEntryInterfaceName, $configured_interfaces)) {
+                            $scrubEntryInterfaceDescrs[] = $configured_interfaces[$scrubEntryInterfaceName]['descr'];
+                        }
+                    }
+                    $scrubEntryInterfaceText = implode(', ', $scrubEntryInterfaceDescrs);?>
+                    <td><?=$scrubEntryInterfaceText;?></td>
                     <td class="hidden-xs hidden-sm">
 <?php
                         if (is_alias($scrubEntry['src'])):?>

--- a/src/www/firewall_scrub.php
+++ b/src/www/firewall_scrub.php
@@ -205,6 +205,15 @@ $( document ).ready(function() {
   // watch scroll position and set to last known on page load
   watchScrollPosition();
 
+  // add titles to the fields having long text cut with ellipsis
+  $('.mightOverflow').on('mouseenter', function(){
+      var $this = $(this);
+
+      if(this.offsetWidth < this.scrollWidth && !$this.attr('title')){
+          $this.attr('title', $this.text());
+      }
+  });
+    
 });
 </script>
 
@@ -323,15 +332,13 @@ $( document ).ready(function() {
                         </a>
                     </td>
 <?php
-                    $scrubEntryInterfaceNames = explode(',', $scrubEntry['interface']);
                     $scrubEntryInterfaceDescrs = [];
-                    foreach ($scrubEntryInterfaceNames as $scrubEntryInterfaceName) {
+                    foreach (explode(',', $scrubEntry['interface']) as $scrubEntryInterfaceName) {
                         if (array_key_exists($scrubEntryInterfaceName, $configured_interfaces)) {
-                            $scrubEntryInterfaceDescrs[] = $configured_interfaces[$scrubEntryInterfaceName]['descr'];
+                            $scrubEntryInterfaceDescrs[] = $configured_interfaces[$scrubEntryInterfaceName]['descr'] ?? strtoupper($scrubEntryInterfaceName);
                         }
-                    }
-                    $scrubEntryInterfaceText = implode(', ', $scrubEntryInterfaceDescrs);?>
-                    <td><?=$scrubEntryInterfaceText;?></td>
+                    }?>
+                    <td class="mightOverflow" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 30ch;"><?=implode(', ', $scrubEntryInterfaceDescrs);?></td>
                     <td class="hidden-xs hidden-sm">
 <?php
                         if (is_alias($scrubEntry['src'])):?>


### PR DESCRIPTION
This PR is a quick fix of an issue on the Firewall/Setting/Normalization page. The page shows interface names (e.g. opt1) in the Interfaces column of the Detailed settings table, while the corresponding editing page shows interface descriptions. I suggest we convert interface names to descriptions using the approach taken from firewall_scrub_edit.php.