### PR TITLE
Firewall/NAT/Port Forward - dont calc local port range for alias

### DIFF
--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -488,7 +488,7 @@ $( document ).ready(function() {
                       <td>
 <?php
                          $localport = $natent['local-port'];
-                         if (strpos($natent['destination']['port'],'-') !== false) {
+                         if (!is_alias($localport) && strpos($natent['destination']['port'],'-') !== false) {
                             $natlocalport = preg_match('/^(\d){1,5}$/', $natent['local-port']) ? (int)$natent['local-port'] : 1;
                             list($dstbeginport, $dstendport) = explode("-", $natent['destination']['port']);
                             $dstbeginport = preg_match('/^\d*$/', $dstbeginport) ? (int)$dstbeginport : 1;


### PR DESCRIPTION
Hi!
Sorry, me again )
If port alias is specified as a Redirect target port, range is not calculated for rdr rule (local port is omitted or first port in alias is used): https://github.com/opnsense/core/blob/fdcd17cd5712f8a166cc76af9ee49cded3e617ff/src/opnsense/mvc/app/library/OPNsense/Firewall/ForwardRule.php#L123-L136
thanks!