### PR TITLE
Fix "Allow service binding" for multiple aliases per interface

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4322,18 +4322,24 @@ function interfaces_addresses($interfaces, $as_subnet = false, $ifconfig_details
                 continue;
             }
 
+            $matched_subnet = false;
             if ($info['family'] == 'inet' && strpos($vip['subnet'], ':') === false) {
-                $info['alias'] = $info['alias'] || $vip['subnet'] == $info['address'];
+                $matched_subnet = $vip['subnet'] == $info['address'];
             } elseif ($info['family'] == 'inet6' && strpos($vip['subnet'], ':') !== false) {
                 /*
                  * Since we do not know what subnet value was given by user
                  * uncompress/compress to match correctly compressed system
                  * value.
                  */
-                $info['alias'] = $info['alias'] || Net_IPv6::compress(Net_IPv6::uncompress($vip['subnet'])) == $info['address'];
+                $matched_subnet = Net_IPv6::compress(Net_IPv6::uncompress($vip['subnet'])) == $info['address'];
+            }
+            if (!$matched_subnet) {
+                continue;
             }
 
-            if ($info['alias'] && !empty($vip['nobind'])) {
+            $info['alias'] = true;
+
+            if (!empty($vip['nobind'])) {
                 $info['bind'] = false;
             }
         }


### PR DESCRIPTION
When using multiple aliases per interface, disabling binding on one could potentially disable binding for other aliases on the same interface, depending on the order of the VIPs in the config. The 'alias' setting was evaluated regardless of whether the subnet matched, so if a previous VIP for a matching interface had matched on subnet, the current VIP's 'bind' setting would be applied to the interface address even though the current VIP's subnet didn't match.