### PR TITLE
unbound: clean up references to legacy code, use mvc instead. also minor style fix

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -255,10 +255,13 @@ EOF;
         $include_dhcpleases = '';
     }
 
+    $unbound_mdl = new \OPNsense\Unbound\Unbound();
+    $unbound_enabled = (string)$unbound_mdl->forwarding->enabled;
+
     $forward_conf = '';
     $forward_local = '';
     $resolv_conf_root = '';
-    if (isset($config['unbound']['forwarding'])) {
+    if ($unbound_enabled) {
         $dnsservers = get_nameservers();
 
         if (!empty($dnsservers)) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
@@ -40,37 +40,6 @@ class SettingsController extends ApiMutableModelControllerBase
 
     private $type = 'dot';
 
-    public function toggleSystemForwardAction()
-    {
-        if ($this->request->isPost() && $this->request->hasPost('forwarding')) {
-            $this->sessionClose();
-            Config::getInstance()->lock();
-            $config = Config::getInstance()->object();
-
-            $val = $this->request->getPost('forwarding')['enabled'];
-
-            /* Write to config exactly as legacy would */
-            $config->unbound->forwarding = !empty($val);
-            if ($val != "1") {
-                /* legacy uses isset() */
-                unset($config->unbound->forwarding);
-            }
-
-            /* save and release lock */
-            Config::getInstance()->save();
-        }
-    }
-
-    public function getSystemForwardAction()
-    {
-        $config = Config::getInstance()->object();
-        return array("forwarding" =>
-            array( "enabled" =>
-                empty($config->unbound->forwarding) ? 0 : 1
-            )
-        );
-    }
-
     public function getNameserversAction()
     {
         if ($this->request->isGet()) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
@@ -11,7 +11,7 @@
         </help>
     </field>
     <field>
-        <id>forwarding.info</id>
+        <id>unbound.forwarding.info</id>
         <type>info</type>
         <label></label>
     </field>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/forwarding.xml
@@ -1,6 +1,6 @@
 <form>
     <field>
-        <id>forwarding.enabled</id>
+        <id>unbound.forwarding.enabled</id>
         <label>Use System Nameservers</label>
         <type>checkbox</type>
         <style>forwarding-enabled</style>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Migrations/M1_0_2.php
@@ -51,5 +51,10 @@ class M1_0_2 extends BaseModelMigration
                 $dot->type = "dot";
             }
         }
+        
+        if (isset($config->unbound->forwarding)) {
+            $model->forwarding->enabled = "1";
+            unset($config->unbound->forwarding);
+        }
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -57,8 +57,9 @@
             </whitelists>
         </dnsbl>
         <forwarding>
-            <enabled type="LegacyLinkField">
-                <Source>unbound.forwarding</Source>
+            <enabled type="BooleanField">
+                <default>0</default>
+                <Required>N</Required>
             </enabled>
         </forwarding>
         <dots>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -27,7 +27,7 @@
 <script>
 
     $( document ).ready(function() {
-        $('tr[id="row_forwarding.info"]').addClass('hidden');
+        $('tr[id="row_unbound.forwarding.info"]').addClass('hidden');
         /* Handle retrieval and saving of the single system forwarding checkbox */
         let data_get_map = {'frm_ForwardingSettings':"/api/unbound/settings/get"};
         mapDataToFormUI(data_get_map).done(function(data) {
@@ -47,25 +47,25 @@
         function toggleNameservers(checked) {
             if (checked) {
                 ajaxGet(url="/api/unbound/settings/getNameservers", {}, callback=function(data, status) {
-                    $('tr[id="row_forwarding.info"]').removeClass('hidden');
+                    $('tr[id="row_unbound.forwarding.info"]').removeClass('hidden');
                     if (data.length && !data.includes('')) {
-                        $('div[id="control_label_forwarding.info"]').append(
+                        $('div[id="control_label_unbound.forwarding.info"]').append(
                             "<span>{{ lang._('The following nameservers are used:') }}</span>"
                         );
-                        $('span[id="forwarding.info"]').append(
+                        $('span[id="unbound.forwarding.info"]').append(
                             "<div><b>" + data.join(", ") + "</b></div>"
                         );
                     } else {
-                        $('div[id="control_label_forwarding.info"]').append(
+                        $('div[id="control_label_unbound.forwarding.info"]').append(
                             "<span>{{ lang._('There are no system nameservers configured. Please do so in ') }}<a href=\"/system_general.php\">System: General setup</a></span>"
                         );
                     }
 
                 });
             } else {
-                $('tr[id="row_forwarding.info"]').addClass('hidden');
-                $('div[id="control_label_forwarding.info"]').children().not(':first').remove();
-                $('span[id="forwarding.info"]').children().remove();
+                $('tr[id="row_unbound.forwarding.info"]').addClass('hidden');
+                $('div[id="control_label_unbound.forwarding.info"]').children().not(':first').remove();
+                $('span[id="unbound.forwarding.info"]').children().remove();
             }
         }
 

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -29,22 +29,22 @@
     $( document ).ready(function() {
         $('tr[id="row_forwarding.info"]').addClass('hidden');
         /* Handle retrieval and saving of the single system forwarding checkbox */
-        let data_get_map = {'frm_ForwardingSettings':"/api/unbound/settings/getSystemForward"};
+        let data_get_map = {'frm_ForwardingSettings':"/api/unbound/settings/get"};
         mapDataToFormUI(data_get_map).done(function(data) {
             /* only called on page load */
-            if (data.frm_ForwardingSettings.forwarding.enabled) {
-                toggle_nameservers(true);
+            if (data.frm_ForwardingSettings.unbound.forwarding.enabled == "1") {
+                toggleNameservers(true);
             }
         });
 
         $(".forwarding-enabled").click(function() {
-            saveFormToEndpoint(url="/api/unbound/settings/toggleSystemForward", formid='frm_ForwardingSettings');
+            saveFormToEndpoint(url="/api/unbound/settings/set", formid='frm_ForwardingSettings');
 
             let checked = ($(this).is(':checked'));
-            toggle_nameservers(checked);
+            toggleNameservers(checked);
         });
 
-        function toggle_nameservers(checked) {
+        function toggleNameservers(checked) {
             if (checked) {
                 ajaxGet(url="/api/unbound/settings/getNameservers", {}, callback=function(data, status) {
                     $('tr[id="row_forwarding.info"]').removeClass('hidden');

--- a/src/wizard/system.xml
+++ b/src/wizard/system.xml
@@ -155,9 +155,6 @@ if (!empty($_POST['secondarydnsserver']) && !is_ipaddr($_POST['secondarydnsserve
 if (!empty($input_errors)) {
     $stepid--;
 } else {
-    if (isset($config['unbound']['forwarding'])) {
-        unset($config['unbound']['forwarding']);
-    }
     if (isset($config['dnsmasq']['enable'])) {
         unset($config['dnsmasq']['enable']);
     }


### PR DESCRIPTION
Migrating to MVC means we can use the existing get/set API calls without having to manually manipulate the legacy configuration.

This PR also adds a migration for the legacy unbound->forwarding configuration.

I'm not sure what the original intent behind https://github.com/opnsense/core/blob/master/src/wizard/system.xml#L158-L159 was, but i'm removing it here. 