### PR TITLE
relax cron job description

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Cron/Cron.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Cron/Cron.xml
@@ -62,7 +62,7 @@
                     <Required>N</Required>
                 </parameters>
                 <description type="TextField">
-                    <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>
+                    <mask>/^(.){1,255}$/u</mask>
                     <ValidationMessage>Enter a description.</ValidationMessage>
                     <Required>Y</Required>
                 </description>


### PR DESCRIPTION
### Proposal

We've noticed that the `description` field in cron jobs is restricted to a subset of characters for no apparent reason. The description is there for the user to describe the item, so it shouldn't be too restricted.

The current restriction has the negative side-effect that we have to cut desired information from the description field, or we have to try to rephrase/reformat it to pet the validator.

I suggest to relax the `description` field, similar to how it's validated in Unbound, Aliases, Monit, etc.

### Another suggestion

I would also be willing to update *all* `description` fields in `core` in the same way: Currently **1/3** uses the **relaxed validation** and **2/3** the **complex validation**. I would change this so that all use the relaxed validation. I'll update my PR accordingly if you agree. :)