### PR TITLE
IDS: 1.0.7 - migrate with policies update

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_0_7.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_0_7.php
@@ -45,19 +45,29 @@ class M1_0_7 extends BaseModelMigration
         if (!isset($cfgObj->OPNsense->IDS->files->file)) {
             return;
         }
-        $csets = array();
-        $nsets = array();
+        $csets = array(); // changed rulesets presented in model
+        $nsets = array(); // new rulesets nodes
+        $uuids = array(); // all enabled sets uuids
+        $c_uuids = array(); // changed sets uuids
+        $n_uuids = array(); // new sets uuids
+        $s_array = array(); // search uuids array for policies update
+        $r_array = array(); // replacement uuids array for policies update
         $changed_sets = ['emerging-current_events.rules', 'emerging-trojan.rules',
                          'emerging-malware.rules',  'emerging-info.rules', 'emerging-policy.rules'];
         $new_sets = ['emerging-ja3.rules', 'emerging-hunting.rules', 'emerging-adware_pup.rules',
                      'emerging-phishing.rules', 'emerging-exploit_kit.rules', 'emerging-coinminer.rules',
                      'emerging-malware.rules'];
         foreach ($model->files->file->iterateItems() as $file) {
+            if ($file->enabled == "1") {
+                $uuids[] = (string)$file->getAttribute('uuid');
+            }
             if (in_array((string)$file->filename, $changed_sets)) {
                 $csets[(string)$file->filename] = $file;
+                $c_uuids[(string)$file->filename] = (string)$file->getAttribute('uuid');
             }
             if (in_array((string)$file->filename, $new_sets)) {
                 $nsets[(string)$file->filename] = $file;
+                $n_uuids[(string)$file->filename] = (string)$file->getAttribute('uuid');
             }
         }
         // add all new to config in deselected state
@@ -66,32 +76,49 @@ class M1_0_7 extends BaseModelMigration
                 $node = $model->files->file->Add();
                 $node->filename = $filename;
                 $nsets[$filename] = $node;
+                $n_uuids[$filename] = (string)$file->getAttribute('uuid');
             }
         }
         // map rulesets
         if (!empty($csets['emerging-malware.rules']) && $csets['emerging-malware.rules']->enabled == "1") {
             $nsets['emerging-adware_pup.rules']->enabled = "1";
-            $nsets['emerging-adware_pup.rules']->filter = (string)$csets['emerging-malware.rules']->filter;
+            $s_array[] = $c_uuids['emerging-malware.rules'];
+            $r_array[] = $n_uuids['emerging-adware_pup.rules'];
         }
         if (!empty($csets['emerging-current_events.rules']) && $csets['emerging-current_events.rules']->enabled == "1") {
             $nsets['emerging-phishing.rules']->enabled = "1";
-            $nsets['emerging-phishing.rules']->filter = (string)$csets['emerging-current_events.rules']->filter;
             $nsets['emerging-exploit_kit.rules']->enabled = "1";
-            $nsets['emerging-exploit_kit.rules']->filter = (string)$csets['emerging-current_events.rules']->filter;
+            $s_array[] = $c_uuids['emerging-current_events.rules'];
+            $r_array[] = $n_uuids['emerging-phishing.rules'] . "," . $n_uuids['emerging-exploit_kit.rules'];
         }
         if (!empty($csets['emerging-trojan.rules']) && $csets['emerging-trojan.rules']->enabled == "1") {
             $nsets['emerging-coinminer.rules']->enabled = "1";
-            $nsets['emerging-coinminer.rules']->filter = (string)$csets['emerging-trojan.rules']->filter;
             $nsets['emerging-malware.rules']->enabled = "1";
-            $nsets['emerging-malware.rules']->filter = (string)$csets['emerging-malware.rules']->filter;
+            $s_array[] = $c_uuids['emerging-trojan.rules'];
+            $r_array[] = $n_uuids['emerging-coinminer.rules'] . "," . $n_uuids['emerging-malware.rules'];
         }
         if (!empty($csets['emerging-info.rules']) && $csets['emerging-info.rules']->enabled == "1") {
             $nsets['emerging-hunting.rules']->enabled = "1";
-            $nsets['emerging-hunting.rules']->filter = (string)$csets['emerging-info.rules']->filter;
+            $s_array[] = $c_uuids['emerging-info.rules'];
+            $r_array[] = $n_uuids['emerging-hunting.rules'];
         }
         if (!empty($csets['emerging-policy.rules']) && $csets['emerging-policy.rules']->enabled == "1") {
             $nsets['emerging-hunting.rules']->enabled = "1";
-            $nsets['emerging-hunting.rules']->filter = (string)$csets['emerging-policy.rules']->filter;
+            $s_array[] = $c_uuids['emerging-policy.rules'];
+            $r_array[] = $n_uuids['emerging-hunting.rules'];
+        }
+        foreach ($model->policies->policy->iterateItems() as $policy) {
+            if ((string)($policy->rulesets) != "") {
+                var_dump((string)$policy->rulesets);
+                // replace changed sets with new one and remove obsolete links (ruleset no exists or not enabled)
+                $sets = array_unique(explode(',', str_replace($s_array, $r_array, $policy->rulesets)));
+                foreach ($sets as $i => $uuid) {
+                    if (!in_array($uuid, $uuids)) {
+                        unset($sets[$i]);
+                    }
+                }
+                $policy->rulesets = implode(',', $sets);
+            }
         }
         if (!empty($csets['emerging-trojan.rules'])) {
             // deprecated ruleset


### PR DESCRIPTION
Hi!
For IDS 1.0.7 migration possible fix with policies update discussion:
-`filter` field references removed (since field is gone in 1.0.6)
-replace old uuids with new one(s) in policies `rulesets` field
-remove possible duplicates and obsolete references in policies (since the model requires the field `enabled` to be equal to "1")

@AdSchellevis Hi! can we discuss this when you have time?
did i get the idea right?
and question: Please explain why the model has a requirement that the ruleset (to which the policy refers) is enabled? If I understand correctly, in this case the following situation is possible:
-Administrator includes the ruleset in the policy.
-For some reason decides to (perhaps temporarily) disable the ruleset.
-If there is a update\migration or just a policy change, since the policy is touched the model checks the value of the `enabled` field and does not allow references to a disabled (but existing) ruleset.
-The policy silently loses ruleset reference (during migration) or the administrator is need to look for the cause of complaints while saving the policy?

and the second one: may be we need to do something with the enabled `$csets` rulesets? may be its worth to disable them?

Thanks!
