### PR TITLE
Interfaces: Other Types: VLAN - Add stacked VLAN support (IEEE 802.1ad / QinQ)

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -182,7 +182,16 @@ function interfaces_vlan_configure($verbose = false)
         echo 'Configuring VLAN interfaces...';
         flush();
     }
-
+    // Handle QinQ dependencies by sorting list of vlans to create (first all vlans so we can stack QinQ on top)
+    usort($config['vlans']['vlan'], function ($a, $b) {
+        $aqinq = strpos($a['vlanif'], 'vlan') !== false ? 0 : 1 ;
+        $bqinq = strpos($b['vlanif'], 'vlan') !== false ? 0 : 1 ;
+        if ($aqinq === $bqinq) {
+            return $a['vlanif'] <=> $b['vlanif'];
+        } else {
+            return $aqinq <=> $bqinq;
+        }
+    });
     foreach ($config['vlans']['vlan'] as $vlan) {
         interface_vlan_configure($vlan);
     }
@@ -196,12 +205,11 @@ function interface_vlan_configure($vlan)
 {
     interfaces_bring_up($vlan['if']); /* XXX overreach? */
 
-    /* XXX avoid destroy/create */
+    /* destroy is a safety precaution, when confguring via api or gui this function should only be called on new vlans */
     legacy_interface_destroy($vlan['vlanif']);
     legacy_interface_create('vlan', $vlan['vlanif']);
 
-    $pcp = isset($vlan['pcp']) ? $vlan['pcp'] : 0;
-    legacy_vlan_tag($vlan['vlanif'], $vlan['if'], $vlan['tag'], $pcp);
+    legacy_vlan_tag($vlan['vlanif'], $vlan['if'], $vlan['tag'], $vlan['pcp']);
 
     interfaces_bring_up($vlan['vlanif']);
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanInterfaceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanInterfaceField.php
@@ -52,9 +52,7 @@ class VlanInterfaceField extends BaseListField
             $ifconfig = json_decode((new Backend())->configdRun('interface list ifconfig'), true);
             if (!empty($ifconfig)) {
                 foreach ($ifconfig as $ifname => $details) {
-                    // XXX: skip same interface types as legacy, may need to revise later
-                    if (
-                        strpos($ifname, "_vlan") > 1 || strpos($ifname, "lo") === 0 || strpos($ifname, "enc") === 0 ||
+                    if (strpos($ifname, "qinq") === 0 || strpos($ifname, "lo") === 0 || strpos($ifname, "enc") === 0 ||
                         strpos($ifname, "pflog") === 0 || strpos($ifname, "pfsync") === 0 ||
                         strpos($ifname, "bridge") === 0 ||
                         strpos($ifname, "gre") === 0 || strpos($ifname, "gif") === 0 || strpos($ifname, "ipsec") === 0


### PR DESCRIPTION
Since FreeBSD 13 its possible to stack vlans on top of vlans (IEEE 802.1ad), although in the past it should have been possible to build a QinQ using netgraph, it didn't work reliable forcing us to remove it back in 2018 (https://github.com/opnsense/core/issues/2274).

Given the new functionality it seems like a good idea to give this another try as the interface is much cleaner now.

Implements https://github.com/opnsense/core/issues/5560