### PR TITLE
system: give configd a chance to load

### DIFF
--- a/src/etc/rc.syshook.d/early/15-templates
+++ b/src/etc/rc.syshook.d/early/15-templates
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo -n "Generating configuration: "
-configctl template reload \*
+configctl -w 3 template reload \*


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=30197.0
Turned out that the templates may not be reloaded at system start.
(returns "configd socket missing..")
Perhaps the call to the service is going too fast and it has not yet been loaded?
May be we can give a second chance? )
This works and with `w 1`.  `w 3` just in case

Thanks!
