### PR TITLE
unbound: restrict creation of PTR records for both the system domain and host overrides

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -463,40 +463,35 @@ function unbound_add_host_entries($ifconfig_details = null)
         $interfaces = array_keys(get_configured_interface_with_descr());
     }
 
-    sort($interfaces);
     foreach ($interfaces as $interface) {
         if ($interface == 'lo0' || substr($interface, 0, 4) == 'ovpn') {
             continue;
         }
 
         list ($laddr) = interfaces_primary_address($interface, $ifconfig_details);
-        if (!empty($laddr)) {
-            $domain = $config['system']['domain'];
-            if (isset($config['dhcpd'][$interface]['enable']) && !empty($config['dhcpd'][$interface]['domain'])) {
-                $domain = $config['dhcpd'][$interface]['domain'];
-            }
-            if ($interface === $interfaces[0] && !in_array($laddr, $ptr_records, true)) {
-                $unbound_entries .= "local-data-ptr: \"{$laddr} {$config['system']['hostname']}.{$domain}\"\n";
-                $ptr_records[] = $laddr;
-            }
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} A {$laddr}\"\n";
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']} A {$laddr}\"\n";
-        }
         list ($laddr6) = interfaces_primary_address6($interface, $ifconfig_details);
-        if (!empty($laddr6)) {
+
+        foreach (['4' => $laddr, '6' => $laddr6] as $ip_version => $addr) {
+            if (empty($addr)) {
+                continue;
+            }
+
             $domain = $config['system']['domain'];
-            if (isset($config['dhcpdv6'][$interface]['enable']) && !empty($config['dhcpdv6'][$interface]['domain'])) {
-                $domain = $config['dhcpdv6'][$interface]['domain'];
+            $dhcpd = $ip_version == '4' ? 'dhcpd' : 'dhcpd6';
+            $record = $ip_version == '4' ? 'A' : 'AAAA';
+            if (isset($config[$dhcpd][$interface]['enable']) && !empty($config[$dhcpd][$interface]['domain'])) {
+                $domain = $config[$dhcpd][$interface]['domain'];
             }
-            if ($interface === $interfaces[0] && !in_array($laddr6, $ptr_records, true)) {
-                $unbound_entries .= "local-data-ptr: \"{$laddr6} {$config['system']['hostname']}.{$domain}\"\n";
-                $ptr_records[] = $laddr6;
+            if ($interface === get_primary_interface_from_list($interfaces) && !in_array($addr, $ptr_records, true)) {
+                $unbound_entries .= "local-data-ptr: \"{$addr} {$config['system']['hostname']}.{$domain}\"\n";
             }
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} AAAA {$laddr6}\"\n";
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']} AAAA {$laddr6}\"\n";
+            $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} {$record} {$addr}\"\n";
+            $unbound_entries .= "local-data: \"{$config['system']['hostname']} {$record} {$addr}\"\n";
+
+            $ptr_records[] = $addr;
         }
+
         if (empty($config['unbound']['noreglladdr6'])) {
-            list ($lladdr6) = interfaces_scoped_address6($interface, $ifconfig_details);
             if (!empty($lladdr6)) {
                 /* cannot embed scope */
                 $lladdr6 = explode('%', $lladdr6)[0];

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -439,7 +439,7 @@ function unbound_add_host_entries($ifconfig_details = null)
     global $config;
 
     $local_zone_type = 'transparent';
-    $ptr_records = [];
+    $ptr_records = ['127.0.0.1', '::1'];
 
     openlog("unbound", LOG_DAEMON, LOG_LOCAL4);
 

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -463,44 +463,46 @@ function unbound_add_host_entries($ifconfig_details = null)
         $interfaces = array_keys(get_configured_interface_with_descr());
     }
 
-    foreach ($interfaces as $interface) {
-        if ($interface == 'lo0' || substr($interface, 0, 4) == 'ovpn') {
-            continue;
-        }
-
-        list ($laddr) = interfaces_primary_address($interface, $ifconfig_details);
-        list ($laddr6) = interfaces_primary_address6($interface, $ifconfig_details);
-
-        foreach (['4' => $laddr, '6' => $laddr6] as $ip_version => $addr) {
-            if (empty($addr)) {
+    if (empty($config['unbound']['noregrecords'])) {
+        foreach ($interfaces as $interface) {
+            if ($interface == 'lo0' || substr($interface, 0, 4) == 'ovpn') {
                 continue;
             }
 
-            $domain = $config['system']['domain'];
-            $dhcpd = $ip_version == '4' ? 'dhcpd' : 'dhcpd6';
-            $record = $ip_version == '4' ? 'A' : 'AAAA';
-            if (isset($config[$dhcpd][$interface]['enable']) && !empty($config[$dhcpd][$interface]['domain'])) {
-                $domain = $config[$dhcpd][$interface]['domain'];
-            }
-            if ($interface === get_primary_interface_from_list($interfaces) && !in_array($addr, $ptr_records, true)) {
-                $unbound_entries .= "local-data-ptr: \"{$addr} {$config['system']['hostname']}.{$domain}\"\n";
-            }
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} {$record} {$addr}\"\n";
-            $unbound_entries .= "local-data: \"{$config['system']['hostname']} {$record} {$addr}\"\n";
+            list ($laddr) = interfaces_primary_address($interface, $ifconfig_details);
+            list ($laddr6) = interfaces_primary_address6($interface, $ifconfig_details);
 
-            $ptr_records[] = $addr;
-        }
-
-        if (empty($config['unbound']['noreglladdr6'])) {
-            if (!empty($lladdr6)) {
-                /* cannot embed scope */
-                $lladdr6 = explode('%', $lladdr6)[0];
-                $domain = $config['system']['domain'];
-                if (isset($config['dhcpdv6'][$interface]['enable']) && !empty($config['dhcpdv6'][$interface]['domain'])) {
-                    $domain = $config['dhcpdv6'][$interface]['domain'];
+            foreach (['4' => $laddr, '6' => $laddr6] as $ip_version => $addr) {
+                if (empty($addr)) {
+                    continue;
                 }
-                $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} AAAA {$lladdr6}\"\n";
-                $unbound_entries .= "local-data: \"{$config['system']['hostname']} AAAA {$lladdr6}\"\n";
+
+                $domain = $config['system']['domain'];
+                $dhcpd = $ip_version == '4' ? 'dhcpd' : 'dhcpd6';
+                $record = $ip_version == '4' ? 'A' : 'AAAA';
+                if (isset($config[$dhcpd][$interface]['enable']) && !empty($config[$dhcpd][$interface]['domain'])) {
+                    $domain = $config[$dhcpd][$interface]['domain'];
+                }
+                if ($interface === get_primary_interface_from_list($interfaces) && !in_array($addr, $ptr_records, true)) {
+                    $unbound_entries .= "local-data-ptr: \"{$addr} {$config['system']['hostname']}.{$domain}\"\n";
+                }
+                $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} {$record} {$addr}\"\n";
+                $unbound_entries .= "local-data: \"{$config['system']['hostname']} {$record} {$addr}\"\n";
+
+                $ptr_records[] = $addr;
+            }
+
+            if (empty($config['unbound']['noreglladdr6'])) {
+                if (!empty($lladdr6)) {
+                    /* cannot embed scope */
+                    $lladdr6 = explode('%', $lladdr6)[0];
+                    $domain = $config['system']['domain'];
+                    if (isset($config['dhcpdv6'][$interface]['enable']) && !empty($config['dhcpdv6'][$interface]['domain'])) {
+                        $domain = $config['dhcpdv6'][$interface]['domain'];
+                    }
+                    $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} AAAA {$lladdr6}\"\n";
+                    $unbound_entries .= "local-data: \"{$config['system']['hostname']} AAAA {$lladdr6}\"\n";
+                }
             }
         }
     }

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -441,6 +441,8 @@ function unbound_add_host_entries($ifconfig_details = null)
     $local_zone_type = 'transparent';
     $ptr_records = [];
 
+    openlog("unbound", LOG_DAEMON, LOG_LOCAL4);
+
     if (!empty($config['unbound']['local_zone_type'])) {
         $local_zone_type = $config['unbound']['local_zone_type'];
     }
@@ -575,6 +577,8 @@ function unbound_add_host_entries($ifconfig_details = null)
                                      */
                                     $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
                                     $ptr_records[] = $host->server;
+                                } else {
+                                    syslog(LOG_WARNING, 'PTR record already exists for ' . $alias['hostname'] . $alias['domain'] . '(' . $host->server . ')');
                                 }
                                 $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             }
@@ -614,6 +618,8 @@ function unbound_add_host_entries($ifconfig_details = null)
     }
 
     file_put_contents('/var/unbound/host_entries.conf', $unbound_entries);
