### PR TITLE
mvc: parseFormNode extension

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -67,7 +67,7 @@
             </td>
         </tr>
 {% endif %}
-        {% for field in fields|default({})%}
+        {% for field in fields['field']|default({})%}
             {% if field['type'] == 'header' %}
               {# close table and start new one with header #}
 

--- a/src/opnsense/mvc/app/views/layout_partials/base_tabs_content.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_tabs_content.volt
@@ -32,13 +32,13 @@
         {# Tab with dropdown #}
         {% for subtab in tab['subtabs']|default({})%}
                 <div id="subtab_{{subtab[0]}}" class="tab-pane fade{% if formData['activetab']|default("") == subtab[0] %} in active {% endif %}">
-                    {{ partial("layout_partials/base_form",['fields':subtab[2]['field'],'id':'frm_'~subtab[0],'data_title':subtab[1],'apply_btn_id':'save_'~subtab[0]])}}
+                    {{ partial("layout_partials/base_form",['fields':subtab[2],'id':'frm_'~subtab[0],'data_title':subtab[1],'apply_btn_id':'save_'~subtab[0]])}}
                 </div>
         {% endfor %}
     {% endif %}
     {% if tab['subtabs']|default(false)==false %}
             <div id="tab_{{tab[0]}}" class="tab-pane fade{% if formData['activetab']|default("") == tab[0] %} in active {% endif %}">
-                {{ partial("layout_partials/base_form",['fields':tab[2]['field'],'id':'frm_'~tab[0],'apply_btn_id':'save_'~tab[0]])}}
+                {{ partial("layout_partials/base_form",['fields':tab[2],'id':'frm_'~tab[0],'apply_btn_id':'save_'~tab[0]])}}
             </div>
     {% endif %}
 {% endfor %}

--- a/src/opnsense/mvc/app/views/layout_partials/base_tabs_content.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_tabs_content.volt
@@ -32,13 +32,13 @@
         {# Tab with dropdown #}
         {% for subtab in tab['subtabs']|default({})%}
                 <div id="subtab_{{subtab[0]}}" class="tab-pane fade{% if formData['activetab']|default("") == subtab[0] %} in active {% endif %}">
-                    {{ partial("layout_partials/base_form",['fields':subtab[2],'id':'frm_'~subtab[0],'data_title':subtab[1],'apply_btn_id':'save_'~subtab[0]])}}
+                    {{ partial("layout_partials/base_form",['fields':subtab[2]['field'],'id':'frm_'~subtab[0],'data_title':subtab[1],'apply_btn_id':'save_'~subtab[0]])}}
                 </div>
         {% endfor %}
     {% endif %}
     {% if tab['subtabs']|default(false)==false %}
             <div id="tab_{{tab[0]}}" class="tab-pane fade{% if formData['activetab']|default("") == tab[0] %} in active {% endif %}">
-                {{ partial("layout_partials/base_form",['fields':tab[2],'id':'frm_'~tab[0],'apply_btn_id':'save_'~tab[0]])}}
+                {{ partial("layout_partials/base_form",['fields':tab[2]['field'],'id':'frm_'~tab[0],'apply_btn_id':'save_'~tab[0]])}}
             </div>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
I don't expect this to be merged, but I'd like to understand if this is a good approach to making these improvements. I use this function extensively in one of my plugins and would like to have the functionality in core to aid the expansion of the layout_partials which hasn't had any significant improvements or added functionality for several years.

While working on one of my plugins I encountered limitations with the information that could be pulled out of the form XMLs. Almost everything I wanted to do in Volt I wasn't able to do because the information I'd put into the XML (nested elements, element attributes) wasn't getting into the environment. Without massively expanding the structure of the XML, and hijacking elements to store what should be element attribute values, there wasn't another way that I knew to accomplish what I was trying to do.

This change expands the functionality of the parseFormNode function which originally performs only a single recursion, and stores any further elements as a key/value (which doesn't work for nested elements). This extended version does primarily two things, recurses infinitely (risky?), and also grabs element attributes and stores them in the array along side the string value (or child arrays).

One of the challenges I encountered while working on this was the fact that the structure allows the possibility that a given object may either be a key/value pair (variable), or an array. This ambiguity is sometimes troublesome when writing the Volt templates because any conditions have to be written in such a way that tests if the object is an array or not before performing any evaluation of the object.

Could anyone provide to me background on why the SimpleXML object isn't just translated to an array wholesale, rather than what is done here with walking the tree and manually re-creating it with a slightly alternative structure? I can only speculate that maybe a limited outcome was desired.

I've included extensive comments for clarity only and wouldn't expect them to be necessary if something like this were to be merged. The comments include XML->Array examples for additional clarification. Note that the "field" case was removed because the functionality provided by that case is provided in the default case instead (though not by name, instead by virtue of the `<field>` element existing in the form XML). The base_form.volt needed a slight modification as the "field" array is no longer assumed as all node types are recursed equally, but instead the array for the fields is called "field" as that's the name of the XML element `<field>`.

I looked around for tests for this PHP but didn't see anything in the tests directory. I did a cursory click through in the UI without any trouble. I've used this function in my plugin for a while, and the complexity of the plugin's XML covers most of what would be included in test cases. That's no substitution for proper testing though.

This added functionality goes beyond what's simply described above. It enables additional structures to be defined and handled in the volt templates via functions, and I've even used them to build Javascript functions as well as defining Javascript attachments. It allows for the possibility of significantly extending the volt templates, and eases plugin development by shifting the burden away from writing static HTML/Javascript. Below are some examples from my plugin which utilize this function:

Defining the entirety of a bootgrid along with definition of the dialog for that bootgrid within the same form XML instead of defining these things manually as HTML and Javascript, and in separate form XML files. This _significantly_ reduces code footprint.
``` xml
<field>
    <target>allowed_ips_internal.entries</target>
    <label>Internal Allowed IPs List</label>
    <help><![CDATA[
        The allow list is managed entirely in OPNsense. This allows
        for adding comments, editing individual entries, searching,
        sorting, as well as quick additions and removals along with
        importing and exporting the entire list.
        ]]>
    </help>
    <type>bootgrid</type>
    <edit>true</edit>
    <columns>
        <select>true</select>
        <column id="expression" width="" size="" type="string" visible="true" data-formatter="">Expression</column>
        <column id="comment" width="" size="" type="string" visible="true" data-formatter="">Comment</column>
    </columns>
    <api>
        <search>/api/dnscryptproxy/settings/grid/search</search>
        <get>/api/dnscryptproxy/settings/grid/get</get>
        <set>/api/dnscryptproxy/settings/grid/set</set>
        <add>/api/dnscryptproxy/settings/grid/add</add>
        <del>/api/dnscryptproxy/settings/grid/del</del>
        <toggle>/api/dnscryptproxy/settings/grid/toggle</toggle>
        <import>/api/dnscryptproxy/settings/import</import>
        <export>/api/dnscryptproxy/settings/export</export>
    </api>
    <row_count>7,14,20,50,100,-1</row_count>
    <dialog>
        <label>Edit Entry</label>
        <field>
            <id>entries.enabled</id>
            <label>Enabled</label>
            <type>checkbox</type>
            <help><![CDATA[
                This will enable or disable the allow list entry.
                ]]>
            </help>
        </field>
        <field>
            <id>entries.expression</id>
            <label>Expression</label>
            <type>text</type>
            <help><![CDATA[
                Set the domain, IP or expression to allow list,
                e.g. ads.* or *.example.com
                ]]>
            </help>
            <hint>*.example.com</hint>
        </field>
        <field>
            <id>entries.comment</id>
            <label>Comment</label>
            <type>text</type>
            <help><![CDATA[
                Optional comment.
                ]]>
            </help>
        </field>
    </dialog>
</field>
```

Defining radio buttons:
``` xml
<field>
    <id>settings.blocked_names_type</id>
    <label>Blocked Names List type</label>
    <type>radio</type>
    <help><![CDATA[
        Select which blocklist type to use:<br>
        <b>Internal</b> - blocklist entries are managed within
        OPNsense via the list on this page.<br>
        <b>External</b> - Specify the filesystem path to a blocklist
        file external to dnscrypt-proxy.<br>
        <b>Manual</b> - Manage the blocklist manaully by uploading
        a blocklist.
        ]]>
    </help>
    <buttons>
        <button value="external">External</button>
        <button value="manual">Manual</button>
        <button value="internal">Internal</button>
    </buttons>
</field>
```

Defining actions to control fields when specific pre-defined events occur:
``` xml
<field>
    <id>settings.nx_log.enabled</id>
    <type>checkbox</type>
    <hidden>true</hidden>
    <control>
        <action on_set="true" type="tab" do_state="visible">tab_header_dnscryptproxy_logs_nx</action>
        <action on_set="false" type="tab" do_state="hidden">tab_header_dnscryptproxy_logs_nx</action>
    </control>
</field>
```

Adding a button (which has an additional two sub-buttons defined), which includes definitions for some style, and identifier attributes.
``` xml
<button type="group" icon="fa fa-floppy-o" label="Save All Settings" id="save_actions">
    <dropdown action="save_all" icon="fa fa-floppy-o">Save Only</dropdown>
    <dropdown action="save_apply_all" icon="fa fa-floppy-o">Save and Apply</dropdown>
</button>
```

Here are some volt templates from my plugin which showcase the reduced codebase required for a plugin:
Simple example: [diagnostics.volt](https://github.com/agh1467/plugins/blob/dnscrypt-proxy-ng/dns/dnscrypt-proxy-ng/src/opnsense/mvc/app/views/OPNsense/Dnscryptproxy/diagnostics.volt)
More complex: [settings.volt](https://github.com/agh1467/plugins/blob/dnscrypt-proxy-ng/dns/dnscrypt-proxy-ng/src/opnsense/mvc/app/views/OPNsense/Dnscryptproxy/settings.volt)