### PR TITLE
system: detect far gateway situation for #5493

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -526,7 +526,12 @@ function system_default_route($gateway, $family, $interface, $far = false)
         @file_put_contents("/tmp/{$realif}_defaultgw", $gateway);
 
         if (!$far) {
-            $realif = null;
+            list (, $network) = interfaces_primary_address($interface);
+            if (ip_in_subnet($gateway, $network)) {
+                $realif = null;
+            } else {
+                log_error("ROUTING: treating '{$gateway}' as far gateway for '{$network}'");
+            }
         }
     } else {
         foreach (glob('/tmp/*_defaultgwv6') as $to_delete) {


### PR DESCRIPTION
The far gateway flag has some benefits for configuration runs
and validation purposes on the GUI but in the end after lots
of reworks we are able to reliably get a network from the interface
to put the default route on so that we can detect if we are in
need of a far gateway or not.  This is required for automatic
gateways on DHCP that hand out these situations while the
gateway code should not be in charge of flipping on the fargw
bit as it does pertain to runtime interface configuration.

We don't modify the configuration: if fargw is set it is used,
if not we force fargw if it is not set but required (automatic
case describe in ticket).

(cherry picked from commit 9cf2b221d8be339b609258b970e89542a2b37f7c)
(cherry picked from commit 9486473b2ff449318c9b1bf451aa9387f7a097c9)
(cherry picked from commit 00a86f74dbbefe3abbb926d98251067df53dfe8e)
(cherry picked from commit 7fa1f8b8bee0e307ed7e2c24e649147167c363a4)
(cherry picked from commit f6551c982d75feed016f1bb33458629915f2fe48)
(cherry picked from commit fc51b1541a8af8ef4ee9059b783bdb1aeb7027b5)