### PR TITLE
VPN / IPsec / Tunnel Settings: Add IPv4+6 protocol for mobile phase1 entries

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -337,7 +337,11 @@ function ipsec_get_phase1_src(&$ph1ent)
     } else {
         $if = "wan";
     }
-    if ($ph1ent['protocol'] == "inet6") {
+    if ($ph1ent['protocol'] == "inet46") {
+        $ipv4 = get_interface_ip($if);
+        $ipv6 = get_interface_ipv6($if);
+        return $ipv4 ? $ipv4.($ipv6 ? ','.$ipv6 : '') : $ipv6;
+    } elseif ($ph1ent['protocol'] == "inet6") {
         return get_interface_ipv6($if);
     } else {
         return get_interface_ip($if);

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/TunnelController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/TunnelController.php
@@ -146,7 +146,7 @@ class TunnelController extends ApiControllerBase
                     "id" => intval((string)$p1->ikeid),   // ikeid should be unique
                     "seqid" => $idx,
                     "enabled" => empty((string)$p1->disabled) ? "1" : "0",
-                    "protocol" => $p1->protocol == "inet" ? "IPv4" : "IPv6",
+                    "protocol" => $p1->protocol == "inet46" ? "IPv4+6" : ($p1->protocol == "inet6" ? "IPv6" : "IPv4"),
                     "iketype" => $ph1type[(string)$p1->iketype],
                     "interface" => !empty($ifs[$interface]) ? $ifs[$interface] : $interface,
                     "remote_gateway" => (string)$p1->{"remote-gateway"},

--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -699,6 +699,9 @@ include("head.inc");
                       <select name="protocol">
                       <?php
                       $protocols = array("inet" => "IPv4", "inet6" => "IPv6");
+                      if (!empty($pconfig['mobile'])) {
+                          $protocols["inet46"] = "IPv4+6";
+                      }
                       foreach ($protocols as $protocol => $name) :
                       ?>
                         <option value="<?=$protocol;?>"  <?=$protocol == $pconfig['protocol'] ? "selected=\"selected\"" : "";?> >


### PR DESCRIPTION
**Issue:**
- You need to configure separate IPv4 and IPv6 phase1 entries for a dual stack mobile setup on each interface, i.e. 2 phase1 entries and 4 phase2 entries for each interface. If you have more than 1 authentication options (e.g. Mutual RSA, EAP-MSCHAPv2, etc.), the number of phase1 entries grows proportionally. It is even more inefficient when/if you need to make a small change - you have to repeat the change multiple times to each phase1 entry.

**Solution:**
- Strongswan provides for multiple IPs separated by commas as left/right side addresses in the ipsec.conf. Thus, we can implement an IPv4+6 protocol option (in addition to the existing IPv4 and IPv6 ones) that halves the number of phase1/phase2 entries required for a dual stack mobile setup. 

**Further ideas:**
- We might also consider this change for other setups (non-mobile), if anyone is interested in it and ready to test the changes. But it is out of scope for the purposes of this PR.
- One might also face the same issue if more than one interface is required to run mobile IPsec. Thus, we could allow multiple interfaces to be selectable for a single phase1 entry at once. But I suggest we move step by step.

**Environment:**
- I have tested ad0cabbc3de266f6444b7208a316c14ed20da9de and b79080256643dd30318652b4699f79e419b3826e on 21.7.6. I haven't tested bc5764f5d96e0ca4d92fe4409c43d93299cbfa07 since I don't have the file it changes, but I made a similar change in src/www/vpn_ipsec.php to fix how the inet46 protocol is displayed on the Tunnel Settings page.