### PR TITLE
MVC: revise route to default

### DIFF
--- a/src/opnsense/www/index.php
+++ b/src/opnsense/www/index.php
@@ -72,14 +72,18 @@ try {
     echo $application->handle($_SERVER['REQUEST_URI'])->getContent();
 } catch (\Exception $e) {
     if (
-        isset($application) || (
-          stripos($e->getMessage(), ' handler class cannot be loaded') !== false ||
-          stripos($e->getMessage(), ' was not found on handler ') !== false
+        stripos($e->getMessage(), ' handler class cannot be loaded') !== false ||
+        stripos($e->getMessage(), ' was not found on handler ') !== false
         )
-    ) {
+    {
         // Render default UI page when controller or action wasn't found
-        echo $application->handle('/ui/')->getContent();
+        if (isset($application)) {
+            echo $application->handle('/ui/')->getContent();
+        } else {
+            echo $e->getMessage();
+        }
     } else {
-        echo $e->getMessage();
+        echo $e->getFile() . ':' . $e->getLine() . ': ' . $e->getMessage() . "<br>";
+        echo "<pre>" . $e->getTraceAsString() . "</pre>";
     }
 }


### PR DESCRIPTION
This logic was originally for an issue #2435

* Original change on commit 1bdef70

* Adjust logic so that exceptions are visible to the user.
  Use some style so that it's easier to read.

I'm leery of changing this logic without additional scrutiny. This might not even be the correct or best way to handle it. The intent here is to present the exceptions that are thrown inside views (and controllers) to the user. Right now, the logic will always catch the first `if`, and simply draw the default page, because `$application` will always be set if the controller was able to load properly. The exception data however is not included in the output.

I found this through digging, and found that a typo in my form XML was causing the issue. However, I thought it was weird that an exception is thrown accordingly, but nothing appears to happen with it. For example, these throws here are never seen:
https://github.com/opnsense/core/blob/59c2059eb206440ab6a7ffa1921c221839e908c5/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php#L95-L114

I'd guess that _any_ throws occurring will never get seen when loaded by `index.php`.

It would be nice to actually show a page, with a dialog box like when an API exception occurs, but it's a bit out of scope for me.

**Maybe related**, attempting to load a non-existent page like "/ui/noexist" doesn't appear throw at all. So the comment doesn't sound like it correlate with what's happening: `// Render default UI page when controller or action wasn't found` As that describes the situation of no controller found but the catch doesn't happen with that condition.