### PR TITLE
Sort Order - Firewall : Aliases

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -61,7 +61,8 @@ class AliasController extends ApiMutableModelControllerBase
             "aliases.alias",
             array('enabled', 'name', 'description', 'type', 'content', 'current_items', 'last_updated'),
             "name",
-            $filter_funct
+            $filter_funct,
+            SORT_NATURAL | SORT_FLAG_CASE
         );
     }
 


### PR DESCRIPTION
Sort Order - Firewall : Aliases

Aliases are sorted case sensitively.  Causing un-natural sort order.  myAlias should come before YourAlias.  Always.

Sort order should be:
my Alias
Your Alias

Not:
YourAlias
myAlias