### PR TITLE
unbound: always use python first

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -139,7 +139,7 @@ function unbound_generate_config()
 
     $optimization = unbound_optimization();
 
-    $module_config = '';
+    $module_config = 'python ';
     $anchor_file = '';
     $dns64_config = '';
 
@@ -154,10 +154,10 @@ function unbound_generate_config()
         $module_config .= 'dns64 ';
     }
     if (isset($config['unbound']['dnssec'])) {
-        $module_config .= 'python validator iterator';
+        $module_config .= 'validator iterator';
         $anchor_file = 'auto-trust-anchor-file: /var/unbound/root.key';
     } else {
-        $module_config .= 'python iterator';
+        $module_config .= 'iterator';
     }
 
     $private_addr = "";


### PR DESCRIPTION
Hi
ref. https://forum.opnsense.org/index.php?topic=31336.0
It turned out that when the DNS64 module is enabled, the blocklists do not work. Looks like the python module always has to be first for blocklists to work
thanks!
