### PR TITLE
Use random_bytes() from PHP 7.0+

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -433,7 +433,7 @@ function local_user_set_password(&$user, $password = null)
 {
     if ($password == null) {
         /* generate a random password */
-        $bytes = openssl_random_pseudo_bytes(50);
+        $bytes = random_bytes(50);
         $password = pack('H*', bin2hex($bytes));
     }
 

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/API.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/API.php
@@ -88,8 +88,8 @@ class API extends Base implements IAuthConnector
                 }
                 $item = $apikeys->addChild('item');
 
-                $newKey = base64_encode(openssl_random_pseudo_bytes(60));
-                $newSecret = base64_encode(openssl_random_pseudo_bytes(60));
+                $newKey = base64_encode(random_bytes(60));
+                $newSecret = base64_encode(random_bytes(60));
 
                 $item->addChild('key', $newKey);
                 $item->addChild('secret', crypt($newSecret, '$6$'));

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Voucher.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Voucher.php
@@ -197,9 +197,9 @@ class Voucher extends Base implements IAuthConnector
                 // create a map of easy to read characters
                 $characterMap = '';
                 while (strlen($characterMap) < 256) {
-                    $random_bytes = openssl_random_pseudo_bytes(10000);
-                    for ($i = 0; $i < strlen($random_bytes); $i++) {
-                        $chr_ord = ord($random_bytes[$i]);
+                    $bytes = random_bytes(10000);
+                    for ($i = 0; $i < strlen($bytes); $i++) {
+                        $chr_ord = ord($bytes[$i]);
                         if (
                             ($chr_ord >= 50 && $chr_ord <= 57) || // 2..9
                             ($chr_ord >= 65 && $chr_ord <= 72) || // A..H
@@ -209,7 +209,7 @@ class Voucher extends Base implements IAuthConnector
                             ($chr_ord >= 109 && $chr_ord <= 110) || // m..n
                             ($chr_ord >= 112 && $chr_ord <= 122)  // p..z
                         ) {
-                            $characterMap .= $random_bytes[$i];
+                            $characterMap .= $bytes[$i];
                         }
                     }
                 }
@@ -220,11 +220,11 @@ class Voucher extends Base implements IAuthConnector
                 // create map of random readable characters
                 $characterMap = '';
                 while (strlen($characterMap) < 256) {
-                    $random_bytes = openssl_random_pseudo_bytes(10000);
-                    for ($i = 0; $i < strlen($random_bytes); $i++) {
-                        $chr_ord = ord($random_bytes[$i]);
-                        if ($chr_ord >= 33 && $chr_ord <= 125 && !in_array($random_bytes[$i], $doNotUseChr)) {
-                            $characterMap .= $random_bytes[$i];
+                    $bytes = random_bytes(10000);
+                    for ($i = 0; $i < strlen($bytes); $i++) {
+                        $chr_ord = ord($bytes[$i]);
+                        if ($chr_ord >= 33 && $chr_ord <= 125 && !in_array($bytes[$i], $doNotUseChr)) {
+                            $characterMap .= $bytes[$i];
                         }
                     }
                 }
@@ -235,14 +235,14 @@ class Voucher extends Base implements IAuthConnector
             $expirytime = $expirytime == 0 ? 0 : $expirytime + time();
             while ($vouchersGenerated < $count) {
                 $generatedUsername = '';
-                $random_bytes = openssl_random_pseudo_bytes($this->usernameLength);
-                for ($j = 0; $j < strlen($random_bytes); $j++) {
-                    $generatedUsername .= $characterMap[ord($random_bytes[$j])];
+                $bytes = random_bytes($this->usernameLength);
+                for ($j = 0; $j < strlen($bytes); $j++) {
+                    $generatedUsername .= $characterMap[ord($bytes[$j])];
                 }
                 $generatedPassword = '';
-                $random_bytes = openssl_random_pseudo_bytes($this->passwordLength);
-                for ($j = 0; $j < strlen($random_bytes); $j++) {
-                    $generatedPassword .= $characterMap[ord($random_bytes[$j])];
+                $bytes = random_bytes($this->passwordLength);
+                for ($j = 0; $j < strlen($bytes); $j++) {
+                    $generatedPassword .= $characterMap[ord($bytes[$j])];
                 }
 
                 if (!$this->userNameExists($generatedUsername)) {

--- a/src/www/system_advanced_network.php
+++ b/src/www/system_advanced_network.php
@@ -77,7 +77,7 @@ function generate_new_duid($duid_type)
             $new_duid = $new_duid.':'.$mac;
             break;
         case '3': //UUID
-            $type = "\x00\x00\x00\x04".openssl_random_pseudo_bytes(16);
+            $type = "\x00\x00\x00\x04".random_bytes(16);
             for ($count = 0; $count < strlen($type); ) {
                 $new_duid .= bin2hex( $type[$count]);
                 $count++;
@@ -87,7 +87,7 @@ function generate_new_duid($duid_type)
             }
             break;
         case '4': //EN - Using Opnsense PEN!!!
-            $type = "\x00\x02\x00\x00\xD2\x6D".openssl_random_pseudo_bytes(8);
+            $type = "\x00\x02\x00\x00\xD2\x6D".random_bytes(8);
             for ($count = 0; $count < strlen($type); ) {
                 $new_duid .= bin2hex( $type[$count]);
                 $count++;

--- a/src/www/system_usermanager.php
+++ b/src/www/system_usermanager.php
@@ -342,7 +342,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $userent['ipsecpsk'] = $pconfig['ipsecpsk'];
             if (!empty($pconfig['gen_otp_seed'])) {
                 // generate 160bit base32 encoded secret
-                $userent['otp_seed'] = Base32\Base32::encode(openssl_random_pseudo_bytes(20));
+                $userent['otp_seed'] = Base32\Base32::encode(random_bytes(20));
             } else {
                 $userent['otp_seed'] = trim($pconfig['otp_seed']);
             }

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     if (!empty($pconfig['request_otp_seed'])) {
         if ($user_allow_gen_token && $userFound) {
-            $new_seed = Base32\Base32::encode(openssl_random_pseudo_bytes(20));
+            $new_seed = Base32\Base32::encode(random_bytes(20));
             $config['system']['user'][$userindex[$username]]['otp_seed'] = $new_seed;
             write_config();
             $otp_url = "otpauth://totp/";


### PR DESCRIPTION
PHP has had native [random_bytes()](https://www.php.net/manual/en/function.random-bytes.php) since version 7.0. Internally on FreeBSD it uses [getrandom()](https://github.com/php/php-src/blob/PHP-7.4.0/ext/standard/random.c#L104-L122) call which is probably a lot faster and more secure than `openssl_random_pseudo_bytes()`.

While making this pull request I also noticed that voucher generation is quite complicated. Should I make an additional pull request that simplifies the voucher generation with `random_int()` instead of those huge byte arrays? It could be optimized by using a string with valid characters and then just looping with `random_int()` like in the example below.

```php
// ...
if ($this->simplePasswords) {
    $characterMap = '23456789ABC...';
} else {
   // the other case here
  $characterMap = '...';
}
// ...
                $generatedUsername = '';
                for ($j = 0; $j < $this->usernameLength; $j++) {
                    $generatedUsername .= $characterMap[random_int(0, strlen($characterMap) - 1)];
                }
// ... and so on ...
```