### PR TITLE
Update OpenDNS ipv6 servers

### DIFF
--- a/src/www/services_opendns.php
+++ b/src/www/services_opendns.php
@@ -73,7 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         } elseif ($config['opendns']['enable']) {
             $config['system']['dnsserver'] = array();
             $v4_server = array('208.67.222.222', '208.67.220.220');
-            $v6_server = array('2620:0:ccc::2', '2620:0:ccd::2');
+            $v6_server = array('2620:119:35::35', '2620:119:53::53');
             if (isset($config['system']['prefer_ipv4'])) {
                 $config['system']['dnsserver'][] = $v4_server[0];
                 $config['system']['dnsserver'][] = $v4_server[1];


### PR DESCRIPTION
https://github.com/opnsense/core/issues/5845

The OpenDNS plugin uses array('2620:0:ccc::2', '2620:0:ccd::2') but should be using:
array('2620:119:35::35', '2620:119:53::53') according to https://www.opendns.com/about/innovations/ipv6/

I have tried with the changed settings and verified that it works whereas it did not with existing addresses.