### PR TITLE
Configuration backup with AES-256-GCM 

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
@@ -47,7 +47,7 @@ abstract class Base
         /* current encryption defaults, change as needed */
         $cipher = 'aes-256-gcm';
         $hash = 'sha512';
-        $pbkdf2 = '100000';
+        $pbkdf2 = 100000;
 
         $output = $this->opensslEncrypt($data, $pass, $cipher, $hash, $pbkdf2);
         if (!is_null($output)) {

--- a/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
@@ -161,7 +161,6 @@ abstract class Base
                 $temp = hash($hashAlgo, $temp . $password . $salt, true);
                 $key .= $temp;
             }
-
         }
         $iv = substr($key, $keyLength, $ivLength);
         $key = substr($key, 0, $keyLength);
@@ -170,19 +169,18 @@ abstract class Base
 
     private function opensslDecrypt(string $data, string $password, string $cipher, string $hashAlgo, ?int $iterations): ?string
     {
-        if ($cipher === 'aes-256-gcm') {
-            $saltOffset = 0;
-            $saltLength = 16;
-            $tagLength = 16;
-        } elseif ($cipher === 'aes-256-cbc') {
+        $saltOffset = 0;
+        $saltLength = 16;
+        $tagLength = 16;
+        if ($cipher === 'aes-256-cbc') {
             // Prior to version XXX ?
             $saltOffset = 8; // skip b'Salted__'
             $saltLength = 8;
             $tagLength = 0;
         }
         $data = base64_decode($data);
-        if (!isset($saltOffset) || strlen($data) < $saltOffset + $saltLength + $tagLength) {
-            // unknown cipher or not enough data
+        if (strlen($data) < $saltOffset + $saltLength + $tagLength) {
+            // not enough data
             return null;
         }
         $salt = substr($data, $saltOffset, $saltLength);

--- a/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
@@ -158,7 +158,7 @@ abstract class Base
             // Prior to version XXX ?
             $key = $temp = '';
             while (strlen($key) < $keyLength + $ivLength) {
-                $temp = md5($temp . $password . $salt, true);
+                $temp = hash($hashAlgo, $temp . $password . $salt, true);
                 $key .= $temp;
             }
 

--- a/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
@@ -172,6 +172,9 @@ abstract class Base
         $saltOffset = 0;
         $saltLength = 16;
         $tagLength = 16;
+        if (!in_array($cipher, openssl_get_cipher_methods())) {
+            return null;
+        }
         if ($cipher === 'aes-256-cbc') {
             // Prior to version XXX ?
             $saltOffset = 8; // skip b'Salted__'

--- a/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Backup/Base.php
@@ -93,7 +93,11 @@ abstract class Base
                         $hash = strtolower($value);
                         break;
                     case 'pbkdf2':
-                        $pbkdf2 = $value;
+                        $pbkdf2 = filter_var(
+                            $value,
+                            FILTER_VALIDATE_INT,
+                            array('options' => array('min_range' => 1, 'default' => null))
+                        );
                         break;
                     default:
                         /* skip unknown */
@@ -172,7 +176,7 @@ abstract class Base
         $saltOffset = 0;
         $saltLength = 16;
         $tagLength = 16;
-        if (!in_array($cipher, openssl_get_cipher_methods())) {
+        if (!in_array($cipher, openssl_get_cipher_methods()) || !in_array($hashAlgo, hash_algos())) {
             return null;
         }
         if ($cipher === 'aes-256-cbc') {

--- a/src/opnsense/mvc/tests/app/library/OPNsense/Backup/LocalTest.php
+++ b/src/opnsense/mvc/tests/app/library/OPNsense/Backup/LocalTest.php
@@ -1,6 +1,11 @@
 <?php
 
-namespace tests\OPNsense\Backup\Local;
+namespace OPNsense\Backup;
+
+function shell_exec($s)
+{
+    return '0.0dev';
+}
 
 class BackupLocalTest extends \PHPUnit\Framework\TestCase
 {

--- a/src/opnsense/mvc/tests/app/library/OPNsense/Backup/LocalTest.php
+++ b/src/opnsense/mvc/tests/app/library/OPNsense/Backup/LocalTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\OPNsense\Backup\Local;
+
+class BackupLocalTest extends \PHPUnit\Framework\TestCase
+{
+    private $backup;
+
+    protected function setUp(): void
+    {
+        $this->backup = new \OPNsense\Backup\Local();
+    }
+
+    public function testCurrentEncryptionAndDecryption()
+    {
+        $localBackup = new \OPNsense\Backup\Local();
+        $encrypted = $this->backup->encrypt('test message 1', 'password 1');
+        $this->assertStringContainsString('---- BEGIN config.xml ----', $encrypted);
+        $this->assertEquals('test message 1', $this->backup->decrypt($encrypted, 'password 1'));
+    }
+
+    public function testWrongPassword()
+    {
+        $localBackup = new \OPNsense\Backup\Local();
+        $encrypted = $localBackup->encrypt('test message 1', 'password 1');
+        $this->assertNull($localBackup->decrypt($encrypted, 'password 2'));
+    }
+
+    /* Test older backup formats */
+
+    public function testAes256CbcSha512()
+    {
+        /*
+        echo -n "plain text" | openssl enc -aes-256-cbc -a -md sha512 -salt -pbkdf2 -iter 100000 -pass pass:'password'
+        */
+        $result = "---- BEGIN config.xml ----\n";
+        $result .= "Version: 22.1\n";
+        $result .= "Cipher: AES-256-CBC\n";
+        $result .= "PBKDF2: 100000\n";
+        $result .= "Hash: SHA512\n\n";
+        $result .= "U2FsdGVkX19UgpJkIGNpAfGjOT4J3tUVmYojxYLPU3c=\n";
+        $result .= "---- END config.xml ----\n";
+        $this->assertEquals('plain text', $this->backup->decrypt($result, 'password'));
+    }
+
+    public function testAes256CbcMd5()
+    {
+        /*
+        echo -n "plain text" | openssl enc -aes-256-cbc -a -md md5 -pass pass:'password'
+        */
+        $result = "---- BEGIN config.xml ----\n";
+        $result .= "Version: 21.1\n";
+        $result .= "Cipher: AES-256-CBC\n";
+        $result .= "Hash: MD5\n\n";
+        $result .= "U2FsdGVkX184SjUAQcAEabH4+AdRnDYwakiPmu4rRkY=\n";
+        $result .= "---- END config.xml ----\n";
+        $this->assertEquals('plain text', $this->backup->decrypt($result, 'password'));
+    }
+}


### PR DESCRIPTION
As discussed a little bit in https://github.com/opnsense/core/pull/5661

AES-256-GCM mode provides proper integrity checking. [Additional authentication data can be added](https://www.php.net/manual/en/function.openssl-encrypt.php) easily if something needs to be authenticated, but made available prior to decryption some time in the future.

This pull request also removes `openssl` shell commands and implements the needed legacy key derivation function in pure PHP.


Example below: I wrapped the three new methods (`keyAndIV`, `opensslDecrypt`, `opensslEncrypt`) in a test class if people want to test easily on their own machines without modifying the whole OPNsense installation.

```php
<?php

class Encryption
{
    private function keyAndIV(string $cipher, string $hashAlgo, string $password, string $salt, ?int $iterations): array
    {
        /* AES-256 key size is 32 bytes */
        $keyLength = 32;
        $ivLength = openssl_cipher_iv_length($cipher);

        if (!is_null($iterations)) {
            $key = hash_pbkdf2($hashAlgo, $password, $salt, $iterations, $keyLength + $ivLength, true);
        } else {
            /* pre-21.7 */
            $key = $temp = '';
            while (strlen($key) < $keyLength + $ivLength) {
                $temp = hash($hashAlgo, $temp . $password . $salt, true);
                $key .= $temp;
            }
        }

        $iv = substr($key, $keyLength, $ivLength);
        $key = substr($key, 0, $keyLength);
        return [$key, $iv];
    }

    private function opensslDecrypt(string $data, string $password, string $cipher, string $hashAlgo, ?int $iterations): ?string
    {
        /* aes-256-gcm defaults */
        $saltOffset = 0;
        $saltLength = 16;
        $tagLength = 16;

        if (!in_array($cipher, openssl_get_cipher_methods()) || !in_array($hashAlgo, hash_algos())) {
            /* ciher or hash not supported */
            return null;
        }
        if ($cipher === 'aes-256-cbc') {
            /* pre- XXX */
            $saltOffset = 8; // skip 'Salted__'
            $saltLength = 8;
            $tagLength = 0;
        }

        $data = base64_decode($data);
        if (strlen($data) < $saltOffset + $saltLength + $tagLength) {
            /* not enough data */
            return null;
        }
        $salt = substr($data, $saltOffset, $saltLength);
        $tag = substr($data, $saltOffset + $saltLength, $tagLength);
        $data = substr($data, $saltOffset + $saltLength + $tagLength);
        [$key, $iv] = $this->keyAndIV($cipher, $hashAlgo, $password, $salt, $iterations);

        $result = openssl_decrypt(
            $data,
            $cipher,
            $key,
            OPENSSL_RAW_DATA,
            $iv,
            $tag
        );
        return $result === false ? null : $result;
    }

    private function opensslEncrypt(string $data, string $password, string $cipher, string $hashAlgo, int $iterations): ?string
    {
        $salt = random_bytes(16);
        [$key, $iv] = $this->keyAndIV($cipher, $hashAlgo, $password, $salt, $iterations);

        $result = openssl_encrypt(
            $data,
            $cipher,
            $key,
            OPENSSL_RAW_DATA,
            $iv,
            $tag,
            '',
            16
        );
        return $result === false ? null : base64_encode($salt . $tag . $result);
    }

    public function decrypt($data, $pass, $cipher = 'aes-256-gcm', $hash = 'sha512', $pbkdf2 = 100000)
    {
        $output = $this->opensslDecrypt($data, $pass, $cipher, $hash, $pbkdf2);
        return $output;
    }

    public function encrypt($data, $pass)
    {
        $cipher = 'aes-256-gcm';
        $hash = 'sha512';
        $pbkdf2 = '100000';
        $output = $this->opensslEncrypt($data, $pass, $cipher, $hash, $pbkdf2);
        return $output;
    }
}

$e = new Encryption();

/*
AES-256-CBC MD5

$ echo "my data to be encrypted" | openssl enc -aes-256-cbc -a -md md5 -p -pass pass:'my super complex password !"#$€éä'
*** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
salt=0BF40F5988DB9F8A
key=AEEA7AC5A93457EF2EE6CA70DBA2A7B0B5DDF7DDE15514B3B3AD0F2E62D2D66B
iv =A2D112F283F15DD112AC2537BDCFCFAF
U2FsdGVkX18L9A9ZiNufihFGyhh0+oyT7B3KDGFd9RoNyDv2VCMDF9Kc3gNSwVG+
*/
echo "### AES-256-CBC MD5\n";
$data = 'U2FsdGVkX18L9A9ZiNufihFGyhh0+oyT7B3KDGFd9RoNyDv2VCMDF9Kc3gNSwVG+';
$pass = 'my super complex password !"#$€éä';
var_dump($e->decrypt($data, $pass, 'aes-256-cbc', 'md5', null));


/*
AES-256-CBC SHA512

$ echo "my data to be encrypted" | openssl enc -aes-256-cbc -a -md sha512 -salt -pbkdf2 -iter 100000 -p -pass pass:'my super complex password !"#$€éä'
salt=7B71AEE703562A1E
key=B990D67A81487531372E9A0FEDE221D9217FFC1F69378D8CA0C257E4B8C65B35
iv =0ED0182EC2BF5BB2AAAFDC6F0EEBF021
U2FsdGVkX197ca7nA1YqHlSOkg0ZTJJ6EBThFdnTV4IzUadvh4+TieKOY/4gCYNw
*/
echo "### AES-256-CBC SHA512\n";
$data = 'U2FsdGVkX197ca7nA1YqHlSOkg0ZTJJ6EBThFdnTV4IzUadvh4+TieKOY/4gCYNw';
$pass = 'my super complex password !"#$€éä';
var_dump($e->decrypt($data, $pass, 'aes-256-cbc', 'sha512', 100000));


/*

AES-256-GCM SHA512

*/
echo "### AES-256-GCM SHA512\n";
$output = $e->encrypt("my data to be encrypted\n", 'my super complex password !"#$€éä');
var_dump($output);
var_dump($e->decrypt($output, 'my super complex password !"#$€éä'));

```
