### PR TITLE
Add ability to set a custom dnsbl target address

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
@@ -21,6 +21,12 @@
         <help>List of domains from where blocklist will be downloaded.</help>
     </field>
     <field>
+        <id>unbound.dnsbl.address</id>
+        <label>Blocklist Address</label>
+        <type>text</type>
+        <help>Destination ip address for entries in the blocklist (leave empty to use default: 0.0.0.0)</help>
+    </field>
+    <field>
         <id>unbound.dnsbl.whitelists</id>
         <label>Whitelist Domains</label>
         <type>select_multiple</type>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
@@ -52,6 +52,11 @@ custom_{{loop.index}}={{uri}}
 {%      endfor %}
 {%    endif %}
 
+{%    if not helpers.empty('OPNsense.unboundplus.dnsbl.address') %}
+[blocklist]
+address={{OPNsense.unboundplus.dnsbl.address}}
+{%    endif %}
+
 [exclude]
 # exclude localhost entries
 default_pattern_1=.*localhost$


### PR DESCRIPTION
Hi,

this PR adds the ability to set a custom target address for the unbound DNS blocklist.
The address can be set using a text field in the advanced blocklist settings of the unbound plugin and will be used in the `blocklists.py` script instead of `0.0.0.0` when matching an ip regex. (I'd prefer validating the ip in the textfield but I was unable to find examples for this in the source code)

My motivation for this is that I want to host a service that shows a blank page for any request to prevent blocked stuff from generating error pages and get some statistics about what stuff actually got blocked. 
