### PR TITLE
unbound: fix model description validation

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -149,7 +149,7 @@
                 </server>
                 <description type="TextField">
                     <Required>N</Required>
-                    <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>
+                    <mask>/^(.){1,255}$/u</mask>
                     <ValidationMessage>Description should be a string between 1 and 255 characters</ValidationMessage>
                 </description>
             </host>
@@ -211,7 +211,7 @@
                 </server>
                 <description type="TextField">
                     <Required>N</Required>
-                    <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>
+                    <mask>/^(.){1,255}$/u</mask>
                     <ValidationMessage>Description should be a string between 1 and 255 characters</ValidationMessage>
                 </description>
             </domain>


### PR DESCRIPTION
We are being too strict with the Unbound host & domain descriptions, this fixes the resulting migration issues.