### PR TITLE
webgui: enable compression

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -446,9 +446,10 @@ debug.log-response-header  = "disable"
 debug.log-request-handling = "disable"
 debug.log-file-not-found   = "disable"
 
-# gzip compression
+# compression
+deflate.mimetypes = ("text/plain", "text/css", "text/javascript", "text/xml")
+deflate.allowed-encodings = ( "br", "gzip", "deflate" )
 deflate.cache-dir = "/tmp/lighttpdcompress/"
-deflate.mimetypes = ("text/plain","text/css", "text/xml", "text/javascript" )
 
 {$server_upload_dirs}
 


### PR DESCRIPTION
Hi!
Noticed that the gui returns the content uncompressed, although the `mod_deflate` module is enabled.
I think lighty expects `deflate.allowed-encodings` to select a method from a match with the browser request.
after adding the option, content is returned gziped.

perhaps building lighty with `--with-brotli` would be good  but I did not find it in the ports..

ref. https://redmine.lighttpd.net/projects/lighttpd/wiki/Mod_deflate

thanks!

ps. I'm not sure about the need to add a cron for old\stale cache entries purge.