### PR TITLE
system: change UX for new notices

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
@@ -90,6 +90,64 @@ class SystemController extends ApiControllerBase
                 'status' => $order[$statusCodes[0] ?? 2]
             ];
 
+            foreach ($statuses as &$status) {
+                if (!empty($status['timestamp'])) {
+                    $age = time() - $status['timestamp'];
+
+                    if ($age < 0) {
+                        /* time jump, do nothing */
+                    } elseif ($age < 60) {
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s second ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s seconds ago'), $age);
+                        }
+                    } elseif ($age < 60 * 60) {
+                         $age = intdiv($age, 60);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s minute ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s minutes ago'), $age);
+                        }
+                    } elseif ($age < 60 * 60 * 24) {
+                         $age = intdiv($age, 60 * 60);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s hour ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s hours ago'), $age);
+                        }
+                    } elseif ($age < 60 * 60 * 24 * 7) {
+                         $age = intdiv($age, 60 * 60 * 24);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s day ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s days ago'), $age);
+                        }
+                    } elseif ($age < 60 * 60 * 24 * 30) {
+                         $age = intdiv($age, 60 * 60 * 24 * 7);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s week ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s weeks ago'), $age);
+                        }
+                    } elseif ($age < 60 * 60 * 24 * 365) {
+                         $age = intdiv($age, 60 * 60 * 24 * 30);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s month ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s months ago'), $age);
+                        }
+                    } else {
+                         $age = intdiv($age, 60 * 60 * 24 * 365);
+                        if ($age == 1) {
+                            $status['age'] = sprintf(gettext('%s year ago'), $age);
+                        } else {
+                            $status['age'] = sprintf(gettext('%s years ago'), $age);
+                        }
+                    }
+                }
+            }
+
             $response = json_encode($statuses);
         }
 

--- a/src/opnsense/mvc/app/library/OPNsense/System/AbstractStatus.php
+++ b/src/opnsense/mvc/app/library/OPNsense/System/AbstractStatus.php
@@ -38,6 +38,7 @@ abstract class AbstractStatus
     protected $internalMessage = 'No problems were detected.';
     protected $internalLogLocation = '';
     protected $internalStatus = self::STATUS_OK;
+    protected $internalTimestamp = '0';
     protected $statusStrings = ['notice', 'warning', 'error'];
 
     public function getStatus()
@@ -53,6 +54,11 @@ abstract class AbstractStatus
     public function getLogLocation()
     {
         return $this->internalLogLocation;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->internalTimestamp;
     }
 
     public function dismissStatus()

--- a/src/opnsense/mvc/app/library/OPNsense/System/Status/CrashReporterStatus.php
+++ b/src/opnsense/mvc/app/library/OPNsense/System/Status/CrashReporterStatus.php
@@ -60,10 +60,11 @@ class CrashReporterStatus extends AbstractStatus
 
         if ($php_errors || $src_errors) {
             $this->internalMessage = gettext('An issue was detected and can be reviewed using the firmware crash reporter.');
-            $this->internalStatus = $php_errors ? static::STATUS_ERROR : static::STATUS_WARNING;
-
-            if (Config::getInstance()->object()->system->deployment == 'development') {
-                $this->internalStatus = static::STATUS_NOTICE;
+            if ($php_errors) {
+                $this->internalStatus = Config::getInstance()->object()->system->deployment != 'development' ? static::STATUS_ERROR : static::STATUS_NOTICE;
+            }
+            if ($src_errors && $this->internalStatus != static::STATUS_ERROR) {
+                $this->internalStatus = static::STATUS_WARNING;
             }
         }
     }

