### PR TITLE
configd: capture scripts outputs

### DIFF
--- a/src/opnsense/service/modules/processhandler.py
+++ b/src/opnsense/service/modules/processhandler.py
@@ -470,6 +470,11 @@ class Action(object):
                         script_output = output_stream.read()
                         script_error_output = error_stream.read()
                         if result.returncode == 0:
+                            if len(script_error_output) > 0 and self.type.lower() == 'script_output' and self.command.endswith('exit 0') and not self.command.startswith('pgrep'):
+                                # backward compatibility with subprocess.check_call version: exit 0 forced for script_output action and stderr is not empty. log stderr
+                                syslog_error('[%s] Script action "%s" stderr returned "%s"' %(
+                                    message_uuid, script_command[:255], script_error_output.decode().strip()
+                                ))
                             return 'OK' if self.type.lower() == 'script' else script_output.decode()
                         else:
                             if len(script_error_output) > 0:


### PR DESCRIPTION
Hi!
For now if the configd action fails, the output of the command can only be seen in the shell.
pr tries to help with this with a migration from `subrocess.call` to `subprocess.run` so that we can grab the commands output.
This can help, for example, with services startup errors debugging (configuration errors, socket conflicts, etc.) when such errors do not get into the plugin log.
![configd](https://user-images.githubusercontent.com/36099472/211036267-b39d397d-a2a8-496f-8211-62c783c141d3.PNG)

(as a bonus, get rid of pgrep false-errors like https://forum.opnsense.org/index.php?topic=31079.0).

catch 'parameter mismatch' for inline actions also (ref. https://forum.opnsense.org/index.php?topic=30908.msg149703#msg149703)

Thanks!
ps. it seems that it was even in the plans, but for some reason did not get around to it? ) (https://github.com/opnsense/core/issues/3574#issuecomment-539113436)