### PR TITLE
show interface IP address in API

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/InterfaceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/InterfaceController.php
@@ -208,6 +208,15 @@ class InterfaceController extends ApiControllerBase
     }
 
     /**
+     * retrieve status/config for each network adapter
+     * @return mixed
+     */
+    public function getInterfaceConfigAction()
+    {
+        return json_decode((new Backend())->configdRun('interface list ifconfig'), true);
+    }
+
+    /**
      * retrieve system-wide socket statistics (merge netstat with sockstat)
      * @return mixed
      */

--- a/src/opnsense/scripts/routes/gateway_status.php
+++ b/src/opnsense/scripts/routes/gateway_status.php
@@ -34,13 +34,8 @@ require_once 'interfaces.inc';
 
 $result = array();
 $gateways_status = return_gateways_status();
-$ifsinfo = get_interfaces_info();
 foreach ((new \OPNsense\Routing\Gateways(legacy_interfaces_details()))->gatewaysIndexedByName() as $gname => $gw) {
     $gatewayItem = array('name' => $gname);
-    $ifdescr = $gw['interface'];
-    $gatewayItem['interface'] = $ifdescr;
-    $ifinfo = $ifsinfo[$ifdescr];
-    $gatewayItem['ipaddr'] = !empty($ifinfo['ipaddr']) ? $ifinfo['ipaddr'] : "~";
     $gatewayItem['address'] = !empty($gw['gateway']) ? $gw['gateway'] : "~";
     if (!empty($gateways_status[$gname])) {
         $gatewayItem['status'] = strtolower($gateways_status[$gname]['status']);

--- a/src/opnsense/scripts/routes/gateway_status.php
+++ b/src/opnsense/scripts/routes/gateway_status.php
@@ -34,8 +34,13 @@ require_once 'interfaces.inc';
 
 $result = array();
 $gateways_status = return_gateways_status();
+$ifsinfo = get_interfaces_info();
 foreach ((new \OPNsense\Routing\Gateways(legacy_interfaces_details()))->gatewaysIndexedByName() as $gname => $gw) {
     $gatewayItem = array('name' => $gname);
+    $ifdescr = $gw['interface'];
+    $gatewayItem['interface'] = $ifdescr;
+    $ifinfo = $ifsinfo[$ifdescr];
+    $gatewayItem['ipaddr'] = !empty($ifinfo['ipaddr']) ? $ifinfo['ipaddr'] : "~";
     $gatewayItem['address'] = !empty($gw['gateway']) ? $gw['gateway'] : "~";
     if (!empty($gateways_status[$gname])) {
         $gatewayItem['status'] = strtolower($gateways_status[$gname]['status']);


### PR DESCRIPTION
**Problem:**
I needed a way to get the currently assigned IP address for a PPPoE interface through API.

At the moment, if you use this command:

```bash
$ curl -sku "${OPNKEY}:${OPNSEC}" https://${OPNSENSE_ADDRESS}/api/routes/gateway/status | jq
```

You get:

```json
{
  "items": [
    {
      "name": "WAN_PPPOE",
      "address": "x.x.x.x",
      "status": "none",
      "loss": "0.0 %",
      "delay": "9.1 ms",
      "stddev": "1.9 ms",
      "status_translated": "Online"
    },
    {
      "name": "WANLTE_GWv4",
      "address": "y.y.y.y",
      "status": "down",
      "loss": "100.0 %",
      "delay": "0.0 ms",
      "stddev": "0.0 ms",
      "status_translated": "Offline"
    }
  ],
  "status": "ok"
}
```

The ip address indicated in the "address" field is the monitored IP address of the gateway.

I found no other suitable API calls to get the currently assigned IP address of an interface, so I modified this one.

**Proposed solution:**

With this modification, with the same command, you get two more fields, the real interface name and the assigned IP address (doesn't matter if it comes from DHCP or is statically assigned).

```json
{
  "items": [
    {
      "name": "WAN_PPPOE",
      "ipaddr": "x.x.x.x",
      "interface": "wan",
      "address": "y.y.y.y",
      "status": "none",
      "loss": "0.0 %",
      "delay": "9.1 ms",
      "stddev": "1.9 ms",
      "status_translated": "Online"
    },
    {
      "name": "WANLTE_GWv4",
      "ipaddr": "x.x.x.x",
      "interface": "opt10",
      "address": "y.y.y.y",
      "status": "down",
      "loss": "100.0 %",
      "delay": "0.0 ms",
      "stddev": "0.0 ms",
      "status_translated": "Offline"
    }
  ],
  "status": "ok"
}
```
