### PR TITLE
Add description to filter sync action

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -8,6 +8,7 @@ message:Reloading filter
 command:/usr/local/etc/rc.filter_synchronize
 parameters:
 type:script
+description:Synchronize configuration to backup firewall
 message:Syncing firewall %s
 
 [refresh_aliases]


### PR DESCRIPTION
To automate the configuration synchronization to the backup firewall with a cronjob a description in the "filter sync" action is needed.