### PR TITLE
fix IntegerValidator returning false for negative numbers

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/Validators/IntegerValidator.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Validators/IntegerValidator.php
@@ -50,7 +50,7 @@ class IntegerValidator extends BaseValidator
     {
         $value = $validator->getValue($attribute);
         $msg = $this->getOption('message');
-        if (ctype_digit(strval(($value))) == false or (string)((int)$value) !== (string)$value) {
+        if (filter_var($value, FILTER_VALIDATE_INT) === false) {
             $validator->appendMessage(new Message($msg, $attribute, 'IntegerValidator'));
             return false;
         }


### PR DESCRIPTION
Fixes validation for valid negative integers

Uses FILTER_VALIDATE_INT which should cover all the cases including min/max int value
