### PR TITLE
Firewall: Categories - do not select filtered-out rules

### DIFF
--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -263,7 +263,7 @@ $( document ).ready(function() {
 
   // select All
   $("#selectAll").click(function(){
-      $(".rule_select").prop("checked", $(this).prop("checked"));
+      $(".rule_select:not(:disabled)").prop("checked", $(this).prop("checked"));
   });
 
   // move category block

--- a/src/www/firewall_nat_1to1.php
+++ b/src/www/firewall_nat_1to1.php
@@ -211,7 +211,7 @@ include("head.inc");
     });
     // select All
     $("#selectAll").click(function(){
-        $(".rule_select").prop("checked", $(this).prop("checked"));
+        $(".rule_select:not(:disabled)").prop("checked", $(this).prop("checked"));
     });
 
     // watch scroll position and set to last known on page load

--- a/src/www/firewall_nat_npt.php
+++ b/src/www/firewall_nat_npt.php
@@ -161,7 +161,7 @@ include("head.inc");
 
     // select All
     $("#selectAll").click(function(){
-        $(".rule_select").prop("checked", $(this).prop("checked"));
+        $(".rule_select:not(:disabled)").prop("checked", $(this).prop("checked"));
     });
 
     // move category block

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -228,7 +228,7 @@ include("head.inc");
 
     // select All
     $("#selectAll").click(function(){
-        $(".rule_select").prop("checked", $(this).prop("checked"));
+        $(".rule_select:not(:disabled)").prop("checked", $(this).prop("checked"));
     });
 
     // watch scroll position and set to last known on page load

--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -492,7 +492,7 @@ $( document ).ready(function() {
 
   // select All
   $("#selectAll").click(function(){
-      $(".rule_select").prop("checked", $(this).prop("checked"));
+      $(".rule_select:not(:disabled)").prop("checked", $(this).prop("checked"));
   });
 
   // move category block


### PR DESCRIPTION
Hi!
`hook_firewall_categories()` function tries to prevent accidental rules mass actions by disabling `".rule_select"` checkboxes for filtered-out rules. But `prop()` not taking this in to account.

Thanks!