### PR TITLE
IPsec: Add EC support for public key authentication

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
@@ -29,6 +29,7 @@
 namespace OPNsense\IPsec\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
 
 /**
  * Class KeyPairsController
@@ -111,5 +112,23 @@ class KeyPairsController extends ApiMutableModelControllerBase
         }
 
         return $response;
+    }
+
+    /**
+     * Generate public and private key pair
+     * @return reponse
+     * @throws \ReflectionException
+     */
+    public function genKeysAction()
+    {
+        if ($this->request->isPost() && $this->request->hasPost('keyType') && $this->request->hasPost('keySize')) {
+            $keyType = preg_replace("/[^A-Za-z0-9 ]/", '', $this->request->getPost('keyType'));
+            $keySize = intval($this->request->getPost('keySize'));
+
+            $backend = new Backend();
+            return $backend->configdRun("ipsec genkeys $keyType $keySize");
+        } else {
+            return [];
+        }
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
@@ -47,10 +47,16 @@ class KeyPairsController extends ApiMutableModelControllerBase
      */
     public function searchItemAction()
     {
-        return $this->searchBase(
+        $data = $this->searchBase(
             'keyPairs.keyPair',
-            ['name', 'keyType', 'keySize', 'keyFingerprint']
+            ['name', 'keyType', 'keySize', 'keyFingerprint', 'privateKey']
         );
+
+        foreach ($data['rows'] as &$row) {
+            $row['privateKey'] = empty($row['privateKey']) ? gettext('no') : gettext('yes');
+        }
+
+        return $data;
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogKeyPair.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogKeyPair.xml
@@ -30,4 +30,10 @@
             Must be pasted including the '-----BEGIN ...-----' and '-----END [...]-----' headers.
         </help>
     </field>
+    <field>
+        <id>keyPair.generate</id>
+        <label><![CDATA[<em>Key Size (for generation only)</em>]]></label>
+        <type>dropdown</type>
+        <help>Enter the desired key size in bits and press "Generate" to generate a new key pair.</help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.php
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (C) 2019 Pascal Mathis <mail@pascalmathis.com>
+ * Copyright (C) 2022 Manuel Faux <mfaux@conf.at>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,7 +85,8 @@ class IPsec extends BaseModel
             try {
                 $publicKey = $this->parseCryptographicKey(
                     (string)$keyPair->publicKey,
-                    (string)$keyPair->keyType . '-public'
+                    (string)$keyPair->keyType,
+                    'public'
                 );
             } catch (\Exception $e) {
                 $messages->appendMessage(new Message($e->getMessage(), $nodeKey . '.publicKey'));
@@ -96,7 +98,8 @@ class IPsec extends BaseModel
             try {
                 $privateKey = $this->parseCryptographicKey(
                     (string)$keyPair->privateKey,
-                    (string)$keyPair->keyType . '-private'
+                    (string)$keyPair->keyType,
+                    'private'
                 );
             } catch (\Exception $e) {
                 $messages->appendMessage(new Message($e->getMessage(), $nodeKey . '.privateKey'));
@@ -124,27 +127,51 @@ class IPsec extends BaseModel
      * Parse a cryptographic key of a given type using OpenSSL and return an array of informational data.
      * @param $keyString string
      * @param $keyType string
+     * @param $keyPart string
      * @return array
      */
-    public function parseCryptographicKey($keyString, $keyType)
+    private function parseCryptographicKey($keyString, $keyType, $keyPart)
     {
+        if (in_array($keyType, ['rsa', 'ecdsa'])) {
+            return $this->parseCryptographicKey_php($keyString, $keyType, $keyPart);
+        }
+        else if (in_array($keyType, ['ed25519', 'ed448'])) {
+            return $this->parseCryptographicKey_openssl($keyString, $keyType, $keyPart);
+        }
+        else {
+            throw new \InvalidArgumentException(sprintf(
+                gettext('Unsupported key type: %s'),
+                strtoupper($keyType)
+            ));
+        }
+    }
+
+    /**
+     * Parse a cryptographic key of a given type using PHP's OpenSSL wrapper and return an array
+     * of informational data.
+     * @param $keyString string
+     * @param $keyType string
+     * @param $keyPart string
+     * @return array
+     */
+    private function parseCryptographicKey_php($keyString, $keyType, $keyPart) {
         // Attempt to load key with correct type
-        if ($keyType === 'rsa-public') {
+        if ($keyPart == 'public') {
             $key = openssl_pkey_get_public($keyString);
-        } elseif ($keyType === 'rsa-private') {
+        } elseif ($keyPart == 'private') {
             $key = openssl_pkey_get_private($keyString);
         } else {
             throw new \InvalidArgumentException(sprintf(
-                gettext('Unsupported key type: %s'),
-                $keyType
+                gettext('Unsupported key type: %s-%s'),
+                $keyType, $keyPart
             ));
         }
 
         // Ensure that key has been successfully loaded
         if ($key === false) {
             throw new \InvalidArgumentException(sprintf(
-                gettext('Could not load potentially invalid %s key: %s'),
-                $keyType,
+                gettext('Could not load potentially invalid %s-%s key: %s'),
+                $keyType, $keyPart,
                 openssl_error_string()
             ));
         }
@@ -153,27 +180,41 @@ class IPsec extends BaseModel
         $keyDetails = openssl_pkey_get_details($key);
         if ($keyDetails === false) {
             throw new \RuntimeException(sprintf(
-                gettext('Could not fetch details for %s key: %s'),
-                $keyType,
+                gettext('Could not fetch details for %s-%s key: %s'),
+                $keyType, $keyPart,
                 openssl_error_string()
             ));
         }
 
         // Verify given public key is valid for usage with Strongswan
-        if ($keyDetails['type'] !== OPENSSL_KEYTYPE_RSA) {
+        if ($keyDetails['type'] !== OPENSSL_KEYTYPE_RSA && $keyDetails['type'] !== OPENSSL_KEYTYPE_EC) {
             throw new \InvalidArgumentException(sprintf(
-                gettext('Unsupported OpenSSL key type [%d] for %s key, expected RSA.'),
+                gettext('Unsupported OpenSSL key type [%d] for %s-%s key, expected RSA or EC.'),
                 $keyDetails['type'],
-                $keyType
+                $keyType, $keyPart
+            ));
+        }
+
+        // Verify that key type matches with actual passed key
+        if ($keyType == 'rsa' && $keyDetails['type'] !== OPENSSL_KEYTYPE_RSA) {
+            throw new \RuntimeException(sprintf(
+                gettext('Passed key is not a RSA key, but a %s key.'),
+                $keyDetails['type'] === OPENSSL_KEYTYPE_EC ? 'ECDSA' : 'unknown'
+            ));
+        }
+        else if ($keyType == 'ecdsa' && $keyDetails['type'] !== OPENSSL_KEYTYPE_EC) {
+            throw new \RuntimeException(sprintf(
+                gettext('Passed key is not a ECDSA key, but a %s key.'),
+                $keyDetails['type'] === OPENSSL_KEYTYPE_RSA ? 'RSA' : 'unknown'
             ));
         }
 
         // Fetch sanitized PEM representation of key
-        if ($keyType === 'rsa-private') {
+        if ($keyPart == 'private') {
             if (!openssl_pkey_export($key, $keySanitized, null)) {
                 throw new \RuntimeException(sprintf(
-                    gettext('Could not generate sanitized %s key in PEM format: %s'),
-                    $keyType,
+                    gettext('Could not generate sanitized %s-%s key in PEM format: %s'),
+                    $keyType, $keyPart,
                     openssl_error_string()
                 ));
             }
@@ -181,14 +222,7 @@ class IPsec extends BaseModel
             $keySanitized = $keyDetails['key'];
         }
 
-        // Calculate fingerprint for the public key (when a private key was given, its public key is calculated)
-        $keyUnwrapped = trim(preg_replace('/\\+s/', '', preg_replace(
-            '~^-----BEGIN(?:[A-Z]+ )? PUBLIC KEY-----([A-Za-z0-9+/=\\s]+)-----END(?:[A-Z]+ )? PUBLIC KEY-----$~m',
-            '\\1',
-            $keyDetails['key']
-        )));
-        $keyFingerprint = substr(chunk_split(hash('sha1', base64_decode($keyUnwrapped)), 2, ':'), 0, -1);
-
+        $keyFingerprint = $this->calculateFingerprint($keyDetails['key']);
         return [
             'resource' => $key,
             'size' => $keyDetails['bits'],
@@ -196,5 +230,144 @@ class IPsec extends BaseModel
             'type' => $keyType,
             'pem' => $keySanitized
         ];
+    }
+
+    /**
+     * Parse a cryptographic key of a given type using OpenSSL directly (without the PHP's wrapper
+     * functions) and return an array of informational data. This function is required as Ed25519
+     * and Ed448 keys are currently not supported by PHP 7.
+     * @param $keyString string
+     * @param $keyType string
+     * @param $keyPart string
+     * @return array
+     */
+    private function parseCryptographicKey_openssl($keyString, $keyType, $keyPart) {
+        $descs = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w']
+        ];
+        $openssl = null;
+        $pipes = [];
+
+        // Attempt to load key with correct type
+        if ($keyPart == 'public') {
+            $openssl = proc_open('/usr/bin/openssl pkey -inform PEM -text -pubin', $descs, $pipes);
+        } elseif ($keyPart == 'private') {
+            $openssl = proc_open('/usr/bin/openssl pkey -inform PEM -text -pubout', $descs, $pipes);
+        } else {
+            throw new \InvalidArgumentException(sprintf(
+                gettext('Unsupported key type: %s-%s'),
+                $keyType, $keyPart
+            ));
+        }
+
+        // Process passed key and read openssl's outputs and return value
+        fwrite($pipes[0], $keyString);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $retcode = proc_close($openssl);
+
+        // Ensure that key has been successfully loaded
+        if ($retcode != 0) {
+            throw new \InvalidArgumentException(sprintf(
+                gettext('Could not load potentially invalid %s-%s key.'),
+                $keyType, $keyPart
+            ));
+        }
+
+        $keyDetails = [];
+        // Attempt to fetch key details
+        if (!preg_match('/^(\S+)\s(Public|Private)-Key:/m', $stdout, $matches)) {
+            throw new \RuntimeException(sprintf(
+                gettext('Could not fetch details for %s-%s key.'),
+                $keyType, $keyPart
+            ));
+        }
+        $keyDetails['type'] = $matches[1];
+        switch ($keyDetails['type']) {
+            case "ED25519":
+                $keyDetails['bits'] = 255;
+                break;
+            case "ED448":
+                $keyDetails['bits'] = 448;
+                break;
+        }
+
+        // Attempt to fetch public key
+        if (!preg_match('~^-----BEGIN(?:[A-Z]+ )? PUBLIC KEY-----([A-Za-z0-9+/=\s]+)-----END(?:[A-Z]+ )? PUBLIC KEY-----~', $stdout, $matches)) {
+            throw new \RuntimeException(sprintf(
+                gettext('Could not fetch public key for %s-%s key.'),
+                $keyType, $keyPart
+            ));
+        }
+        $keyDetails['key'] = $matches[0];
+
+        // Verify that key type matches with actual passed key
+        if (strtoupper($keyType) != $keyDetails['type']) {
+            throw new \RuntimeException(sprintf(
+                gettext('Passed key is not a %s key, but a %s key.'),
+                strtoupper($keyType), $keyDetails['type']
+            ));
+        }
+
+        // Fetch sanitized PEM representation of key
+        if ($keyPart == 'private') {
+            $openssl = proc_open('/usr/bin/openssl pkey -inform PEM -text', $descs, $pipes);
+
+            // Process passed key and read openssl's outputs and return value
+            fwrite($pipes[0], $keyString);
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[2]);
+            $retcode = proc_close($openssl);
+
+            // Ensure that key has been successfully loaded
+            if ($retcode != 0) {
+                throw new \InvalidArgumentException(sprintf(
+                    gettext('Could not generate sanitized %s-%s key in PEM format.'),
+                    $keyType, $keyPart
+                ));
+            }
+
+            // Attempt to fetch sanitized key
+            if (!preg_match('~^-----BEGIN(?:[A-Z]+ )? PRIVATE KEY-----([A-Za-z0-9+/=\s]+)-----END(?:[A-Z]+ )? PRIVATE KEY-----~', $stdout, $matches)) {
+                throw new \RuntimeException(sprintf(
+                    gettext('Could not fetch sanitized key for %s-%s key.'),
+                    $keyType, $keyPart
+                ));
+            }
+            $keySanitized = $matches[0];
+        } else {
+            $keySanitized = $keyDetails['key'];
+        }
+
+        $keyFingerprint = $this->calculateFingerprint($keyDetails['key']);
+        return [
+            'size' => $keyDetails['bits'],
+            'fingerprint' => $keyFingerprint,
+            'type' => $keyType,
+            'pem' => $keySanitized
+        ];
+    }
+
+    /**
+     * Calculate fingerprint for the public key (when a private key was given, its public key
+     * is calculated)
+     * @param $key string
+     * @return string
+     */
+    private function calculateFingerprint($key) {
+        $keyUnwrapped = trim(preg_replace('/\\+s/', '', preg_replace(
+            '~^-----BEGIN(?:[A-Z]+ )? PUBLIC KEY-----([A-Za-z0-9+/=\\s]+)-----END(?:[A-Z]+ )? PUBLIC KEY-----$~m',
+            '\\1',
+            $key
+        )));
+        return substr(chunk_split(hash('sha1', base64_decode($keyUnwrapped)), 2, ':'), 0, -1);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
@@ -20,6 +20,9 @@
                     <default>rsa</default>
                     <OptionValues>
                         <rsa>RSA</rsa>
+                        <ecdsa>ECDSA</ecdsa>
+                        <ed25519>Ed25519</ed25519>
+                        <ed448>Ed448</ed448>
                     </OptionValues>
                 </keyType>
                 <publicKey type="TextField">

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Menu/Menu.xml
@@ -11,7 +11,7 @@
             <Keys order="30" VisibleName="Pre-Shared Keys" url="/vpn_ipsec_keys.php">
                 <Edit url="/vpn_ipsec_keys_edit.php*" visibility="hidden"/>
             </Keys>
-            <KeyPairs order="40" VisibleName="RSA Key Pairs" url="/ui/ipsec/key-pairs" />
+            <KeyPairs order="40" VisibleName="Key Pairs" url="/ui/ipsec/key-pairs" />
             <Settings order="50" VisibleName="Advanced Settings" url="/vpn_ipsec_settings.php"/>
             <Status order="60" VisibleName="Status Overview" url="/diag_ipsec.php">
                 <Act url="/diag_ipsec.php?*" visibility="hidden"/>

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
@@ -99,7 +99,7 @@
           keySizes = [255];
           break;
         case "ed448":
-          keySizes = [488];
+          keySizes = [448];
           break;
       }
 

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
@@ -155,8 +155,9 @@
         <tr>
             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
             <th data-column-id="name" data-type="string">{{ lang._('Name') }}</th>
-            <th data-column-id="keyType" data-width="20em" data-type="string">{{ lang._('Key Type') }}</th>
-            <th data-column-id="keySize" data-width="20em" data-type="number">{{ lang._('Key Size') }}</th>
+            <th data-column-id="keyType" data-width="10em" data-type="string">{{ lang._('Key Type') }}</th>
+            <th data-column-id="keySize" data-width="10em" data-type="number">{{ lang._('Key Size') }}</th>
+            <th data-column-id="privateKey" data-width="10em" data-type="string">{{ lang._('Private Key') }}</th>
             <th data-column-id="keyFingerprint" data-type="string">{{ lang._('Key Fingerprint') }}</th>
             <th data-column-id="commands" data-width="7em" data-formatter="commands"
                 data-sortable="false">{{ lang._('Commands') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
@@ -79,6 +79,37 @@
     // Refresh status of legacy subsystem when grid has changed
     $grid.on('loaded.rs.jquery.bootgrid', updateLegacyStatus);
     updateServiceControlUI('ipsec');
+
+    // Populate bit sizes for key generation
+    const generateSelect = $('#keyPair\\.generate');
+    [1024, 2048, 3072, 4096, 8192].forEach(function(size){
+      let opt = $(`<option>${size}</option>`).appendTo(generateSelect);
+      if (size == 2048) {
+          opt.prop("selected", true);
+      }
+    });
+    generateSelect.selectpicker('refresh');
+
+    // Add "Generate" button to dialog
+    const generateButton = $('<button>{{ lang._('Generate') }}</button>');
+    const generateProgress = $('<i></i>');
+    generateButton.prepend(generateProgress);
+    generateButton.on('click', function(e) {
+      e.preventDefault();
+      generateButton.prop('disabled', true);
+      generateProgress.addClass("fa fa-spinner fa-pulse");
+      keyType = $('#keyPair\\.keyType').val();
+      keySize = generateSelect.val();
+      ajaxCall(url='/api/ipsec/key-pairs/genKeys',
+        sendData={'keyType': keyType, 'keySize': keySize},
+        callback=function(data, status){
+          $('#keyPair\\.publicKey').val(data['pubkey']);
+          $('#keyPair\\.privateKey').val(data['privkey']);
+          generateButton.prop('disabled', false);
+          generateProgress.removeClass("fa fa-spinner fa-pulse");
+        });
+    });
+    $('#row_keyPair\\.generate td:nth-child(3)').prepend(generateButton);
   });
 </script>
 

--- a/src/opnsense/scripts/ipsec/genkeys.py
+++ b/src/opnsense/scripts/ipsec/genkeys.py
@@ -37,19 +37,26 @@ if __name__ == '__main__':
     # parse input parameter
     keytype = None
     keysize = None
-    if len(sys.argv) > 2:
+    if len(sys.argv) > 1:
         keytype = sys.argv[1].strip().lower()
-        if keytype not in ['rsa']:
+        if keytype not in ['rsa', 'ecdsa', 'ed25519', 'ed448']:
             print('Invalid keytype passed')
             sys.exit(1)
 
-        keysize = sys.argv[2].strip()
-        if not keysize.isdigit():
-            print('Invalid keysize passed')
-            sys.exit(1)
-            
+        # Not all keytypes require a key size
+        if len(sys.argv) > 2:
+            keysize = sys.argv[2].strip()
+            if not keysize.isdigit():
+                print('Invalid keysize passed')
+                sys.exit(1)
+            keysize = int(keysize)
+
         if keytype == 'rsa':
-            if int(keysize) < 512 or int(keysize) > 65536:
+            if keysize < 512 or keysize > 65536:
+                print('Invalid keysize passed')
+                sys.exit(1)
+        elif keytype == 'ecdsa':
+            if keysize != 256 and keysize != 384 and keysize != 521:
                 print('Invalid keysize passed')
                 sys.exit(1)
     else:
@@ -59,7 +66,7 @@ if __name__ == '__main__':
     # Generate private key
     spprv = subprocess.run(['/usr/local/sbin/ipsec', 'pki',
         '--gen', '--type', keytype,
-        '--size', keysize,
+        '--size', str(keysize),
         '--outform', 'pem'], capture_output=True, text=True)
     result['privkey'] = spprv.stdout.strip()
 

--- a/src/opnsense/scripts/ipsec/genkeys.py
+++ b/src/opnsense/scripts/ipsec/genkeys.py
@@ -1,0 +1,74 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2022 Manuel Faux <mfaux@conf.at>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+    --------------------------------------------------------------------------------------
+"""
+
+import sys
+import subprocess
+import ujson
+
+result = dict()
+if __name__ == '__main__':
+    # parse input parameter
+    keytype = None
+    keysize = None
+    if len(sys.argv) > 2:
+        keytype = sys.argv[1].strip().lower()
+        if keytype not in ['rsa']:
+            print('Invalid keytype passed')
+            sys.exit(1)
+
+        keysize = sys.argv[2].strip()
+        if not keysize.isdigit():
+            print('Invalid keysize passed')
+            sys.exit(1)
+            
+        if keytype == 'rsa':
+            if int(keysize) < 512 or int(keysize) > 65536:
+                print('Invalid keysize passed')
+                sys.exit(1)
+    else:
+        print('Insufficient parameters passed')
+        sys.exit(1)
+
+    # Generate private key
+    spprv = subprocess.run(['/usr/local/sbin/ipsec', 'pki',
+        '--gen', '--type', keytype,
+        '--size', keysize,
+        '--outform', 'pem'], capture_output=True, text=True)
+    result['privkey'] = spprv.stdout.strip()
+
+    # Extract public key
+    sppub = subprocess.run(['/usr/local/sbin/ipsec', 'pki', '--pub', '--outform', 'pem'],
+        capture_output=True, text=True, input=result['privkey'])
+    result['pubkey'] = sppub.stdout.strip()
+
+    if spprv.returncode != 0 or sppub.returncode != 0:
+        sys.exit(1)
+
+print(ujson.dumps(result))

--- a/src/opnsense/scripts/ipsec/genkeys.py
+++ b/src/opnsense/scripts/ipsec/genkeys.py
@@ -28,6 +28,7 @@
     --------------------------------------------------------------------------------------
 """
 
+import argparse
 import sys
 import subprocess
 import ujson
@@ -35,33 +36,23 @@ import ujson
 result = dict()
 if __name__ == '__main__':
     # parse input parameter
-    keytype = None
-    keysize = None
-    if len(sys.argv) > 1:
-        keytype = sys.argv[1].strip().lower()
-        if keytype not in ['rsa', 'ecdsa', 'ed25519', 'ed448']:
-            print('Invalid keytype passed')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--type', help='key type (rsa, ecdsa, ed25519, ed488)',
+        choices=['rsa', 'ecdsa', 'ed25519', 'ed488'], default='rsa')
+    parser.add_argument('--size', help='key size (only for rsa and ecdsa)',
+        type=int, default=0)
+    inputargs = parser.parse_args()
+
+    keytype = inputargs.type
+    keysize = inputargs.size
+    if keytype == 'rsa':
+        if keysize < 512 or keysize > 65536:
+            print('Invalid keysize passed')
             sys.exit(1)
-
-        # Not all keytypes require a key size
-        if len(sys.argv) > 2:
-            keysize = sys.argv[2].strip()
-            if not keysize.isdigit():
-                print('Invalid keysize passed')
-                sys.exit(1)
-            keysize = int(keysize)
-
-        if keytype == 'rsa':
-            if keysize < 512 or keysize > 65536:
-                print('Invalid keysize passed')
-                sys.exit(1)
-        elif keytype == 'ecdsa':
-            if keysize != 256 and keysize != 384 and keysize != 521:
-                print('Invalid keysize passed')
-                sys.exit(1)
-    else:
-        print('Insufficient parameters passed')
-        sys.exit(1)
+    elif keytype == 'ecdsa':
+        if keysize != 256 and keysize != 384 and keysize != 521:
+            print('Invalid keysize passed')
+            sys.exit(1)
 
     # Generate private key
     spprv = subprocess.run(['/usr/local/sbin/ipsec', 'pki',

--- a/src/opnsense/scripts/ipsec/genkeys.py
+++ b/src/opnsense/scripts/ipsec/genkeys.py
@@ -37,8 +37,8 @@ result = dict()
 if __name__ == '__main__':
     # parse input parameter
     parser = argparse.ArgumentParser()
-    parser.add_argument('--type', help='key type (rsa, ecdsa, ed25519, ed488)',
-        choices=['rsa', 'ecdsa', 'ed25519', 'ed488'], default='rsa')
+    parser.add_argument('--type', help='key type (rsa, ecdsa, ed25519, ed448)',
+        choices=['rsa', 'ecdsa', 'ed25519', 'ed448'], default='rsa')
     parser.add_argument('--size', help='key size (only for rsa and ecdsa)',
         type=int, default=0)
     inputargs = parser.parse_args()

--- a/src/opnsense/service/conf/actions.d/actions_ipsec.conf
+++ b/src/opnsense/service/conf/actions.d/actions_ipsec.conf
@@ -56,6 +56,6 @@ description:Reconfigure IPsec service
 
 [genkeys]
 command:/usr/local/opnsense/scripts/ipsec/genkeys.py
-parameters:%s %s
+parameters: --type %s --size %s
 type:script_output
 description:Generates public keys

--- a/src/opnsense/service/conf/actions.d/actions_ipsec.conf
+++ b/src/opnsense/service/conf/actions.d/actions_ipsec.conf
@@ -53,3 +53,9 @@ parameters:
 type:script
 message:IPsec config generation
 description:Reconfigure IPsec service
+
+[genkeys]
+command:/usr/local/opnsense/scripts/ipsec/genkeys.py
+parameters:%s %s
+type:script_output
+description:Generates public keys


### PR DESCRIPTION
This PR adds elliptic curve support for public key authentication, namely ECDSA, Ed25519 and Ed448.

* Also PR #5449 is part of this, as the functionality depends on this (if this PR gets accepted, other PR can be closed).
* Additional column in key overview: private key (yes/no)
* Renamed menu entry "RSA Key Pairs" to "Key Pairs"

Unfortunately the PHP wrapper for OpenSSL does not support Ed25519 and Ed448 (only ECDSA). Therefore the sanity check of the pasted key needs to be done quite awkwardly by directly calling the openssl binary and parsing the output using preg_match:
https://github.com/8191/opnsense-core/blob/d580772baddcda67d0a7a8bc4658341332bbcea2/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.php#L255-L290
Hopefully this could be removed in near future as soon as PHP supports those curves.

The implementation itself was partially tested between two OPNsense installations, meaning it was checked that the authentication succeeds (` 15[IKE] <con4|1> authentication of '10.4.1.1' (myself) with ED25519 successful`). A full end-to-end test was not yet done due to [an open issue with my IPsec setup](https://forum.opnsense.org/index.php?topic=26231.0).

Potential improvements:
* Detect pasted key type instead of requesting the user to select it (the model validator determines the key type anyway to perform sanity checks)
* Move key generation from view to controller (as suggested by @AdSchellevis in #5499)

![image](https://user-images.githubusercontent.com/5854959/148090075-11ea8985-3a2d-4dc8-b8b1-2f3ab25ee30d.png)
