### PR TITLE
MVC: match multivalued references on 'safe delete'

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -90,7 +90,7 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
             $configObj = Config::getInstance()->object();
             $usages = array();
             // find uuid's in our config.xml
-            foreach ($configObj->xpath("//text()[.='{$uuid}']") as $node) {
+            foreach ($configObj->xpath("//text()[contains(.,'{$uuid}')]") as $node) {
                 $referring_node = $node->xpath("..")[0];
                 if (!empty($referring_node->attributes()['uuid'])) {
                     // this looks like a model node, try to find module name (first tag with version attribute)


### PR DESCRIPTION
Hi!
noticed trying to enable `$internalModelUseSafeDelete` in nginx api settings controller (for  https://github.com/opnsense/plugins/issues/3196).
looks like the referencing nodes only matches if it matches exactly (only one uuid is specified?).
pr tries to make matches possible for multivalued referencing nodes.
tested on HAProxy and nginx configs
I hope I didn't miss anything
Thanks!