### PR TITLE
unbound / overview: migrate to duckdb

### DIFF
--- a/plist
+++ b/plist
@@ -1106,6 +1106,7 @@
 /usr/local/opnsense/site-python/__init__.py
 /usr/local/opnsense/site-python/daemonize.LICENSE
 /usr/local/opnsense/site-python/daemonize.py
+/usr/local/opnsense/site-python/duckdb_helper.py
 /usr/local/opnsense/site-python/log_helper.py
 /usr/local/opnsense/site-python/params.py
 /usr/local/opnsense/site-python/sqlite3_helper.py

--- a/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
@@ -565,6 +565,13 @@
             <pattern>api/diagnostics/traffic*</pattern>
         </patterns>
     </page-status-trafficgraph>
+    <page-status-dnsoverview>
+        <name>Status: DNS Overview</name>
+        <patterns>
+            <pattern>ui/unbound/overview*</pattern>
+            <pattern>api/unbound/overview*</pattern>
+        </patterns>
+    </page-status-dnsoverview>
     <page-diagnostics-wirelessstatus>
         <name>Status: Wireless</name>
         <patterns>

--- a/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
@@ -12,8 +12,9 @@
         <Logout order="3" url="/index.php?logout" cssClass="fa fa-sign-out fa-fw"/>
     </Lobby>
     <Reporting order="15" cssClass="fa fa-area-chart">
-        <Settings url="/reporting_settings.php" cssClass="fa fa-cog fa-fw"/>
-        <Traffic url="/ui/diagnostics/traffic" cssClass="fa fa-line-chart fa-fw"/>
+        <Settings order="10" url="/reporting_settings.php" cssClass="fa fa-cog fa-fw"/>
+        <Traffic order="20" url="/ui/diagnostics/traffic" cssClass="fa fa-line-chart fa-fw"/>
+        <DNS order="30" url="/ui/unbound/overview" cssClass="fa fa-bar-chart fa-fw"/>
     </Reporting>
     <System order="20" cssClass="fa fa-server">
         <Access cssClass="fa fa-users fa-fw">

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Menu/Menu.xml
@@ -2,7 +2,6 @@
     <Services>
         <Unbound VisibleName="Unbound DNS" cssClass="fa fa-tags fa-fw">
             <General order="10" url="/services_unbound.php"/>
-            <Overview order="15" url="/ui/unbound/overview"/>
             <Overrides order="20" url="/ui/unbound/overrides/"/>
             <Advanced order="30" url="/ui/unbound/advanced/"/>
             <ACL VisibleName="Access Lists" order="40" url="/services_unbound_acls.php">

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
@@ -361,6 +361,26 @@
             }
         }
 
+        function create_or_update_totals() {
+            ajaxGet('/api/unbound/overview/totals/10', {}, function(data, status) {
+                $('#top').not(':first').empty();
+                $('#top-blocked').not(':first').empty();
+
+                $('#totalCounter').html(data.total);
+                $('#blockedCounter').html(data.blocked.total + " (" + data.blocked.pcnt + "%)");
+                $('#sizeCounter').html(data.blocklist_size);
+                $('#resolvedCounter').html(data.resolved.total + " (" + data.resolved.pcnt + "%)");
+
+                createTopList('top', data.top);
+                createTopList('top-blocked', data.top_blocked);
+
+                $('#top li:nth-child(even)').addClass('odd-bg');
+                $('#top-blocked li:nth-child(even)').addClass('odd-bg');
+
+                $('#bannersub').html("Starting from " + (new Date(data.start_time * 1000)).toLocaleString());
+            });
+        }
+
         g_queryChart = null;
         g_clientChart = null;
 
@@ -385,20 +405,7 @@
                 }
                 $('#timeperiod-clients').selectpicker('refresh');
 
-                ajaxGet('/api/unbound/overview/totals/10', {}, function(data, status) {
-                    $('#totalCounter').html(data.total);
-                    $('#blockedCounter').html(data.blocked.total + " (" + data.blocked.pcnt + "%)");
-                    $('#sizeCounter').html(data.blocklist_size);
-                    $('#localCounter').html(data.local.total + " (" + data.local.pcnt + "%)");
-
-                    createTopList('top', data.top);
-                    createTopList('top-blocked', data.top_blocked);
-
-                    $('#top li:nth-child(even)').addClass('odd-bg');
-                    $('#top-blocked li:nth-child(even)').addClass('odd-bg');
-
-                    $('#bannersub').html("Starting from " + (new Date(data.start_time * 1000)).toLocaleString());
-                });
+                create_or_update_totals();
 
                 ajaxGet('/api/unbound/overview/rolling/' + $("#timeperiod").val(), {}, function(data, status) {
                     let formatted = formatQueryData(data, $("#toggle-log-qchart").is(":checked"));
@@ -439,10 +446,44 @@
         })
 
         do_startup().done(function() {
-            $('.content-box').show();
+            $('.wrapper').show();
         }).fail(function() {
-            $('.content-box').hide();
+            $('.wrapper').hide();
             $('#info').show();
+        });
+
+        $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+            if (e.target.id == 'query_details_tab') {
+                $("#grid-queries").bootgrid('destroy');
+                let grid_queries = $("#grid-queries").UIBootgrid({
+                    search:'/api/unbound/overview/searchQueries/',
+                    options: {
+                        rowSelect: false,
+                        multiSelect: false,
+                        selection: false,
+                        formatters: {
+                            "timeformatter": function (column, row) {
+                                return moment.unix(row.time).local().format('YYYY-MM-DD HH:mm:ss');
+                            },
+                            "resolveformatter": function (column, row) {
+                                return row.resolve_time_ms + 'ms';
+                            }
+                        },
+                        statusMapping: {
+                            0: "query-success",
+                            1: "info",
+                            2: "query-warning",
+                            3: "query-danger",
+                            4: "danger"
+                        }
+                    }
+                });
+            }
+            if (e.target.id == 'query_overview_tab') {
+                create_or_update_totals();
+                updateQueryChart($("#toggle-log-qchart")[0].checked);
+                updateClientChart($("#toggle-log-cchart")[0].checked);
+            }
         });
 
         updateServiceControlUI('unbound');
