### PR TITLE
Firewall / Rules - allow per-rule adaptive timeouts

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -232,6 +232,9 @@ class FilterRule extends Rule
                             $rule['state']['options'][] = $state_tag . " " . $rule[$state_tag];
                         }
                     }
+                    if (is_numeric($rule['adaptivestart']) && is_numeric($rule['adaptiveend'])) {
+                        $rule['state']['options'][] = "adaptive.start " . $rule['adaptivestart'] . ", adaptive.end " . $rule['adaptiveend'];
+                    }
                     if (!empty($rule['statetimeout'])) {
                         $rule['state']['options'][] = "tcp.established " . $rule['statetimeout'];
                     }


### PR DESCRIPTION
Hi!
may close https://github.com/opnsense/core/issues/5487 i hope.
No existing code touched except `FormSetAdvancedOptions` to allow '0' as a value of Advanced fields.
Thanks!