--- a/src/opnsense/mvc/app/library/OPNsense/System/Status/FirewallStatus.php
+++ b/src/opnsense/mvc/app/library/OPNsense/System/Status/FirewallStatus.php
@@ -32,18 +32,24 @@ use OPNsense\System\AbstractStatus;
 
 class FirewallStatus extends AbstractStatus
 {
+    protected $rules_error = '/tmp/rules.error';
+
     public function __construct()
     {
         $this->internalLogLocation = '/ui/diagnostics/log/core/firewall';
 
-        if (file_exists('/tmp/rules.error')) {
-            $this->internalMessage = file_get_contents('/tmp/rules.error');
+        if (file_exists($this->rules_error)) {
+            $this->internalMessage = file_get_contents($this->rules_error);
             $this->internalStatus = constant("static::STATUS_ERROR");
+            $info = stat($this->rules_error);
+            if (!empty($info['mtime'])) {
+                $this->internalTimestamp = $info['mtime'];
+            }
         }
     }
 
     public function dismissStatus()
     {
-        @unlink('/tmp/rules.error');
+        @unlink($this->rules_error);
     }
 }

--- a/src/opnsense/mvc/app/library/OPNsense/System/SystemStatus.php
+++ b/src/opnsense/mvc/app/library/OPNsense/System/SystemStatus.php
@@ -75,7 +75,8 @@ class SystemStatus
             $result[$shortName] = [
                 'statusCode' => $obj->getStatus(),
                 'message' => $obj->getMessage(),
-                'logLocation' => $obj->getLogLocation()
+                'logLocation' => $obj->getLogLocation(),
+                'timestamp' => $obj->getTimestamp(),
             ];
         }
 

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -26,24 +26,6 @@
       .typeahead {
         overflow: hidden;
       }
