### PR TITLE
Unbound: Clarify “Verify CN” option field

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -33,7 +33,7 @@
         <help>
             The Common Name of the DNS server (e.g. dns.example.com). This field is required to verify its TLS certificate.
             DNS-over-TLS is susceptible to man-in-the-middle attacks unless certificates can be verified.
-            Leave empty to accept self-signed (and potentially fraudulent) certificates.
+            Leave empty to accept self-signed yet also potentially fraudulent certificates.
         </help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -31,7 +31,7 @@
         <label>Verify CN</label>
         <type>text</type>
         <help>
-            The DNS servers' Common Name (e.g. dns.example.com). This field is required to verify the server's TLS certificate.
+            The Common Name of the DNS server (e.g. dns.example.com). This field is required to verify its TLS certificate.
             DNS-over-TLS is susceptible to man-in-the-middle attacks unless certificates can be verified.
             Leave empty to accept self-signed (and potentially fraudulent) certificates.
         </help>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -31,8 +31,8 @@
         <label>Verify CN</label>
         <type>text</type>
         <help>
-            Verify if CN in certificate matches this value. Please note that if this field is omitted,
-            Unbound will not perform any certificate verification. Therefore, man-in-the-middle attacks are still possible.
+            Verify TLS certificates against the specified Common Name (e.g. dns.example.com). Please note that if this field is
+            omitted, Unbound will not perform any certificate verification. Therefore, man-in-the-middle attacks are still possible.
         </help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -31,8 +31,9 @@
         <label>Verify CN</label>
         <type>text</type>
         <help>
-            Verify TLS certificates against the specified Common Name (e.g. dns.example.com). Please note that if this field is
-            omitted, Unbound will not perform any certificate verification. Therefore, man-in-the-middle attacks are still possible.
+            The DNS servers' Common Name (e.g. dns.example.com). This field is required to verify the server's TLS certificate.
+            DNS-over-TLS is susceptible to man-in-the-middle attacks unless certificates can be verified.
+            Leave empty to accept self-signed (and potentially fraudulent) certificates.
         </help>
     </field>
 </form>


### PR DESCRIPTION
A small option string change that’ll hopefully make it clearer what the setting is for and what to enter.