### PR TITLE
webgui: match cipher suites and openssl config commands

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -411,14 +411,21 @@ ssl.openssl.ssl-conf-cmd = (
 
 EOD;
         } else {
-            $lighty_config .= <<<EOD
-
-ssl.openssl.ssl-conf-cmd = (
-    "MinProtocol" => "TLSv1",
-    "CipherString" => "{$config['system']['webgui']['ssl-ciphers']}"
-)
-
-EOD;
+            // use the same supported ciphers source as system_advanced_admin.php page do (its not a full list. but its openssl defaults)
+            $sys_ciphers = json_decode(configd_run("system ssl ciphers"), true);
+            $tls13_suites = array_keys(array_filter($sys_ciphers, function($val) { return $val['version'] == "TLSv1.3"; }));
+            $suites_selected = explode(":", $config['system']['webgui']['ssl-ciphers']);
+            $tls_suites_selected = array_diff($suites_selected, $tls13_suites);
+            $tls13_suites_selected = array_intersect($tls13_suites,$suites_selected);
+            $lighty_config .= "ssl.openssl.ssl-conf-cmd = (\n";
+            $lighty_config .= "    \"MinProtocol\" => \"TLSv1\"";
+            if ($tls13_suites_selected) {
+                $lighty_config .= ",\n    \"Ciphersuites\" => \"" . implode(":", $tls13_suites_selected) . "\"";
+            }
+            if ($tls_suites_selected) {
+                $lighty_config .= ",\n    \"CipherString\" => \"" . implode(":", $tls_suites_selected) . "\"";
+            }
+            $lighty_config .= "\n)\n";
         }
 
         if (!empty($config['system']['webgui']['ssl-hsts'])) {


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=29284
ref. https://forum.opnsense.org/index.php?topic=30048.0
It turned out that the administrator can break access to the gui by selecting  TLSv1.3 ciphersuites only.
OpenSSL uses different config file options and commands to define ciphersuites for TLS1.2 and below (`CipherString`) and for TLS1.3 suites (`Ciphersuites`): 
https://www.openssl.org/docs/manmaster/man3/SSL_CONF_cmd.html#SUPPORTED-CONFIGURATION-FILE-COMMANDS
PR tries to follow this logic and use matching command for defined ciphers.
RFC8446 Compliance Requirements (https://www.rfc-editor.org/rfc/rfc8446#section-9.1) is also fulfilled when using TLS1.3 suites: the presence of the TLS_AES_128_GCM_SHA256 is controlled.
Thanks!

UPD. RFC8446 Compliance Requirements check implemented in https://github.com/opnsense/core/commit/d31bff3c3975fe8c043538bcccbe30674068eae8 and removed from pr