### PR TITLE
Unbound overrides: fix handling of wildcard aliases

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -199,7 +199,7 @@
                             <check></check>
                         </check001>
                     </Constraints>
-                    <WildcardAllowed>Y</WildcardAllowed>
+                    <HostWildcardAllowed>Y</HostWildcardAllowed>
                 </hostname>
                 <domain type="TextField">
                     <Constraints>


### PR DESCRIPTION
Wildcard functionality of HostnameField was refactored
See f110c988d4c5722308d0ec7a4ef5b86c0b3f767c