### PR TITLE
Alias Tables Natural Sort Order

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
@@ -117,9 +117,9 @@ class AliasUtilController extends ApiControllerBase
             array_key_exists('ip', $this->request->getPost('sort')) &&
             $this->request->getPost('sort')['ip'] === 'desc'
         ) {
-            rsort($entry_keys);
+            rsort($entry_keys, SORT_NATURAL);
         } else {
-            sort($entry_keys);
+            sort($entry_keys, SORT_NATURAL);
         }
 
         $formatted_full = array_map(function ($value) use (&$entries) {


### PR DESCRIPTION
Sort IP addresses in natural order.

FIREWALL: DIAGNOSTICS: ALIASES

i.e.
sort as
 2.3.4.5
12.3.4.5

rather than
12.3.4.5
 2.3.4.5