+
+    closelog();
 }
 
 function unbound_acls_subnets()

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -483,13 +483,12 @@ function unbound_add_host_entries($ifconfig_details = null)
                 if (isset($config[$dhcpd][$interface]['enable']) && !empty($config[$dhcpd][$interface]['domain'])) {
                     $domain = $config[$dhcpd][$interface]['domain'];
                 }
-                if ($interface === get_primary_interface_from_list($interfaces) && !in_array($addr, $ptr_records, true)) {
+                if ($interface === get_primary_interface_from_list($interfaces)) {
                     $unbound_entries .= "local-data-ptr: \"{$addr} {$config['system']['hostname']}.{$domain}\"\n";
+                    $ptr_records[] = $addr;
                 }
                 $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} {$record} {$addr}\"\n";
                 $unbound_entries .= "local-data: \"{$config['system']['hostname']} {$record} {$addr}\"\n";
-
-                $ptr_records[] = $addr;
             }
 
             if (empty($config['unbound']['noreglladdr6'])) {

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -439,6 +439,7 @@ function unbound_add_host_entries($ifconfig_details = null)
     global $config;
 
     $local_zone_type = 'transparent';
+    $ptr_records = [];
 
     if (!empty($config['unbound']['local_zone_type'])) {
         $local_zone_type = $config['unbound']['local_zone_type'];
@@ -459,6 +460,8 @@ function unbound_add_host_entries($ifconfig_details = null)
     } else {
         $interfaces = array_keys(get_configured_interface_with_descr());
     }
+
+    sort($interfaces);
     foreach ($interfaces as $interface) {
         if ($interface == 'lo0' || substr($interface, 0, 4) == 'ovpn') {
             continue;
@@ -470,7 +473,10 @@ function unbound_add_host_entries($ifconfig_details = null)
             if (isset($config['dhcpd'][$interface]['enable']) && !empty($config['dhcpd'][$interface]['domain'])) {
                 $domain = $config['dhcpd'][$interface]['domain'];
             }
-            $unbound_entries .= "local-data-ptr: \"{$laddr} {$config['system']['hostname']}.{$domain}\"\n";
+            if ($interface === $interfaces[0] && !in_array($laddr, $ptr_records, true)) {
+                $unbound_entries .= "local-data-ptr: \"{$laddr} {$config['system']['hostname']}.{$domain}\"\n";
+                $ptr_records[] = $laddr;
+            }
             $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} A {$laddr}\"\n";
             $unbound_entries .= "local-data: \"{$config['system']['hostname']} A {$laddr}\"\n";
         }
@@ -480,7 +486,10 @@ function unbound_add_host_entries($ifconfig_details = null)
             if (isset($config['dhcpdv6'][$interface]['enable']) && !empty($config['dhcpdv6'][$interface]['domain'])) {
                 $domain = $config['dhcpdv6'][$interface]['domain'];
             }
-            $unbound_entries .= "local-data-ptr: \"{$laddr6} {$config['system']['hostname']}.{$domain}\"\n";
+            if ($interface === $interfaces[0] && !in_array($laddr6, $ptr_records, true)) {
+                $unbound_entries .= "local-data-ptr: \"{$laddr6} {$config['system']['hostname']}.{$domain}\"\n";
+                $ptr_records[] = $laddr6;
+            }
             $unbound_entries .= "local-data: \"{$config['system']['hostname']}.{$domain} AAAA {$laddr6}\"\n";
             $unbound_entries .= "local-data: \"{$config['system']['hostname']} AAAA {$laddr6}\"\n";
         }
