### PR TITLE
ACPI Battery Status - System Information Widget - Meter

### DIFF
--- a/src/www/widgets/api/plugins/system.inc
+++ b/src/www/widgets/api/plugins/system.inc
@@ -194,6 +194,70 @@ function system_api_firmware($product)
     return $ret;
 }
 
+function system_api_acpi_power_status()
+{
+    // List of ACPI items to retrieve (battery units must be first)
+    $acpi_items = 
+    'hw.acpi.battery.units ' .    # number of batteries
+    'hw.acpi.battery.state ' .    # 0 high, 1 discharging, 2 charging, 3 ambigous (charge & discharge), 4 critical, 5 critical discharging, 6 critical charging, 7 not present
+    'hw.acpi.battery.time '  .    # remaining battery time (minutes); -1 if unknown
+    'hw.acpi.battery.life '  .    # remaining battery percent
+    'hw.acpi.acline';             # 0 off-line, 1 on-line
+
+    exec('/sbin/sysctl -eiq ' . $acpi_items, $acpi_power_status);
+
+    // No ACPI batteries (immediate return)
+    $battery_units = explode('=', $acpi_power_status[0]);
+    if ($battery_units[1] <= 0 || $battery_units[0] != 'hw.acpi.battery.units') {
+        $result['battery']['units'] = 0;
+        return $result;
+    }
+
+	// Dynamically make variables
+	foreach ($acpi_power_status as $line) {
+        list($key, $value) = explode('=', $line);
+        $key = str_replace('hw.acpi.', '', $key);
+        $key = str_replace('.', '_', $key);
+        ${$key} = $value;
+    }
+
+    // Remaining battery percent
+    $status_text = (($battery_life >= '0') && ($battery_life <= '100')) ? $battery_life . ' %' : gettext('unknown') . ' %';
+
+    // Power source: Battery
+    if ($acline == '0') {              # AC line state
+        $status_text .= ' ' . gettext('remaining');
+        $status_text .= ($battery_time > '0') ? ' (' . gettext('est.') . ' ' . gmdate('G:i', $battery_time * 60) . ')' : '';
+    }
+
+    // Power source: Line
+    elseif ($acline == '1') {          # AC line state
+        // 0 high, 1 discharging, 2 charging, 3 ambiguous, 4 critical, 5 critical discharging, 6 critical charging, 7 not present
+        switch ($battery_state) {      # Battery state                                                # bit 0 - discharge; bit 1 - charge; bit 2 - critical
+            case '0': $status_text .= ' (' . gettext('fully charged') . ')'; break;                   # (000) high (fully charged)
+            case '2': $status_text .= ' (' . gettext('plugged in, charging') . ')'; break;            # (010) charging
+            case '3': $status_text .= ' (' . gettext('ambiguous') . ')'; break;                       # (011) ambiguous (simultaneous charge and discharge bits)
+            case '4': $status_text .= ' (' . gettext('critical') . ')'; break;                        # (100) critical (lone critical bit set)
+            case '6': $status_text .= ' (' . gettext('plugged in, critical charging') . ')'; break;   # (110) critical charging
+            case '7': $status_text  = gettext('Not present'); break;                                  # (111) not present
+
+            // Plugged in and discharging (conditioning)
+            case '1':
+            case '5': $status_text .= ' (' . gettext('conditioning') . ')'; break;                    # (001) discharging, (101) critical discharging
+
+            // Other/unexpected
+            default: break;
+        }
+    }
+
+    # Return as associative array; raw values and status text
+    $result = array();
+    $result['battery']['units'] = $battery_units;
+    $result['battery']['life'] = $battery_life;
+    $result['battery']['status_text'] = $status_text;
+    return $result;
+}
+
 /**
  * widget system data
  */
@@ -211,6 +275,7 @@ function system_api()
     $result['kernel'] = system_api_kernel();
     $result['disk'] = system_api_disk();
     $result['firmware'] = system_api_firmware($product);
+    $result['acpi_power_status'] = system_api_acpi_power_status();
 
     return $result;
 }

--- a/src/www/widgets/widgets/system_information.widget.php
+++ b/src/www/widgets/widgets/system_information.widget.php
@@ -145,6 +145,18 @@ require_once("system.inc");
       } else {
           $("#system_information_widget_disk_info").hide();
       }
+
+      // ACPI battery
+      if (data['acpi_power_status']['battery']['units'] >= 1) {
+          var bat_perc = parseInt(data['acpi_power_status']['battery']['life']);
+          $("#system_information_widget_acpi_battery .progress-bar").css("width",  bat_perc + "%").attr("aria-valuenow", bat_perc + "%");
+          var bat_text = data['acpi_power_status']['battery']['status_text'];
+          $("#system_information_widget_acpi_battery .state_text").html(bat_text);
+
+          $("#system_information_widget_acpi_battery_info").show();
+      } else {
+          $("#system_information_widget_acpi_battery_info").hide();
+      }
    }
 
   /**
@@ -280,6 +292,15 @@ require_once("system.inc");
           </div>
           <div class="disk_devices">
           </div>
+      </td>
+    </tr>
+    <tr id="system_information_widget_acpi_battery_info" style="display:none">
+      <td><?=gettext("Battery level (ACPI)");?></td>
+      <td id="system_information_widget_acpi_battery">
+        <div class="progress" style="text-align:center;">
+          <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%; z-index: 0;"></div>
+          <span class="state_text" style="position:absolute;right:0;left:0;"></span>
+        </div>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
If an ACPI battery exists, show battery level meter and status in the dashboard system information widget.