### PR TITLE
Monit starttimeout

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/services.xml
@@ -43,6 +43,13 @@
       <help><![CDATA[The timeout for custom program checks.]]></help>
    </field>
    <field>
+      <id>service.starttimeout</id>
+      <label>Start Timeout</label>
+      <type>text</type>
+      <advanced>true</advanced>
+      <help><![CDATA[The timeout for custom program to start a service.]]></help>
+   </field>
+   <field>
       <id>service.address</id>
       <label>Address</label>
       <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -231,6 +231,13 @@
             <MaximumValue>86400</MaximumValue>
             <ValidationMessage>Program Timeout needs to be an integer value between 1 and 86400</ValidationMessage>>
          </timeout>
+         <starttimeout type="IntegerField">
+            <default>30</default>
+            <Required>N</Required>
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>86400</MaximumValue>
+            <ValidationMessage>Start Delay needs to be an integer value between 0 and 86400</ValidationMessage>
+         </starttimeout>
          <address type="HostnameField">
             <Required>N</Required>
          </address>

--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -135,7 +135,11 @@ check {{ service.type }} {{ service.name }} {{ path }}
 {%      endfor %}
 {%     endif %}
 {%     if service.start|default('') != '' %}
-   start program = "{{ service.start }}"
+{%       set srv_start_timeout = '' %}
+{%       if service.starttimeout|default('') != '' %}
+{%         set srv_start_timeout = "with timeout " ~ service.starttimeout ~ " seconds" %}
+{%       endif %}
+   start program = "{{ service.start }}" {{ srv_start_timeout }}
 {%     endif %}
 {%     if service.stop|default('') != '' %}
    stop program = "{{ service.stop }}"

--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -135,11 +135,7 @@ check {{ service.type }} {{ service.name }} {{ path }}
 {%      endfor %}
 {%     endif %}
 {%     if service.start|default('') != '' %}
-{%       set srv_start_timeout = '' %}
-{%       if service.starttimeout|default('') != '' %}
-{%         set srv_start_timeout = "with timeout " ~ service.starttimeout ~ " seconds" %}
-{%       endif %}
-   start program = "{{ service.start }}" {{ srv_start_timeout }}
+   start program = "{{ service.start }}" with timeout {{service.starttimeout|default('30')}} seconds
 {%     endif %}
 {%     if service.stop|default('') != '' %}
    stop program = "{{ service.stop }}"


### PR DESCRIPTION
The PR is to add the ability via the web to configure Service Start Timeout.

This could be extended to include Service Stop Timeout as well but I wanted to see if this was going to be accepted first.

This is my first PR so take it easy, I willing to accept any pointers to feedback.

Thanks
