### PR TITLE
dhcpd: add support for client-updates option

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -766,6 +766,10 @@ EOPP;
             } else {
                 $newzone['domain-name'] = $config['system']['domain'];
             }
+            if (!empty($dhcpifconf['ddnsclientupdates'])) {
+                $dnscfg .= "  {$dhcpifconf['ddnsclientupdates']} client-updates;\n";
+            }
+            
             $revsubnet = array_reverse(explode(".", $subnet));
             $subnetmask_rev = array_reverse(explode('.', $subnetmask));
             foreach ($subnetmask_rev as $octet) {
@@ -1500,6 +1504,9 @@ EOD;
                 $newzone['domain-name'] = $dhcpv6ifconf['ddnsdomain'];
             } else {
                 $newzone['domain-name'] = $config['system']['domain'];
+            }
+            if (!empty($dhcpv6ifconf['ddnsclientupdates'])) {
+                $dnscfgv6 .= "  {$dhcpv6ifconf['ddnsclientupdates']} client-updates;\n";
             }
 
             $subnetv6 = explode("/", $networkv6)[0];

--- a/src/www/services_dhcp.php
+++ b/src/www/services_dhcp.php
@@ -56,7 +56,7 @@ function reconfigure_dhcpd()
 
 $config_copy_fieldsnames = array('enable', 'staticarp', 'failover_peerip', 'failover_split', 'dhcpleaseinlocaltime','descr',
   'defaultleasetime', 'maxleasetime', 'gateway', 'domain', 'domainsearchlist', 'denyunknown','ignoreuids', 'ddnsdomain',
-  'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsupdate', 'mac_allow',
+  'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsclientupdates', 'ddnsupdate', 'mac_allow',
   'mac_deny', 'tftp', 'bootfilename', 'ldap', 'netboot', 'nextserver', 'filename', 'filename32', 'filename64',
   'filename32arm', 'filename64arm', 'rootpath', 'netmask', 'numberoptions', 'interface_mtu', 'wpad', 'omapi', 'omapiport',
   'omapialgorithm', 'omapikey', 'minsecs');
@@ -907,6 +907,20 @@ include("head.inc");
                             }
                           }?>
                           <option value="<?=$algorithm;?>" <?=$selected;?>><?=$algorithm;?></option>
+<?php
+                        endforeach; ?>
+                        </select><br />
+                        <?=gettext("Choose how the server should handle updates from clients.");?><br />
+                        <select name='ddnsclientupdates' id="ddnsclientupdates" class="selectpicker">
+<?php
+                        foreach (array("allow", "deny", "ignore") as $clientupdates) :
+                          $selected = "";
+                          if (! empty($pconfig['ddnsclientupdates'])) {
+                            if ($pconfig['ddnsclientupdates'] == $clientupdates) {
+                              $selected = "selected=\"selected\"";
+                            }
+                          }?>
+                          <option value="<?=$clientupdates;?>" <?=$selected;?>><?=$clientupdates;?></option>
 <?php
                         endforeach; ?>
                         </select>

--- a/src/www/services_dhcpv6.php
+++ b/src/www/services_dhcpv6.php
@@ -97,7 +97,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $pconfig['prefixrange_length'] = $config['dhcpdv6'][$if]['prefixrange']['prefixlength'];
     }
     $config_copy_fieldsnames = array('defaultleasetime', 'maxleasetime', 'domain', 'domainsearchlist', 'ddnsdomain',
-        'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'bootfile_url', 'netmask',
+        'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsclientupdates', 'bootfile_url', 'netmask',
         'numberoptions', 'dhcpv6leaseinlocaltime', 'staticmap', 'minsecs');
     foreach ($config_copy_fieldsnames as $fieldname) {
         if (isset($config['dhcpdv6'][$if][$fieldname])) {
@@ -264,7 +264,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             // simple 1-on-1 copy
             $config_copy_fieldsnames = array('defaultleasetime', 'maxleasetime', 'netmask', 'domainsearchlist',
-              'ddnsdomain', 'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'bootfile_url',
+              'ddnsdomain', 'ddnsdomainprimary', 'ddnsdomainkeyname', 'ddnsdomainkey', 'ddnsdomainalgorithm', 'ddnsclientupdates', 'bootfile_url',
               'dhcpv6leaseinlocaltime', 'minsecs');
             foreach ($config_copy_fieldsnames as $fieldname) {
                 if (!empty($pconfig[$fieldname])) {
@@ -648,6 +648,16 @@ include("head.inc");
                           foreach (array("hmac-md5", "hmac-sha512") as $algorithm) :?>
                               <option value="<?=$algorithm;?>" <?=$pconfig['ddnsdomainalgorithm'] == $algorithm ? "selected=\"selected\"" :"";?>>
                                 <?=$algorithm;?>
+                              </option>
+<?php
+                          endforeach; ?>
+                          </select><br />
+                          <?=gettext("Choose how the server should handle updates from clients.");?><br />
+                          <select name='ddnsclientupdates' id="ddnsclientupdates" class="selectpicker">
+<?php
+                          foreach (array("allow", "deny", "ignore") as $clientupdates) :?>
+                              <option value="<?=$clientupdates;?>" <?=$pconfig['ddnsclientupdates'] == $clientupdates ? "selected=\"selected\"" :"";?>>
+                                <?=$clientupdates;?>
                               </option>
 <?php
                           endforeach; ?>


### PR DESCRIPTION
Adds support for the client-updates option for DDNS updates in dhcpd.

Can specify whether client updates should be allowed (default), denied, or ignored. dhcpd defaults to "allow client-updates" if nothing is specified, so that was chosen as the default to ensure any existing configs with DDNS continue to work as expected.

If DDNS updates are already configured on the DHCP subnet, then no changes will be made until the next time the DHCP config is save for that interface.