### PR TITLE
IPsec: Remove deprecated P2 algorithms

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -119,10 +119,6 @@ function ipsec_p2_ealgos()
         'aes128gcm16' => array( 'name' => 'aes128gcm16'),
         'aes192gcm16' => array( 'name' => 'aes192gcm16'),
         'aes256gcm16' => array( 'name' => 'aes256gcm16'),
-        'blowfish' => array( 'name' => 'Blowfish', 'keysel' => array( 'lo' => 128, 'hi' => 256, 'step' => 64 ) ),
-        '3des' => array( 'name' => '3DES' ),
-        'cast128' => array( 'name' => 'CAST128' ),
-        'des' => array( 'name' => 'DES' ),
         'null' => array( 'name' => gettext("NULL (no encryption)"))
     );
 }
@@ -130,7 +126,6 @@ function ipsec_p2_ealgos()
 function ipsec_p2_halgos()
 {
     return array(
-        'hmac_md5' => 'MD5',
         'hmac_sha1' => 'SHA1',
         'hmac_sha256' => 'SHA256',
         'hmac_sha384' => 'SHA384',

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/TunnelController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/TunnelController.php
@@ -175,14 +175,9 @@ class TunnelController extends ApiControllerBase
             'aes128gcm16' => 'aes128gcm16',
             'aes192gcm16' => 'aes192gcm16',
             'aes256gcm16' => 'aes256gcm16',
-            'blowfish' => 'Blowfish',
-            '3des' => '3DES',
-            'cast128' => 'CAST128',
-            'des' => 'DES',
             'null' => gettext("NULL (no encryption)")
         ];
         $ph2halgos = [
-            'hmac_md5' => 'MD5',
             'hmac_sha1' => 'SHA1',
             'hmac_sha256' => 'SHA256',
             'hmac_sha384' => 'SHA384',
@@ -255,21 +250,31 @@ class TunnelController extends ApiControllerBase
                     if (!empty($ph2proposal)) {
                         $ph2proposal .= " , ";
                     }
-                    $ph2proposal .= $ph2algos[(string)$node->name];
-                    if ((string)$node->keylen == 'auto') {
-                        $ph2proposal .= " (auto) ";
-                    } elseif (!empty((string)$node->keylen)) {
-                        $ph2proposal .= sprintf(" ({$node->keylen} %s) ", gettext("bits"));
+
+                    if (isset($ph2algos[(string)$node->name])) {
+                        $ph2proposal .= $ph2algos[(string)$node->name];
+
+                        if ((string)$node->keylen == 'auto') {
+                            $ph2proposal .= " (auto) ";
+                        } elseif (!empty((string)$node->keylen)) {
+                            $ph2proposal .= sprintf(" ({$node->keylen} %s) ", gettext("bits"));
+                        }
+                    } else {
+                        $ph2proposal .= gettext("unsupported");
                     }
                 }
                 $ph2proposal .= " + ";
                 $idx = 0;
                 foreach ($p2->{"hash-algorithm-option"} as $node) {
                     $ph2proposal .= ($idx++) > 0 ? " , " : "";
-                    $ph2proposal .= $ph2halgos[(string)$node];
+                    if (isset($ph2halgos[(string)$node])) {
+                        $ph2proposal .= $ph2halgos[(string)$node];
+                    } else {
+                        $ph2proposal .= gettext("unsupported");
+                    }
                 }
                 if (!empty((string)$p2->pfsgroup)) {
-                    $ph2proposal .= sprintf("+ %s %s", gettext("DH Group"), "{$p2->pfsgroup}");
+                    $ph2proposal .= sprintf(" + %s %s", gettext("DH Group"), "{$p2->pfsgroup}");
                 }
                 $item = [
                     "id" => $p2idx,

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/tunnels.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/tunnels.volt
@@ -127,6 +127,9 @@
               } else {
                   return '<span style="cursor: pointer;" class="fa fa-fw fa-square-o command-toggle bootgrid-tooltip" data-value="0" data-row-id="' + row.id + '"></span>';
               }
+          },
+          "proposal": function (column, row) {
+            return row.proposal.replace(/unsupported/g, "<em>unsupported</em>");
           }
       };
       const $grid_phase1 = $('#grid-phase1').UIBootgrid({
@@ -256,7 +259,7 @@
               <th data-column-id="type" data-width="8em" data-type="string" data-formatter="mode_type">{{ lang._('Type') }}</th>
               <th data-column-id="local_subnet" data-width="18em" data-type="string">{{ lang._('Local Subnet') }}</th>
               <th data-column-id="remote_subnet" data-width="18em" data-type="string">{{ lang._('Remote Subnet') }}</th>
-              <th data-column-id="proposal" data-width="20em" data-type="string">{{ lang._('Phase 2 Proposal') }}</th>
+              <th data-column-id="proposal" data-width="20em" data-type="string" data-formatter="proposal">{{ lang._('Phase 2 Proposal') }}</th>
               <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
               <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
           </tr>

--- a/src/www/vpn_ipsec_phase2.php
+++ b/src/www/vpn_ipsec_phase2.php
@@ -702,7 +702,7 @@ endif; ?>
                   </td>
                 </tr>
                 <tr id="opt_enc">
-                  <td><a id="help_for_encalg" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Encryption algorithms"); ?></td>
+                  <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Encryption algorithms"); ?></td>
                   <td>
 <?php
                   foreach (ipsec_p2_ealgos() as $algo => $algodata) :?>
@@ -728,10 +728,6 @@ endif; ?>
 
 <?php
                       endforeach; ?>
-
-                      <div class="hidden" data-for="help_for_encalg">
-                          <?=gettext("Note: For security reasons avoid the use of DES,3DES,CAST and BLOWFISH protocols"); ?>.
-                      </div>
                   </td>
                 </tr>
                 <tr>
@@ -745,7 +741,7 @@ endif; ?>
 <?php endforeach ?>
                     </select>
                     <div class="hidden" data-for="help_for_hashalg">
-                        <?=gettext("Note: For security reasons avoid the use of MD5 and SHA1 algorithms."); ?>
+                        <?=gettext("Note: For security reasons avoid the use of the SHA1 algorithm."); ?>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
Fixes #5450
As of freebsd/freebsd-src@16aabb761c0a8e5fb120594fcce4f2bf79fad61e Blowfish, 3DES, CAST128, DES and MD5 are not supported by FreeBSD 13.

This PR removes those algorithms from the P2 GUI page, but handles them correctly in the tunnels overview page (show "unsupported" instead of algorithm name).