### PR TITLE
ARP Table: hostname uses reverse DNS lookup as fallback

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/InterfaceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/InterfaceController.php
@@ -70,7 +70,12 @@ class InterfaceController extends ApiControllerBase
     public function getArpAction()
     {
         $backend = new Backend();
-        $response = $backend->configdRun('interface list arp json');
+        if (strtolower($this->request->get('resolve')) == 'yes') {
+            $response = $backend->configdRun('interface list arp -r json');
+        } else {
+            $response = $backend->configdRun('interface list arp json');
+        }
+
         $arptable = json_decode($response, true);
 
         $intfmap = $this->getInterfaceNames();

--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/arp.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/arp.volt
@@ -41,7 +41,12 @@ POSSIBILITY OF SUCH DAMAGE.
                     multiSelect: false
                 });
             }
-            ajaxGet("/api/diagnostics/interface/getArp", {}, function (data, status) {
+            let resolve = '';
+            if ($("#resolve").prop("checked")) {
+                resolve = "yes";
+            }
+
+            ajaxGet("/api/diagnostics/interface/getArp", {resolve:resolve}, function (data, status) {
                         if (status == "success") {
                             $("#grid-arp").bootgrid('append', data);
                         }
@@ -101,18 +106,33 @@ POSSIBILITY OF SUCH DAMAGE.
             </div>
             <div  class="col-sm-12">
                 <div class="row">
-                    <div class="col-xs-12">
-                        <div class="pull-right">
-                            <button type="button" class="btn btn-default" id="flushModal">
-                                <span>{{ lang._('Flush') }}</span>
-                                <span class="fa fa-trash"></span>
-                            </button>
-                            <button id="refresh" type="button" class="btn btn-default">
-                                <span>{{ lang._('Refresh') }}</span>
-                                <span class="fa fa-refresh"></span>
-                            </button>
-                        </div>
-                    </div>
+                    <table class="table">
+                        <tr>
+                            <td>
+                                <input type="checkbox" id="resolve" name="resolve" value="yes">
+                            </td>
+                            <td>
+                                <strong><?=gettext("Name resolution");?></strong>
+                                <p class="text-muted">
+                                    <small>
+                                        {{ lang._('Enable this to attempt to resolve names when displaying the tables. By enabling name resolution, the query may take longer.') }}
+                                    </small>
+                                </p>
+                            </td>
+                            <td>
+                                <div class="pull-right">
+                                    <button type="button" class="btn btn-default" id="flushModal">
+                                        <span>{{ lang._('Flush') }}</span>
+                                        <span class="fa fa-trash"></span>
+                                    </button>
+                                    <button id="refresh" type="button" class="btn btn-default">
+                                        <span>{{ lang._('Refresh') }}</span>
+                                        <span class="fa fa-refresh"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
                 <hr/>
             </div>

--- a/src/opnsense/scripts/interfaces/list_arp.py
+++ b/src/opnsense/scripts/interfaces/list_arp.py
@@ -36,6 +36,21 @@ import netaddr
 sys.path.insert(0, "/usr/local/opnsense/site-python")
 import watchers.dhcpd
 
+
+# do we use reverse DNS lookup (only when hostanme is not found in our dhcp leases) ?
+use_dns = True
+
+# translate IP address into hostname, using a DNS PTR lookup.
+import socket
+def dns_ptr_lookup(addr):
+    try:
+        name,alias,adlist= socket.gethostbyaddr(addr)
+        return name
+    except socket.herror:
+        return ''
+
+
+
 if __name__ == '__main__':
     # index mac database (shipped with netaddr)
     macdb = dict()
@@ -76,6 +91,8 @@ if __name__ == '__main__':
             record['manufacturer'] = macdb[record['mac'][0:8]]
         if record['ip'] in dhcp_leases:
             record['hostname'] = dhcp_leases[record['ip']]['hostname']
+        if use_dns is True and  record['hostname'] == '':
+            record['hostname'] = dns_ptr_lookup(record['ip'])
         result.append(record)
 
     # handle command line argument (type selection)

--- a/src/opnsense/scripts/interfaces/list_arp.py
+++ b/src/opnsense/scripts/interfaces/list_arp.py
@@ -36,6 +36,14 @@ import netaddr
 sys.path.insert(0, "/usr/local/opnsense/site-python")
 import watchers.dhcpd
 
+import re
+def natural_sort(list, key=lambda s:s):
+    def get_alphanum_key_func(key):
+        convert = lambda text: int(text) if text.isdigit() else text 
+        return lambda s: [convert(c) for c in re.split('([0-9]+)', key(s))]
+    sort_key = get_alphanum_key_func(key)
+    list.sort(key=sort_key)
+
 
 if __name__ == '__main__':
 
@@ -66,6 +74,8 @@ if __name__ == '__main__':
     sp = subprocess.run(['/usr/sbin/arp', '-a'+arp_arg, '--libxo','json'], capture_output=True, text=True)
     libxo_out = ujson.loads(sp.stdout)
     arp_cache = libxo_out['arp']['arp-cache'] if 'arp' in libxo_out and 'arp-cache' in libxo_out['arp'] else []
+    natural_sort(arp_cache, key=lambda s: s['ip-address']) 
+    
     for src_record in arp_cache:
         if 'incomplete' in src_record and src_record['incomplete'] is True:
             continue

--- a/src/opnsense/service/conf/actions.d/actions_interface.conf
+++ b/src/opnsense/service/conf/actions.d/actions_interface.conf
@@ -43,7 +43,7 @@ message:update carp service status
 
 [list.arp]
 command:/usr/local/opnsense/scripts/interfaces/list_arp.py
-parameters: %s
+parameters:%s %s
 type:script_output
 message:request arp table
 


### PR DESCRIPTION
Arp table only relies on dhcp-leases entries to get the hostname. So when using an external DHCP server, or for IP addresses that are not assigned by DHCP, the displayed hostnames are always blank.

Features added:
- if hostame is not found in the dhcp-leases, the hostname is fetched from a DNS PTR query, (using the system's DNS server).
- use_dns variable can allow/disallow this behaviour (useful is someone would like to move this to a system preference)

HTH