### PR TITLE
improve diag_dns

### DIFF
--- a/src/www/diag_dns.php
+++ b/src/www/diag_dns.php
@@ -28,38 +28,90 @@
  */
 
 require_once("guiconfig.inc");
+require_once("system.inc");
+require_once("interfaces.inc");
 
 $resolved = array();
-$dns_speeds = array();
-if (!empty($_REQUEST['host'])) {
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    // set form defaults
+    $pconfig = array();
+    $pconfig['host'] = isset($_GET['host']) ? $_GET['host'] : null;
+    $pconfig['interface'] = isset($_GET['interface']) ? $_GET['interface'] : null;
+    $pconfig['dnsserverinput'] = isset($_GET['dnsserverinput']) ? $_GET['dnsserverinput'] : null;
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // validate formdata and schedule action
+    $pconfig = $_POST;
     $input_errors = array();
-    $host = trim($_REQUEST['host'], " \t\n\r\0\x0B[];\"'");
-    $host_esc = escapeshellarg($host);
-
-    if (!is_hostname($host) && !is_ipaddr($host)) {
+    /* input validation */
+    $reqdfields = array("host");
+    $reqdfieldsn = array(gettext("Host"));
+    do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
+    if (!is_hostname($pconfig['host']) && !is_ipaddr($pconfig['host'])) {
         $input_errors[] = gettext("Host must be a valid hostname or IP address.");
-    } else {
-        // Test resolution speed of each DNS server.
-        $dns_servers = array();
-        exec("/usr/bin/grep nameserver /etc/resolv.conf | /usr/bin/cut -f2 -d' '", $dns_servers);
-        foreach ($dns_servers as $dns_server) {
-            $query_time = exec("/usr/bin/drill {$host_esc} " . escapeshellarg("@" . trim($dns_server)) . " | /usr/bin/grep Query | /usr/bin/cut -d':' -f2");
-            if ($query_time == "") {
-                $query_time = gettext("No response");
-            }
-            $dns_speeds[] = array('dns_server' => $dns_server, 'query_time' => $query_time);
-        }
     }
-
     if (count($input_errors) == 0) {
-        if (is_ipaddr($host)) {
-            $resolved[] = "PTR " . gethostbyaddr($host);
-        } elseif (is_hostname($host)) {
-            exec("(/usr/bin/drill {$host_esc} AAAA; /usr/bin/drill {$host_esc} A) | /usr/bin/grep 'IN' | /usr/bin/grep -v ';' | /usr/bin/grep -v 'SOA' | /usr/bin/awk '{ print $4 \" \" $5 }'", $resolved);
+        $command_args = "";
+        list ($ifaddr) = interfaces_primary_address($pconfig['interface']);
+        if (!empty($ifaddr)) {
+            $command_args .= exec_safe(' -I %s ', $ifaddr);
+        }
+        if (is_ipaddr($pconfig['host'])) {
+            $command_args .= ' -x ';
+        }
+        $dns_servers = array();
+        if (strlen($pconfig['dnsserverinput']) > 0) {
+            $dns_servers = explode(' ', $pconfig['dnsserverinput']);
+        } else {
+            exec("/usr/bin/grep nameserver /etc/resolv.conf | /usr/bin/cut -f2 -d' '", $dns_servers);
+        }
+        foreach ($dns_servers as $dns_server) {
+            if (!is_hostname($dns_server) && !is_ipaddr($dns_server)) {
+                $input_errors[] = gettext("DNS Server must be a valid hostname or IP address.") . " " . $dns_server;
+            }
+            $queryoutput = [];
+            $query_time = "";
+            $dnsrcode = "";
+            $dnsanswer = "";
+            $dnssoa = "";
+            exec("/usr/bin/drill " . $command_args . " " . $pconfig['host'] . " " . escapeshellarg("@" . trim($dns_server)) . " 2>&1", $queryoutput, $retval);
+            if ($retval > 0) {
+                $input_errors[] = "command exit code: $retval for server $dns_server : " . join(' ', $queryoutput);
+                continue;
+            }
+            for ($i = 0; $i < count($queryoutput); $i++) {
+                $qoutline = $queryoutput[$i];
+                if ($i == 0) {
+                    $larr = explode(', ', $qoutline);
+                    $dnsrcode = trim(explode(': ', $larr[1])[1]);
+                } elseif (strpos($qoutline, 'ANSWER SECTION:')) {
+                    if (strlen(trim($queryoutput[$i+1])) > 0) {
+                        $dnsa = preg_split('/\s+/', trim($queryoutput[$i+1]));
+                        $dnsanswer = $dnsa[3]." ".$dnsa[4];
+                    }
+                } elseif (strpos($qoutline, 'AUTHORITY SECTION:')) {
+                    if (strlen(trim($queryoutput[$i+1])) > 0) {
+                        $soa = preg_split('/\s+/', trim($queryoutput[$i+1]));
+                        $dnssoa = $soa[3]." ".$soa[4];
+                    }
+                } elseif (strpos($qoutline, 'Query time:')) {
+                    $query_time = trim(explode(': ', $qoutline)[1]);
+                }
+            }
+            if (strlen($dnsanswer) == 0 && strlen($dnssoa) > 0) {
+                $dnsanswer = $dnssoa;
+            }
+            $resolved[] = array(
+                'dns_server' => $dns_server,
+                'query_time' => $query_time,
+                'rcode' => $dnsrcode,
+                'answer' => $dnsanswer,
+                );
         }
     }
 }
 
+legacy_html_escape_form_data($pconfig);
 include("head.inc"); ?>
 <body>
 <?php include("fbegin.inc"); ?>
@@ -70,16 +122,43 @@ include("head.inc"); ?>
         <section class="col-xs-12">
           <div class="content-box">
             <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
-            <header class="content-box-head container-fluid">
-              <h3><?=gettext("Resolve DNS hostname or IP");?></h3>
-            </header>
             <div class="table-responsive">
-              <table class="table table-striped">
+              <table class="table table-striped opnsense_standard_table_form">
                 <tbody>
                   <tr>
-                    <td style="width: 22%"><?=gettext("Hostname or IP");?></td>
+                    <td style="width:22%"><strong><?= gettext('Resolve DNS hostname or IP') ?></strong></td>
+                    <td style="width:78%; text-align:right">
+                      <small><?=gettext("full help"); ?> </small>
+                      <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
+                      &nbsp;
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Hostname or IP");?></td>
                     <td>
-                      <input name="host" type="text" value="<?=htmlspecialchars($host);?>" />
+                      <input name="host" type="text" value="<?=htmlspecialchars($pconfig['host']);?>" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><a id="help_for_dnsserverinput" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("DNS Server");?></td>
+                    <td>
+                      <input name="dnsserverinput" type="text" value="<?=htmlspecialchars($pconfig['dnsserverinput']);?>" />
+                      <div class="hidden" data-for="help_for_dnsserverinput">
+                          <?=gettext("IP or hostname for the DNS server to be queried. You can define multiple servers separated by spaces. If you do not define servers here, the DNS servers configured for the system itself will be queried."); ?>
+                        </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Source Address"); ?></td>
+                    <td>
+                      <select name="interface" class="selectpicker">
+                        <option value=""><?= gettext('Default') ?></option>
+<?php foreach (get_configured_interface_with_descr() as $ifname => $ifdescr): ?>
+                        <option value="<?= html_safe($ifname) ?>" <?=!link_interface_to_bridge($ifname) && $ifname == $pconfig['interface'] ? 'selected="selected"' : '' ?>>
+                          <?= htmlspecialchars($ifdescr) ?>
+                        </option>
+<?php endforeach ?>
+                      </select>
                     </td>
                   </tr>
 <?php
@@ -89,37 +168,23 @@ include("head.inc"); ?>
                     <td>
                       <table class="table table-striped table-condensed">
                         <tr>
+                          <th><?=gettext("Server");?></th>
+                          <th><?=gettext("DNS Result Code");?></th>
                           <th><?=gettext("Type");?></th>
                           <th><?=gettext("Address");?></th>
+                          <th><?=gettext("Query time");?></th>
                         </tr>
 <?php
-                        foreach($resolved as $hostitem):?>
+                        foreach($resolved as $resolveditem):?>
                         <tr>
-                          <td><?=explode(' ',$hostitem)[0];?></td>
-                          <td><?=explode(' ',$hostitem)[1];?></td>
+                          <td><?=$resolveditem['dns_server'];?>
+                          <td><?=$resolveditem['rcode'];?>
+                          <td><?=explode(' ',$resolveditem['answer'])[0];?></td>
+                          <td><?=explode(' ',$resolveditem['answer'])[1];?></td>
+                          <td><?=$resolveditem['query_time'];?>
                         </tr>
 <?php
                         endforeach;?>
-                      </table>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td><?=gettext("Resolution time per server");?></td>
-                    <td colspan="2">
-                      <table class="table table-striped table-condensed">
-                        <tr>
-                          <th><?=gettext("Server");?></th>
-                          <th><?=gettext("Query time");?></th>
-                        </tr>
-
-<?php
-                        foreach($dns_speeds as $qt): ?>
-                        <tr>
-                          <td><?=$qt['dns_server']?></td>
-                          <td><?=$qt['query_time']?></td>
-                        </tr>
-<?php
-                        endforeach; ?>
                       </table>
                     </td>
                   </tr>

--- a/src/www/diag_dns.php
+++ b/src/www/diag_dns.php
@@ -47,7 +47,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $reqdfields = array("host");
     $reqdfieldsn = array(gettext("Host"));
     do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
-    if (!is_hostname($pconfig['host']) && !is_ipaddr($pconfig['host'])) {
+    $host = trim($pconfig['host'], " \t\n\r\0\x0B[];\"'");
+    if (!is_hostname($host) && !is_ipaddr($host)) {
         $input_errors[] = gettext("Host must be a valid hostname or IP address.");
     }
     if (count($input_errors) == 0) {
@@ -56,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (!empty($ifaddr)) {
             $command_args .= exec_safe(' -I %s ', $ifaddr);
         }
-        if (is_ipaddr($pconfig['host'])) {
+        if (is_ipaddr($host)) {
             $command_args .= ' -x ';
         }
         $dns_servers = array();
@@ -65,7 +66,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         } else {
             exec("/usr/bin/grep nameserver /etc/resolv.conf | /usr/bin/cut -f2 -d' '", $dns_servers);
         }
-        foreach ($dns_servers as $dns_server) {
+        foreach ($dns_servers as $dnsserver) {
+            $dns_server = trim($dnsserver, " \t\n\r\0\x0B[];\"'");
             if (!is_hostname($dns_server) && !is_ipaddr($dns_server)) {
                 $input_errors[] = gettext("DNS Server must be a valid hostname or IP address.") . " " . $dns_server;
             }
@@ -74,7 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $dnsrcode = "";
             $dnsanswer = "";
             $dnssoa = "";
-            exec("/usr/bin/drill " . $command_args . " " . $pconfig['host'] . " " . escapeshellarg("@" . trim($dns_server)) . " 2>&1", $queryoutput, $retval);
+            exec("/usr/bin/drill " . $command_args . " " . escapeshellarg($host) . " " . escapeshellarg("@" . trim($dns_server)) . " 2>&1", $queryoutput, $retval);
             if ($retval > 0) {
                 $input_errors[] = "command exit code: $retval for server $dns_server : " . join(' ', $queryoutput);
                 continue;


### PR DESCRIPTION
During some posts in the opnsense forum, I realized that many users are mostly overwhelmed if you ask for some debugging information for dns problems from the console.
So I decidet to extend the diag_dns script with the option to add the option for selecting a source IP for the queries (required for example for queries passing ipsec VPNs etc...).
While looking at the script I realized some disagreements, so the PR is about a little bit more ...

 * allow setting a source address for the query
 * allow specifying the DNS server to be queried
 * collect and display more results like rcode and answer per server (not just the query time)
 * refactored the DNS diag process

Well, my PHP foo is in fact from the time of PHP 3/4, but I hope the code fulfills your requirements.

Some examples of the resulting UI:
 * https://ibb.co/k4WvzF1
 * https://ibb.co/QPpXwss