### PR TITLE
Improve configctl help output - cosmetic change

### DIFF
--- a/src/sbin/configctl
+++ b/src/sbin/configctl
@@ -5,4 +5,4 @@ if [ ! -e /var/run/configd.pid ]; then
 	exit 1
 fi
 
-exec /usr/local/opnsense/service/configd_ctl.py "${@}"
+exec /usr/local/opnsense/service/configd_ctl.py "${@}" | sed 's/configd_ctl.py/configctl/g'


### PR DESCRIPTION
A cosmetic change. It will reflect the configctl (instead of configd_ctl.py) command output while invoking  /usr/local/sbin/configctl -h for example.