### PR TITLE
unbound: log startup errors

### DIFF
--- a/src/opnsense/scripts/unbound/start.sh
+++ b/src/opnsense/scripts/unbound/start.sh
@@ -63,7 +63,12 @@ rm -f /usr/local/etc/unbound.opnsense.d/dnsbl.conf
 
 chown -R unbound:unbound /var/unbound
 
-/usr/local/sbin/unbound -c /var/unbound/unbound.conf
+if ! start_output=$(/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1); then
+        msg="$(echo "$start_output" | tr '\n' ';')"
+	logger -s -t unbound -p user.error "unbound start failed. output was: $msg"
+	exit 1
+fi
+
 /usr/local/opnsense/scripts/unbound/cache.sh load
 
 if [ -n "${DOMAIN}" ]; then


### PR DESCRIPTION
Hi!
there still seems to be an issue with the lack of diagnostic messages if an unbound  error occurs before logging is switched to syslog. (ref. https://forum.opnsense.org/index.php?topic=31865.0)

pr passes the output of `/usr/local/sbin/unbound` to the syslog if it fails and aborts script execution.

![unbound_err](https://user-images.githubusercontent.com/36099472/212823728-c5413a13-112a-4370-aecd-d0cc8e6a41ba.PNG)

thanks!
