### PR TITLE
Dynamically generated bcrypt cost

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -439,9 +439,8 @@ function local_user_set_password(&$user, $password = null)
     $cost = 10;
     do {
         $timer = hrtime(true);
-        $hash = password_hash($password, PASSWORD_BCRYPT, [ 'cost' => $cost ]);
+        $hash = password_hash($password, PASSWORD_BCRYPT, [ 'cost' => $cost++ ]);
         $timer = (hrtime(true) - $timer) / 10 ** 9;
-        $cost++;
     } while ($timer < 0.2 && $cost < 32);
     if ($hash !== false) {
         $user['password'] = $hash;

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -438,6 +438,7 @@ function local_user_set_password(&$user, $password = null)
 
     $cost = 10;
     do {
+        /* increase bcrypt cost until it takes at least 0.2 seconds */
         $timer = hrtime(true);
         $hash = password_hash($password, PASSWORD_BCRYPT, [ 'cost' => $cost++ ]);
         $timer = (hrtime(true) - $timer) / 10 ** 9;

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -436,8 +436,13 @@ function local_user_set_password(&$user, $password = null)
         $bytes = random_bytes(50);
         $password = pack('H*', bin2hex($bytes));
     }
-
-    $hash = password_hash($password, PASSWORD_BCRYPT, [ 'cost' => 10 ]);
+    $cost = 10;
+    do {
+        $timer = hrtime(true);
+        $hash = password_hash($password, PASSWORD_BCRYPT, [ 'cost' => $cost ]);
+        $timer = (hrtime(true) - $timer) / 10 ** 9;
+        $cost++;
+    } while ($timer < 0.2 && $cost < 32);
     if ($hash !== false) {
         $user['password'] = $hash;
     }

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -433,9 +433,9 @@ function local_user_set_password(&$user, $password = null)
 {
     if ($password == null) {
         /* generate a random password */
-        $bytes = random_bytes(50);
-        $password = pack('H*', bin2hex($bytes));
+        $password = random_bytes(50);
     }
+
     $cost = 10;
     do {
         $timer = hrtime(true);


### PR DESCRIPTION
If I understood correctly, bcrypt cost was set to `10` in 2016. While bcrypt is still an excellent algorithm, the computers get faster every year. This pull request increases bcrypt cost dynamically until it takes at least 0.2 seconds. This shouldn't make the authentication process horrible on slower machines, but especially faster machines will benefit from better security. If 0.2 seconds is too long, maybe it could be lowered to 0.1s...

For example on my cheap and couple of years old laptop this would mean at least `$cost = 12`.