### PR TITLE
unbound: catch exception on blocklist reading

### DIFF
--- a/src/opnsense/scripts/unbound/blocklists.py
+++ b/src/opnsense/scripts/unbound/blocklists.py
@@ -52,19 +52,24 @@ def uri_reader(uri):
         req.raw.decode_content = True
         prev_chop  = ''
         while True:
-            chop = req.raw.read(1024).decode()
-            if not chop:
-                if prev_chop:
-                    yield prev_chop
-                break
-            else:
-                parts = (prev_chop + chop).split('\n')
-                if parts[-1] != "\n":
-                    prev_chop = parts.pop()
+            try:
+                chop = req.raw.read(1024).decode()
+                if not chop:
+                    if prev_chop:
+                        yield prev_chop
+                    break
                 else:
-                    prev_chop = ''
-                for part in parts:
-                    yield part
+                    parts = (prev_chop + chop).split('\n')
+                    if parts[-1] != "\n":
+                        prev_chop = parts.pop()
+                    else:
+                        prev_chop = ''
+                    for part in parts:
+                        yield part
+            except Exception as e:
+                syslog.syslog(syslog.LOG_ERR,'blocklist download : error reading file from %s (error : %s)' % (uri, e))
+                return
+
     else:
         syslog.syslog(syslog.LOG_ERR,
             'blocklist download : unable to download file from %s (status_code: %d)' % (uri, req.status_code)


### PR DESCRIPTION
Hi!
another thing noticed when trying to reproduce https://github.com/opnsense/core/issues/6026
if the connection or server is very (i made it 5 kbit/s) slow (and we also reduced the timeout value), the update may fail with a non-obvious `Command ' /usr/local/opnsense/scripts/unbound/blocklists.py && /usr/local/opnsense/scripts/unbound/wrapper.py -b ' returned non-zero exit status 1` error in backend log. Perhaps it makes sense to catch exceptions when reading a file? Then a more understandable message like
 ```blocklist download : error reading file from https://blocklistproject.github.io/Lists/alt-version/malware-nl.txt (error : HTTPSConnectionPool(host='blocklistproject.github.io', port=443): Read timed out.)```  will get into the unbound log, and script execution will continue
Thanks!