### PR TITLE
Bypass cache with timestamp in upgradestatus call

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -260,7 +260,9 @@
     }
 
     function trackStatus() {
-        ajaxGet('/api/core/firmware/upgradestatus', {}, function(data, status) {
+        // append Date.now() (epoch time in millisecods) to the end of the URL to force browsers to
+        // bypass aggressive caching. The use of the "_" param is to mimic jQuery's cache: false.
+        ajaxGet('/api/core/firmware/upgradestatus', { _: Date.now() }, function(data, status) {
             if (status != 'success') {
                 // recover from temporary errors
                 setTimeout(trackStatus, 1000);

--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -330,7 +330,6 @@
             $("#statustab_progress").removeClass("fa fa-spinner fa-pulse");
 
             if (reset === true) {
-                // bust aggressive caching with adding a timestamp to the request.
                 ajaxGet('/api/core/firmware/upgradestatus', { _: Date.now() }, function(data, status) {
                     if (data['log'] != undefined && data['log'] != '') {
                         $('#update_status').html(data['log']);

--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -260,8 +260,6 @@
     }
 
     function trackStatus() {
-        // append Date.now() (epoch time in millisecods) to the end of the URL to force browsers to
-        // bypass aggressive caching. The use of the "_" param is to mimic jQuery's cache: false.
         ajaxGet('/api/core/firmware/upgradestatus', { _: Date.now() }, function(data, status) {
             if (status != 'success') {
                 // recover from temporary errors

--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -330,7 +330,8 @@
             $("#statustab_progress").removeClass("fa fa-spinner fa-pulse");
 
             if (reset === true) {
-                ajaxGet('/api/core/firmware/upgradestatus', {}, function(data, status) {
+                // bust aggressive caching with adding a timestamp to the request.
+                ajaxGet('/api/core/firmware/upgradestatus', { _: Date.now() }, function(data, status) {
                     if (data['log'] != undefined && data['log'] != '') {
                         $('#update_status').html(data['log']);
                     } else {


### PR DESCRIPTION
Even though the server responds with proper cache headers to avoid
browser caching, it seems that Safari (and maybe others) may still cache
repeated calls to `/api/core/firmware/upgradestatus`. This change adds
in the time-old tradition of appending the current timestamp in
milliseconds to each request which should force the browser to fetch the
resource.

Ref: https://www.reddit.com/r/opnsense/comments/umhx04/opnsense_2217_released/i83bp36/?context=5