@@ -451,146 +492,180 @@
 </script>
 
 <div id="info" class="alert alert-warning" role="alert">
-    {{ lang._('Local gathering of statistics is not enabled. Enable it in the Unbound General page.') }}
+    {{ lang._('Local gathering of statistics is not enabled. Enable it in Reporting Settings page.') }}
     <br />
-    <a href="/services_unbound.php">{{ lang._('Go the Unbound configuration') }}</a>
+    <a href="/reporting_settings.php">{{ lang._('Go to the Reporting configuration') }}</a>
 </div>
-<div class="content-box" style="margin-bottom: 10px;">
-    <div id="counters" class="container-fluid">
-        <div class="col-md-12">
-            <h3 id="bannersub"></h3>
+<div class="wrapper">
+    <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs" style="border-bottom: none">
+        <li><a data-toggle="tab" href="#query-overview" id="query_overview_tab">{{ lang._('Overview') }}</a></li>
+        <li><a data-toggle="tab" href="#query-details" id="query_details_tab">{{ lang._('Details') }}</a></li>
+    </ul>
+    <div class="tab-content content-box" style="padding: 10px; border-top: 1px solid #E5E5E5;">
+        <div id="query-overview" class="tab-pane fade in active">
+            <div class="content-box" style="margin-bottom: 10px;">
+                <div id="counters" class="container-fluid">
+                    <div class="col-md-12">
+                        <h3 id="bannersub"></h3>
+                    </div>
+                    <div class="row" style="margin-bottom: 20px; margin-top: 20px;">
+                        <div class="banner col-xs-3 justify-content-center">
+                            <div class="stats-element">
+                                <div class="stats-icon">
+                                    <i class="large-icon fa fa-cogs text-success" aria-hidden="true"></i>
+                                </div>
+                                <div class="stats-text">
+                                    <h2 id="totalCounter" class="stats-counter-text"></h2>
+                                    <p class="stats-inner-text">{{ lang._('Total')}}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="banner col-xs-3 justify-content-center">
+                            <div class="stats-element">
+                                <div class="stats-icon">
+                                    <i class="large-icon fa fa-arrows-v text-info" aria-hidden="true"></i>
+                                </div>
+                                <div class="stats-text">
+                                    <h2 id="resolvedCounter" class="stats-counter-text"></h2>
+                                    <p class="stats-inner-text">{{ lang._('Resolved') }}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="banner col-xs-3 justify-content-center">
+                            <div class="stats-element">
+                                <div class="stats-icon">
+                                    <i class="large-icon fa fa-hand-paper-o text-danger" aria-hidden="true"></i>
+                                </div>
+                                <div class="stats-text">
+                                    <h2 id="blockedCounter" class="stats-counter-text"></h2>
+                                    <p class="stats-inner-text pull-right">{{ lang._('Blocked') }}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="banner col-xs-3 justify-content-center">
+                            <div class="stats-element">
+                                <div class="stats-icon">
+                                    <i class="large-icon fa fa-list text-primary" aria-hidden="true"></i>
+                                </div>
+                                <div class="stats-text">
+                                    <h2 id="sizeCounter" class="stats-counter-text"></h2>
+                                    <p class="stats-inner-text">{{ lang._('Size of blocklist') }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="content-box" style="margin-bottom: 10px;">
+                <div id="graph" class="container-fluid">
+                    <div class="row justify-content-center" style="display: flex; flex-wrap: wrap;">
+                        <div class="col-md-4"></div>
+                        <div class="col-md-4 text-center" style="padding: 10px;">
+                            <span id="qGraphTitle" style="padding: 5px;"><b>{{ lang._('Queries over the last ') }}</b></span>
+                            <select class="selectpicker" id="timeperiod" data-width="auto">
+                                <option value="24">{{ lang._('24 Hours') }}</option>
+                                <option value="12">{{ lang._('12 Hours') }}</option>
+                                <option value="1">{{ lang._('1 Hour') }}</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2"></div>
+                        <div class="col-md-2">
+                            <div class="vertical-center">
+                                <label class="h-100" style="margin-right: 5px;">Logarithmic</label>
+                                <input id="toggle-log-qchart" type="checkbox"></input>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-2"></div>
+                        <div class="col-8">
+                            <div class="chart-container">
+                                <canvas id="rollingChart"></canvas>
+                            </div>
+                        </div>
+                        <div class="col-2"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="content-box" style="margin-bottom: 10px;">
+                <div id="graph" class="container-fluid">
+                    <div class="row justify-content-center" style="display: flex; flex-wrap: wrap;">
+                        <div class="col-md-4"></div>
+                        <div class="col-md-4 text-center" style="padding: 10px;">
+                            <span id="cGraphTitle" style="padding: 5px;"><b>{{ lang._('Top 10 client activity over the last ') }}</b></span>
+                            <select class="selectpicker" id="timeperiod-clients" data-width="auto">
+                                <option value="24">{{ lang._('24 Hours') }}</option>
+                                <option value="12">{{ lang._('12 Hours') }}</option>
+                                <option value="1">{{ lang._('1 Hour') }}</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2"></div>
+                        <div class="col-md-2">
+                            <div class="vertical-center">
+                                <label class="h-100" style="margin-right: 5px;">Logarithmic</label>
+                                <input id="toggle-log-cchart" type="checkbox"></input>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-2"></div>
+                        <div class="col-8">
+                            <div class="chart-container">
+                                <canvas id="rollingChartClient"></canvas>
+                            </div>
+                        </div>
+                        <div class="col-2"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="content-box">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="top-list">
+                                <ul class="list-group" id="top">
+                                    <li class="list-group-item list-group-item-border">
+                                        <b>{{ lang._('Top passed domains') }}</b>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="top-list">
+                                <ul class="list-group" id="top-blocked">
+                                    <li class="list-group-item list-group-item-border">
+                                        <b>{{ lang._('Top blocked domains') }}</b>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="row" style="margin-bottom: 20px; margin-top: 20px;">
-            <div class="banner col-xs-3 justify-content-center">
-                <div class="stats-element">
-                    <div class="stats-icon">
-                        <i class="icon fa fa-cogs text-success" aria-hidden="true"></i>
-                    </div>
-                    <div class="stats-text">
-                        <h2 id="totalCounter" class="stats-counter-text"></h2>
-                        <p class="stats-inner-text">{{ lang._('Total')}}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="banner col-xs-3 justify-content-center">
-                <div class="stats-element">
-                    <div class="stats-icon">
-                        <i class="icon fa fa-hand-paper-o text-danger" aria-hidden="true"></i>
-                    </div>
-                    <div class="stats-text">
-                        <h2 id="blockedCounter" class="stats-counter-text"></h2>
-                        <p class="stats-inner-text pull-right">{{ lang._('Blocked') }}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="banner col-xs-3 justify-content-center">
-                <div class="stats-element">
-                    <div class="stats-icon">
-                        <i class="icon fa fa-list text-primary" aria-hidden="true"></i>
-                    </div>
-                    <div class="stats-text">
-                        <h2 id="sizeCounter" class="stats-counter-text"></h2>
-                        <p class="stats-inner-text">{{ lang._('Size of blocklist') }}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="banner col-xs-3 justify-content-center">
-                <div class="stats-element">
-                    <div class="stats-icon">
-                        <i class="icon fa fa-database text-info" aria-hidden="true"></i>
-                    </div>
-                    <div class="stats-text">
-                        <h2 id="localCounter" class="stats-counter-text"></h2>
-                        <p class="stats-inner-text">{{ lang._('From Local-data') }}</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-<div class="content-box" style="margin-bottom: 10px;">
-    <div id="graph" class="container-fluid">
-        <div class="row justify-content-center" style="display: flex; flex-wrap: wrap;">
-            <div class="col-md-4"></div>
-            <div class="col-md-4 text-center" style="padding: 10px;">
-                <span id="qGraphTitle" style="padding: 5px;"><b>{{ lang._('Queries over the last ') }}</b></span>
-                <select class="selectpicker" id="timeperiod" data-width="auto">
-                    <option value="24">{{ lang._('24 Hours') }}</option>
-                    <option value="12">{{ lang._('12 Hours') }}</option>
-                    <option value="1">{{ lang._('1 Hour') }}</option>
-                </select>
-            </div>
-            <div class="col-md-2"></div>
-            <div class="col-md-2">
-                <div class="vertical-center">
-                    <label class="h-100" style="margin-right: 5px;">Logarithmic</label>
-                    <input id="toggle-log-qchart" type="checkbox"></input>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-2"></div>
-            <div class="col-8">
-                <div class="chart-container">
-                    <canvas id="rollingChart"></canvas>
-                </div>
-            </div>
-            <div class="col-2"></div>
-        </div>
-    </div>
-</div>
-<div class="content-box" style="margin-bottom: 10px;">
-    <div id="graph" class="container-fluid">
-        <div class="row justify-content-center" style="display: flex; flex-wrap: wrap;">
-            <div class="col-md-4"></div>
-            <div class="col-md-4 text-center" style="padding: 10px;">
-                <span id="cGraphTitle" style="padding: 5px;"><b>{{ lang._('Top 10 client activity over the last ') }}</b></span>
-                <select class="selectpicker" id="timeperiod-clients" data-width="auto">
-                    <option value="24">{{ lang._('24 Hours') }}</option>
-                    <option value="12">{{ lang._('12 Hours') }}</option>
-                    <option value="1">{{ lang._('1 Hour') }}</option>
-                </select>
-            </div>
-            <div class="col-md-2"></div>
-            <div class="col-md-2">
-                <div class="vertical-center">
-                    <label class="h-100" style="margin-right: 5px;">Logarithmic</label>
-                    <input id="toggle-log-cchart" type="checkbox"></input>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-2"></div>
-            <div class="col-8">
-                <div class="chart-container">
-                    <canvas id="rollingChartClient"></canvas>
-                </div>
-            </div>
-            <div class="col-2"></div>
-        </div>
-    </div>
-</div>
-<div class="content-box">
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-6">
-                <div class="top-list">
-                    <ul class="list-group" id="top">
-                      <li class="list-group-item list-group-item-border">
-                        <b>{{ lang._('Top passed domains') }}</b>
-                      </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="top-list">
-                    <ul class="list-group" id="top-blocked">
-                      <li class="list-group-item list-group-item-border">
-                        <b>{{ lang._('Top blocked domains') }}</b>
-                      </li>
-                    </ul>
-                </div>
-            </div>
+        <div id="query-details" class="tab-pane fade in">
+            <table id="grid-queries" class="table table-condensed">
+                <thead>
+                <tr>
+                    <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                    <th data-column-id="status" data-type="numeric" data-visible="false" data-formatter="statusformatter">{{ lang._('status') }}</th>
+                    <th data-column-id="time" data-type="string" data-formatter="timeformatter">{{ lang._('Time') }}</th>
+                    <th data-column-id="client" data-type="string">{{ lang._('Client') }}</th>
+                    <th data-column-id="family" data-width="6em" data-visible="false" data-type="string">{{ lang._('Family') }}</th>
+                    <th data-column-id="type" data-width="6em" data-type="string">{{ lang._('Type') }}</th>
+                    <th data-column-id="domain" data-type="string">{{ lang._('Domain') }}</th>
+                    <th data-column-id="action" data-width="6em" data-type="string">{{ lang._('Action') }}</th>
+                    <th data-column-id="source" data-type="string">{{ lang._('Source') }}</th>
+                    <th data-column-id="rcode" data-type="string">{{ lang._('Return Code') }}</th>
+                    <th data-column-id="resolve_time_ms" data-type="string" data-formatter="resolveformatter">{{ lang._('Resolve time') }}</th>
+                    <th data-column-id="blocklist" data-type="string">{{ lang._('Blocklist') }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                </tbody>
+                <tfoot>
+                </tfoot>
+            </table>
         </div>
     </div>
 </div>

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
@@ -398,18 +398,18 @@
                     $('#top-blocked li:nth-child(even)').addClass('odd-bg');
 
                     $('#bannersub').html("Starting from " + (new Date(data.start_time * 1000)).toLocaleString());
+                });
 
