### PR TITLE
Firewall/Diagnostics/Sessions: parse pftop internal data conversion

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
@@ -64,9 +64,9 @@
                             bytes: function(column, row) {
                                 if (!isNaN(row[column.id]) && row[column.id] > 0) {
                                     let fileSizeTypes = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
-                                    let ndx = Math.floor(Math.log(row[column.id]) / Math.log(1000) );
+                                    let ndx = Math.floor(Math.log(row[column.id]) / Math.log(1024) );
                                     if (ndx > 0) {
-                                        return  (row[column.id] / Math.pow(1000, ndx)).toFixed(2) + ' ' + fileSizeTypes[ndx];
+                                        return  (row[column.id] / Math.pow(1024, ndx)).toFixed(2) + ' ' + fileSizeTypes[ndx];
                                     } else {
                                         return row[column.id].toFixed(2);
                                     }


### PR DESCRIPTION
Hi!
ref. https://github.com/opnsense/core/issues/6008
Turned out that for sessions with large values of Age or Bytes, the `pftop` utility can change the display format of this fields even with a large value of the `-w` parameter. So internal Age value conversion can break  Firewall/Diagnostics/Sessions page display

[print_fld_sdiv(field_def *fld, u_int64_t size, int div)](https://github.com/araujobsd/pftop/blob/ab98de9ce24f0b15da5ab677acb50db187ad1094/engine.c#L661)
[print_fld_age(field_def *fld, unsigned int age)](https://github.com/araujobsd/pftop/blob/ab98de9ce24f0b15da5ab677acb50db187ad1094/engine.c#L607)

PR tries to take this into account and returns the values to a single format.
The value of the multiplier for converting units on the frontend has also been changed to align with the `pftop` logic.
Thanks!

ps. not so happy with the if-elif-elif-else expression for age/expire fields, but at least tried to make it according to the probability of a match