### PR TITLE
unbound: allow setting forwarder type via API

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/SettingsController.php
@@ -63,7 +63,8 @@ class SettingsController extends ApiMutableModelControllerBase
         if (substr($method, -6) == 'Action') {
             $fn = preg_replace('/Dot/', 'Forward', $method);
             if (method_exists(get_class($this), $fn)) {
-                if (preg_match("/forward/i", $this->request->getHTTPReferer())) {
+                // set the type to forward if the request came from the corresponding gui page or is explicitly set in the API call
+                if (preg_match("/forward/i", $this->request->getHTTPReferer()) || $this->request->getPost('dot')['type'] == 'forward') {
                     $this->type = "forward";
                 }
                 return $this->$fn(...$args);


### PR DESCRIPTION
Hi!
ref. https://github.com/opnsense/core/issues/6047
It turned out that the unbound api does not allow adding a simple (non-DoT) forwarder in the usual way (have to emulate the browser behavior by setting the HTTP Referer header value).
PR tries to add the ability to set the forwarder type by explicitly specifying the type in the request.
Thanks!