### PR TITLE
unbound: change working dir before unbound-checkconf on start

### DIFF
--- a/src/opnsense/scripts/unbound/start.sh
+++ b/src/opnsense/scripts/unbound/start.sh
@@ -35,6 +35,7 @@ for FILE in $(find /var/unbound/etc -depth 1); do
 done
 
 # if the root.key file is missing or damaged, run unbound-anchor
+cd /var/unbound/
 if ! /usr/local/sbin/unbound-checkconf /var/unbound/unbound.conf 2> /dev/null; then
 	# unbound-anchor has undefined behaviour if file is corrupted, start clean
 	rm -f /var/unbound/root.key


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=31475.0 and https://github.com/opnsense/core/commit/13ea70af049dabcec3f7fe907240d3a8aaeef4dc
just another place where the unbound-checkconf messes things up
( false-error triggers trust anchor update on every unbound (re)start)

Thanks!