### PR TITLE
MVC - bootgrid - regression from 79f5d8f

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -140,7 +140,7 @@ $.fn.UIBootgrid = function (params) {
         // merge additional options (if any)
         if (params['options'] !== undefined) {
             $.each(params['options'],  function(key, value) {
-                if (typeof(value) === 'object') {
+                if (typeof(value) === 'object' && Array.isArray(value) == false) {
                     gridopt[key] = Object.assign({}, gridopt[key], value);
                 } else {
                     gridopt[key] = value;


### PR DESCRIPTION
* Exclude if array, primarily for rowCount

I found that this condition was also picking up rowCount as an object, it would then convert it to an object which breaks a couple of things down the line, which I noticed with LogController, and jquery.bootgrid.js.

This should be visible by going to System -> Log Files -> General (or any other log page that uses LogController).

An API exception appears reporting `/usr/local/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/LogController.php:76: Unsupported operand types`

This is due to `$itemsPerPage` being an array instead of an integer.

Also the row selector doesn't appear, which is normally between the refresh button, and column selector.

I think these issues stem from jquery.bootgrid.js doing unexpected things since it's expecting an array for rowCount in a couple of locations, but it doesn't handle these situations well, and instead of selecting the first index like it's supposed to, it just leaves the value as is, and it passes through as an array when handled in the UI and the PHP.
