### PR TITLE
Firewall: Alias - toggle formatter updates

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -54,11 +54,19 @@
                         }
                     },
                     "rowtoggle": function (column, row) {
-                        if (parseInt(row[column.id], 2) === 1) {
-                            return '<span style="cursor: pointer;" class="fa fa-fw fa-check-square-o command-toggle bootgrid-tooltip" data-value="1" data-row-id="' + row.uuid + '"></span>';
-                        } else {
-                            return '<span style="cursor: pointer;" class="fa fa-fw fa-square-o command-toggle bootgrid-tooltip" data-value="0" data-row-id="' + row.uuid + '"></span>';
-                        }
+                        var data_value = parseInt(row[column.id], 2); // 1 = Enabled, 0 = Disabled
+                        var is_uuid = row.uuid.includes('-');         // true = row is UUID, false = row is internal aliases
+                        var html = '<span class="fa fa-fw bootgrid-tooltip';
+                        html += ' ' + ((data_value === 1) ? 'fa-check-square-o' : 'fa-square-o');
+                        html += ' ' + ((is_uuid === true) ? 'command-toggle' : 'text-muted');
+                        html += '" ' + ((is_uuid === true) ? 'style="cursor: pointer;"' : 'disabled=""');
+                        html += ' ' + ((is_uuid === false) ? 'title="Toggle disabled for internal aliases"' : '');
+                        //html += ' ' + ((is_uuid === false && data_value === 1) ? 'title="' + $.fn.UIBootgrid.defaults.disableText + '"' : '');
+                        //html += ' ' + ((is_uuid === false && data_value === 0) ? 'title="' + $.fn.UIBootgrid.defaults.enableText + '"' : '');
+                        html += ' ' + 'data-row-id="' + row.uuid + '"';
+                        html += ' ' + 'data-value="' + data_value + '"';
+                        html += '></span>'
+                        return html;
                     },
                 }
             }


### PR DESCRIPTION
* Disable toggle for internal aliases
* Add bootgrid-tooltip title override for internal aliases

The intent with this is to improve the user experience. Stemming from looking at #5808, I found the experience of the toggle functionality to be confusing with the recently added internal aliases. It took me a bit to realize that the internal aliases can't be disabled, even though the API returns that one was disabled via the toggle functionality. Regardless of clicking the toggle, I found that the `get` always returns `enabled: 1` for these entries.

Instead of allowing these toggles to function, this intends to accommodate this condition by disabling these toggle boxes for the internal alias rows.

In the code, there are a couple of lines commented out, these are some other ideas about how to present to the user. I thought about the various ways this could be handled in the UI, and I came up with three methods which would improve the experience:
1. Tell the user directly what's going on with a hoverover tooltip, "Toggle disabled for internal aliases"
2. Convey to the user the current enabled status the same as other (non-internal) aliases, and disable the toggle box.
3. Provide no feedback to the user, no tooltip, and simply disable the toggle (checked or unchecked).

I think generally the user would arrive at the same conclusion with any of these experiences. The list goes from most descriptive (verbose) to least descriptive, and the code included provides the first experience in the list.

Also, up for debate is the re-write of the function to use an assembly approach with ternary functions with a single return, rather than the multiple return full string approach. I'll be the first to admit it's not the easiest to read, but makes for less copy/paste activities, and shorter lines.