### PR TITLE
unbound: don't wait blocklist too long

### DIFF
--- a/src/opnsense/scripts/unbound/blocklists.py
+++ b/src/opnsense/scripts/unbound/blocklists.py
@@ -39,7 +39,7 @@ import requests
 def uri_reader(uri):
     req_opts = {
         'url': uri,
-        'timeout': 120,
+        'timeout': 5,
         'stream': True
     }
     try:


### PR DESCRIPTION
Hi!
as discussed at https://github.com/opnsense/core/issues/6026#issuecomment-1249704152 [Requests timeout](https://requests.readthedocs.io/en/stable/user/advanced/#timeouts) parameter limits the server response time and time between bytes. So there is no need to wait so long for unresponsive server.
Thanks!