### PR TITLE
MR for Feature Request "Unbound: Support Additional Serve Expired Settings"

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -244,6 +244,9 @@ EOF;
     $rrsetcachesize = $msgcachesize * 2;
     $dnssecstripped = !empty($config['unbound']['dnssecstripped']) ? 'yes' : 'no';
     $serveexpired = !empty($config['unbound']['serveexpired']) ? 'yes' : 'no';
+    $serveexpiredtimelimit = !empty($config['unbound']['serveexpiredtimelimit']) ? $config['unbound']['serveexpiredtimelimit'] : "0";
+    $serveexpiredclienttimeout = !empty($config['unbound']['serveexpiredclienttimeout']) ? $config['unbound']['serveexpiredclienttimeout'] : "0";
+    $serveexpiredreplyttl = !empty($config['unbound']['serveexpiredreplyttl']) ? $config['unbound']['serveexpiredreplyttl'] : "30";
 
     /* do not touch prefer-ip6 as it is defaulting to 'no' anyway */
     $do_ip6 = isset($config['system']['ipv6allow']) ? 'yes' : 'no';
@@ -323,6 +326,9 @@ cache-max-ttl: {$cache_max_ttl}
 cache-min-ttl: {$cache_min_ttl}
 harden-dnssec-stripped: {$dnssecstripped}
 serve-expired: {$serveexpired}
+serve-expired-ttl: {$serveexpiredtimelimit}
+serve-expired-client-timeout: {$serveexpiredclienttimeout}
+serve-expired-reply-ttl: {$serveexpiredreplyttl}
 outgoing-num-tcp: {$outgoing_num_tcp}
 incoming-num-tcp: {$incoming_num_tcp}
 num-queries-per-thread: {$num_queries_per_thread}

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -45,6 +45,9 @@ $copy_fields = array(
     'num_queries_per_thread',
     'outgoing_num_tcp',
     'unwanted_reply_threshold',
+    'serveexpiredtimelimit',
+    'serveexpiredclienttimeout',
+    'serveexpiredreplyttl',
 );
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
@@ -181,6 +184,33 @@ include_once("head.inc");
                           <input name="serveexpired" type="checkbox" id="serveexpired" value="yes" <?= empty($pconfig['serveexpired']) ? '' : 'checked="checked"' ?> />
                           <div class="hidden" data-for="help_for_serveexpired">
                             <?= gettext('Serve expired responses from the cache with a TTL of 0 without waiting for the actual resolution to finish.') ?>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><a id="help_for_serveexpiredtimelimit" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Serve expired responses time limit') ?></td>
+                        <td>
+                          <input name="serveexpiredtimelimit" type="text" id="serveexpiredtimelimit" size="5" value="<?= $pconfig['serveexpiredtimelimit'] ?>" />
+                          <div class="hidden" data-for="help_for_serveexpiredtimelimit">
+                            <?= gettext('Limit serving of expired responses to configured seconds after expiration. 0 disables the limit. This option only applies when serve-expired is enabled. A suggested value per RFC 8767 is between 86400 (1 day) and 259200 (3 days). The default is 0.') ?>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><a id="help_for_serveexpiredclienttimeout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Serve expired responses client timeout') ?></td>
+                        <td>
+                          <input name="serveexpiredclienttimeout" type="text" id="serveexpiredclienttimeout" size="5" value="<?= $pconfig['serveexpiredclienttimeout'] ?>" />
+                          <div class="hidden" data-for="help_for_serveexpiredclienttimeout">
+                            <?= gettext('Time in milliseconds before replying to the client with expired data. This essentially enables the serve-stale behavior as specified in RFC 8767 that first tries to resolve before immediately responding with expired data. A recommended value per RFC 8767 is 1800. Setting this to 0 will disable this behavior. Default is 0.') ?>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><a id="help_for_serveexpiredreplyttl" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Serve expired responses ttl') ?></td>
+                        <td>
+                          <input name="serveexpiredreplyttl" type="text" id="serveexpiredreplyttl" size="5" value="<?= $pconfig['serveexpiredreplyttl'] ?>" />
+                          <div class="hidden" data-for="help_for_serveexpiredreplyttl">
+                            <?= gettext('TTL value to use when replying with expired data. If serve-expired-client-timeout is also used, then it is RECOMMENDED to use 30 as the value (RFC 8767). The default is 30.') ?>
                           </div>
                         </td>
                       </tr>

--- a/src/www/services_unbound_advanced.php
+++ b/src/www/services_unbound_advanced.php
@@ -183,7 +183,7 @@ include_once("head.inc");
                         <td>
                           <input name="serveexpired" type="checkbox" id="serveexpired" value="yes" <?= empty($pconfig['serveexpired']) ? '' : 'checked="checked"' ?> />
                           <div class="hidden" data-for="help_for_serveexpired">
-                            <?= gettext('Serve expired responses from the cache with a TTL of 0 without waiting for the actual resolution to finish.') ?>
+                            <?= gettext('Serve expired responses from the cache with a TTL of (Serve expired responses ttl) in the response without waiting for the actual resolution to finish.') ?>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
This MR adds new fields in allow setting new unbound settings outlined in the linked issue.

#5795 

NOTE: I'm not familiar with the opnsense codebase - so this should be reviewed carefully to ensure I didn't miss any other areas that may need updates. Initial testing on my VM seems ok. 