### PR TITLE
system: write a boot log using the embedded configuration messages

### DIFF
--- a/src/etc/inc/config.inc
+++ b/src/etc/inc/config.inc
@@ -46,6 +46,12 @@ final class product
     private function __construct()
     {
         self::$data = json_decode(file_get_contents('/usr/local/opnsense/version/core'), true);
+
+        /* boot detection via exit_on_bootup()  */
+        $bootflag = '/var/run/booting';
+        @touch($bootflag);
+        $fp = fopen($bootflag, 'r');
+        self::$data['product_booting'] = $fp && !flock($fp, LOCK_SH | LOCK_NB);
     }
 
     private function __clone()

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2213,10 +2213,7 @@ function interface_configure($verbose = false, $interface = 'wan', $reload = fal
 
     /* XXX mpd5 $realhwif may be a device node path */
 
-    if ($verbose) {
-        echo sprintf('Configuring %s interface...', $wandescr);
-        flush();
-    }
+    service_log(sprintf('Configuring %s interface...', $wandescr), $verbose);
 
     if (!empty($wancfg['ipaddr'])) {
         interfaces_addresses_flush($realif, 4, $ifconfig_details);
@@ -2382,9 +2379,7 @@ function interface_configure($verbose = false, $interface = 'wan', $reload = fal
     /* XXX may be called twice since also tied to dhcp configure */
     interfaces_staticarp_configure($interface, $ifconfig_details);
 
-    if ($verbose) {
-        echo "done.\n";
-    }
+    service_log("done.\n", $verbose);
 
     if ($reload) {
         system_routing_configure($verbose, $interface);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -320,6 +320,31 @@ function exit_on_bootup($callback = null, $arguments = [])
     fclose($fp);
 }
 
+/**
+ * service logger with additional boot-time performance logging
+ * @param $message string message to log
+ * @param $verbose boolean verbose|bool (send to console),
+ * @return void
+ */
+function service_log(string $message, bool $verbose = true): void
+{
+    if ($verbose) {
+        echo $message;
+        flush();
+    }
+
+    if (product::getInstance()->booting()) {
+        $bt = debug_backtrace();
+        $caller = !empty($bt[1]['function']) ? $bt[1]['function'] : 'unknown';
+
+        file_put_contents('/var/log/boot.log', implode(' ', [
+            (new DateTime())->format('c'),
+            $caller . '[' . getmypid() . ']',
+            rtrim($message) . PHP_EOL
+        ]), FILE_APPEND | LOCK_EX);
+    }
+}
+
 /* validate non-negative numeric string, or equivalent numeric variable */
 function is_numericint($arg)
 {

--- a/src/etc/rc.subr.d/var
+++ b/src/etc/rc.subr.d/var
@@ -79,3 +79,6 @@ if [ ${USE_MFS_VAR} -ne 0 ]; then
 	mount -t tmpfs -o size=$((MAX_MEM_SYS / 100 * MAX_MFS_VAR)) tmpfs /var/log
 	echo "done."
 fi
+
+# prep boog log
+: > /var/log/boot.log


### PR DESCRIPTION
```
# cat /var/log/boot.log 
2022-10-19T12:19:27+02:00 interface_configure[316] Configuring OPT3 interface...
2022-10-19T12:19:27+02:00 interface_configure[316] done.
2022-10-19T12:19:28+02:00 interface_configure[316] Configuring boring interface...
2022-10-19T12:19:28+02:00 interface_configure[316] done.
2022-10-19T12:19:29+02:00 interface_configure[316] Configuring foobaz interface...
2022-10-19T12:19:29+02:00 interface_configure[316] done.
2022-10-19T12:19:31+02:00 interface_configure[316] Configuring yes interface...
2022-10-19T12:19:31+02:00 interface_configure[316] done.
2022-10-19T12:19:31+02:00 interface_configure[316] Configuring LAN interface...
2022-10-19T12:19:32+02:00 interface_configure[316] done.
2022-10-19T12:19:32+02:00 interface_configure[316] Configuring WAN interface...
2022-10-19T12:19:36+02:00 interface_configure[316] done.
```