### PR TITLE
Don't sort IP address tables.  Though allow to be reversed.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasUtilController.php
@@ -121,12 +121,18 @@ class AliasUtilController extends ApiControllerBase
             $sortcolumn = array_key_first($this->request->getPost('sort'));
             $sort_order = $this->request->getPost('sort')[$sortcolumn];
             if (!empty(array_column($formatted_full, $sortcolumn))) {
-                array_multisort(
-                    array_column($formatted_full, $sortcolumn),
-                    $sort_order == 'asc' ? SORT_ASC : SORT_DESC,
-                    SORT_NATURAL,
-                    $formatted_full
-                );
+                if ($sortcolumn == 'ip') {
+                    if ($sort_order == 'desc') {
+                        $formatted_full = array_reverse($formatted_full);
+                     }
+                } else {
+                    array_multisort(
+                        array_column($formatted_full, $sortcolumn),
+                        $sort_order == 'asc' ? SORT_ASC : SORT_DESC,
+                        SORT_NATURAL | SORT_FLAG_CASE,
+                        $formatted_full
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Don't sort IP address tables.  Though allow to be reversed.

If the table is IP addresses (IPv4 or IPv6) then don't sort, but still allow to be reversed.
If the table is not IP addresses then sort natural case insensitive.

For background see: https://github.com/opnsense/core/pull/5716