### PR TITLE
Web GUI: fix IPv6 link-local HTTP_REFERER check

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -52,6 +52,8 @@ function isAuthLocalIP($http_host)
     }
     $address_in_list = function ($interface_list_ips, $http_host) {
         foreach ($interface_list_ips as $ilips => $ifname) {
+            // remove scope from link-local IPv6 addresses
+            $ilips = preg_replace('/%.*/', '', $ilips);
             if (strcasecmp($http_host, $ilips) == 0) {
                 return true;
             }


### PR DESCRIPTION
Allow accessing Web GUI via link-local IPv6 addresses by ignoring %scope suffix when performing HTTP_REFERER check.

Closes #5971.