### PR TITLE
Default subnet mask of 24 instead of 32 if value unset

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -824,7 +824,7 @@ function is_openvpn_server_crl($crlref)
 
 function is_crl_internal($crl)
 {
-    return (!(!empty($crl['text']) && empty($crl['cert'])) || ($crl["crlmethod"] ?? '' == "internal"));
+    return $crl["crlmethod"] ?? '' == "internal";
 }
 
 function cert_get_cn($crt, $isref = false)

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -2113,7 +2113,7 @@ include("head.inc");
 
 <?php
                                     for ($i = 32; $i > 0; $i--):?>
-                                    <option value="<?=$i;?>" <?=$i == $pconfig['subnet'] ? "selected=\"selected\"" : "";?>><?=$i;?></option>
+                                    <option value="<?=$i;?>" <?=($i == $pconfig['subnet'] || ($pconfig['subnet'] == "" && $i == 24)) ? "selected=\"selected\"" : "";?>><?=$i;?></option>
 <?php
                                     endfor;?>
                                   </select>

--- a/src/www/system_crlmanager.php
+++ b/src/www/system_crlmanager.php
@@ -237,6 +237,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 $crl['cert'] = array();
             }
 
+            crl_update($crl);
             if (!isset($id)) {
                 $a_crl[] = $crl;
             }


### PR DESCRIPTION
**Improvement**
Default value for IPv4 subnet mask on interfaces should be 24 not 32

Currently the default value for a subnet mask is 32 if the value was not set before. This for example is the default if you are changing an interface from DHCP to Static IPv4. The downside is that someone who oversees the value might lock himself out from the machine.

Example:
Someone (indeed this someone was me 😜) is connected to the firewall through VPN and changes the WAN interface from DHCP to Static IPv4. After entering the right IPv4 address the person forgets to set the corresponding subnet mask from 32 to 24 (where the latter is mostly standard on local networks). After applying the changes the person gets locked out from the firewall and has to fix it locally because no traffic can get in and out.

A default setting of 24 instead of 32 would have prevented this situation. A subnet mask of 32 also doesn't make any sense on a WAN interfaces IP address from my perspective.