### PR TITLE
Firewall / Aliases - various usability and visibility improvements

### DIFF
--- a/src/etc/inc/legacy_bindings.inc
+++ b/src/etc/inc/legacy_bindings.inc
@@ -88,13 +88,16 @@ function legacy_html_escape_form_data(&$settings)
  */
 function legacy_list_aliases($type)
 {
-    $result = array();
+    $result = [];
 
     foreach ((new \OPNsense\Firewall\Alias())->aliasIterator() as $alias) {
-        if ($type == "port" && preg_match("/port/i", $alias['type'])) {
-            $result[] = array('name' => $alias['name'], 'type' => $alias['type']);
+        if ($alias['type'] == 'internal') {
+            // XXX: skip internal aliases while still defined as "networks" in the rules pages
+            continue;
+        } elseif ($type == "port" && preg_match("/port/i", $alias['type'])) {
+            $result[] = ['name' => $alias['name'], 'type' => $alias['type']];
         } elseif ($type != "port" && !preg_match("/port/i", $alias['type'])) {
-            $result[] = array('name' => $alias['name'], 'type' => $alias['type']);
+            $result[] = ['name' => $alias['name'], 'type' => $alias['type']];
         }
     }
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -110,7 +110,7 @@ class AliasController extends ApiMutableModelControllerBase
         $selected_aliases = array_keys($response['alias']['content']);
         foreach ($this->getModel()->aliasIterator() as $alias) {
             // external aliases can't be nested (always empty according to our administration)
-            if (!in_array($alias['name'], $selected_aliases) && $alias['type'] != "external") {
+            if (!in_array($alias['name'], $selected_aliases)) {
                 $response['alias']['content'][$alias['name']] = [
                   "selected" => 0, "value" => $alias['name']
                 ];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -109,12 +109,13 @@ class AliasController extends ApiMutableModelControllerBase
         $response = $this->getBase("alias", "aliases.alias", $uuid);
         $selected_aliases = array_keys($response['alias']['content']);
         foreach ($this->getModel()->aliasIterator() as $alias) {
-            // external aliases can't be nested (always empty according to our administration)
             if (!in_array($alias['name'], $selected_aliases)) {
                 $response['alias']['content'][$alias['name']] = [
                   "selected" => 0, "value" => $alias['name']
                 ];
             }
+            // append descriptions
+            $response['alias']['content'][$alias['name']]['description'] = $alias['description'];
         }
         return $response;
     }
@@ -216,10 +217,13 @@ class AliasController extends ApiMutableModelControllerBase
      */
     public function listNetworkAliasesAction()
     {
-        $result = array();
+        $result = [];
         foreach ($this->getModel()->aliases->alias->iterateItems() as $alias) {
             if (!in_array((string)$alias->type, ['external', 'port'])) {
-                $result[(string)$alias->name] = (string)$alias->name;
+                $result[(string)$alias->name] = [
+                    "name" => (string)$alias->name,
+                    "description" => (string)$alias->description
+                ];
             }
         }
         ksort($result);

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -162,25 +162,12 @@ class Alias extends BaseModel
      */
     public function aliasIterator()
     {
-        $use_legacy = true;
         foreach ($this->aliases->alias->iterateItems() as $alias) {
             $record = array();
             foreach ($alias->iterateItems() as $key => $value) {
                 $record[$key] = (string)$value;
             }
             yield $record;
-            $use_legacy = false;
-        }
-        // MVC not used (yet) return legacy type aliases
-        if ($use_legacy) {
-            $cfgObj = Config::getInstance()->object();
-            if (!empty($cfgObj->aliases->alias)) {
-                foreach ($cfgObj->aliases->children() as $alias) {
-                    $alias = (array)$alias;
-                    $alias['content'] = !empty($alias['address']) ? str_replace(" ", "\n", $alias['address']) : null;
-                    yield $alias;
-                }
-            }
         }
     }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
@@ -37,6 +37,7 @@
                         <networkgroup>Network group</networkgroup>
                         <mac>MAC address</mac>
                         <external>External (advanced)</external>
+                        <internal>Internal (product)</internal>
                         <dynipv6host>Dynamic IPv6 Host</dynipv6host>
                     </OptionValues>
                     <Constraints>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasField.php
@@ -34,41 +34,37 @@ use OPNsense\Base\FieldTypes\ArrayField;
 use OPNsense\Base\FieldTypes\TextField;
 use OPNsense\Base\FieldTypes\IntegerField;
 use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
 
 class AliasField extends ArrayField
 {
-    private static $reservedItems = [
-        "bogons" => [
-            "enabled" => "1",
-            "name" => "bogons",
-            "type" => "external",
-            "description" => "bogon networks (internal)",
-            "content" => ""
-        ],
-        "bogonsv6" => [
-            "enabled" => "1",
-            "name" => "bogonsv6",
-            "type" => "external",
-            "description" => "bogon networks IPv6 (internal)",
-            "content" => ""
-        ],
-        "virusprot" => [
-            "enabled" => "1",
-            "name" => "virusprot",
-            "type" => "external",
-            "description" => "overload table for rate limiting (internal)",
-            "content" => ""
-        ],
-        "sshlockout" => [
-            "enabled" => "1",
-            "name" => "sshlockout",
-            "type" => "external",
-            "description" => "abuse lockout table (internal)",
-            "content" => ""
-        ]
-    ];
+    private static $reservedItems = [];
 
     private static $current_stats = null;
+
+    public function __construct($ref = null, $tagname = null)
+    {
+        foreach (glob(__DIR__ . "/../static_aliases/*.json") as $filename) {
+            $payload = json_decode(file_get_contents($filename), true);
+            if (is_array($payload)) {
+                foreach ($payload as $aliasname => $content) {
+                    self::$reservedItems[$aliasname] = $content;
+                }
+            }
+        }
+        foreach (Config::getInstance()->object()->interfaces->children() as $k => $n) {
+            $table_name = sprintf("__%s_network", $k);
+            $table_desc = !empty((string)$n->descr) ? (string)$n->descr : $k;
+            self::$reservedItems[$table_name] = [
+                "enabled" => "1",
+                "name" => $table_name,
+                "type" => "internal",
+                "description" => sprintf("%s %s", $table_desc, gettext("net")),
+                "content" => ""
+            ];
+        }
+        parent::__construct($ref, $tagname);
+    }
 
     protected function actionPostLoadingEvent()
     {

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/static_aliases/core.json
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/static_aliases/core.json
@@ -1,0 +1,30 @@
+{
+  "bogons": {
+    "enabled": "1",
+    "name": "bogons",
+    "type": "external",
+    "description": "bogon networks (internal)",
+    "content": ""
+  },
+  "bogonsv6": {
+    "enabled": "1",
+    "name": "bogonsv6",
+    "type": "external",
+    "description": "bogon networks IPv6 (internal)",
+    "content": ""
+  },
+  "virusprot": {
+    "enabled": "1",
+    "name": "virusprot",
+    "type": "external",
+    "description": "overload table for rate limiting (internal)",
+    "content": ""
+  },
+  "sshlockout": {
+    "enabled": "1",
+    "name": "sshlockout",
+    "type": "external",
+    "description": "abuse lockout table (internal)",
+    "content": ""
+  }
+}

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -67,7 +67,9 @@
             ajaxGet("/api/firewall/alias/listNetworkAliases", {}, function(data){
                 $("#network_content").empty();
                 $.each(data, function(alias, value) {
-                    $("#network_content").append($("<option/>").val(alias).text(value));
+                    let $opt = $("<option/>").val(alias).text(value.name);
+                    $opt.data('subtext', value.description);
+                    $("#network_content").append($opt);
                 });
                 $("#network_content").selectpicker('refresh');
             });

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -508,6 +508,7 @@
                                 <option value="networkgroup">{{ lang._('Network group') }}</option>
                                 <option value="dynipv6host">{{ lang._('Dynamic IPv6 Host') }}</option>
                                 <option value="external">{{ lang._('External (advanced)') }}</option>
+                                <option value="internal">{{ lang._('Internal (product)') }}</option>
                             </select>
                         </div>
                     </div>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -43,6 +43,16 @@
                         request['type'] = $('#type_filter').val();
                     }
                     return request;
+                },
+                formatters: {
+                    "commands": function (column, row) {
+                        if (row.uuid.includes('-') === true) {
+                            // exclude buttons for internal aliases (which uses names instead of valid uuid's)
+                            return '<button type="button" class="btn btn-xs btn-default command-edit bootgrid-tooltip" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-pencil"></span></button> ' +
+                                '<button type="button" class="btn btn-xs btn-default command-copy bootgrid-tooltip" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-clone"></span></button>' +
+                                '<button type="button" class="btn btn-xs btn-default command-delete bootgrid-tooltip" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-trash-o"></span></button>';
+                        }
+                    },
                 }
             }
         });

--- a/src/opnsense/scripts/filter/lib/alias.py
+++ b/src/opnsense/scripts/filter/lib/alias.py
@@ -291,6 +291,7 @@ class Alias(object):
                 ['/sbin/pfctl', '-t', self.get_name(), '-T', 'replace', '%s:network' % self._interface],
                 capture_output=True
             )
+        # collect current table contents for selected types
         if self.get_type() in ['interface_net', 'external']:
             pfctl_cmd = ['/sbin/pfctl', '-t', self.get_name(), '-T', 'show']
             for line in subprocess.run(pfctl_cmd, capture_output=True, text=True).stdout.split('\n'):

--- a/src/opnsense/scripts/filter/lib/alias.py
+++ b/src/opnsense/scripts/filter/lib/alias.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2017-2021 Ad Schellevis <ad@opnsense.org>
+    Copyright (c) 2017-2022 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@ import requests
 import ipaddress
 import dns.resolver
 import syslog
+import subprocess
 from hashlib import md5
 from dns.exception import DNSException
 from . import geoip
@@ -240,9 +241,10 @@ class Alias(object):
                 else:
                     undo_content = ""
                 try:
+                    self._resolve_content = self.pre_process()
                     address_parser = self.get_parser()
-                    for item in self.items():
-                        if address_parser:
+                    if address_parser:
+                        for item in self.items():
                             for address in address_parser(item):
                                 self._resolve_content.add(address)
                     # resolve hostnames (async) if there are any in the collected set
@@ -263,7 +265,7 @@ class Alias(object):
         return list(self._resolve_content)
 
     def get_parser(self):
-        """ fetch address parser to use, None if alias type is not handled here
+        """ fetch address parser to use, None if alias type is not handled here or only during pre processing
             :return: function or None
         """
         if self._type in ['host', 'network', 'networkgroup']:
@@ -278,6 +280,23 @@ class Alias(object):
             return ArpCache().iter_addresses
         else:
             return None
+
+    def pre_process(self):
+        """ alias type pre processors
+            :return: set initial alias content
+        """
+        result = set()
+        if self.get_type() == 'interface_net':
+            subprocess.run(
+                ['/sbin/pfctl', '-t', self.get_name(), '-T', 'replace', '%s:network' % self._interface],
+                capture_output=True
+            )
+        if self.get_type() in ['interface_net', 'external']:
+            pfctl_cmd = ['/sbin/pfctl', '-t', self.get_name(), '-T', 'show']
+            for line in subprocess.run(pfctl_cmd, capture_output=True, text=True).stdout.split('\n'):
+                result.add(line.strip())
+
+        return result
 
     def get_type(self):
         """ get type of alias

--- a/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
+++ b/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
@@ -41,31 +41,15 @@
 {%     endif %}
 {%   endfor %}
 {% endif %}
-{# -------------------------------------------------------- #}
-{# fallback to legacy alias definitions (temporary measure) #}
-{# -------------------------------------------------------- #}
-{% if new_style_aliases == 0 and helpers.exists('aliases.alias') %}
-{%    for alias in helpers.toList('aliases.alias') %}
-{%      if alias.type.find('port') == -1 %}
+{%  if not helpers.empty('interfaces') %}
+{%      for intf_key,intf_item in interfaces.items() %}
     <table>
-      <name>{{ alias.name|e }}</name>
-      <descr>{{ alias.descr|default('')|e}}</descr>
-      <type>{{ alias.type }}</type>
-{%      if alias.url %}
-      <url>{{ alias.url|e }}</url>
-{%      endif %}{% if alias.aliasurl %}
-      <aliasurl>{{ alias.aliasurl|e }}</aliasurl>
-{%      endif %}{% if alias.proto %}
-      <proto>{{ alias.proto|e }}</proto>
-{%      endif %}{% if alias.address %}
-      <address>{{ alias.address|e }}</address>
-{%      endif %}{% if alias.updatefreq %}
-      <ttl>{{ alias.updatefreq|float * 86400 }}</ttl>
-{% elif alias.type == 'host' %}
-      <ttl>{{ system.aliasesresolveinterval|default('300') }}</ttl>
-{%      endif %}
+        <name>__{{intf_key}}_network</name>
+        <descr>{% if intf_item.descr %}{{ intf_item.descr|e }}{% else %}{{intf_key}} net{% endif %}</descr>
+        <type>interface_net</type>
+        <ttl>1</ttl>
+        <interface>{{intf_item.if}}</interface>
     </table>
-{%     endif %}
-{%   endfor %}
-{% endif %}
+{%      endfor %}
+{%  endif %}
 </tabledef>


### PR DESCRIPTION
This PR contains various improvements to the alias subsystem. 

o change /api/firewall/alias/listNetworkAliases endpoint to return name and address
o add alias description as subtext in network group dropdown
o exclude row buttons for internal aliases
o support nesting of external aliases
o attach statistics to external aliases (like bogons and new interface network types)
o add preprocess in alias to handle non gui defined types
o network aliases will flush :network into the table
o aliases which aren't managed via configured settings will be fetched for nesting
o gather pf tables which aren't generated into filter_tables.conf as being external so the new imported static_aliases are usable without the need to import the settings in the template language
o initial work to support interface networks, register internal types and flush to alias template
o support imported static aliases using json definitions and move core aliases in there
