### PR TITLE
Logs: handle Firewall Plain View

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -143,6 +143,10 @@
       // move filter into action header
       $("#severity_filter_container").detach().prependTo('#grid-log-header > .row > .actionBar > .actions');
 
+      // handle Firewall Log Plain View (lock with Informational severity)
+      if ("{{module}}_{{scope}}" == "core_filter") {
+          $("#severity_filter").val("Informational").prop("disabled", true).change();
+      }
 
       function switch_mode(value) {
           let select = $("#severity_filter");


### PR DESCRIPTION
Hi!
can fix regression in https://github.com/opnsense/core/pull/5370 for Firewall Plain View Log (empty with default parameters as it is written with Informational severity)
ref. https://forum.opnsense.org/index.php?topic=26325.0

sorry for the inattention
thanks!