### PR TITLE
CRL management small adjustments

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -612,6 +612,10 @@ function crl_update(&$crl)
     $crl['serial']++;
     $ca_str_crt = base64_decode($ca['crt']);
     $ca_str_key = base64_decode($ca['prv']);
+    if (!openssl_x509_check_private_key($ca_str_crt, $ca_str_key)) {
+        syslog(LOG_ERR, "Cert revocation error: CA keys mismatch");
+        return false;
+    }
 
     /* Load in the CA's cert */
     $ca_cert = new \phpseclib\File\X509();
@@ -632,10 +636,18 @@ function crl_update(&$crl)
      * CRL container must load the same CA using loadCA() with a direct reference
      * to the CA's public cert.
      */
+
     $x509_crl->loadCRL($x509_crl->saveCRL($x509_crl->signCRL($ca_cert, $x509_crl)));
 
     /* Now validate the CRL to see if everything went well */
     if (!$x509_crl->validateSignature(false)) {
+        /* phpseclib2 not throws exceptions on validation fail. let's try to guess */
+        if (openssl_pkey_get_details(openssl_pkey_get_private($ca_str_key))['type'] === 0) {
+            syslog(LOG_ERR, "Cert revocation error: CRL validation failed at first step.");
+        } else {
+            /* phpseclib2 Crypt not supporting ECDSA / ECDH algorithms. May be the reason of sign/validateion fail */
+            syslog(LOG_ERR, "Cert revocation error: Only RSA key type currently supported for CRL signing.");
+        }
         return false;
     }
 
@@ -646,6 +658,7 @@ function crl_update(&$crl)
             $x509_cert->loadCA($ca_str_crt);
             $raw_cert = $x509_cert->loadX509(base64_decode($cert['crt']));
             if (!$x509_cert->validateSignature(false)) {
+                syslog(LOG_ERR, "Cert revocation error: CA validation failed.");
                 return false;
             }
             /* Get serial number of cert */
@@ -672,10 +685,14 @@ function cert_revoke($cert, &$crl, $reason = CERT_CRL_STATUS_UNSPECIFIED)
     if (!is_crl_internal($crl)) {
         return false;
     }
+    $crl_before = $crl;
     $cert["reason"] = $reason;
     $cert["revoke_time"] = time();
     $crl["cert"][] = $cert;
-    crl_update($crl);
+    if (!crl_update($crl)) {
+        $crl = $crl_before;
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=29567.0
it turned out that phpseclib2.0 does not support some algos and does not throw exceptions on errors (hope that with phpseclib3.0 it will be possible to do everything more correctly).
https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md#300---2020-12-16
https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md#303---2021-01-16

PR:
add some debug info
dont add cert to crl if cert_revoke() / crl_update() failed
check if CA can sign anything before CRL create
set "method" param to set Method select value

Thanks!