### PR TITLE
configd - except configparser read

### DIFF
--- a/src/opnsense/service/modules/processhandler.py
+++ b/src/opnsense/service/modules/processhandler.py
@@ -262,7 +262,7 @@ class ActionHandler(object):
             cnf = configparser.RawConfigParser()
             try:
                 cnf.read(config_filename)
-            except:
+            except configparser.Error:
                 syslog_error('exception occurred while reading "%s": %s' % (config_filename, traceback.format_exc(0)))
 
             for section in cnf.sections():

--- a/src/opnsense/service/modules/processhandler.py
+++ b/src/opnsense/service/modules/processhandler.py
@@ -260,7 +260,11 @@ class ActionHandler(object):
 
             # traverse config directory and open all filenames starting with actions_
             cnf = configparser.RawConfigParser()
-            cnf.read(config_filename)
+            try:
+                cnf.read(config_filename)
+            except:
+                syslog_error('exception occurred while reading "%s": %s' % (config_filename, traceback.format_exc(0)))
+
             for section in cnf.sections():
                 # map configuration data on object
                 action_obj = Action(config_environment=self.config_environment)


### PR DESCRIPTION
* except when an Exception occurs reading a config file

This intends to mitigate an issue that I encountered through a mistake that I made copy/pasting actions for a plugin where I ended up with two sections in the conf file with the same name.

#### Issue

This duplicate name situation appears to stall configd, and it doesn't open the socket to interact with it. Attempts to `configctl` result in only a message:
```
configd socket missing (@/var/run/configd.socket)
```

However, the configd service is running according to the status:
```
# service configd status
configd is running as pid 92539.
```

No error is presented when starting the service at the command line.

A log message is recorded in `/var/log/configd/latest.log` though:
```
<11>1 2022-06-28T17:50:40-04:00 OPNsense.localdomain configd.py 62084 - [meta sequenceId="136"] Handler died on Traceback (most recent call last):   File "/usr/local/opnsense/service/modules/processhandler.py", line 85, in run     act_handler = ActionHandler(config_path=self.config_path,   File "/usr/local/opnsense/service/modules/__init__.py", line 38, in getinstance     instances[cls] = cls(*args, **kwargs)   File "/usr/local/opnsense/service/modules/processhandler.py", line 250, in __init__     self.load_config()   File "/usr/local/opnsense/service/modules/processhandler.py", line 268, in load_config     cnf.read(config_filename)   File "/usr/local/lib/python3.8/configparser.py", line 697, in read     self._read(fp, filename)   File "/usr/local/lib/python3.8/configparser.py", line 1067, in _read     raise DuplicateSectionError(sectname, fpname, configparser.DuplicateSectionError: While reading from '/usr/local/opnsense/service/conf/actions.d/actions_noexist.conf' [line  6]: section 'status' already exists
```

This issue is currently caught here in `Handler.run()`:
https://github.com/opnsense/core/blob/ee81d4adfd8ef4f17064fa2cd9123f9b700304e7/src/opnsense/service/modules/processhandler.py#L126-L130

However, this appears to result in an infinite loop, and the log begins repeating the exception stack every second in accordance with the timer period.

#### Explanation

This PR will except on the configparser read of the configuration file instead of letting it fall through to be caught in `run()`. It reports the exception in the logs, and moves on to the next config file. This allows configd to load the rest of the config files, and open the socket necessary to interact with it.

I'm not sure about the message style/formatting, but it is simplified and doesn't include the full traceback stack, this is an example:
```
<11>1 2022-06-28T18:17:01-04:00 OPNsense.localdomain configd.py 93418 - [meta sequenceId="3"] Exception occurred while reading "/usr/local/opnsense/service/conf/actions.d/actions_noexist.conf": configparser.DuplicateSectionError: While reading from '/usr/local/opnsense/service/conf/actions.d/actions_noexist.conf' [line  6]: section 'status' already exists 
```
