### PR TITLE
unbound: Add support for native IPv6 prefix tracking in host overrides

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -552,13 +552,21 @@ function unbound_add_host_entries($ifconfig_details = null)
                     switch ($host->rr) {
                         case 'A':
                         case 'AAAA':
+                            if (!empty((string) $host->interface) && strpos($host->server, "::") === 0) {
+                                list ($address) = interfaces_primary_address6((string) $host->interface, $ifconfig_details);
+                                $server = make_ipv6_64_address($address, $host->server);
+                                $server = Net_IPv6::compress(Net_IPv6::uncompress($server));
+                            } else {
+                                $server = $host->server;
+                            }
+
                             /* Handle wildcard entries which have "*" as a hostname. Since we added a . above, we match on "*.". */
                             if ($alias['hostname'] == '*.') {
                                 $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
-                                $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
+                                $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$server}\"\n";
                             } else {
-                                $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
-                                $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
+                                $unbound_entries .= "local-data-ptr: \"{$server} {$alias['hostname']}{$alias['domain']}\"\n";
+                                $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$server}\"\n";
                             }
                             break;
                         case 'MX':

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
@@ -72,7 +72,7 @@ class SettingsController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             'hosts.host',
-            ['enabled', 'hostname', 'domain', 'rr', 'mxprio', 'mx', 'server', 'description'],
+            ['enabled', 'hostname', 'domain', 'rr', 'mxprio', 'mx', 'interface', 'server', 'description'],
             "sequence"
         );
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogHostOverride.xml
@@ -36,10 +36,16 @@
         <help>Host name of MX host, e.g. mail.example.com</help>
     </field>
     <field>
+        <id>host.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>Interface to take the prefix for a dynamic IP address from, e.g. LAN</help>
+    </field>
+    <field>
         <id>host.server</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address of the host, e.g. 192.168.100.100 or fd00:abcd::1</help>
+        <help>IP address of the host, e.g. 192.168.100.100, fd00:abcd::1 or ::abcd:1</help>
     </field>
     <field>
         <id>host.description</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -131,6 +131,9 @@
                         </check001>
                     </Constraints>
                 </mx>
+                <interface type="InterfaceField">
+                    <Required>N</Required>
+                </interface>
                 <server type="NetworkField">
                     <Constraints>
                         <check001>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
@@ -47,9 +47,12 @@ $( document ).ready(function() {
                     rowSelect: true,
                     formatters: {
                         "mxformatter": function (column, row) {
-                            /* Format the "Value" column so it shows either an MX host ("MX" type) or a raw IP address ("A" type) */
+                            /* Format the "Value" column so it shows either an MX host ("MX" type), IPv6 suffix or a raw IP address ("A" & "AAAA" type) */
                             if (row.mx.length > 0) {
                                 row.server = row.mx + ' (prio ' + row.mxprio + ')';
+                            }
+                            if (row.interface != "none") {
+                                row.server += ' (' + row.interface + ' interface)';
                             }
                             return row.server;
                         },
@@ -80,12 +83,19 @@ $( document ).ready(function() {
 
                 /* Hide/unhide input fields based on selected RR (Type) value */
                 $('select[id="host.rr"]').on('change', function(e) {
-                    if (this.value == "A" || this.value == "AAAA") {
+                    if (this.value == "A") {
                         $('tr[id="row_host.mx"]').addClass('hidden');
                         $('tr[id="row_host.mxprio"]').addClass('hidden');
                         $('tr[id="row_host.server"]').removeClass('hidden');
+                        $('tr[id="row_host.interface"]').addClass('hidden');
+                    } else if (this.value == "AAAA") {
+                        $('tr[id="row_host.mx"]').addClass('hidden');
+                        $('tr[id="row_host.mxprio"]').addClass('hidden');
+                        $('tr[id="row_host.server"]').removeClass('hidden');
+                        $('tr[id="row_host.interface"]').removeClass('hidden');
                     } else if (this.value == "MX") {
                         $('tr[id="row_host.server"]').addClass('hidden');
+                        $('tr[id="row_host.interface"]').addClass('hidden');
                         $('tr[id="row_host.mx"]').removeClass('hidden');
                         $('tr[id="row_host.mxprio"]').removeClass('hidden');
                     }


### PR DESCRIPTION
This PR add support for native tracking of dynamic IPv6 prefixes in Unbound host overrides.
It allows one to be using SLAAC provide the clients with a network prefix, let them auto-configure on their own and only add the client's IID and the interface to track to Unbound.

It is similar to Unbounds DHCP Static Mapping, but without requiring DHCPv6. Personally, I don't run DHCPv6 in my network and hence cannot use the static mappings and would also like to avoid cross-dependencies between DHCPv6 and Unbound.

With this patch applied you can optionally add an interface to track to an AAAA record:
![Screenshot of Editing host override](https://user-images.githubusercontent.com/46975855/153769906-f3537076-72d1-4069-a04a-c90ba1781df2.png)

The table also shows the interface, `LAN` in this example, because it's configured as a Track Interface of WAN.
![Screenshot of host overrides](https://user-images.githubusercontent.com/46975855/153769902-5b9886fc-9068-43f8-b476-b21fae5ff2f4.png)

The host overrides as seen above result in the following `host_entries.conf` (see last two lines):
```
root@OPNsense:~ # cat /var/unbound/host_entries.conf
[... snip ...]
local-data-ptr: "2003:[redacted]:5076:9bff:fe04:e801 OPNsense.localdomain"
local-data: "OPNsense.localdomain AAAA 2003:[redacted]:5076:9bff:fe04:e801"
local-data: "OPNsense AAAA 2003:[redacted]:5076:9bff:fe04:e801"
local-data: "OPNsense.localdomain AAAA fe80::5076:9bff:fe04:e801"
local-data: "OPNsense AAAA fe80::5076:9bff:fe04:e801"
local-data-ptr: "1.1.1.1 some-a-host.domain"
local-data: "some-a-host.domain IN A 1.1.1.1"
local-data-ptr: "2606:4700:4700::1111 some-aaaa-host.domain"
local-data: "some-aaaa-host.domain IN AAAA 2606:4700:4700::1111"
local-data-ptr: "2003:[redacted]::1337 tracked-prefix-host.domain"
local-data: "tracked-prefix-host.domain IN AAAA 2003:[redacted]::1337"
```
