### PR TITLE
Fix bug in ipsec when tunnel isolation is disabled

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1743,7 +1743,7 @@ function ipsec_get_configured_vtis()
                     $descr = $ph1ent['descr'] ?? '';
                 }
                 $intfnm = sprintf("ipsec%s", $reqid);
-                if (empty($tunnels[$intfnm])) {
+                if (empty($configured_intf[$intfnm])) {
                     $configured_intf[$intfnm] = ['reqid' => $reqid];
                     $configured_intf[$intfnm]['local'] = ipsec_get_phase1_src($ph1ent);
                     $configured_intf[$intfnm]['remote'] = $ph1ent['remote-gateway'];


### PR DESCRIPTION
Fix #6022 that will add multiple phase 2 IPs to the same interface when tunnel isolation is disabled.

@AdSchellevis I believe that as $tunnels is not defined anywhere on this function, using $configured_intf it's able to append to the ['networks'] array which configures multiple IPs on the ipsec interface when tunnel isolation is disabled. This will imitate pfsense behavior.