### PR TITLE
Firewall: Aliases - encode rule name in response

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -153,7 +153,7 @@ class AliasController extends ApiMutableModelControllerBase
             if (!empty($uses)) {
                 $message = "";
                 foreach ($uses as $key => $value) {
-                    $message .= sprintf("\n[%s] %s", $key, $value);
+                    $message .= htmlspecialchars(sprintf("\n[%s] %s", $key, $value), ENT_NOQUOTES | ENT_HTML401);
                 }
                 $message = sprintf(gettext("Cannot delete alias. Currently in use by %s"), $message);
                 throw new \OPNsense\Base\UserException($message, gettext("Alias in use"));


### PR DESCRIPTION
Hi!
Accidentally stumbled while playing with the pf table counters issue.
Since html special chars are allowed in the rules descriptons returning plain `sprintf` may lead to possible XSS vul. imho.
example:
Choose any pf rule using aliases, change rule descripton to `<img src=& onerror=alert("XSS")>`, try to delete Alias associated with this rule

thanks!