### PR TITLE
jquery.bootgrid.js: add a reset button

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/routes.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/routes.volt
@@ -29,6 +29,7 @@
         let grid = $("#grid-routes").bootgrid({
             ajax: false,
             selection: false,
+            resetButton: true,
             multiSelect: false,
             formatters: {
                 "commands": function (column, row) {
@@ -86,7 +87,7 @@
                             <th data-column-id="destination" data-type="string">{{ lang._('Destination') }}</th>
                             <th data-column-id="gateway" data-type="string">{{ lang._('Gateway') }}</th>
                             <th data-column-id="flags" data-type="string" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('Flags') }}</th>
-                            <th data-column-id="use" data-type="numeric" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('Use') }}</th>
+                            <th data-column-id="nhop#" data-type="numeric" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('Nhop#') }}</th>
                             <th data-column-id="mtu" data-type="numeric" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('MTU') }}</th>
                             <th data-column-id="netif" data-type="string" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('Netif') }}</th>
                             <th data-column-id="intf_description" data-type="string" data-css-class="hidden-xs hidden-sm" data-header-css-class="hidden-xs hidden-sm">{{ lang._('Netif (name)') }}</th>

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -363,6 +363,25 @@ function renderActions()
                 actions.append(refresh);
             }
 
+            if (this.options.resetButton)
+            {
+                var resetIcon = tpl.icon.resolve(getParams.call(this, { iconCss: css.iconReset })),
+                    reset = $(tpl.actionButton.resolve(getParams.call(this,
+                        { content: resetIcon, text: this.options.labels.reset })))
+                        .on("click" + namespace, function (e)
+                        {
+                            e.stopPropagation();
+                            for (var i = 0; i < that.columns.length; i++)
+                            {
+                                localStorage.removeItem('sortColumns[' + that.uid + '][' + that.columns[i].id + ']');
+                                localStorage.removeItem('visibleColumns[' + that.uid + '][' + that.columns[i].id + ']');
+                            }
+                            localStorage.removeItem('rowCount[' + that.uid + ']');
+                            location.reload();
+                        });
+                actions.append(reset);
+            }
+
             // Row count selection
             renderRowCountSelection.call(this, actions);
 
@@ -1305,6 +1324,7 @@ Grid.defaults = {
         iconRefresh: "glyphicon-refresh",
         iconSearch: "glyphicon-search",
         iconUp: "glyphicon-chevron-up",
+        iconReset: "glyphicon-flash",
         infos: "infos", // must be a unique class name or constellation of class names within the header and footer,
         left: "text-left",
         pagination: "pagination", // must be a unique class name or constellation of class names within the header and footer
@@ -1365,6 +1385,7 @@ Grid.defaults = {
         loading: "Loading...",
         noResults: "No results found!",
         refresh: "Refresh",
+        reset: "Reset stored settings and refresh page",
         search: "Search"
     },
 


### PR DESCRIPTION
Hi!
[FR] https://forum.opnsense.org/index.php?topic=29740.0
PR extends plugin with "Reset" button to clear sort, row count and visible columns in localStoarge and reload page
(use `resetButton: true` option to enable button on grid)

routes.volt:
add reset button
fix Nhop# display

Thanks!