### PR TITLE
CRL: decode stored crl data before display

### DIFF
--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -453,7 +453,7 @@ include("head.inc");
               <tr>
                 <td><a id="help_for_crltext" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("CRL data");?></td>
                 <td>
-                  <textarea name="crltext" id="crltext" cols="65" rows="7"><?=$thiscrl['text'];?></textarea>
+                  <textarea name="crltext" id="crltext" cols="65" rows="7"><?=base64_decode($thiscrl['text']);?></textarea>
                   <div class="hidden" data-for="help_for_crltext">
                     <?=gettext("Paste a Certificate Revocation List in X.509 CRL format here.");?>
                   </div>


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=29937.0
Turned out that administrator may accidentally break the **imported** CRL by clicking Save when viewing crl data: `CRL data` field shows encoded string.
Thanks!
