### PR TITLE
Unbound: handle host/domain overrides dynamically

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -560,6 +560,7 @@ function unbound_add_host_entries($ifconfig_details = null)
                                 $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
                                 $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             } else {
+                                $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
                                 $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             }
                             break;

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -560,7 +560,6 @@ function unbound_add_host_entries($ifconfig_details = null)
                                 $unbound_entries .= "local-zone: \"{$alias['domain']}\" redirect\n";
                                 $unbound_entries .= "local-data: \"{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             } else {
-                                $unbound_entries .= "local-data-ptr: \"{$host->server} {$alias['hostname']}{$alias['domain']}\"\n";
                                 $unbound_entries .= "local-data: \"{$alias['hostname']}{$alias['domain']} IN {$host->rr} {$host->server}\"\n";
                             }
                             break;
@@ -689,8 +688,6 @@ function unbound_hosts_generate()
 
     $ifconfig_details = legacy_interfaces_details();
     unbound_add_host_entries($ifconfig_details);
-
-    killbypid('/var/run/unbound.pid', 'HUP');
 }
 
 function unbound_local_zone_types()

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -465,6 +465,7 @@ function system_hosts_generate($verbose = false)
     file_put_contents('/etc/hosts', $hosts);
 
     plugins_configure('hosts');
+    configd_run('unbound overrides');
 
     if ($verbose) {
         echo "done.\n";

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -60,4 +60,25 @@ class ServiceController extends ApiMutableServiceControllerBase
             'status_msg' => gettext('An error occurred during script execution. Check the logs for details'),
         );
     }
+
+    public function overridesAction()
+    {
+        $this->sessionClose();
+        $backend = new Backend();
+        /* Do a template reload for the domain overrides which have been migrated to a template */
+        $backend->configdRun('template reload ' . escapeshellarg(static::$internalServiceTemplate));
+        $overrides = json_decode(trim($backend->configdRun(static::$internalServiceName . ' overrides')), true);
+
+        if ($overrides !== null) {
+            return [
+                'status' => "OK",
+                'status_msg' => "Successfully updated Unbound"
+            ];
+        }
+
+        return array(
+            'status' => 'ERR',
+            'status_msg' => gettext('An error occurred during script execution. Check the logs for details'),
+        );
+    }
 }

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
@@ -156,7 +156,13 @@ $( document ).ready(function() {
     /**
      * Reconfigure unbound - activate changes
      */
-    $("#reconfigureAct").SimpleActionButton();
+    $("#reconfigureAct").SimpleActionButton({
+        onAction: function(data, status) {
+          if (data['status'].toLowerCase().trim() == 'ok') {
+              $("#responseMsg").removeClass("hidden").html(data['status_msg']);
+          }
+        }
+    });
     updateServiceControlUI('unbound');
 });
 </script>
@@ -171,6 +177,8 @@ $( document ).ready(function() {
         margin: 1em;
     }
 </style>
+
+<div class="alert alert-info hidden" role="alert" id="responseMsg"></div>
 
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li><a data-toggle="tab" href="#host_overrides" id="host_overrides_tab">{{ lang._('Host Overrides') }}</a></li>
@@ -276,7 +284,7 @@ $( document ).ready(function() {
         <tr>
             <td>
                 <button class="btn btn-primary" id="reconfigureAct"
-                        data-endpoint='/api/unbound/service/reconfigure'
+                        data-endpoint='/api/unbound/service/overrides'
                         data-label="{{ lang._('Apply') }}"
                         data-service-widget="unbound"
                         data-error-title="{{ lang._('Error reconfiguring unbound') }}"

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -74,6 +74,14 @@ type:script_output
 message:Updating Unbound DNSBLs
 description:Update Unbound DNSBLs
 
+[overrides]
+command:
+    /usr/local/sbin/pluginctl -c hosts &&
+    /usr/local/opnsense/scripts/unbound/wrapper.py -o
+parameters:
+type:script_output
+message:Updating Unbound overrides
+
 [status]
 command:pgrep -q -nF /var/run/unbound.pid && echo "unbound is running" || echo "unbound is not running" ;exit 0
 parameters:


### PR DESCRIPTION
Since DNS blocklists are now done dynamically, it would make sense for other areas of Unbound to do the same in an effort to reduce the amount of restarts.

One such possibility of a restart is the 'hosts' `pluginctl/plugins_configure`, as well as CRUD operations from the WebGUI - which is addressed here.

The dnsbl code has also been refactored to be shorter, as most of this (future) functionality looks more or less the same.