@@ -527,7 +536,6 @@ function unbound_add_host_entries($ifconfig_details = null)
     $aliases = iterator_to_array($unbound_mdl->aliases->alias->iterateItems());
 
     if (!empty($hosts)) {
-        $ptr_records = [];
         foreach ($hosts as $host) {
             if ($host->enabled == '1') {
                 $tmp_aliases = array(array(
@@ -561,8 +569,10 @@ function unbound_add_host_entries($ifconfig_details = null)
                                 $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
                                 $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             } else {
-                                if (current($tmp_aliases) === $tmp_aliases[0] && !in_array($host->server, $ptr_records)) {
-                                    /* Only generate a PTR record for the non-alias override and only if the IP is not already associated with a PTR */
+                                if (($alias === $tmp_aliases[0] || $tmp_aliases[0]['hostname'] === '*') && !in_array($host->server, $ptr_records, true)) {
+                                    /* Only generate a PTR record for the non-alias override and only if the IP is not already associated with a PTR.
+                                     * The exception to this is an alias whose parent uses a wildcard and as such does not specify a PTR record.
+                                     */
                                     $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
                                     $ptr_records[] = $host->server;
                                 }

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -527,6 +527,7 @@ function unbound_add_host_entries($ifconfig_details = null)
     $aliases = iterator_to_array($unbound_mdl->aliases->alias->iterateItems());
 
     if (!empty($hosts)) {
+        $ptr_records = [];
         foreach ($hosts as $host) {
             if ($host->enabled == '1') {
                 $tmp_aliases = array(array(
@@ -560,7 +561,11 @@ function unbound_add_host_entries($ifconfig_details = null)
                                 $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
                                 $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             } else {
-                                $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
+                                if (current($tmp_aliases) === $tmp_aliases[0] && !in_array($host->server, $ptr_records)) {
+                                    /* Only generate a PTR record for the non-alias override and only if the IP is not already associated with a PTR */
+                                    $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
+                                    $ptr_records[] = $host->server;
+                                }
                                 $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             }
                             break;

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -303,11 +303,11 @@ include_once("head.inc");
                               <input name="noregrecords" type="checkbox" id="noregrecords" value="yes" <?= !empty($pconfig['noregrecords']) ? 'checked="checked"' : '' ?>/>
                               <?= gettext('Do not register system A/AAAA records') ?>
                               <div class="hidden" data-for="help_for_noregrecords">
-                                  <?= sprintf(gettext("If this option is set, then A/AAAA records for " .
-                                  "all configured listen interfaces will not be generated. " .
+                                  <?= sprintf(gettext("If this option is set, then no A/AAAA records for " .
+                                  "the configured listen interfaces will be generated. " .
                                   "If desired, you can manually add them in %sUnbound DNS: Overrides%s. " .
-                                  "Use this to control which interface IP addresses are mapped to the system domain name " .
-                                  "as well as to restrict the amount of information exposed in replies."), '<a href="ui/unbound/overrides/">', '</a>'); ?>
+                                  "Use this to control which interface IP addresses are mapped to the system host/domain name " .
+                                  "as well as to restrict the amount of information exposed in replies to queries for the system host/domain name ."), '<a href="ui/unbound/overrides/">', '</a>'); ?>
                               </div>
                           </td>
                       </tr>

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -48,6 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['regdhcpstatic'] = isset($a_unboundcfg['regdhcpstatic']);
     $pconfig['txtsupport'] = isset($a_unboundcfg['txtsupport']);
     $pconfig['cacheflush'] = isset($a_unboundcfg['cacheflush']);
+    $pconfig['noregrecords'] = isset($a_unboundcfg['noregrecords']);
     // text values
     $pconfig['port'] = !empty($a_unboundcfg['port']) ? $a_unboundcfg['port'] : null;
     $pconfig['regdhcpdomain'] = !empty($a_unboundcfg['regdhcpdomain']) ? $a_unboundcfg['regdhcpdomain'] : null;
@@ -111,6 +112,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             }
 
             // boolean values
+            $a_unboundcfg['noregrecords'] = !empty($pconfig['noregrecords']);
             $a_unboundcfg['cacheflush'] = !empty($pconfig['cacheflush']);
             $a_unboundcfg['dns64'] = !empty($pconfig['dns64']);
             $a_unboundcfg['dnssec'] = !empty($pconfig['dnssec']);
@@ -294,6 +296,20 @@ include_once("head.inc");
                             "than one listen interface is configured."); ?>
                           </div>
                         </td>
+                      </tr>
+                      <tr>
+                          <td><a id="help_for_noregrecords" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('System A/AAAA records') ?></td>
+                          <td>
+                              <input name="noregrecords" type="checkbox" id="noregrecords" value="yes" <?= !empty($pconfig['noregrecords']) ? 'checked="checked"' : '' ?>/>
+                              <?= gettext('Do not register system A/AAAA records') ?>
+                              <div class="hidden" data-for="help_for_noregrecords">
+                                  <?= sprintf(gettext("If this option is set, then A/AAAA records for " .
+                                  "all configured listen interfaces will not be generated. " .
+                                  "If desired, you can manually add them in %sUnbound DNS: Overrides%s. " .
+                                  "Use this to control which interface IP addresses are mapped to the system domain name " .
+                                  "as well as to restrict the amount of information exposed in replies."), '<a href="ui/unbound/overrides/">', '</a>'); ?>
+                              </div>
+                          </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_txtsupport" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("TXT Comment Support");?></td>


### PR DESCRIPTION
In order to prevent unpredictable behaviour from something that is not explicitly prohibited in RFC1035, it is best to restrict the creation of PTR records from every single host and alias (except for wildcard entries, no PTR records are created here), to only non-alias overrides (edit: the exception here is an alias whose parent does not create a PTR record). We also further restrict it to unique IP addresses so there can be no confusion in how to maintain the entries within the running Unbound instance.

Hopefully this can pave the way for adding PTR records as a separate type instead of generating them under the hood, as is done currently.

This change should at least address inconsistencies regarding random PTR records being returned as mentioned in https://github.com/opnsense/core/issues/5477