### PR TITLE
mvc: Add <hint> support for text fields

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -62,7 +62,15 @@
     </td>
     <td>
         {% if type == "text" %}
-            <input type="text" class="form-control {{style|default('')}}" size="{{size|default("50")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} >
+            <input
+                type="text"
+                class="form-control {{style|default('')}}"
+                size="{{size|default("50")}}"
+                id="{{ id }}"
+                {{ readonly|default(false) ?
+                    'readonly="readonly"' : '' }}
+                {{ hint is defined ?
+                    'placeholder="'~hint~'"' : '' }}>
         {% elseif type == "hidden" %}
             <input type="hidden" id="{{ id }}" class="{{style|default('')}}" >
         {% elseif type == "checkbox" %}


### PR DESCRIPTION
This is visually similar to select_multiple's placeholder text.

* Add support for hint (placeholder) for text field type
* Re-style similar to select_multiple to shorten line length