### PR TITLE
interfaces: add VlanDeviceField and proper population of text field

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanDeviceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanDeviceField.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (C) 2022 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+
+class VlanDeviceField extends BaseListField
+{
+    private static $interface_devices = null;
+
+    protected function actionPostLoadingEvent()
+    {
+        if (self::$interface_devices === null) {
+            $configHandle = Config::getInstance()->object();
+            $ifnames = [];
+            if (!empty($configHandle->interfaces)) {
+                foreach ($configHandle->interfaces->children() as $ifname => $node) {
+                    $ifnames[(string)$node->if] = !empty((string)$node->descr) ? (string)$node->descr : strtoupper($ifname);
+                }
+            }
+            self::$interface_devices = [];
+            // add assignments to label if found
+            foreach ($this->getParentModel()->vlan->iterateItems() as $key => $vlan) {
+                self::$interface_devices[(string)$vlan->vlanif] = sprintf(
+                    gettext('%s%s'),
+                    (string)$vlan->vlanif,
+                    !empty($ifnames[(string)$vlan->vlanif]) ? sprintf(' [%s]', $ifnames[(string)$vlan->vlanif]) : ''
+                );
+            }
+        }
+        $this->internalOptionList = self::$interface_devices;
+        return parent::actionPostLoadingEvent();
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vlan.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vlan.xml
@@ -45,7 +45,7 @@
             <descr type="TextField">
               <Required>N</Required>
             </descr>
-            <vlanif type="TextField">
+            <vlanif type=".\VlanDeviceField">
               <Required>Y</Required>
               <Constraints>
                 <check001>

--- a/src/opnsense/www/js/opnsense.js
+++ b/src/opnsense/www/js/opnsense.js
@@ -161,8 +161,17 @@ function setFormData(parent,data) {
                         // if the input field is JSON data, serialize the data into the field
                         targetNode.data('data', node[keypart]);
                     } else {
+                        // unwrap selected item if given as list
+                        if (typeof node[keypart] === 'object') {
+                            $.each(node[keypart], function (indxItem, keyItem) {
+                                if (keyItem["selected"] != "0") {
+                                    targetNode.val(htmlDecode(indxItem));
+                                }
+                            });
                         // regular input type
-                        targetNode.val(htmlDecode(node[keypart]));
+                        } else {
+                            targetNode.val(htmlDecode(node[keypart]));
+                        }
                     }
                     targetNode.change();
                 }


### PR DESCRIPTION
This allows to add "labels" to internal values for text fields. In this case VLAN device names can be associated with their assigned interface since when these are assigned one cannot rename them. Which is not obvious while trying to do so.

Small issue remains that "option not in list" is returned for selecting a value not yet known to the configuration.