### PR TITLE
certs: typo in is_crl_internal

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -663,7 +663,7 @@ function is_openvpn_server_crl($crlref)
 
 function is_crl_internal($crl)
 {
-    return $crl["crlmethod"] ?? '' == "internal";
+    return ($crl["crlmethod"] ?? '') == "internal";
 }
 
 function cert_get_cn($crt, $isref = false)


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=31109.0
(external (imported) CRLs cannot be viewed\edited)
since comparision have highest precedence then coalescing, `is_crl_internal` returns string if array member exists.
so all CRLs starts treated as internal
Thanks!

