### PR TITLE
Fireewall : Aliases - PHP8 error fix

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -71,7 +71,7 @@ class Util
     {
         $tmp = explode('/', $network);
         if (count($tmp) == 2) {
-            if (self::isIpAddress($tmp[0]) && abs($tmp[1]) == $tmp[1] && ctype_digit($tmp[1])) {
+            if (self::isIpAddress($tmp[0]) && ctype_digit($tmp[1]) && abs($tmp[1]) == $tmp[1]) {
                 if (strpos($tmp[0], ':') !== false && $tmp[1] <= 128) {
                     // subnet v6
                     return true;


### PR DESCRIPTION
Hi!
ref https://forum.opnsense.org/index.php?topic=30368.0
`abs()` "no longer accepts internal objects which support numeric conversion." [(ref)](https://www.php.net/manual/en/function.abs.php)

Thanks!