### PR TITLE
MVC - LogController - rowCount validation

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/LogController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/LogController.php
@@ -44,6 +44,8 @@ class LogController extends ApiControllerBase
         $action = count($arguments) > 1 ? $arguments[1] : "";
         $searchPhrase = '';
         $severities = '';
+        $defaultRows = 10;
+        $maxRows = 5000;
         // create filter to sanitize input data
         $filter = new Filter([
             'query' => function ($value) {
@@ -59,7 +61,13 @@ class LogController extends ApiControllerBase
                 return ["status" => "ok"];
             } else {
                 // fetch query parameters (limit results to prevent out of memory issues)
-                $itemsPerPage = $this->request->getPost('rowCount') == -1 ? 5000 : $this->request->getPost('rowCount', 'int', 9999);
+                $itemsPerPage = $this->request->getPost('rowCount', 'int', $defaultRows);
+                if (is_integer($itemsPerPage)) {
+                    $itemsPerPage = ($itemsPerPage > $maxRows ||
+                                     $itemsPerPage <= 0) ? $maxRows : $itemsPerPage;
+                } else {
+                    $itemsPerPage = $defaultRows;
+                }
                 $currentPage = $this->request->getPost('current', 'int', 1);
 
                 if ($this->request->getPost('searchPhrase', 'string', '') != "") {


### PR DESCRIPTION
* Use int filter in getPost() call
* Use variables for default and maximium rows
* Set $itemsPerPage to max if over, all, or invalid
* Set a default if input is not an integer

This is a follow up to the issue mitigated with 5cb6a89

This PR intends to provide input validation for the rowCount to mitigate any issues with improperly set values in a bootgrid's UIBootgrid options rowCount configuration. It goes a little further than the original catching invalid values like string, array, negative numbers below -1, 0, and also if the rowCount is set above 5000. It will use either the default with invalid input, or 5000 for everything below 1.

Two new variables are set for the maximum, and default number of rows. The max was taken from the original, while the default was taken from https://github.com/opnsense/core/blob/e6518fcd14062e2c62bef43cff82db7acea7689f/src/opnsense/www/js/jquery.bootgrid.js#L1038

This approach also employs the `int` filter in the getPost() and using the default (10) instead of 9999.

There are two bugs with jquery.bootgrid.js that I found as well, but they don't cause anything to break per se.

"Showing NaN of NaN" at the bottom of the page, from trying to multiply against rowCount when it's not an integer.
https://github.com/opnsense/core/blob/e6518fcd14062e2c62bef43cff82db7acea7689f/src/opnsense/www/js/jquery.bootgrid.js#L431

No row selector button, where rowCountList (rowCount) is checked if it's an array.
https://github.com/opnsense/core/blob/e6518fcd14062e2c62bef43cff82db7acea7689f/src/opnsense/www/js/jquery.bootgrid.js#L548

With rowCount in jquery.bootgrid.js it seems that it's generally assumed that it will be an array with integers, and practically no validation is performed on it.

If this is agreed to be a good approach I could cover the other instances where this input occurs:
```
src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php:        $itemsPerPage = intval($this->request->getPost('rowCount', 'int', 9999));
src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php:            $itemsPerPage = $this->request->getPost('rowCount', 'int', 9999);
src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php:            $itemsPerPage = $this->request->getPost('rowCount', 'int', 9999);
src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php:        $itemsPerPage = intval($this->request->getPost('rowCount', 'int', -1));
src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/ServiceController.php:            $itemsPerPage = $this->request->getPost('rowCount', 'int', 9999);
src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php:            $itemsPerPage = $this->request->getPost('rowCount', 'int', 9999);
src/opnsense/mvc/app/controllers/OPNsense/Syslog/Api/ServiceController.php:        $itemsPerPage = intval($this->request->getPost('rowCount', 'int', 9999));
```

I also noted the use of `intval()` in one of the cases which is a pretty good alternative, but it does have the possibility of returning `0`, which jquery.bootgrid.js doesn't handle well, so I went with this approach which is more explicit and covers a couple more scenarios.

On an aside, would it be practical to move this functionality to the library instead of have it individually throughout the controllers?