### PR TITLE
Disable IPv6 inside 4in6 and 4in4 gif tunnels

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -657,6 +657,7 @@ function _interfaces_gif_configure($gif)
     if ((is_ipaddrv6($gif['tunnel-local-addr'])) || (is_ipaddrv6($gif['tunnel-remote-addr']))) {
         mwexec("/sbin/ifconfig {$gif['gifif']} inet6 " . escapeshellarg($gif['tunnel-local-addr']) . " " . escapeshellarg($gif['tunnel-remote-addr']) . " prefixlen 128");
     } else {
+        mwexec("/sbin/ifconfig {$gif['gifif']} inet6 ifdisabled");
         mwexec("/sbin/ifconfig {$gif['gifif']} " . escapeshellarg($gif['tunnel-local-addr']) . " " . escapeshellarg($gif['tunnel-remote-addr']) . " netmask " . gen_subnet_mask($gif['tunnel-remote-net']));
     }
 


### PR DESCRIPTION
When setting up an IPv4-over-IPv6 or IPv4-over-IPv4 gif tunnel, IPv6 should be disabled inside the tunnel to prevent the automatic configuration of an IPv6 link-local address. From man gif(4):

> Note that IPv6 link-local addresses (those that start with fe80::) will be automatically configured whenever possible. You may need to remove IPv6 link-local addresses manually	using ifconfig(8), if you want to disable the use of IPv6 as the inner header (for example, if you need a pure IPv4-over-IPv6 tunnel).