### PR TITLE
Fixed a bug in BaseModel.php where raising a meaningful Error did not work

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php
@@ -135,19 +135,21 @@ abstract class BaseModel
         $classname_idx = str_replace("\\", "_", $classname);
         if (!isset(self::$internalCacheReflectionClasses[$classname_idx])) {
             $is_derived_from_basefield = false;
-            if (class_exists($classname)) {
-                $field_rfcls = new ReflectionClass($classname);
-                $check_derived = $field_rfcls->getParentClass();
-                while ($check_derived != false) {
-                    if ($check_derived->name == 'OPNsense\Base\FieldTypes\BaseField') {
-                        $is_derived_from_basefield = true;
-                        break;
-                    }
-                    $check_derived = $check_derived->getParentClass();
-                }
-            } else {
+            
+            if (!class_exists($classname)) {
                 throw new ModelException("class " . $classname . " missing");
             }
+          
+            $field_rfcls = new ReflectionClass($classname);
+            $check_derived = $field_rfcls->getParentClass();
+            while ($check_derived != false) {
+                if ($check_derived->name == 'OPNsense\Base\FieldTypes\BaseField') {
+                    $is_derived_from_basefield = true;
+                    break;
+                 }
+                $check_derived = $check_derived->getParentClass();
+            }
+
             if (!$is_derived_from_basefield) {
                 // class found, but of wrong type. raise an exception.
                 throw new ModelException("class " . $field_rfcls->name . " of wrong type in model definition");


### PR DESCRIPTION
In line 153 $field_rfcls could not be resolved because it is declared in the scope of "if (class_exists($classname))"