### PR TITLE
Services: Intrusion Detection: Administration - Alerts: reload grid after log drop

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -687,7 +687,9 @@ POSSIBILITY OF SUCH DAMAGE.
                     cssClass: 'btn-primary',
                     action: function(dlg){
                         ajaxCall("/api/ids/service/dropAlertLog/", {filename: selected_log.data('filename')}, function(data,status){
+                            $('#alert-logfile option').prop('selected', false);
                             updateAlertLogs();
+                            $('#grid-alerts').bootgrid('reload');
                         });
                         dlg.close();
                     }


### PR DESCRIPTION
Hi!
tested https://github.com/opnsense/core/commit/92e5536ca039ed558b5027077ed2e71a04230598 and it works great, thanks!
sorry, I did not mention one more in pr  - the alerts grid is not updated after log drop.

Thanks!
