### PR TITLE
Unbound overrides: fix validation message style issue

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/FieldTypes/UnboundServerField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/FieldTypes/UnboundServerField.php
@@ -51,17 +51,19 @@ class UnboundServerField extends BaseField
     public function getValidators()
     {
         $validators = parent::getValidators();
-        $validators[] = new CallbackValidator([
-            "callback" => function ($value) {
-                $parts = explode("@", $value);
-                if (count($parts) == 2 && (!Util::isIpAddress($parts[0]) || !Util::isPort($parts[1]))) {
-                    return [gettext("A valid IP address and port must be specified, for example 192.168.100.10@5353.")];
-                } elseif (count($parts) != 2 && !Util::isIpAddress($value)) {
-                    return [gettext("A valid IP address must be specified, for example 192.168.100.10.")];
+        if ($this->internalValue != null) {
+            $validators[] = new CallbackValidator([
+                "callback" => function ($value) {
+                    $parts = explode("@", $value);
+                    if (count($parts) == 2 && (!Util::isIpAddress($parts[0]) || !Util::isPort($parts[1]))) {
+                        return [gettext("A valid IP address and port must be specified, for example 192.168.100.10@5353.")];
+                    } elseif (count($parts) != 2 && !Util::isIpAddress($value)) {
+                        return [gettext("A valid IP address must be specified, for example 192.168.100.10.")];
+                    }
+                    return [];
                 }
-                return [];
-            }
-        ]);
+            ]);
+        }
         return $validators;
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -233,6 +233,7 @@
                 </domain>
                 <server type=".\UnboundServerField">
                     <Required>Y</Required>
+                    <ValidationMessage>A valid IP must be specified.</ValidationMessage>
                 </server>
                 <description type="TextField">
                     <Required>N</Required>


### PR DESCRIPTION
Current implementation is correct, but looks like this if the IP field is left empty:

![validation_style_issue](https://user-images.githubusercontent.com/33954429/162731332-340ce073-7820-4954-b341-d839f749a002.png)

