### PR TITLE
update pattern to zst for the Arch packages

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -334,7 +334,7 @@ coredump_dir /var/squid/cache
 
 {% if helpers.exists('OPNsense.proxy.general.cache.local.cache_linux_packages') and OPNsense.proxy.general.cache.local.cache_linux_packages == '1' %}
 # Linux package cache:
-refresh_pattern pkg\.tar\.xz$   0       20%     4320 refresh-ims
+refresh_pattern pkg\.tar\.zst$  0       20%     4320 refresh-ims
 refresh_pattern d?rpm$          0       20%     4320 refresh-ims
 refresh_pattern deb$            0       20%     4320 refresh-ims
 refresh_pattern udeb$           0       20%     4320 refresh-ims


### PR DESCRIPTION
Arch Linux moved from `xz` compression to `zst` some time ago: [Now using Zstandard instead of xz for package compression](https://archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/).

The change simply replaces the pattern for the `xz` compressed package names for Arch Linux with the `zst` in the `squid.conf`.