### PR TITLE
system: wait 1 second for configd daemon

### DIFF
--- a/src/opnsense/service/configd.py
+++ b/src/opnsense/service/configd.py
@@ -170,6 +170,4 @@ else:
                        logger=loghandle
                        )
     daemon.start()
-    # wait for the socket to come up before yielding to the caller
-    time.sleep(1)
 sys.exit(0)

--- a/src/opnsense/service/modules/daemonize.py
+++ b/src/opnsense/service/modules/daemonize.py
@@ -9,6 +9,7 @@ import signal
 import resource
 import logging
 import atexit
+import time
 from logging import handlers
 
 
@@ -107,6 +108,8 @@ class Daemonize(object):
                 sys.exit(1)
             elif process_id != 0:
                 # This is the parent process. Exit.
+                # Wait a second (so fork can do a deed) and exit
+                time.sleep(1)
                 sys.exit(0)
             # This is the child process. Continue.
 


### PR DESCRIPTION
Hi!
It turned out that unfortunately there is no luck with https://github.com/opnsense/core/commit/9b0d87261d6a49f50019f151852990602fb6d6df
(still "configd socket missing.." on boot and no templates reload)
if I understand correctly, after forking, the parent process exits and, accordingly, `sleep` is not performed
https://github.com/opnsense/core/blob/0ae0c2fc9307d89c449a61605a1af50e35c54fdd/src/opnsense/service/modules/daemonize.py#L108-L110

pr moves `sleep` to daemonizer
worked for me, however I'm not sure if it's the correct way
Thanks!