### PR TITLE
Fix CARP PPP hook.

### DIFF
--- a/src/etc/rc.syshook.d/carp/20-ppp
+++ b/src/etc/rc.syshook.d/carp/20-ppp
@@ -54,7 +54,7 @@ if (!empty($a_hasync['disconnectppps'])) {
                     if ($type == 'BACKUP') {
                         interface_bring_down($ifkey);
                     } else {
-                        interface_ppps_configure(false, $ifkey);
+                        interface_ppps_configure($ifkey);
                     }
                 }
             }


### PR DESCRIPTION
The `interface_ppps_configure` only takes one argument.