### PR TITLE
tokenize2: unicode content in CSS

### DIFF
--- a/src/opnsense/www/css/tokenize2.css
+++ b/src/opnsense/www/css/tokenize2.css
@@ -120,7 +120,7 @@
 }
 
 .tokenize > .tokens-container > .token > .dismiss:after {
-    content: "×";
+    content: "\00D7";
 }
 
 .tokenize > .tokens-container > .token.pending-delete > .dismiss {


### PR DESCRIPTION
Hi!
not a big deal but can annoy sometimes)
after some work in dev console, chrome may return tokenized field content with a garbage like

![css](https://user-images.githubusercontent.com/36099472/205224609-846ac99b-3528-41d7-9666-3933360a2a9e.PNG)

pr uses escaped unicode number

thanks!