### PR TITLE
unbound: implement custom forwarders over current dot setup

### DIFF
--- a/plist
+++ b/plist
@@ -567,6 +567,7 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
 /usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_0.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_1.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
 /usr/local/opnsense/mvc/app/views/OPNsense/CaptivePortal/clients.volt

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
@@ -48,7 +48,7 @@ class SettingsController extends ApiMutableModelControllerBase
         if (substr($method, -6) == 'Action') {
             $fn = preg_replace('/Dot/', 'Forward', $method);
             if (method_exists(get_class($this), $fn)) {
-                if (substr($this->request->getHTTPReferer(), -7) == 'forward') {
+                if (preg_match("/forward/i", $this->request->getHTTPReferer())) {
                     $this->type = "forward";
                 }
                 return $this->$fn(...$args);

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
@@ -35,6 +35,7 @@ class DotController extends IndexController
     public function indexAction()
     {
         $this->view->selected_forward = "";
+        $this->view->forwardingForm = $this->getForm('forwarding');
         $this->view->formDialogEdit = $this->getForm('dialogDot');
         $this->view->pick('OPNsense/Unbound/dot');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
@@ -32,9 +32,9 @@ use OPNsense\Base\IndexController;
 
 class DotController extends IndexController
 {
-    public function indexAction($selected = null)
+    public function indexAction()
     {
-        $this->view->selected_forward = $selected;
+        $this->view->selected_forward = "";
         $this->view->formDialogEdit = $this->getForm('dialogDot');
         $this->view->pick('OPNsense/Unbound/dot');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
@@ -35,6 +35,7 @@ class ForwardController extends IndexController
     public function indexAction()
     {
         $this->view->selected_forward = "forward";
+        $this->view->forwardingForm = $this->getForm('forwarding');
         $this->view->formDialogEdit = $this->getForm('dialogDot');
         $this->view->pick('OPNsense/Unbound/dot');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (C) 2021 Michael Muenz <m.muenz@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Unbound;
+
+use OPNsense\Base\IndexController;
+
+class ForwardController extends IndexController
+{
+    public function indexAction()
+    {
+        $this->view->selected_forward = "forward";
+        $this->view->formDialogEdit = $this->getForm('dialogDot');
+        $this->view->pick('OPNsense/Unbound/dot');
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2021 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2022 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -6,6 +6,15 @@
         <help>Enable or disable this server.</help>
     </field>
     <field>
+        <id>dot.domain</id>
+        <label>Domain</label>
+        <type>text</type>
+        <help>
+            If a domain is entered here, queries for this specific domain will be forwarded to the specified server.
+            Leave blank to forward all queries to the specified server (default).
+        </help>
+    </field>
+    <field>
         <id>dot.server</id>
         <label>Server IP</label>
         <type>text</type>
@@ -21,6 +30,9 @@
         <id>dot.verify</id>
         <label>Verify CN</label>
         <type>text</type>
-        <help>Verify if CN in certificate matches this value.</help>
+        <help>
+            Verify if CN in certificate matches this value. Please note that if this field is omitted,
+            Unbound will not perform any certificate verification. Therefore, man-in-the-middle attacks are still possible.
+        </help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
@@ -1,0 +1,17 @@
+<form>
+    <field>
+        <id>forwarding.enabled</id>
+        <label>Use System Nameservers</label>
+        <type>checkbox</type>
+        <style>forwarding-enabled</style>
+        <help>
+            The configured system nameservers will be used to forward queries to.
+            This will override any entry in the grid below.
+        </help>
+    </field>
+    <field>
+        <id>forwarding.info</id>
+        <type>info</type>
+        <label></label>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
@@ -8,7 +8,7 @@
                 <All url="/services_unbound_acls.php*" visibility="hidden"/>
             </ACL>
             <Blocklist order="50" url="/ui/unbound/dnsbl/index"/>
-            <Forward VisibleName="Custom Forwarding" order="60" url="/ui/unbound/forward"/>
+            <Forward VisibleName="Query Forwarding" order="60" url="/ui/unbound/forward"/>
             <Dot VisibleName="DNS over TLS" order="70" url="/ui/unbound/dot"/>
             <Statistics order="90" url="/ui/unbound/stats"/>
             <LogFile VisibleName="Log File" order="100" url="/ui/diagnostics/log/core/resolver"/>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
@@ -8,7 +8,8 @@
                 <All url="/services_unbound_acls.php*" visibility="hidden"/>
             </ACL>
             <Blocklist order="50" url="/ui/unbound/dnsbl/index"/>
-            <Dot VisibleName="DNS over TLS" order="60" url="/ui/unbound/dot/index"/>
+            <Forward VisibleName="Query Forwarding" order="60" url="/ui/unbound/dot/index/forward"/>
+            <Dot VisibleName="DNS over TLS" order="70" url="/ui/unbound/dot/index"/>
             <Statistics order="90" url="/ui/unbound/stats"/>
             <LogFile VisibleName="Log File" order="100" url="/ui/diagnostics/log/core/resolver"/>
         </Unbound>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
@@ -8,8 +8,8 @@
                 <All url="/services_unbound_acls.php*" visibility="hidden"/>
             </ACL>
             <Blocklist order="50" url="/ui/unbound/dnsbl/index"/>
-            <Forward VisibleName="Query Forwarding" order="60" url="/ui/unbound/dot/index/forward"/>
-            <Dot VisibleName="DNS over TLS" order="70" url="/ui/unbound/dot/index"/>
+            <Forward VisibleName="Query Forwarding" order="60" url="/ui/unbound/forward"/>
+            <Dot VisibleName="DNS over TLS" order="70" url="/ui/unbound/dot"/>
             <Statistics order="90" url="/ui/unbound/stats"/>
             <LogFile VisibleName="Log File" order="100" url="/ui/diagnostics/log/core/resolver"/>
         </Unbound>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
@@ -8,7 +8,7 @@
                 <All url="/services_unbound_acls.php*" visibility="hidden"/>
             </ACL>
             <Blocklist order="50" url="/ui/unbound/dnsbl/index"/>
-            <Forward VisibleName="Query Forwarding" order="60" url="/ui/unbound/forward"/>
+            <Forward VisibleName="Custom Forwarding" order="60" url="/ui/unbound/forward"/>
             <Dot VisibleName="DNS over TLS" order="70" url="/ui/unbound/dot"/>
             <Statistics order="90" url="/ui/unbound/stats"/>
             <LogFile VisibleName="Log File" order="100" url="/ui/diagnostics/log/core/resolver"/>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2021 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2022 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,16 +26,31 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OPNsense\Unbound;
+namespace OPNsense\Unbound\Migrations;
 
-use OPNsense\Base\IndexController;
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Base\FieldTypes\BooleanField;
+use OPNsense\Base\FieldTypes\NetworkField;
+use OPNsense\Base\FieldTypes\PortField;
+use OPNsense\Core\Config;
 
-class DotController extends IndexController
+class M1_0_2 extends BaseModelMigration
 {
-    public function indexAction($selected = null)
+    /**
+     * Migrate older models into shared model
+     * @param $model
+     */
+    public function run($model)
     {
-        $this->view->selected_forward = $selected;
-        $this->view->formDialogEdit = $this->getForm('dialogDot');
-        $this->view->pick('OPNsense/Unbound/dot');
+        $config = Config::getInstance()->object();
+
+        $node = $config->OPNsense->unboundplus;
+
+        if (!empty($node->dots) && !empty($node->dots->dot)) {
+            foreach ($model->dots->dot->iterateItems() as $dot) {
+                $dot->type = "dot";
+                $dot->domain = "";
+            }
+        }
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
@@ -49,7 +49,6 @@ class M1_0_2 extends BaseModelMigration
         if (!empty($node->dots) && !empty($node->dots->dot)) {
             foreach ($model->dots->dot->iterateItems() as $dot) {
                 $dot->type = "dot";
-                $dot->domain = "";
             }
         }
     }

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/unboundplus</mount>
     <description>Unbound configuration</description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <items>
         <service_enabled type="LegacyLinkField">
             <Source>unbound.enable</Source>
@@ -62,6 +62,19 @@
                     <Required>Y</Required>
                     <default>1</default>
                 </enabled>
+                <type type="OptionField">
+                    <Required>Y</Required>
+                    <default>dot</default>
+                    <OptionValues>
+                        <dot>DNS over TLS</dot>
+                        <forward>Forward</forward>
+                    </OptionValues>
+                </type>
+                <domain type="TextField">
+                    <Required>N</Required>
+                    <mask>/^(?:(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$/i</mask>
+                    <ValidationMessage>A valid domain must be specified.</ValidationMessage>
+                </domain>
                 <server type="NetworkField">
                     <Required>Y</Required>
                 </server>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -56,6 +56,11 @@
                 <Required>N</Required>
             </whitelists>
         </dnsbl>
+        <forwarding>
+            <enabled type="LegacyLinkField">
+                <Source>unbound.forwarding</Source>
+            </enabled>
+        </forwarding>
         <dots>
             <dot type="ArrayField">
                 <enabled type="BooleanField">

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -134,8 +134,9 @@
         </table>
     </div>
     <div id="infosection" class="tab-content col-xs-12 __mb">
-        {{ lang._('Please note that entries without a specific domain (and thus all domains) specified in both Query Forwarding and DNS over TLS
-        are considered duplicates. One of these zones will be ignored.') }}
+        {{ lang._('Please note that entries without a specific domain (and thus all domains) specified in both Custom Forwarding and DNS over TLS
+        are considered duplicates, DNS over TLS will be preferred. Also, Enabling DNS Query Forwarding in General will override all entries 
+        specified here except for entries with a domain.') }}
     </div>
     <div class="col-md-12">
         <hr/>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -66,7 +66,7 @@
          *************************************************************************************************************/
 
         $("#grid-dot").UIBootgrid(
-                {   'search':'/api/unbound/settings/searchDot',
+                {   'search':'/api/unbound/settings/searchDot/',
                     'get':'/api/unbound/settings/getDot/',
                     'set':'/api/unbound/settings/setDot/',
                     'add':'/api/unbound/settings/addDot/',
@@ -74,6 +74,13 @@
                     'toggle':'/api/unbound/settings/toggleDot/'
                 }
         );
+
+        /* Hide/unhide verify field based on type */
+        if ("{{selected_forward}}" == "forward") {
+            $('tr[id="row_dot.verify"]').addClass('hidden');
+        } else {
+            $('tr[id="row_dot.verify"]').removeClass('hidden');
+        }
 
         {% if (selected_uuid|default("") != "") %}
             openDialog('{{selected_uuid}}');
@@ -103,9 +110,12 @@
             <thead>
             <tr>
                 <th data-column-id="enabled" data-width="6em" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                <th data-column-id="domain" data-type="string">{{ lang._('Domain') }}</th>
                 <th data-column-id="server" data-type="string">{{ lang._('Address') }}</th>
                 <th data-column-id="port" data-type="int">{{ lang._('Port') }}</th>
+                {% if (selected_forward|default("") == "") %}
                 <th data-column-id="verify" data-type="int">{{ lang._('Hostname') }}</th>
+                {% endif %}
                 <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Edit') }} | {{ lang._('Delete') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
             </tr>
@@ -122,6 +132,10 @@
             </tr>
             </tfoot>
         </table>
+    </div>
+    <div id="infosection" class="tab-content col-xs-12 __mb">
+        {{ lang._('Please note that entries without a specific domain (and thus all domains) specified in both Query Forwarding and DNS over TLS
+        are considered duplicates. One of these zones will be ignored.') }}
     </div>
     <div class="col-md-12">
         <hr/>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -192,8 +192,7 @@
     <div id="infosection" class="tab-content col-xs-12 __mb">
         {{ lang._('Please note that entries without a specific domain (and thus all domains) specified in both Custom Forwarding and DNS over TLS
         are considered duplicates, DNS over TLS will be preferred. If "Use System Nameservers" is checked, Unbound will use the DNS servers entered
-        in %s or those obtained via DHCP or PPP on WAN if the "Allow DNS server list to be overridden by DHCP/PPP on WAN" is checked.')
-        | format('<a href="/system_general.php">System: General setup</a>') }}
+        in System->Settings->General or those obtained via DHCP or PPP on WAN if the "Allow DNS server list to be overridden by DHCP/PPP on WAN" is checked.') }}
     </div>
     <div class="col-md-12">
         <hr/>

--- a/src/opnsense/scripts/system/nameservers.php
+++ b/src/opnsense/scripts/system/nameservers.php
@@ -1,0 +1,26 @@
+#!/usr/local/bin/php
+<?php
+
+require_once 'config.inc';
+require_once 'system.inc';
+require_once 'util.inc';
+
+use OPNsense\Core\Config;
+
+$config = Config::getInstance()->object();
+
+$result = array();
+
+/* get dynamic nameservers */
+foreach (get_nameservers() as $nameserver) {
+    $result["dynamic"][] = $nameserver;
+}
+
+/* get manually entered nameservers */
+foreach ($config->system->children() as $key => $node) {
+    if ($key == "dnsserver") {
+        $result["static"][] = (string)$node;
+    }
+}
+
+echo json_encode($result) . PHP_EOL;

--- a/src/opnsense/scripts/system/nameservers.php
+++ b/src/opnsense/scripts/system/nameservers.php
@@ -1,6 +1,32 @@
 #!/usr/local/bin/php
 <?php
 
+/*
+ * Copyright (C) 2022 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 require_once 'config.inc';
 require_once 'system.inc';
 require_once 'util.inc';

--- a/src/opnsense/service/conf/actions.d/actions_system.conf
+++ b/src/opnsense/service/conf/actions.d/actions_system.conf
@@ -79,3 +79,9 @@ parameters:
 type:script
 message: ha_reconfigure_backup
 description: HA update and reconfigure backup
+
+[list.nameservers]
+command:/usr/local/opnsense/scripts/system/nameservers.php
+parameters:
+type:script_output
+message:list nameservers

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
@@ -1,26 +1,51 @@
 {% if not helpers.empty('OPNsense.unboundplus.dots.dot') %}
-{%   set dots = [] %}
+{%   set all_dots = [] %}
+{%   set all_forwards = [] %}
 {%   set local = [] %}
-{%   for dot in helpers.toList('OPNsense.unboundplus.dots.dot') %}
-{%     if dot.enabled == '1' %}
-{%       if dot.server.startswith('127.') or dot.server == '::1' %}
-{%         do local.append('1') %}
+{%   set all = helpers.toList('OPNsense.unboundplus.dots.dot') %}
+{%   for type, dots in all|groupby("type") %}
+{%     for dot in dots %}
+{%       if dot.enabled == '1' %}
+{%         if dot.server.startswith('127.') or dot.server == '::1' %}
+{%           do local.append('1') %}
+{%         endif %}
+{%         if type == 'dot' %}
+{%           do all_dots.append(dot) %}
+{%         else %}
+{%           do all_forwards.append(dot) %}
+{%         endif %}
 {%       endif %}
-{%       do dots.append(dot) %}
-{%     endif %}
+{%     endfor %}
 {%   endfor %}
-{%   if dots|length > 0 %}
+{%   if local|length > 0 %}
+# Forward zones
+server:
+  do-not-query-localhost: no
+{%   endif %}
+{%   if all_forwards|length > 0 %}
+{%     for domain, forwards in all_forwards|groupby("domain", default=".") %}
+forward-zone:
+  name: "{{ domain }}"
+{%       for forward in forwards %}
+  forward-addr: {{ forward.server }}{% if forward.port %}@{{ forward.port }}{% endif %}
+
+{%       endfor %}
+{%     endfor %}
+{%   endif %}
+
+{%   if all_dots|length > 0 %}
+# Forward zones over TLS
 server:
   tls-cert-bundle: /etc/ssl/cert.pem
-{%     if local|length > 0 %}
-  do-not-query-localhost: no
-{%     endif %}
+{%     for domain, dots in all_dots|groupby("domain", default=".") %}
+
 forward-zone:
-  name: "."
-  forward-tls-upstream: yes
-{%     for dot in dots %}
+  name: "{{ domain }}"
+{%       for dot in dots %}
   forward-addr: {{ dot.server }}{% if dot.port %}@{{ dot.port }}{% endif %}{% if dot.verify %}#{{ dot.verify }}{% endif %}
 
+{%       endfor %}
 {%     endfor %}
 {%   endif %}
 {% endif %}
+

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
@@ -18,11 +18,12 @@
 {%     endfor %}
 {%   endfor %}
 {%   if local|length > 0 %}
-# Forward zones
 server:
   do-not-query-localhost: no
 {%   endif %}
+
 {%   if all_forwards|length > 0 %}
+# Forward zones
 {%     for domain, forwards in all_forwards|groupby("domain", default=".") %}
 forward-zone:
   name: "{{ domain }}"

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
@@ -42,6 +42,7 @@ server:
 
 forward-zone:
   name: "{{ domain }}"
+  forward-tls-upstream: yes
 {%       for dot in dots %}
   forward-addr: {{ dot.server }}{% if dot.port %}@{{ dot.port }}{% endif %}{% if dot.verify %}#{{ dot.verify }}{% endif %}
 

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -43,7 +43,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['enable_wpad'] = isset($a_unboundcfg['enable_wpad']);
     $pconfig['dnssec'] = isset($a_unboundcfg['dnssec']);
     $pconfig['dns64'] = isset($a_unboundcfg['dns64']);
-    $pconfig['forwarding'] = isset($a_unboundcfg['forwarding']);
     $pconfig['reglladdr6'] = empty($a_unboundcfg['noreglladdr6']);
     $pconfig['regdhcp'] = isset($a_unboundcfg['regdhcp']);
     $pconfig['regdhcpstatic'] = isset($a_unboundcfg['regdhcpstatic']);
@@ -117,7 +116,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $a_unboundcfg['dnssec'] = !empty($pconfig['dnssec']);
             $a_unboundcfg['enable'] = !empty($pconfig['enable']);
             $a_unboundcfg['enable_wpad'] = !empty($pconfig['enable_wpad']);
-            $a_unboundcfg['forwarding'] = !empty($pconfig['forwarding']);
             $a_unboundcfg['noreglladdr6'] = empty($pconfig['reglladdr6']);
             $a_unboundcfg['regdhcp'] = !empty($pconfig['regdhcp']);
             $a_unboundcfg['regdhcpstatic'] = !empty($pconfig['regdhcpstatic']);
@@ -318,16 +316,6 @@ include_once("head.inc");
                         </td>
                       </tr>
                       <tr>
-                        <td><a id="help_for_forwarding" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Query Forwarding");?></td>
-                        <td>
-                          <input name="forwarding" type="checkbox" value="yes" <?=!empty($pconfig['forwarding']) ? 'checked="checked"' : '';?> />
-                          <?= gettext('Enable Forwarding Mode') ?>
-                          <div class="hidden" data-for="help_for_forwarding">
-                            <?= gettext('The configured system nameservers will be used to forward queries to.') ?>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
                         <td><a id="help_for_local_zone_type" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Local Zone Type"); ?></td>
                         <td>
                           <select name="local_zone_type" size="3" class="selectpicker" >
@@ -379,14 +367,10 @@ include_once("head.inc");
                       </tr>
                       <tr>
                         <td colspan="2">
-                          <?= sprintf(gettext('If Unbound is enabled, the DHCP'.
+                          <?= gettext('If Unbound is enabled, the DHCP'.
                           ' service (if enabled) will automatically serve the LAN IP'.
                           ' address as a DNS server to DHCP clients so they will use'.
-                          ' Unbound resolver. If forwarding is enabled, Unbound'.
-                          ' will use the DNS servers entered in %sSystem: General setup%s'.
-                          ' or those obtained via DHCP or PPP on WAN if the "Allow'.
-                          ' DNS server list to be overridden by DHCP/PPP on WAN"'.
-                          ' is checked.'),'<a href="system_general.php">','</a>');?>
+                          ' Unbound resolver.');?>
                         </td>
                       </tr>
                     </tbody>


### PR DESCRIPTION
resolves https://github.com/opnsense/core/issues/5138

This PR pulls query forwarding over the current dot setup, so visually nothing changes.

All API calls are redirected to new Forward functions, which slightly modifies what is returned based on whether "Query Forwarding" or "DNS over TLS" is selected from the menu. This way backwards compatibility is preserved.

As an addition, a user is now able to specify a specific domain for a forward zone as well. Meaning that queries for this specific domain will skip a catch-all (".") domain (if specified), and instead use the server specified for this domain.

Entering a forward zone with a catch-all domain (".") in both Query Forwading and DNS over TLS is considered a duplicate by Unbound, so a static warning for this has been attached in the grid - however, it might be possible for a user to be warned dynamically over this.