### PR TITLE
MVC - model: throw when no mount found

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
@@ -319,6 +319,9 @@ abstract class BaseModel
         if ($model_xml->getName() != "model") {
             throw new ModelException('model xml ' . $model_filename . ' seems to be of wrong type');
         }
+        if (!$model_xml->mount) {
+            throw new ModelException('model xml ' . $model_filename . ' missing mount definition');
+        }
         /*
          *  XXX: we should probably replace start with // for absolute root, but to limit impact only select root for
          *       mountpoints starting with a single /


### PR DESCRIPTION
* Return a useful message to the UI if no mount is found in the model XML.
  Otherwise this condition results in a SimpleXMLElement error, trying to
  parse an empty string in toXml(), `$xml = new SimpleXMLElement($xml_root_node);`

I followed the pattern of error handling of the two throws above it. I'm not sure about the message, but it should be clear enough.

Message looks like:
```
/usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:323: model xml /usr/local/opnsense/mvc/app/models/OPNsense/Myplugin/Settings.xml missing mount definition
```