### PR TITLE
ui: bootgrid override formatters

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -140,7 +140,12 @@ $.fn.UIBootgrid = function (params) {
         // merge additional options (if any)
         if (params['options'] !== undefined) {
             $.each(params['options'],  function(key, value) {
-                gridopt[key] = value;
+                if (key == 'formatters') {
+                    // Add formatters to existing defaults and overwrite any of the same name.
+                    gridopt[key] = Object.assign({}, gridopt[key], value);
+                } else {
+                    gridopt[key] = value;
+                }
             });
         }
 


### PR DESCRIPTION
Keep default formatters, but allow them to be overridden with options.

I'm not an expert in Javascript, so this may not be the best way to get the intended result.

This intends to allow plugin authors to define new formatters without also having to re-define the default ones. In the case where a custom formatter is desired along with the desire to use one of the default formatters at the same time.

This has manifested recently in #5808, and was fixed by re-defining the `rowtoggle` formatter in 3dac44b within the plugin. This should address this type of issue in the future.

This should allow for two things:
1. Define new formatters without wiping out the default ones.
2. Override default formatters without wiping out the other default ones.

I looked at the other params/options, and formatters seemed to be the only one where this kind of accommodation would be necessary.