### PR TITLE
util/log_error: keep it clear. add a log_msg

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -130,7 +130,7 @@ function session_auth()
     function auth_log($message, $prio = LOG_ERR)
     {
         openlog("audit", LOG_ODELAY, LOG_AUTH);
-        log_error($message, $prio);
+        log_msg($message, $prio);
         closelog();
     }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -928,12 +928,31 @@ function get_interface_list($only_active = false, $include_dmesg = false)
 * NAME
 *   log_error  - Sends a string to syslog.
 * INPUTS
-*   $msg     - string containing the syslog message.
-*   $prio    - syslog severity level
+*   $error     - string containing the syslog message.
 * RESULT
 *   null
 ******/
-function log_error($msg, $prio = LOG_ERR)
+function log_error($error)
+{
+    $page = $_SERVER['SCRIPT_NAME'];
+    if (empty($page)) {
+        $files = get_included_files();
+        $page = basename($files[0]);
+    }
+
+    syslog(LOG_ERR, "$page: $error");
+}
+
+/****f* util/log_msg
+* NAME
+*   log_msg  - Sends a string to syslog with the required severity level.
+* INPUTS
+*   $msg     - string containing the syslog message.
+*   $prio    - syslog severity level.
+* RESULT
+*   null
+******/
+function log_msg($msg, $prio = LOG_ERR)
 {
     $page = $_SERVER['SCRIPT_NAME'];
     if (empty($page)) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -926,7 +926,7 @@ function get_interface_list($only_active = false, $include_dmesg = false)
 
 /****f* util/log_error
 * NAME
-*   log_error  - Sends a string to syslog.
+*   log_error  - Sends a string to syslog with LOG_ERR severity.
 * INPUTS
 *   $error     - string containing the syslog message.
 * RESULT
@@ -934,13 +934,7 @@ function get_interface_list($only_active = false, $include_dmesg = false)
 ******/
 function log_error($error)
 {
-    $page = $_SERVER['SCRIPT_NAME'];
-    if (empty($page)) {
-        $files = get_included_files();
-        $page = basename($files[0]);
-    }
-
-    syslog(LOG_ERR, "$page: $error");
+    log_msg($error, LOG_ERR);
 }
 
 /****f* util/log_msg


### PR DESCRIPTION
Hi!
in https://github.com/opnsense/core/pull/5497 continuation
don't obfuscate `log_error`, add `log_msg()`
will try to traverse `log_error` calls and move to `log_msg`  where appropriate in next pr
thanks!