### PR TITLE
ui: bootgrid, correct required api for command-info #5478

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -82,7 +82,7 @@ $.fn.UIBootgrid = function (params) {
             },
             "command-info": {
                 method: this_grid.command_info,
-                requires: ['get']
+                requires: ['info']
             },
             "command-toggle": {
                 method: this_grid.command_toggle,


### PR DESCRIPTION
* command-info uses this.command_info method, which expects
  params['info'] to be populated, not 'get'.

I stumbled across this issue ticket and saw that this wasn't addressed yet. I looked into it and I think it should be changed to info, as the method does use 'info', and not the 'get' param. If 'info' is not provided, the method still executes without error, but ends up with a literal `undefined` as the URL in the ajaxGet call. Which gets caught by the API error handler as action not found.

https://github.com/opnsense/core/blob/91b840d5d2ae0d274c3b7b105d2a76bef2209598/src/opnsense/www/js/opnsense_bootgrid_plugin.js#L333-L347

I expect anyone that's using `commandsWithInfo` data-formatter will have an info URL defined, since the button won't do anything without it.