### PR TITLE
Move storing jQuery Bootgrid settings in browser from core to bootgrid

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -208,7 +208,7 @@
                         </select>
                     </div>
                 </div>
-                <table id="grid-log" class="table table-condensed table-hover table-striped table-responsive" data-store-selection="true">
+                <table id="grid-log" class="table table-condensed table-hover table-striped table-responsive">
                     <thead>
                     <tr>
                         <th data-column-id="timestamp" data-width="11em" data-type="string">{{ lang._('Date') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -511,7 +511,7 @@
                             </select>
                         </div>
                     </div>
-                    <table id="grid-aliases" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogAlias" data-editAlert="aliasChangeMessage" data-store-selection="true">
+                    <table id="grid-aliases" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogAlias" data-editAlert="aliasChangeMessage">
                         <thead>
                         <tr>
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -818,7 +818,7 @@ POSSIBILITY OF SUCH DAMAGE.
         </div>
 
         <!-- tab page "installed rules" -->
-        <table id="grid-installedrules" data-store-selection="true" class="table table-condensed table-hover table-striped table-responsive" data-editAlert="ruleChangeMessage" data-editDialog="DialogRule">
+        <table id="grid-installedrules" class="table table-condensed table-hover table-striped table-responsive" data-editAlert="ruleChangeMessage" data-editDialog="DialogRule">
             <thead>
             <tr>
                 <th data-column-id="sid" data-type="numeric" data-visible="true" data-identifier="true" data-width="6em">{{ lang._('sid') }}</th>
@@ -860,7 +860,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
     <div id="userrules" class="tab-pane fade in">
         <!-- tab page "userrules" -->
-        <table id="grid-userrules" data-store-selection="true" class="table table-condensed table-hover table-striped table-responsive" data-editAlert="userdefineChangeMessage" data-editDialog="DialogUserDefined">
+        <table id="grid-userrules" class="table table-condensed table-hover table-striped table-responsive" data-editAlert="userdefineChangeMessage" data-editDialog="DialogUserDefined">
             <thead>
                 <tr>
                     <th data-column-id="enabled" data-formatter="rowtoggle" data-sortable="false" data-width="10em">{{ lang._('Enabled') }}</th>
@@ -922,7 +922,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 </div>
             </div>
         </div>
-        <table id="grid-alerts" data-store-selection="true" class="table table-condensed table-hover table-striped table-responsive">
+        <table id="grid-alerts" class="table table-condensed table-hover table-striped table-responsive">
             <thead>
               <tr>
                   <th data-column-id="timestamp" data-type="string" data-sortable="false">{{ lang._('Timestamp') }}</th>

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -559,7 +559,7 @@ function renderRowCountSelection(actions)
         {
             var item = $(tpl.actionDropDownItem.resolve(getParams.call(that,
                 { text: getText(value), action: value })))
-                    ._bgSelectAria(value === that.rowCount)
+                    ._bgSelectAria(value.toString() === that.rowCount.toString())
                     .on("click" + namespace, menuItemSelector, function (e)
                     {
                         e.preventDefault();

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -1,6 +1,6 @@
-/*!
- * jQuery Bootgrid v1.3.5 - 03/11/2019
- * Copyright © 2014-2015 Rafael J. Staib; Copyright © 2018-2019 Deciso B.V. (http://www.jquery-bootgrid.com)
+/*! 
+ * jQuery Bootgrid v1.4.0 - 12/31/2021
+ * Copyright © 2014-2015 Rafael J. Staib; Copyright © 2018-2021 Deciso B.V. (http://www.jquery-bootgrid.com)
  * Licensed under the MIT license. See LICENSE.txt for more details.
  */
 ;(function ($, window, undefined)
@@ -78,6 +78,7 @@ function init()
 
     loadColumns.call(this); // Loads columns from HTML thead tag
     this.selection = this.options.selection && this.identifier != null;
+    this.rowCount = localStorage.getItem('rowCount[' + this.uid + ']') || this.rowCount;
     loadRows.call(this); // Loads rows from HTML tbody tag if ajax is false
     prepareTable.call(this);
     renderTableHeader.call(this);
@@ -112,6 +113,8 @@ function loadColumns()
     {
         var $this = $(this),
             data = $this.data(),
+            visibilityStorage = localStorage.getItem('visibleColumns[' + that.uid + '][' + data.columnId + ']'),
+            sortingStorage = localStorage.getItem('sortColumns[' + that.uid + '][' + data.columnId + ']'),
             column = {
                 id: data.columnId,
                 identifier: that.identifier == null && data.identifier || false,
@@ -122,10 +125,13 @@ function loadColumns()
                 cssClass: data.cssClass || "",
                 headerCssClass: data.headerCssClass || "",
                 formatter: that.options.formatters[data.formatter] || null,
-                order: (!sorted && (data.order === "asc" || data.order === "desc")) ? data.order : null,
+                order: !sorted ?
+                    (sortingStorage === null ? (data.order === "asc" || data.order === "desc" ? data.order : null) :
+                        (sortingStorage === "asc" || sortingStorage === "desc" ? sortingStorage : null)) :
+                    null, // If no other column is sorted already (or multiSort is enabled), check if sorting was stored
                 searchable: !(data.searchable === false), // default: true
                 sortable: !(data.sortable === false), // default: true
-                visible: !(data.visible === false), // default: true
+                visible: visibilityStorage === null ? !(data.visible === false) : (visibilityStorage === 'true'), // default: true
                 visibleInSelection: !(data.visibleInSelection === false), // default: true
                 width: ($.isNumeric(data.width)) ? data.width + "px" :
                     (typeof(data.width) === "string") ? data.width : null
@@ -393,9 +399,10 @@ function renderColumnSelection(actions)
 
                             var $this = $(this),
                                 checkbox = $this.find(checkboxSelector);
+                            localStorage.setItem('visibleColumns[' + that.uid + '][' + column.id + ']', checkbox.prop("checked"));
                             if (!checkbox.prop("disabled"))
                             {
-                                column.visible = checkbox.prop("checked");
+                                column.visible = localStorage.getItem('visibleColumns[' + that.uid + '][' + column.id + ']') === 'true';
                                 var enable = that.columns.where(isVisible).length > 1;
                                 $this.parents(itemsSelector).find(selector + ":has(" + checkboxSelector + ":checked)")
                                     ._bgEnableAria(enable).find(checkboxSelector)._bgEnableField(enable);
@@ -559,6 +566,7 @@ function renderRowCountSelection(actions)
 
                         var $this = $(this),
                             newRowCount = $this.data("action");
+                        localStorage.setItem('rowCount[' + that.uid + ']', newRowCount);
                         if (newRowCount !== that.rowCount)
                         {
                             // todo: sophisticated solution needed for calculating which page is selected
@@ -843,11 +851,16 @@ function setTableHeaderSortDirection(element)
     {
         element.parents("tr").first().find(iconSelector).removeClass(css.iconDown + " " + css.iconUp);
         this.sortDictionary = {};
+        for (var i = 0; i < this.columns.length; i++)
+        {
+            localStorage.removeItem('sortColumns[' + this.uid + '][' + this.columns[i].id + ']');
+        }
     }
 
     if (sortOrder && sortOrder === "asc")
     {
         this.sortDictionary[columnId] = "desc";
+        localStorage.setItem('sortColumns[' + this.uid + '][' + columnId + ']', "desc");
         icon.removeClass(css.iconUp).addClass(css.iconDown);
     }
     else if (sortOrder && sortOrder === "desc")
@@ -863,17 +876,20 @@ function setTableHeaderSortDirection(element)
                 }
             }
             this.sortDictionary = newSort;
+            localStorage.removeItem('sortColumns[' + this.uid + '][' + columnId + ']');
             icon.removeClass(css.iconDown);
         }
         else
         {
             this.sortDictionary[columnId] = "asc";
+            localStorage.setItem('sortColumns[' + this.uid + '][' + columnId + ']', "asc");
             icon.removeClass(css.iconDown).addClass(css.iconUp);
         }
     }
     else
     {
         this.sortDictionary[columnId] = "asc";
+        localStorage.setItem('sortColumns[' + this.uid + '][' + columnId + ']', "asc");
         icon.addClass(css.iconUp);
     }
 }
@@ -997,6 +1013,7 @@ var Grid = function(element, options)
     this.header = null;
     this.footer = null;
     this.xqr = null;
+    this.uid = window.location.pathname + "#" + this.element.attr('id');
 
     // todo: implement cache
 };
@@ -1881,8 +1898,8 @@ $.fn.extend({
 
     _bgBusyAria: function(busy)
     {
-        return (busy == null || busy) ?
-            this._bgAria("busy", "true") :
+        return (busy == null || busy) ? 
+            this._bgAria("busy", "true") : 
             this._bgAria("busy", "false");
     },
 
@@ -1893,29 +1910,29 @@ $.fn.extend({
 
     _bgEnableAria: function (enable)
     {
-        return (enable == null || enable) ?
-            this.removeClass("disabled")._bgAria("disabled", "false") :
+        return (enable == null || enable) ? 
+            this.removeClass("disabled")._bgAria("disabled", "false") : 
             this.addClass("disabled")._bgAria("disabled", "true");
     },
 
     _bgEnableField: function (enable)
     {
-        return (enable == null || enable) ?
-            this.removeAttr("disabled") :
+        return (enable == null || enable) ? 
+            this.removeAttr("disabled") : 
             this.attr("disabled", "disable");
     },
 
     _bgShowAria: function (show)
     {
-        return (show == null || show) ?
+        return (show == null || show) ? 
             this.show()._bgAria("hidden", "false") :
             this.hide()._bgAria("hidden", "true");
     },
 
     _bgSelectAria: function (select)
     {
-        return (select == null || select) ?
-            this.addClass("active")._bgAria("selected", "true") :
+        return (select == null || select) ? 
+            this.addClass("active")._bgAria("selected", "true") : 
             this.removeClass("active")._bgAria("selected", "false");
     },
 
@@ -2005,8 +2022,8 @@ if (!Array.prototype.page)
     {
         var skip = (page - 1) * size,
             end = skip + size;
-        return (this.length > skip) ?
-            (this.length > end) ? this.slice(skip, end) :
+        return (this.length > skip) ? 
+            (this.length > end) ? this.slice(skip, end) : 
                 this.slice(skip) : [];
     };
 }

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -151,21 +151,6 @@ $.fn.UIBootgrid = function (params) {
         }
         this_grid.onBeforeRenderDialog = gridopt.onBeforeRenderDialog;
 
-        if ($(this_grid).data('store-selection') === true && window.localStorage) {
-            // fetch last selected rowcount, sort on top so it will be the current active selection
-            let grid_id = window.location.pathname + '#' + this_grid.attr('id');
-            let count = parseInt(window.localStorage.getItem(grid_id+"_items")) ;
-            if (count !== null) {
-                if (Array.isArray(gridopt.rowCount)) {
-                    let index = gridopt.rowCount.indexOf(count);
-                    if (index > -1) {
-                        gridopt.rowCount.splice(index, 1);
-                        gridopt.rowCount.unshift(count);
-                    }
-                }
-            }
-        }
-
         // construct a new grid
         return this_grid.bootgrid(gridopt).on("loaded.rs.jquery.bootgrid", function (e) {
             // scale footer on resize
@@ -375,53 +360,6 @@ $.fn.UIBootgrid = function (params) {
     };
 
     /**
-     * load previous selections
-     */
-    this.load_selection = function() {
-        if ($(this_grid).data('store-selection') === true && window.localStorage) {
-            const grid_id = window.location.pathname + '#' + this_grid.attr('id');
-            try {
-                const settings = JSON.parse(window.localStorage.getItem(grid_id));
-                if (settings != null) {
-                    $.each(settings, function(field, value){
-                        $('#'+ this_grid.attr('id')).find('[data-column-id="' +field+ '"]').data('visible', value);
-                    });
-                }
-            } catch (e) {
-            }
-        }
-    };
-
-    /**
-     * store selections when data-store-selection=true
-     */
-    this.store_selection = function() {
-        if ($(this_grid).data('store-selection') === true && window.localStorage) {
-            const grid_id = window.location.pathname + '#' + this_grid.attr('id');
-            // hook event handler to catch changing column selections
-            $("#"+this_grid.attr('id')+"-header .dropdown-item-checkbox").unbind('click').click(function () {
-                let settings = {};
-                try {
-                    settings = JSON.parse(window.localStorage.getItem(grid_id));
-                    if (settings == null) {
-                        settings = {};
-                    }
-                } catch (e) {
-                    settings = {};
-                }
-                if ($(this).attr('name') !== undefined) {
-                    settings[$(this).attr('name')] = $(this).is(':checked');
-                }
-                window.localStorage.setItem(grid_id, JSON.stringify(settings));
-            });
-            // hook event handler to catch changing row counters
-            $("#"+this_grid.attr('id')+"-header .dropdown-item-button").unbind('click').click(function () {
-                window.localStorage.setItem(grid_id+"_items", $(this).data('action'));
-            });
-        }
-    };
-
-    /**
      * init bootgrids
      */
     return this.each((function(){
@@ -431,8 +369,6 @@ $.fn.UIBootgrid = function (params) {
         $(this).find("*[data-action=deleteSelected]").addClass('command-delete-selected bootgrid-tooltip');
 
         if (params !== undefined && params['search'] !== undefined) {
-            // load previous selections when enabled
-            this_grid.load_selection();
             // create new bootgrid component and link source
             const grid = this_grid.construct();
 
@@ -484,8 +420,6 @@ $.fn.UIBootgrid = function (params) {
                         console.log("not all requirements met to link " + k);
                     }
                 });
-                // store selections when enabled
-                this_grid.store_selection();
             });
 
             return grid;


### PR DESCRIPTION
Implementation of #5439 to store settings of bootgrids (sort order, visible columns, row count) in local browser storage.

- Update of jquery.bootgrid.js from 1.3.5 to 1.4.0 (opnsense/jquery-bootgrid#5)
- Removing of equivalent functionality from opnsense_bootgrid_plugin.js