### PR TITLE
ipsec: fixed widget link

### DIFF
--- a/src/www/widgets/include/ipsec.inc
+++ b/src/www/widgets/include/ipsec.inc
@@ -1,4 +1,4 @@
 <?php
 
 $ipsec_title = gettext('IPsec');
-$ipsec_title_link = 'diag_ipsec.php';
+$ipsec_title_link = 'ui/ipsec/sessions';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2029878/187088122-fa218297-cb05-4b05-894e-3a0fe4f89ac6.png)

The IPsec widget on dashboard by default links to `diag_ipsec.php`, which doesn't seem to exist anymore and results in:
![image](https://user-images.githubusercontent.com/2029878/187088107-4081c167-2c32-4dde-84f3-1aebf5fdf11d.png)

This quick PR changes the link to `ui/ipsec/sessions`, which is the "Status Overview" page:
![image](https://user-images.githubusercontent.com/2029878/187088154-bc3a6f4a-0074-4f3c-a937-dc1e6e91775d.png)

Tested the change locally by modifying the file:
```shell
# cat /usr/local/www/widgets/include/ipsec.inc
<?php

$ipsec_title = gettext('IPsec');
$ipsec_title_link = 'ui/ipsec/sessions';
```