### PR TITLE
Fixed route-to interface not being set correctly in firewall rules when using 6rd/6to4 IPv6 gateways with gateway groups.

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
@@ -195,7 +195,10 @@ class Gateways
                             // default address family
                             $gw_arr['ipprotocol'] = 'inet';
                         }
-                        $gw_arr["if"] = $definedIntf[$gw_arr["interface"]]['if'];
+                        // Make sure to use the tunnel interface for 6rd and 6to4 setups.
+                        $ifname = $gw_arr["interface"];
+                        $ifcfg = $definedIntf[$ifname];
+                        $gw_arr["if"] = $gw_arr['ipprotocol'] == 'inet6' && in_array($ifcfg['ipaddrv6'] ?? null, ['6to4', '6rd']) ? "{$ifname}_stf" : $ifcfg['if'];
                         $gw_arr["attribute"] = $i++;
                         if (Util::isIpAddress($gateway->gateway)) {
                             if (empty($gw_arr['monitor_disable']) && empty($gw_arr['monitor'])) {


### PR DESCRIPTION
Hello. First-time contributor here.

I've been battling with an annoying problem on my OPNsense box (great software, btw). So, I have a dual-WAN setup and one of the WANs uses 6rd for IPv6. I followed the guide to set up a gateway group and then configured the right firewall rules. However, OPNsense was not routing IPv6 traffic at all. I was annoyed by this, so I spent a day debugging the issue and coding up a fix (which is this pull request). This problem ONLY occurs when you use a gateway group that contains a gateway that uses either 6rd or 6to4 for IPv6 connectivity. Here is what I discovered:

## Root Cause
The root cause ended up being that OPNsense wasn't correctly writing the firewall rule to set the gateway policy for traffic entering the gateway. To be more precise, instead of using the correct `wan_stf` interface (which in my case is called `opt1_stf`), it would use the interface for the underlying IPv4 gateway (which in my case is `pppoe0`). This would result in the gateway trying to send un-encapsulated IPv6 packets on the underlying IPv4 WAN interface instead of first adding 6rd or 6to4 headers to the packets. Since my ISP doesn't do native IPv6, this is roughly equivalent to sending all IPv6 packets to `/dev/null`. I was able to discover this by inspecting a packet capture of my `pppoe0` interface and pinging an IP address that isn't normally queried by my network (to make filtering the packet capture easier). When I set up my firewall rules to use the default gateway, IPv6 packets would be correctly encapsulated in a 6rd-compliant IPv4 header. When I set up the firewall rules to point to my gateway group, I would see raw IPv6 packets sent to `pppoe0`.

After this, I inspected the firewall rules that OPNsense was actually producing, and noticed that when I pointed it at my gateway group, it issued these entries (perhaps I changed a couple things because privacy):

```
pass in quick on vlan0.2 route-to {( pppoe0 2608::207.171.2.60 )} inet6 from {any} to {any} keep state label "81498130b9824e4f784fe38058fcbcfa" # : IPv6 Gateway Policy
pass in quick on lagg1 route-to {( pppoe0 2608::207.171.2.60 )} inet6 from {any} to {any} keep state label "81498130b9824e4f784fe38058fcbcfa" # : IPv6 Gateway Policy
```

Oh yeah, vlan0.2 is my guest network and lagg1 is my primary LAN.

You'll notice that it's routing packets to `pppoe0`, where they're not supposed to go. This is the root cause of the problems.

## Fix
As you might guess, the fix is getting OPNsense to issue the correct rule for 6rd and 6to4 setups. As it turns out it already does this correctly for dynamic gateways (which is why the issue is only present for gateway groups). You can see this a little further down in `getGateways()` on line 229. So I simply copied this code up above to where it handles statically-defined gateways and it fixed my problems. I refreshed my firewall rules and all of a sudden I had IPv6 connectivity!

Of course, that's probably not enough proof for you. So I took copies of /tmp/rules.debug before and after I applied my fix and ran them through `diff` to see if anything else got changed. The only stuff that got changed was what I wanted to be changed. Attached are the before and after `/tmp/rules.debug` files for you to inspect. I may or may not have fiddled with some IP addresses (again, because privacy). I also had to rename them because it seems GitHub is picky about file extensions.
[rules-before.txt](https://github.com/opnsense/core/files/10349881/rules-before.txt)
[rules-after.txt](https://github.com/opnsense/core/files/10349882/rules-after.txt)

## Testing
While I have tested that it fixes my problem, I haven't tested to make sure my change doesn't break stuff elsewhere. Although, it seems like a fairly safe change considering that this exact same change is already done for dynamic gateways in the same function.