### PR TITLE
MVC: SimpleActionButton, add catch undefined TypeError

### DIFF
--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -571,7 +571,7 @@ $.fn.SimpleActionButton = function (params) {
                     if (params && params.onAction) {
                         params.onAction(data, status);
                     }
-                    if ((status != "success" || data['status'].toLowerCase().trim() != 'ok') && data['status']) {
+                    if ((status != "success" || ('status' in data && data['status'].toLowerCase().trim() != 'ok')) && data['status']) {
                           BootstrapDialog.show({
                               type: BootstrapDialog.TYPE_WARNING,
                               title: this_button.data('error-title'),


### PR DESCRIPTION
* Add condition for data existing before others
  catches Uncaught TypeError: data.status is undefined

I encountered this when I was using SimpleActionButton with a custom API that doesn't have 'status' in the response.

Adding a condition that requires `status` key existing in `data` appears to mitigate the error. I assume that it doesn't evaluate the rest of the conditions with this one failing. Since `data['status']` is used later on, this will require that it exists first.