### PR TITLE
Make description field show for all types of VIP

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVip.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVip.xml
@@ -73,6 +73,5 @@
         <label>Description</label>
         <type>text</type>
         <help>You may enter a description here for your reference (not parsed).</help>
-        <style>mode mode_carp</style>
     </field>
 </form>


### PR DESCRIPTION
Currently description only shows for CARP type, but the description should show for all.