### PR TITLE
Logs: prevent possible racing

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -74,6 +74,7 @@
           search:'/api/diagnostics/log/{{module}}/{{scope}}'
       });
       $("#severity_filter").change(function(){
+          $('#severity_filter').attr('disabled',true);
           if (window.localStorage) {
               localStorage.setItem('log_severity_{{module}}_{{scope}}', $("#severity_filter").val());
           }
@@ -97,6 +98,10 @@
                   $("#severity_filter").val("Debug").change();
               }
           });
+          setTimeout(function() {
+              $('#severity_filter').attr('disabled',false);
+              $('#severity_filter_container').find('a[role="option"]').css('cursor', '');
+          }, 500);
       });
 
       $("#flushlog").on('click', function(event){
@@ -156,6 +161,12 @@
 
           let header_val = filter_exact ? m_header : s_header;
           select.selectpicker({ header: header_val });
+
+          select.on('shown.bs.select', function () {
+              $('#severity_filter_container').find('a[role="option"]').click(function() {
+                  $('#severity_filter_container').find('a[role="option"]').css('cursor', 'not-allowed');
+              });
+          });
 
           // attach event handler each time header created
           $("#exact_severity").on("click", function(event) {


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=26867.msg131115#msg131115
it seems that the user rapidly changing the severity filter may cause some race condition, especially if a large rowCounter value is selected.
pr disable severity filter change until the results of the previous query are received

and I have another question: since now the log sizes have increased, choosing the value "All" for row count can lead to receiving such an amount of data that the uibootgrid plugin is not able to pass. perhaps it makes sense to limit the choice to some reasonable value (5K?)?

thanks!