### PR TITLE
MVC/Firewall/Util - prevent possible infinite loop in port aliases parsing

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -208,6 +208,7 @@ class Util
         $result = array();
         foreach (self::$aliasObject->aliasIterator() as $node) {
             if (!empty($name) && (string)$node['name'] == $name && $node['type'] == 'port') {
+                $aliases[] = $name;
                 foreach ($node['content'] as $address) {
                     if (Util::isAlias($address)) {
                         if (!in_array($address, $aliases)) {


### PR DESCRIPTION
Hi!
possible fix for https://github.com/opnsense/core/commit/2ba91361a7e27f616fa8f1b46250267ffac34e74#commitcomment-98713264
Prevent possible infinite loop in getPortAlias if alias references itself somehow (add current (or nested) alias to "parsed aliases" array before parsing)