### PR TITLE
Change system domain name suggestions

### DIFF
--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -304,7 +304,7 @@ $( document ).ready(function() {
                 <div class="hidden" data-for="help_for_domain">
                   <?=gettext("Do not use 'local' as your internal domain name. It is reserved for and will interfere with mDNS (avahi, bonjour, etc.). Use the special-purpose home.arpa domain instead."); ?>
                   <br />
-                  <?=sprintf(gettext("e.g. %example.net, london-office.example.com, home.arpa, etc.%s"),'<em>','</em>') ?>
+                  <?=sprintf(gettext("e.g. %sexample.net, branch.example.com, home.arpa, etc.%s"),'<em>','</em>') ?>
                 </div>
               </td>
             </tr>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -302,7 +302,7 @@ $( document ).ready(function() {
               <td>
                 <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
                 <div class="hidden" data-for="help_for_domain">
-                  <?=gettext("Do not use 'local' as your internal domain name. It's reserved for and will interfere with mDNS (avahi, bonjour, etc.). Use the special-purpose home.arpa domain instead."); ?>
+                  <?=gettext("Do not use 'local' as your internal domain name. It is reserved for and will interfere with mDNS (avahi, bonjour, etc.). Use the special-purpose home.arpa domain instead."); ?>
                   <br />
                   <?=sprintf(gettext("e.g. %example.net, london-office.example.com, home.arpa, etc.%s"),'<em>','</em>') ?>
                 </div>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -302,9 +302,9 @@ $( document ).ready(function() {
               <td>
                 <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
                 <div class="hidden" data-for="help_for_domain">
-                  <?=gettext("Do not use 'local' as a domain name. It will cause local hosts running mDNS (avahi, bonjour, etc.) to be unable to resolve local hosts not running mDNS."); ?>
+                  <?=gettext("Do not use 'local' as your internal domain name. It's reserved for and will interfere with mDNS (avahi, bonjour, etc.). Use the special-purpose home.arpa domain instead."); ?>
                   <br />
-                  <?=sprintf(gettext("e.g. %smycorp.com, home, office, private, etc.%s"),'<em>','</em>') ?>
+                  <?=sprintf(gettext("e.g. %example.net, london-office.example.com, home.arpa, etc.%s"),'<em>','</em>') ?>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
* Don't suggest using unreserved top-level domains.
* Use the reserved example.com|net domains for other examples.
* Encourage adoption of the special-purpose internal/site home.arpa (RFC 8375) domain.