-
-      /* On upstream Bootstrap, these properties are set in list-group-item. (format status popup) */
-      :is(.opn-status-group) .list-group-item-border {
-          border: 1px solid #ddd;
-      }
-
-      :is(.opn-status-group) .list-group-item-border:first-child {
-          border-top-left-radius: 4px;
-          border-top-right-radius: 4px;
-      }
-
-      :is(.opn-status-group) .list-group-item-border:last-child {
-          border-bottom-left-radius: 4px;
-          border-bottom-right-radius: 4px;
-      }
-      :is(.opn-status-group) .btn.pull-right {
-          margin-left: 3px;
-      }
     </style>
 
     <!-- legacy browser functions -->

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -124,7 +124,6 @@
                      title: '{{ lang._('System Status')}}',
                      buttons: [{
                          label: '{{ lang._('Close') }}',
-                         cssClass: 'btn-primary',
                          action: function(dialogRef) {
                              dialogRef.close();
                          }
@@ -255,7 +254,7 @@
             </li>
             <li>
               <span class="navbar-text" style="margin-left: 0">
-                <i id="system_status" data-toggle="tooltip left" title="Show system status" style="cursor:pointer"></i>
+                <i id="system_status" data-toggle="tooltip left" title="{{ lang._('Show system status') }}" style="cursor:pointer" class="fa fa-circle text-muted"></i>
               </span>
             </li>
             <li>

--- a/src/opnsense/www/js/opnsense_status.js
+++ b/src/opnsense/www/js/opnsense_status.js
@@ -26,17 +26,10 @@
  */
 
 function updateStatusDialog(dialog, status, subjectRef = null) {
-    let $ret = $('<div>No problems were detected.</div>');
+    let $ret = $('<div><div>No problems were detected.</div></div>');
     let $message = $(
-        '<div class="row">' +
-        '<div class="col-md-6">' +
-        '<div class="list-group" id="list-tab" role="tablist" style="margin-bottom: 0">' +
-        '</div>' +
-        '</div>' +
-        '<div class="col-md-6">' +
-        '<div class="tab-content" id="nav-tabContent">' +
-        '</div>' +
-        '</div>'+
+        '<div>' +
+        '<div id="opn-status-list"></div>' +
         '</div>'
     );
 
@@ -50,39 +43,20 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
         }
 
         let formattedSubject = subject.replace(/([A-Z])/g, ' $1').trim();
-        let $listItem = $(
-            '<a class="list-group-item list-group-item-border" data-toggle="list" href="#list-' + subject + '" role="tab" style="outline: 0">' +
-            formattedSubject +
-            '<span class="' + statusObject.icon + '" style="float: right"></span>' +
-            '</a>'
-        );
-        let referral = statusObject.status !== 'OK' ? 'Click <a href="' + statusObject.logLocation + '">here</a> for more information.' : ''
-        let $pane = $(
-            '<div class="tab-pane fade" id="list-' + subject + '" role="tabpanel"><p>' + statusObject.message + ' ' + referral + '</p>' +
-            '</div>'
-        );
-
-        $message.find('#list-tab').addClass('opn-status-group').append($listItem);
-        $message.find('#nav-tabContent').append($pane);
-
-        if (subjectRef) {
-            $message.find('#list-tab a[href="#list-' + subjectRef + '"]').addClass('active').tab('show').siblings().removeClass('active');
-            $pane.addClass('active in').siblings().removeClass('active in');
-        } else {
-            $message.find('#list-tab a:first-child').addClass('active').tab('show');
-            $message.find('#nav-tabContent div:first-child').addClass('active in');
+        if (status.data[subject].age != undefined) {
+            formattedSubject += '&nbsp;<small>(' + status.data[subject].age + ')</small>';
         }
+        let listItem = '<a class="btn btn-default" style="width:100%; text-align: left;" href="' + statusObject.logLocation + '">' +
+            '<h4><span class="' + statusObject.icon + '"></span>&nbsp;' + formattedSubject +
+            '<button id="dismiss-'+ subject + '" class="close"><span aria-hidden="true">&times;</span></button></h4></div>' +
+            '<p>' + statusObject.message + '</p></a>';
 
-        $message.find('#list-tab a[href="#list-' + subject + '"]').on('click', function(e) {
+        let referral = statusObject.logLocation;
+
+        $message.find('#opn-status-list').append(listItem);
+
+        $message.find('#dismiss-' + subject).on('click', function (e) {
             e.preventDefault();
-            $(this).tab('show');
-            $(this).toggleClass('active').siblings().removeClass('active');
-        });
-
-        let $button = $('<div><button id="dismiss-'+ subject + '" type="button" class="btn btn-link btn-sm" style="padding: 0px;">Dismiss</button></div>');
-        $pane.append($button);
-
-        $message.find('#dismiss-' + subject).on('click', function(e) {
             $.ajax('/api/core/system/dismissStatus', {
                 type: 'post',
                 data: {'subject': subject},
@@ -100,7 +74,7 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
             });
         });
 
-	$ret = $message;
+        $ret = $message;
     }
     return $ret;
 }

--- a/src/opnsense/www/js/opnsense_status.js
+++ b/src/opnsense/www/js/opnsense_status.js
@@ -102,7 +102,6 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
                     updateSystemStatus().then((data) => {
                         let newStatus = parseStatus(data);
                         let $newMessage = updateStatusDialog(this.dialogRef, newStatus, this.subjectRef);
-                        this.dialogRef.setType(newStatus.severity);
                         this.dialogRef.setMessage($newMessage);
                         $('#system_status').attr("class", newStatus.data['System'].icon);
                         registerStatusDelegate(this.dialogRef, newStatus);
@@ -116,33 +115,30 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
 
 function parseStatus(data) {
     let status = {};
-    let severity = BootstrapDialog.TYPE_SUCCESS;
+    let severity = BootstrapDialog.TYPE_PRIMARY;
     $.each(data, function(subject, statusObject) {
         switch (statusObject.status) {
             case "Error":
-                statusObject.icon = 'fa fa-exclamation-triangle text-danger'
+                statusObject.icon = 'fa fa-circle text-danger'
                 if (subject != 'System') break;
-                $('#system_status').toggleClass(statusObject.icon);
                 severity = BootstrapDialog.TYPE_DANGER;
                 break;
             case "Warning":
-                statusObject.icon = 'fa fa-exclamation-triangle text-warning';
+                statusObject.icon = 'fa fa-circle text-warning';
                 if (subject != 'System') break;
-                $('#system_status').toggleClass(statusObject.icon);
                 severity = BootstrapDialog.TYPE_WARNING;
                 break;
             case "Notice":
-                statusObject.icon = 'fa fa-check-circle text-info';
+                statusObject.icon = 'fa fa-circle text-info';
                 if (subject != 'System') break;
-                $('#system_status').toggleClass(statusObject.icon);
                 severity = BootstrapDialog.TYPE_INFO;
                 break;
             default:
-                statusObject.icon = 'fa fa-check-circle text-success';
+                statusObject.icon = 'fa fa-circle text-muted';
                 if (subject != 'System') break;
-                $('#system_status').toggleClass(statusObject.icon);
                 break;
         }
+        $('#system_status').removeClass().addClass(statusObject.icon);
     });
     status.severity = severity;
     status.data = data;
@@ -152,7 +148,6 @@ function parseStatus(data) {
 
 function registerStatusDelegate(dialog, status) {
     $("#system_status").click(function() {
-        dialog.setType(status.severity);
         dialog.setMessage(function(dialogRef) {
             let $message = updateStatusDialog(dialogRef, status);
             return $message;

--- a/src/opnsense/www/js/opnsense_status.js
+++ b/src/opnsense/www/js/opnsense_status.js
@@ -26,7 +26,7 @@
  */
 
 function updateStatusDialog(dialog, status, subjectRef = null) {
-    let $ret = $('<div><div>No problems were detected.</div></div>');
+    let $ret = $('<div><div><a data-dismiss="modal" class="btn btn-default" style="width:100%;text-align:left;" href="#"><h4><span class="fa fa-circle text-muted"></span>&nbsp;System</h4><p>No pending messages.</p></a></div></div>');
     let $message = $(
         '<div>' +
         '<div id="opn-status-list"></div>' +
@@ -42,11 +42,13 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
             continue;
         }
 
+        $message.find('a').last().addClass('__mb');
+
         let formattedSubject = subject.replace(/([A-Z])/g, ' $1').trim();
         if (status.data[subject].age != undefined) {
             formattedSubject += '&nbsp;<small>(' + status.data[subject].age + ')</small>';
         }
-        let listItem = '<a class="btn btn-default" style="width:100%; text-align: left;" href="' + statusObject.logLocation + '">' +
+        let listItem = '<a class="btn btn-default" style="width:100%;text-align:left;" href="' + statusObject.logLocation + '">' +
             '<h4><span class="' + statusObject.icon + '"></span>&nbsp;' + formattedSubject +
             '<button id="dismiss-'+ subject + '" class="close"><span aria-hidden="true">&times;</span></button></h4></div>' +
             '<p>' + statusObject.message + '</p></a>';

--- a/src/opnsense/www/js/opnsense_status.js
+++ b/src/opnsense/www/js/opnsense_status.js
@@ -26,10 +26,8 @@
  */
 
 function updateStatusDialog(dialog, status, subjectRef = null) {
-    const keys = Object.keys(status.data);
-    const statusAvailable = !(keys.length === 1 && keys[0] === 'System');
-
-    let $message = statusAvailable ? $(
+    let $ret = $('<div>No problems were detected.</div>');
+    let $message = $(
         '<div class="row">' +
         '<div class="col-md-6">' +
         '<div class="list-group" id="list-tab" role="tablist" style="margin-bottom: 0">' +
@@ -40,23 +38,17 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
         '</div>' +
         '</div>'+
         '</div>'
-    ) :
-        $('<div>No problems were detected.</div>');
-
-    if (!statusAvailable) {
-        return $message;
-    }
+    );
 
     for (let subject in status.data) {
         if (subject === 'System') {
             continue;
         }
         let statusObject = status.data[subject];
-        let dismissNeeded = true;
-
         if (status.data[subject].status == "OK") {
-            dismissNeeded = false;
+            continue;
         }
+
         let formattedSubject = subject.replace(/([A-Z])/g, ' $1').trim();
         let $listItem = $(
             '<a class="list-group-item list-group-item-border" data-toggle="list" href="#list-' + subject + '" role="tab" style="outline: 0">' +
@@ -87,10 +79,8 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
             $(this).toggleClass('active').siblings().removeClass('active');
         });
 
-        if (dismissNeeded) {
-            let $button = $('<div><button id="dismiss-'+ subject + '" type="button" class="btn btn-link btn-sm" style="padding: 0px;">Dismiss</button></div>');
-            $pane.append($button);
-        }
+        let $button = $('<div><button id="dismiss-'+ subject + '" type="button" class="btn btn-link btn-sm" style="padding: 0px;">Dismiss</button></div>');
+        $pane.append($button);
 
         $message.find('#dismiss-' + subject).on('click', function(e) {
             $.ajax('/api/core/system/dismissStatus', {
@@ -109,8 +99,10 @@ function updateStatusDialog(dialog, status, subjectRef = null) {
                 }
             });
         });
+
+	$ret = $message;
     }
-    return $message;
+    return $ret;
 }
 
 function parseStatus(data) {
@@ -157,8 +149,5 @@ function registerStatusDelegate(dialog, status) {
 }
 
 function updateSystemStatus() {
-    return $.ajax("/api/core/system/status", {
-        type: 'get',
-        dataType: "json"
-    });
+    return $.ajax('/api/core/system/status', { type: 'get', dataType: 'json' });
 }

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -62,7 +62,7 @@ $aclObj = new \OPNsense\Core\ACL();
           <li id="menu_messages"><?= get_menu_user() ?></li>
           <li>
             <span class="navbar-text" style="margin-left: 0">
-              <i id="system_status" data-toggle="tooltip left" title="Show system status" style="cursor:pointer"></i>
+              <i id="system_status" data-toggle="tooltip left" title="<?= html_safe(gettext('Show system status')) ?>" style="cursor:pointer" class="fa fa-circle text-muted"></i>
             </span>
           </li>
           <li>

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -213,10 +213,9 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
 
       // Create status dialog instance
       let dialog = new BootstrapDialog({
-          title: 'System Status',
+          title: "<?= html_safe(gettext('System Status')) ?>",
           buttons: [{
-              label: 'Close',
-              cssClass: 'btn-primary',
+              label: "<?= html_safe(gettext('Close')) ?>",
               action: function(dialogRef) {
                   dialogRef.close();
               }

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -73,24 +73,6 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
       ol.example li.placeholder:before {
         position: absolute;
       }
-
-      /* On upstream Bootstrap, these properties are set in list-group-item. (format status popup) */
-      :is(.opn-status-group) .list-group-item-border {
-          border: 1px solid #ddd;
-      }
-
-      :is(.opn-status-group) .list-group-item-border:first-child {
-          border-top-left-radius: 4px;
-          border-top-right-radius: 4px;
-      }
-
-      :is(.opn-status-group) .list-group-item-border:last-child {
-          border-bottom-left-radius: 4px;
-          border-bottom-right-radius: 4px;
-      }
-      :is(.opn-status-group) .btn.pull-right {
-          margin-left: 3px;
-      }
     </style>
 
     <!-- Favicon -->


### PR DESCRIPTION
o Switch to shared circle with coloring (no visual jumping)
o Switch SUCCESS circle to muted (muted keeps us calm)
o Switch dialog color to primary (keep one consistent "neutral" layout)
o Switch dialog close button to plain (it doesn't do anything)
o Add translation in legacy template (because that's nice)
o Add muted circle to page load (to avoid shifts and jumps)
o Check error level for crash report in production (probably better as warning)
o Rearrange dismiss and error presentation, inline "circle" indicator (perhaps)

Behavioural changes thought of but discarded:

o ~~Open error dialog right away~~ (it implies action to be taken but might be annoying especially if the reporting page is already open)
o ~~Dismiss on redirect also?~~ (can't do this, clears crash report)