### PR TITLE
dhcpd6: allow rapid-commit message exchange

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1397,6 +1397,7 @@ function dhcpd_dhcp6_configure($verbose = false, $blacklist = array())
 
     $dhcpdv6conf = <<<EOD
 option dhcp6.domain-search "{$config['system']['domain']}";
+option dhcp6.rapid-commit;
 {$custoptionsv6}
 default-lease-time 7200;
 max-lease-time 86400;


### PR DESCRIPTION
Allow the DHCPv6 two-message exchange for clients which don't support the four-message exchange. Closes #5947.