### PR TITLE
dnsmasq: DNSSEC: Remove expired root trust anchor

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -178,7 +178,6 @@ function dnsmasq_configure_do($verbose = false)
 
     if (isset($config['dnsmasq']['dnssec'])) {
         $args .= ' --dnssec ';
-        $args .= ' --trust-anchor=.,19036,8,2,49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5 ';
         $args .= ' --trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D ';
     }
 


### PR DESCRIPTION
See: https://data.iana.org/root-anchors/root-anchors.xml