### PR TITLE
Ping diagnostics tool, explicitly set IP version for IPv4

### DIFF
--- a/src/www/diag_ping.php
+++ b/src/www/diag_ping.php
@@ -54,13 +54,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         switch ($pconfig['ipproto']) {
             case 'ipv6':
                 list ($ifaddr) = interfaces_primary_address6($pconfig['interface']);
-                $command .= '6';
+                $command .= ' -6';
                 break;
             case 'ipv6-ll':
-                $command .= '6';
+                $command .= ' -6';
                 list ($ifaddr) = interfaces_scoped_address6($pconfig['interface']);
                 break;
             default:
+                $command .= ' -4';
                 list ($ifaddr) = interfaces_primary_address($pconfig['interface']);
                 break;
         }


### PR DESCRIPTION
Invoking ping with a hostname without -6 or -4 gives no control over which IP version is used. From man ping(8):

> When invoked with a hostname, the version to which	the target is resolved first is used.

```
# /sbin/ping -c '3' 'opnsense.org'
PING6(56=40+8+8 bytes) 2a02:8071:3100::xxxx --> 2001:1af8:4700:a1fa:3::2
16 bytes from 2001:1af8:4700:a1fa:3::2, icmp_seq=0 hlim=56 time=28.444 ms
16 bytes from 2001:1af8:4700:a1fa:3::2, icmp_seq=1 hlim=56 time=20.165 ms
16 bytes from 2001:1af8:4700:a1fa:3::2, icmp_seq=2 hlim=56 time=27.399 ms

--- opnsense.org ping6 statistics ---
3 packets transmitted, 3 packets received, 0.0% packet loss
round-trip min/avg/max/std-dev = 20.165/25.336/28.444/3.681 ms
```