-                    ajaxGet('/api/unbound/overview/rolling/' + $("#timeperiod").val(), {}, function(data, status) {
-                        let formatted = formatQueryData(data, $("#toggle-log-qchart").is(":checked"));
-                        let stepSize = $("#timeperiod").val() == 1 ? 5 : 60;
-                        g_queryChart = create_chart($("#rollingChart"), stepSize, formatted, $("#toggle-log-qchart").is(":checked"));
+                ajaxGet('/api/unbound/overview/rolling/' + $("#timeperiod").val(), {}, function(data, status) {
+                    let formatted = formatQueryData(data, $("#toggle-log-qchart").is(":checked"));
+                    let stepSize = $("#timeperiod").val() == 1 ? 5 : 60;
+                    g_queryChart = create_chart($("#rollingChart"), stepSize, formatted, $("#toggle-log-qchart").is(":checked"));
+                });
 
-                        ajaxGet('/api/unbound/overview/rolling/' + $("#timeperiod-clients").val() + '/1', {}, function(data, status) {
-                            let formatted = formatClientData(data, $("#toggle-log-qchart").is(":checked"));
-                            let stepSize = $("#timeperiod-clients").val() == 1 ? 5 : 60;
-                            g_clientChart = create_client_chart($("#rollingChartClient"), stepSize, formatted, $("#toggle-log-qchart").is(":checked"));
-                        });
-                    });
+                ajaxGet('/api/unbound/overview/rolling/' + $("#timeperiod-clients").val() + '/1', {}, function(data, status) {
+                    let formatted = formatClientData(data, $("#toggle-log-qchart").is(":checked"));
+                    let stepSize = $("#timeperiod-clients").val() == 1 ? 5 : 60;
+                    g_clientChart = create_client_chart($("#rollingChartClient"), stepSize, formatted, $("#toggle-log-qchart").is(":checked"));
                 });
             });
 

