### PR TITLE
Fix implode() call

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -2009,7 +2009,7 @@ function dhcpd_leases($inet = 4)
             if (strpos($line, $token) === 0) {
                 $section = [];
             } elseif (strpos($line, '}') === 0 && count($section) > 0) {
-                $content[] = implode($section, '');
+                $content[] = implode('', $section);
             }
             $section[] = rtrim($line, "\n;");
         }


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.implode.php and PHP warning since 7.4.0:
Exception: Error at /usr/local/etc/inc/plugins.inc.d/dhcpd.inc:2012 - implode(): Passing glue string after array is deprecated. Swap the parameters (errno=8192) in /usr/local/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php:96