### PR TITLE
IPsec: Allow to set rightca in mobile ipsec P1 with EAP-TLS

### DIFF
--- a/src/www/vpn_ipsec_phase1.php
+++ b/src/www/vpn_ipsec_phase1.php
@@ -537,6 +537,8 @@ include("head.inc");
             $(".auth_opt :input").prop( "disabled", true );
             switch ($("#authentication_method").val()) {
                 case 'eap-tls':
+                    $(".auth_eap_tls_caref").show();
+                    $(".auth_eap_tls_caref :input").prop( "disabled", false );
                 case 'psk_eap-tls':
                 case 'eap-mschapv2':
                 case 'rsa_eap-mschapv2':


### PR DESCRIPTION
It seems that Windows EAP-TLS requires a rightca value. This PR is leaned on this commit https://github.com/opnsense/core/commit/71bc4cb39bf5ea98f2629cf3e821394a44d7add2 and was quickly discussed with @AdSchellevis in IRC. Requires broader testing of course.

Initial discussion: https://forum.opnsense.org/index.php?topic=29457.0
Would also explain why my tests with EAP-TLS failed when writing compatiblity matrix: https://github.com/opnsense/docs/blob/master/source/manual/how-tos/ipsec-rw.rst