--- a/src/opnsense/scripts/unbound/logger.py
+++ b/src/opnsense/scripts/unbound/logger.py
@@ -42,7 +42,6 @@ from duckdb_helper import DbConnection
 class DNSReader:
     def __init__(self, target_pipe, flush_interval):
         self.target_pipe = target_pipe
-        syslog.syslog(syslog.LOG_NOTICE, "self.target_pipe: %s" % self.target_pipe)
         self.timer = 0
         self.flush_interval = flush_interval
         self.buffer = deque()

--- a/src/opnsense/scripts/unbound/logger.py
+++ b/src/opnsense/scripts/unbound/logger.py
@@ -59,8 +59,9 @@ class DNSReader:
                     type TEXT,
                     domain TEXT,
                     action INTEGER,
-                    response_type INTEGER,
+                    source INTEGER,
                     blocklist TEXT,
+                    rcode INTEGER,
                     resolve_time_ms INTEGER,
                     dnssec_status INTEGER
                 )

--- a/src/opnsense/scripts/unbound/logger.py
+++ b/src/opnsense/scripts/unbound/logger.py
@@ -52,6 +52,7 @@ class DNSReader:
         with DbConnection('/var/unbound/data/unbound.duckdb', read_only=False) as db:
             db.connection.execute("""
                 CREATE TABLE IF NOT EXISTS query (
+                    uuid UUID,
                     time INTEGER,
                     client TEXT,
                     family TEXT,

--- a/src/opnsense/scripts/unbound/stats.py
+++ b/src/opnsense/scripts/unbound/stats.py
@@ -32,6 +32,7 @@ import sys
 import re
 import os
 import pandas
+import numpy as np
 from time import time
 from operator import itemgetter
 sys.path.insert(0, "/usr/local/opnsense/site-python")
@@ -70,10 +71,8 @@ def handle_rolling(args):
                 GROUP_CONCAT(cl) as clients,
                 GROUP_CONCAT(cnt_cl) as client_totals
             FROM grouped
-            GROUP BY
-                s, e
-            ORDER BY
-                e;
+            GROUP BY s, e
+            ORDER BY e
         """.format(intv=interval//60, tp=tp)
     else:
         query = """
@@ -99,8 +98,8 @@ def handle_rolling(args):
 
     if not data.empty:
         if args.clients:
-            # first, in-place drop any rows that do not have any clients
-            data.dropna(inplace=True)
+            # a group_concat without any client returns NaN in a Dataframe, replace it with an empty string
+            data = data.replace(np.nan, '', regex=True)
             data = list(data.itertuples(index=False, name=None))
             result = {}
             for row in data:

--- a/src/opnsense/scripts/unbound/stats.py
+++ b/src/opnsense/scripts/unbound/stats.py
@@ -27,133 +27,112 @@
 """
 
 import argparse
-import sqlite3
 import ujson
 import sys
-import syslog
 import re
 import os
+import pandas
 from time import time
 from operator import itemgetter
-
-class DBWrapper:
-    def __init__(self):
-        syslog.openlog('unbound', logoption=syslog.LOG_DAEMON, facility=syslog.LOG_LOCAL4)
-        self.db_name = "/var/unbound/data/unbound.sqlite"
-        self.con = sqlite3.connect(self.db_name)
-        self.cursor = self.con.cursor()
-        self.exit = False # let the subcommands handle what to return when no db is available
-
-        check = "SELECT name FROM sqlite_master WHERE type='table' AND name='query';"
-        res = self.cursor.execute(check)
-        if not res.fetchone():
-            self.exit = True
-
-    def execute(self, query, params=None):
-        try:
-            if params:
-                self.cursor.execute(query, params)
-            else:
-                self.cursor.execute(query)
-        except sqlite3.DatabaseError as e:
-            syslog.syslog(syslog.LOG_ERR, "Unable to execute database operation: %s." % e)
-
-        return self.cursor.fetchall()
-
-    def close(self):
-        self.cursor.close()
-        self.con.close()
+sys.path.insert(0, "/usr/local/opnsense/site-python")
+from duckdb_helper import DbConnection
 
 def percent(val, total):
     if val == 0 or total == 0:
         return 0
     return '{:.2f}'.format(round(((val / total) * 100), 2))
 
-def handle_rolling(db, args):
+def handle_rolling(args):
+    # sanitize input
     interval = int(re.sub("^(?:(?!300|60).)*$", "300", str(args.interval)))
     tp = int(re.sub("^(?:(?!24|12|1).)*$", "24", str(args.timeperiod)))
+    data = pandas.DataFrame()
 
     result = {}
 
-    if not db.exit:
-        if args.clients:
-            query = """
-                WITH grouped AS (
-                    SELECT v.start_timestamp s, v.end_timestamp e, c.client cl, COUNT(c.client) cnt_cl
-                    FROM v_time_buckets_{intv}min v
-                    LEFT JOIN query c ON
-                        c.time >= v.start_timestamp AND
-                        c.time <= v.end_timestamp
-                    WHERE DATETIME(v.start_timestamp, 'unixepoch') > DATETIME('now', '-{tp} hour')
-                    GROUP BY
-                        v.end_timestamp,
-                        c.client
-                    ORDER BY
-                        v.end_timestamp
-                )
-                SELECT s, e, GROUP_CONCAT(cl), GROUP_CONCAT(cnt_cl)
-                FROM grouped
+    if args.clients:
+        query = """
+            WITH grouped AS (
+                SELECT v.start_timestamp s, v.end_timestamp e, c.client cl, COUNT(c.client) cnt_cl
+                FROM v_time_series_{intv}min v
+                LEFT JOIN query c ON
+                    c.time >= v.start_timestamp AND
+                    c.time <= v.end_timestamp
+                WHERE to_timestamp(v.start_timestamp) > (to_timestamp(epoch(now())) - INTERVAL {tp} HOUR)
                 GROUP BY
-                    e
+                    v.end_timestamp, v.start_timestamp, c.client
                 ORDER BY
-                    e;
-            """.format(intv=interval//60, tp=tp)
-        else:
-            query = """
-                SELECT v.start_timestamp, v.end_timestamp, COUNT(q.qid) AS cnt,
-                    COUNT(case q.action when 0 then 1 else null end) AS passed,
-                    COUNT(case q.action when 1 then 1 else null end) AS blocked,
-                    COUNT(case q.action when 2 then 1 else null end) AS dropped,
-                    COUNT(case q.response_type when 0 then 1 else null end) AS resolved,
-                    COUNT(case q.response_type when 1 then 1 else null end) AS local,
-                    COUNT(case q.response_type when 2 then 1 else null end) AS cached
-                FROM v_time_buckets_{intv}min v
-                LEFT JOIN query q ON
-                    q.time >= v.start_timestamp AND
-                    q.time <= v.end_timestamp
-                WHERE DATETIME(v.start_timestamp, 'unixepoch') > DATETIME('now', '-{tp} hour')
-                GROUP BY
                     v.end_timestamp
-                ORDER BY
-                    v.end_timestamp;
-            """.format(intv=(interval//60), tp=tp)
+            )
+            SELECT
+                s as start_timestamp,
+                e as end_timestamp,
+                GROUP_CONCAT(cl) as clients,
+                GROUP_CONCAT(cnt_cl) as client_totals
+            FROM grouped
+            GROUP BY
+                s, e
+            ORDER BY
+                e;
+        """.format(intv=interval//60, tp=tp)
+    else:
+        query = """
+            SELECT v.start_timestamp, v.end_timestamp, COUNT(q.time) AS total,
+                COUNT(case q.action when 0 then 1 else null end) AS passed,
+                COUNT(case q.action when 1 then 1 else null end) AS blocked,
+                COUNT(case q.action when 2 then 1 else null end) AS dropped,
+                COUNT(case q.response_type when 0 then 1 else null end) AS resolved,
+                COUNT(case q.response_type when 1 then 1 else null end) AS local,
+                COUNT(case q.response_type when 2 then 1 else null end) AS cached
+            FROM v_time_series_{intv}min v
+            LEFT JOIN query q ON
+                q.time >= v.start_timestamp AND
+                q.time <= v.end_timestamp
+            WHERE to_timestamp(v.start_timestamp) > (to_timestamp(epoch(now())) - INTERVAL {tp} HOUR)
+            GROUP BY v.end_timestamp, v.start_timestamp
+            ORDER BY v.end_timestamp
+        """.format(intv=(interval//60), tp=tp)
 
-        data = db.execute(query)
+    with DbConnection('/var/unbound/data/unbound.duckdb', read_only=True) as db:
+        if db.connection is not None and db.table_exists('query'):
+            data = db.connection.execute(query).fetchdf().astype('object')
 
-        if data:
-            if args.clients:
-                result = {}
-                for row in data:
-                    interval = {row[0]: {}}
-                    if row[2]:
-                        tmp = []
-                        counts = row[3].split(',')
-                        for idx, client in enumerate(row[2].split(',')):
-                            tmp.append((client, int(counts[idx])))
-                        # sort the list by most active client
-                        tmp.sort(key=itemgetter(1), reverse=True)
-                        # limit by 10
-                        tmp = tmp[:10]
-                        interval[row[0]] |= dict(tmp)
-                    result |= interval
-            else:
-                result = {
-                    tup[0]: {
-                            'total': tup[2],
-                            'passed': tup[3],
-                            'blocked': tup[4],
-                            'dropped': tup[5],
-                            'resolved': tup[6],
-                            'local': tup[7],
-                            'cached': tup[8]
-                        }
-                    for tup in data
-                }
+    if not data.empty:
+        if args.clients:
+            # first, in-place drop any rows that do not have any clients
+            data.dropna(inplace=True)
+            data = list(data.itertuples(index=False, name=None))
+            result = {}
+            for row in data:
+                interval = {row[0]: {}}
+                if row[2]:
+                    tmp = []
+                    counts = row[3].split(',')
+                    for idx, client in enumerate(row[2].split(',')):
+                        tmp.append((client, int(counts[idx])))
+                    # sort the list by most active client
+                    tmp.sort(key=itemgetter(1), reverse=True)
+                    # limit by 10
+                    tmp = tmp[:10]
+                    interval[row[0]] |= dict(tmp)
+                result |= interval
+        else:
+            result = data.set_index('start_timestamp').apply(lambda x: {
+                'total': x.total,
+                'passed': x.passed,
+                'blocked': x.blocked,
+                'dropped': x.dropped,
+                'resolved': x.resolved,
+                'local': x.local,
+                'cached': x.cached
+            }, axis=1).to_dict()
+
     print(ujson.dumps(result))
 
-def handle_top(db, args):
+def handle_top(args):
     total = blocked = local = passed = blocklist_size = 0
-    r_top = r_top_blocked = {}
+    r_top = r_top_blocked = r_total = r_start_time = pandas.DataFrame()
+    top = top_blocked = {}
     start_time = int(time())
 
     bl_path = '/var/unbound/data/dnsbl.size'
@@ -161,58 +140,62 @@ def handle_top(db, args):
         with open(bl_path, 'r') as f:
             blocklist_size = int(f.readline())
 
-    if not db.exit:
-        # get top N of all passed queries
-        top = """
-            SELECT domain, COUNT(domain) as cnt
-            FROM query
-            WHERE action == 0
-            GROUP BY domain
-            ORDER BY cnt DESC
-            LIMIT :max;
-        """
+    with DbConnection('/var/unbound/data/unbound.duckdb') as db:
+        if db.connection is not None and db.table_exists('query'):
+            # all queries are stored in a DataFrame() and its resulting set
+            # cast to native python types (`int` instead of `numpy.int64`)
+            # in order to properly convert it to json format
+            r_top = db.connection.execute("""
+                SELECT domain, COUNT(domain) as cnt
+                FROM query
+                WHERE action == 0
+                GROUP BY domain
+                ORDER BY cnt DESC
+                LIMIT ?
+            """, [args.max]).fetchdf().astype('object')
 
-        r_top = db.execute(top, {"max": args.max})
+            r_top_blocked = db.connection.execute("""
+                SELECT domain, COUNT(domain) as cnt, blocklist
+                FROM query
+                WHERE action == 1
+                GROUP BY domain, blocklist
+                ORDER BY cnt DESC
+                LIMIT ?
+            """, [args.max]).fetchdf().astype('object')
 
-        # get top N of all blocked queries
-        top_blocked = """
-            SELECT domain, COUNT(domain) as cnt, blocklist
-            FROM query
-            WHERE action == 1
-            GROUP BY DOMAIN
-            ORDER BY cnt DESC
-            LIMIT :max;
-        """
+            r_total = db.connection.execute("""
+                SELECT COUNT(*) AS total,
+                    COUNT(case q.action when 1 then 1 else null end) AS blocked,
+                    COUNT(case q.response_type when 1 then 1 else null end) AS local,
+                    COUNT(case q.action when 0 then 1 else null end) AS passed
+                FROM query q
+            """).fetchdf().astype('object')
 
-        r_top_blocked = db.execute(top_blocked, {"max": args.max})
+            r_start_time = db.connection.execute("""
+                SELECT time
+                FROM query
+                ORDER BY time ASC
+                LIMIT 1
+            """).fetchdf().astype('object')
 
-        # get counters of total values
-        total = """
-            SELECT COUNT(*) AS total,
-                COUNT(case q.action when 1 then 1 else null end) AS blocked,
-                COUNT(case q.response_type when 1 then 1 else null end) AS local,
-                COUNT(case q.action when 0 then 1 else null end) AS passed
-            FROM query q;
-        """
-
-        r_total = db.execute(total)
-
-        # get initial start time
-        t = """
-            SELECT time
-            FROM query
-            ORDER BY qid ASC
-            LIMIT 1;
-        """
-
-        r_start_time = db.execute(t)
-
-        if r_total and r_start_time:
-            total = r_total[0][0]
-            blocked = r_total[0][1]
-            local = r_total[0][2]
-            passed = r_total[0][3]
-            start_time = r_start_time[0][0]
+    if not r_total.empty:
+        total = r_total.total.iloc[0]
+        blocked = r_total.blocked.iloc[0]
+        local = r_total.local.iloc[0]
+        passed = r_total.passed.iloc[0]
+    if not r_start_time.empty:
+        start_time = r_start_time.time.iloc[0]
+    if not r_top.empty:
+        top = r_top.set_index('domain').apply(lambda x: {
+            "total": x.cnt,
+            "pcnt": percent(x.cnt, passed)
+        }, axis=1).to_dict()
+    if not r_top_blocked.empty:
+        top_blocked = r_top_blocked.set_index('domain').apply(lambda x: {
+            "total": x.cnt,
+            "pcnt": percent(x.cnt, blocked),
+            "blocklist": x.blocklist
+        }, axis=1).to_dict()
 
     print(ujson.dumps({
         "total": total,
@@ -221,19 +204,8 @@ def handle_top(db, args):
         "blocked": {"total": blocked, "pcnt": percent(blocked, total)},
         "local": {"total": local, "pcnt": percent(local, total)},
         "start_time": start_time,
-        "top": {
-            k: {
-                "total": v,
-                "pcnt": percent(v, passed)
-            } for k, v in dict(r_top).items()
-        },
-        "top_blocked": {
-            tup[0]: {
-                "total": tup[1],
-                "pcnt": percent(tup[1], blocked),
-                "blocklist": tup[2]
-            } for tup in r_top_blocked
-        }
+        "top": top,
+        "top_blocked": top_blocked
     }))
 
 if __name__ == '__main__':
@@ -254,8 +226,5 @@ if __name__ == '__main__':
         sys.exit(1)
 
     inputargs = parser.parse_args()
-    db = DBWrapper()
 
-    inputargs.func(db, inputargs)
-
-    db.close()
+    inputargs.func(inputargs)

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -34,6 +34,18 @@ parameters:--max %s
 type:script_output
 message: fetch top queried domains
 
+[qstats.details]
+command:/usr/local/opnsense/scripts/unbound/stats.py details
+parameters:--limit %s
+type:script_output
+message: fetch query details
+
+[qstats.reset]
+command:/bin/rm -f /var/unbound/data/unbound.duckdb && configctl unbound restart; exit 0
+parameters:
+type:script
+message: reset Unbound DNS statistics
+
 [listinsecure]
 command:/usr/local/opnsense/scripts/unbound/wrapper.py -I
 parameters:

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
@@ -28,6 +28,7 @@ import os
 import json
 import time
 import errno
+import uuid
 from threading import Lock
 from collections import deque
 
@@ -123,7 +124,8 @@ class ModuleContext:
         if not self.stats_enabled:
             return
 
-        self.pipe_buffer.append(args)
+        entry = (uuid.uuid4(), *args)
+        self.pipe_buffer.append(entry)
         if self.pipe_fd is None:
             if (time.time() - self.pipe_timer) > 10:
                 self.pipe_timer = time.time()
@@ -139,7 +141,7 @@ class ModuleContext:
             try:
                 while len(self.pipe_buffer) > 0:
                     l = self.pipe_buffer.popleft()
-                    res = "{} {} {} {} {} {} {} {} {} {}\n".format(*l)
+                    res = "{} {} {} {} {} {} {} {} {} {} {}\n".format(*l)
                     os.write(self.pipe_fd, res.encode())
             except (BrokenPipeError, BlockingIOError) as e:
                 if e.__class__.__name__ == 'BrokenPipeError':

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
@@ -278,8 +278,8 @@ def operate(id, event, qstate, qdata):
         # Iterator finished, show response (if any)
         if 'query' in qdata and 'start_time' in qdata:
             ctx = mod_env['context']
-            dnssec_state = qstate.return_msg.rep.security
-            ctx.log_entry(*qdata['query'], round((time.time() - qdata['start_time']) * 1000), dnssec_state)
+            dnssec = qstate.return_msg.rep.security if qstate.return_msg else DNSSEC_UNCHECKED
+            ctx.log_entry(*qdata['query'], round((time.time() - qdata['start_time']) * 1000), dnssec)
         qstate.ext_state[id] = MODULE_FINISHED
         return True
 

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
@@ -103,7 +103,7 @@ class ModuleContext:
             self.pipe_fd = os.open(self.pipe_name, os.O_NONBLOCK | os.O_WRONLY)
         except OSError as e:
             if e.errno == errno.ENXIO:
-                log_warn("dnsbl_module: no logging backend found.")
+                log_info("dnsbl_module: no logging backend found.")
                 self.pipe_fd = None
                 return False
             else:
@@ -136,7 +136,7 @@ class ModuleContext:
                     os.write(self.pipe_fd, log.encode())
             except (BrokenPipeError, BlockingIOError) as e:
                 if e.__class__.__name__ == 'BrokenPipeError':
-                    log_warn("dnsbl_module: Logging backend closed connection. Closing pipe and continuing.")
+                    log_info("dnsbl_module: Logging backend closed connection. Closing pipe and continuing.")
                     os.close(self.pipe_fd)
                     self.pipe_fd = None
 

--- a/src/opnsense/site-python/duckdb_helper.py
+++ b/src/opnsense/site-python/duckdb_helper.py
@@ -88,6 +88,9 @@ class DbConnection():
 
         Note: not used with prepared statements, duckdb doesn't support it in this manner.
         """
+        if self.connection is None:
+            return False
+
         try:
             self.connection.execute("DESCRIBE %s" % table_name)
         except duckdb.CatalogException:

--- a/src/opnsense/site-python/duckdb_helper.py
+++ b/src/opnsense/site-python/duckdb_helper.py
@@ -30,7 +30,7 @@ import os
 import duckdb
 import fcntl
 
-class DbConnection():
+class DbConnection:
     """
     ContextManager wrapper for a DuckDb connection. Use this to synchronize
     access to a DuckDb instance in cases where there is both a writer and

--- a/src/opnsense/site-python/duckdb_helper.py
+++ b/src/opnsense/site-python/duckdb_helper.py
@@ -1,0 +1,97 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2022 Deciso B.V.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import os
+import duckdb
+import fcntl
+
+class DbConnection():
+    """
+    ContextManager wrapper for a DuckDb connection. Use this to synchronize
+    access to a DuckDb instance in cases where there is both a writer and
+    one or more readers. Since this isn't natively supported by DuckDb,
+    the assumption here is that both the reader and the writer can afford
+    to block for the duration of an arbitrary operation of its counterpart.
+    For example, when a reader has a connection, a writer blocks until the readers drops
+    the connection and vice versa. The use of this ContextManager therefore forces
+    a connection to only last for the duration of its operation.
+    """
+
+    def __init__(self, path, read_only=True):
+        self._path = path
+        self._read_only = read_only
+        self._fd = None
+        self.connection = None
+
+    def __enter__(self):
+        """
+        :return duckdb.DuckDBPyConnection or None if the database doesn't exist
+        while in read_only mode
+        """
+        while self.connection is None:
+            try:
+                self.connection = duckdb.connect(database=self._path, read_only=self._read_only)
+
+                # Doing any call to now()/get_current_timestamp() etc. in DuckDb will result
+                # in a timestamp adjusted for the current time zone. Since we want to store and query 
+                # UTC at all times also set the database time zone to UTC. This is scoped within the connection.
+                self.connection.execute("SET TimeZone='UTC'")
+            except duckdb.IOException:
+                # write-only, but no truncating, so use os-level open
+                self._fd = os.open(self._path, os.O_WRONLY)
+                # Try to obtain an exclusive lock and block when unable to.
+                # Since we aren't able to hold both an flock() and connect()
+                # at the same time, we wrap the connection in a try-except
+                # and retry if another connect() was done in between
+                fcntl.flock(self._fd, fcntl.LOCK_EX)
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            except duckdb.CatalogException:
+                # Tried to open a non-existing database in read_only mode.
+                return None
+
+        return self
+
+    def __exit__(self, ex_type, ex_value, traceback):
+        if self.connection is not None:
+            self.connection.close()
+        if self._fd is not None:
+            os.close(self._fd)
+
+    def table_exists(self, table_name):
+        """
+        :return True if table exists, else False
+
+        Note: not used with prepared statements, duckdb doesn't support it in this manner.
+        """
+        try:
+            self.connection.execute("DESCRIBE %s" % table_name)
+        except duckdb.CatalogException:
+            return False
+
+        return True
+

--- a/src/opnsense/www/css/dns-overview.css
+++ b/src/opnsense/www/css/dns-overview.css
@@ -22,7 +22,7 @@
     box-shadow: 3px 5px 1px 3px rgba(217,79,0,0.25);
 }
 
-.icon {
+.large-icon {
     position: relative;
     top: 50%;
     left: 50%;
@@ -100,4 +100,24 @@
     top: 50%;
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
+}
+
+#maintabs > li > a {
+    border: 1px solid #E5E5E5;
+}
+
+.query-success {
+    background-color: #c3e6cb;
+}
+
+.query-info {
+    background-color: #bee5eb;
+}
+
+.query-danger {
+    background-color: #f5c6cb;
+}
+
+.query-warning {
+    background-color: #ffeeba;
 }

--- a/src/www/services_unbound.php
+++ b/src/www/services_unbound.php
@@ -40,7 +40,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig = array();
     // boolean values
     $pconfig['enable'] = isset($a_unboundcfg['enable']);
-    $pconfig['stats'] = isset($a_unboundcfg['stats']);
     $pconfig['enable_wpad'] = isset($a_unboundcfg['enable_wpad']);
     $pconfig['dnssec'] = isset($a_unboundcfg['dnssec']);
     $pconfig['dns64'] = isset($a_unboundcfg['dns64']);
@@ -120,7 +119,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $a_unboundcfg['noarecords'] = !empty($pconfig['noarecords']);
             $a_unboundcfg['dnssec'] = !empty($pconfig['dnssec']);
             $a_unboundcfg['enable'] = !empty($pconfig['enable']);
-            $a_unboundcfg['stats'] = !empty($pconfig['stats']);
             $a_unboundcfg['enable_wpad'] = !empty($pconfig['enable_wpad']);
             $a_unboundcfg['noreglladdr6'] = empty($pconfig['reglladdr6']);
             $a_unboundcfg['regdhcp'] = !empty($pconfig['regdhcp']);
@@ -208,17 +206,6 @@ include_once("head.inc");
                           <input name="enable" type="checkbox" value="yes" <?=!empty($pconfig['enable']) ? 'checked="checked"' : '';?> />
                           <?= gettext('Enable Unbound') ?>
                         </td>
-                      </tr>
-                      <tr>
-                        <td><a id="help_for_stats" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Query Statistics");?></td>
-                          <td>
-                            <input name="stats" type="checkbox" value="yes" <?=!empty($pconfig['stats']) ? 'checked="checked"' : '';?> />
-                              <?= gettext('Enable statistics') ?>
-                              <div class="hidden" data-for="help_for_stats">
-                                <?= gettext("Enable the local collection of statistics including, but not limited to, top searched domains, " .
-                                    "blocked domains, client activity, cache hits and local-data hits."); ?>
-                              </div>
-                          </td>
                       </tr>
                       <tr>
                         <td><a id="help_for_port" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Listen Port");?></td>


### PR DESCRIPTION
Moves the reporting backend from sqlite to duckdb.

Since, unlike sqlite, duckdb does not support concurrency, a wrapper has been written to synchronize access to the database. Refer to the class itself for further documentation.

If you were on the master branch and had unbound statistics enabled prior to this commit, you should `rm -f /var/unbound/data/unbound.sqlite` and restart Unbound. 
