### PR TITLE
OpenVPN widget: bring back the buttons action

### DIFF
--- a/src/www/widgets/widgets/openvpn.widget.php
+++ b/src/www/widgets/widgets/openvpn.widget.php
@@ -35,7 +35,7 @@ $clients = openvpn_get_active_clients();
 
 ?>
 <script>
-    $(window).on("load", function() {
+    $("#dashboard_container").on("WidgetsReady", function() {
         // link kill buttons
         $(".act_kill_client").click(function(event){
             event.preventDefault();


### PR DESCRIPTION
Hi!
seems to have overlooked a small regression after https://github.com/opnsense/core/commit/405395264ffb4f77e298a3bfa5d670b9a53eeda6 at openvpn widget (script with event binding stripped before execute).
(a little strange that there were no complaints)

thanks!