### PR TITLE
unbound: make blocklist additions/removals dynamic to prevent a restart

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -44,7 +44,11 @@ class ServiceController extends ApiMutableServiceControllerBase
         $this->sessionClose();
         $backend = new Backend();
         $backend->configdRun('template reload ' . escapeshellarg(static::$internalServiceTemplate));
-        $response = $backend->configdRun(static::$internalServiceName . ' dnsbl');
-        return array('status' => $response);
+        $response = json_decode(trim($backend->configdRun(static::$internalServiceName . ' dnsbl')), true);
+        if ($response !== null) {
+            $response['status'] = "OK";
+            return $response;
+        }
+        return array('message' => 'unable to run configd action');
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -47,6 +47,11 @@ class ServiceController extends ApiMutableServiceControllerBase
         $response = json_decode(trim($backend->configdRun(static::$internalServiceName . ' dnsbl')), true);
         if ($response !== null) {
             $response['status'] = "OK";
+            $response['status_msg'] = sprintf(
+              gettext("Added %d and remove %d  resource records."),
+              $response['additions'],
+              $response['removals']
+            );
             return $response;
         }
         return array('message' => 'unable to run configd action');

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -48,7 +48,7 @@ class ServiceController extends ApiMutableServiceControllerBase
         if ($response !== null) {
             $response['status'] = "OK";
             $response['status_msg'] = sprintf(
-              gettext("Added %d and remove %d  resource records."),
+              gettext("Added %d and removed %d  resource records."),
               $response['additions'],
               $response['removals']
             );

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
@@ -40,6 +40,10 @@
                   dfObj.resolve();
               });
               return dfObj;
+          },
+          onAction: function(data, status) {
+              $("#responseMsg").removeClass("hidden");
+              $("#responseMsg").html('Added ' + data['additions'] + ' and removed ' + data['removals'] + ' resource records.');
           }
       });
 
@@ -47,14 +51,16 @@
    });
 </script>
 
+<div class="alert alert-info hidden" role="alert" id="responseMsg"></div>
+
 <div class="content-box" style="padding-bottom: 1.5em;">
     {{ partial("layout_partials/base_form",['fields':dnsblForm,'id':'frm_dnsbl_settings'])}}
     <div class="col-md-12">
         <hr />
         <button class="btn btn-primary" id="saveAct"
                 data-endpoint='/api/unbound/service/dnsbl'
-                data-label="{{ lang._('Apply') }}"
-                data-error-title="{{ lang._('Error reloading unbound') }}"
+                data-label="{{ lang._('Download & Apply') }}"
+                data-error-title="{{ lang._('Error updating blocklists') }}"
                 type="button">
         </button>
     </div>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
@@ -42,8 +42,7 @@
               return dfObj;
           },
           onAction: function(data, status) {
-              $("#responseMsg").removeClass("hidden");
-              $("#responseMsg").html('Added ' + data['additions'] + ' and removed ' + data['removals'] + ' resource records.');
+              $("#responseMsg").removeClass("hidden").html(data['status_msg']);
           }
       });
 

--- a/src/opnsense/scripts/unbound/blocklists.py
+++ b/src/opnsense/scripts/unbound/blocklists.py
@@ -147,7 +147,6 @@ if __name__ == '__main__':
     # write out results
     with open("/usr/local/etc/unbound.opnsense.d/dnsbl.conf", 'w') as unbound_outf:
         if blocklist_items:
-            unbound_outf.write('server:\n')
             for entry in blocklist_items:
                 unbound_outf.write("local-data: \"%s A %s\"\n" % (entry, destination_address))
 

--- a/src/opnsense/scripts/unbound/wrapper.py
+++ b/src/opnsense/scripts/unbound/wrapper.py
@@ -79,17 +79,17 @@ if args.dnsbl:
             with open(dnsbl_files[filetype], 'r') as current_f:
                 for line in current_f:
                     if line.startswith('local-data:'):
-                        dnsbl_contents[filetype].add(line[11:].strip('" '))
+                        dnsbl_contents[filetype].add(line[11:].strip(' "\'\t\r\n'))
 
     additions = dnsbl_contents['new'] - dnsbl_contents['cache']
     removals = dnsbl_contents['cache'] - dnsbl_contents['new']
-    if additions:
-        uc = unbound_control_do('local_datas', additions)
-        syslog.syslog(syslog.LOG_NOTICE, 'unbound-control returned: %s' % uc)
     if removals:
         # RR removals only accept domain names, so strip it again (xxx.xx 0.0.0.0 --> xxx.xx)
         removals = {line.split(' ')[0].strip() for line in removals}
         uc = unbound_control_do('local_datas_remove', removals)
+        syslog.syslog(syslog.LOG_NOTICE, 'unbound-control returned: %s' % uc)
+    if additions:
+        uc = unbound_control_do('local_datas', additions)
         syslog.syslog(syslog.LOG_NOTICE, 'unbound-control returned: %s' % uc)
 
     output = {'additions': len(additions), 'removals': len(removals)}

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -68,9 +68,9 @@ message:Checking Unbound configuration
 [dnsbl]
 command:
     /usr/local/opnsense/scripts/unbound/blocklists.py &&
-    /usr/local/sbin/pluginctl -s unbound restart
+    /usr/local/opnsense/scripts/unbound/wrapper.py -b -f json
 parameters:
-type:script
+type:script_output
 message:Updating Unbound DNSBLs
 description:Update Unbound DNSBLs
 

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -68,7 +68,7 @@ message:Checking Unbound configuration
 [dnsbl]
 command:
     /usr/local/opnsense/scripts/unbound/blocklists.py &&
-    /usr/local/opnsense/scripts/unbound/wrapper.py -b -f json
+    /usr/local/opnsense/scripts/unbound/wrapper.py -b
 parameters:
 type:script_output
 message:Updating Unbound DNSBLs


### PR DESCRIPTION
This PR contains an optimization for the way unbound can be updated in its' configuration
without the need for restarting Unbound and by extension a loss of internet connectivity.

Hopefully this will pave the way for optimizations on other aspects of Unbounds' configuration as well.
We could for example look into making the provided wrapper function more generic.

The GUI has also been modified slightly to inform the user of the amount of RRs added/removed.