### PR TITLE
Add base-uri and report-sample csp directives

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -282,6 +282,7 @@ class ControllerBase extends ControllerRoot
         // set security policies
         $policies = array(
             "default-src" => "'self'",
+            "base-uri" => "'self'",
             "img-src" => "'self'",
             "script-src" => "'self' 'unsafe-inline' 'unsafe-eval'",
             "style-src" => "'self' 'unsafe-inline' 'unsafe-eval'");

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -41,7 +41,7 @@ require_once("config.inc");
 /* CSRF BEGIN: CHECK MUST BE EXECUTED FIRST; NO EXCEPTIONS */
 require_once('csrf.inc');
 // hardening
-header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' 'unsafe-eval';");
+header("Content-Security-Policy: default-src 'self' 'report-sample'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'report-sample'; style-src 'self' 'unsafe-inline' 'unsafe-eval' 'report-sample'; base-uri 'self'");
 header('X-Frame-Options: SAMEORIGIN');
 header('X-Content-Type-Options: nosniff');
 header('X-XSS-Protection: 1; mode=block');

--- a/src/www/guiconfig.inc
+++ b/src/www/guiconfig.inc
@@ -44,7 +44,6 @@ require_once('csrf.inc');
 header("Content-Security-Policy: default-src 'self' 'report-sample'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'report-sample'; style-src 'self' 'unsafe-inline' 'unsafe-eval' 'report-sample'; base-uri 'self'");
 header('X-Frame-Options: SAMEORIGIN');
 header('X-Content-Type-Options: nosniff');
-header('X-XSS-Protection: 1; mode=block');
 header('Referrer-Policy: same-origin');
 /* CSRF END: THANK YOU FOR YOUR COOPERATION */
 


### PR DESCRIPTION
The base-uri directive prevents base elements from injected as a way to bypass the csp. Also adding report-sample which helps with debugging what is being blocked with the CSP so can be easier fixed