### PR TITLE
Changes for issue 5569

### DIFF
--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -335,9 +335,9 @@ function ntpd_configure_do($verbose = false)
     foreach (explode(' ', $config['system']['timeservers']) as $ts) {
         /* Determine if Network Time Server is from the NTP Pool or not */
         if (preg_match("/\.pool\.ntp\.org$/", $ts)) {
-        $ntpcfg .= "pool {$ts}";
+            $ntpcfg .= "pool {$ts}";
         } else {
-        $ntpcfg .= "server {$ts}";
+            $ntpcfg .= "server {$ts}";
         }
         if (in_array($ts, $iburst)) {
             $ntpcfg .= ' iburst';

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -323,7 +323,12 @@ function ntpd_configure_do($verbose = false)
     $ntpcfg .= "\n\n# Upstream Servers\n";
     /* foreach through ntp servers and write out to ntpd.conf */
     foreach (explode(' ', $config['system']['timeservers']) as $ts) {
+        /* Determine if Network Time Server is from the NTP Pool or not */
+        if (preg_match("/\.pool\.ntp\.org$/", $ts)) {
+        $ntpcfg .= "pool {$ts}";
+        } else {
         $ntpcfg .= "server {$ts}";
+        }
         if (in_array($ts, $iburst)) {
             $ntpcfg .= ' iburst';
         }
@@ -412,6 +417,26 @@ function ntpd_configure_do($verbose = false)
     }
     if (empty($config['ntpd']['notrap'])) { /*note: this one works backwards */
         $ntpcfg .= ' notrap';
+    }
+            /* Access restrictions for Pool */
+    $ntpcfg .= "\nrestrict source";
+    if (empty($config['ntpd']['kod'])) { /*note: this one works backwards */
+        $ntpcfg .= ' kod';
+    }
+    if (empty($config['ntpd']['limited'])) { /*note: this one works backwards */
+        $ntpcfg .= ' limited';
+    }
+    if (empty($config['ntpd']['nomodify'])) { /*note: this one works backwards */
+        $ntpcfg .= ' nomodify';
+    }
+    if (!empty($config['ntpd']['noquery'])) {
+        $ntpcfg .= ' noquery';
+    }
+    if (empty($config['ntpd']['notrap'])) { /*note: this one works backwards */
+        $ntpcfg .= ' notrap';
+    }
+    if (!empty($config['ntpd']['noserve'])) {
+        $ntpcfg .= ' noserve';
     }
     $ntpcfg .= "\n";
 

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -200,7 +200,6 @@ function ntpd_configure_do($verbose = false)
         $ntpcfg .= '12';
     }
     $ntpcfg .= "\n";
-    
     /* Add Max Clock Count */
     $ntpcfg .= "# Max number of associations\n";
     $ntpcfg .= 'tos maxclock ';

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -200,7 +200,17 @@ function ntpd_configure_do($verbose = false)
         $ntpcfg .= '12';
     }
     $ntpcfg .= "\n";
-
+    
+    /* Add Max Clock Count */
+    $ntpcfg .= "# Max number of associations\n";
+    $ntpcfg .= 'tos maxclock ';
+    if (!empty($config['ntpd']['maxclock'])) {
+        $ntpcfg .= $config['ntpd']['maxclock'];
+    } else {
+        $ntpcfg .= '10';
+    }
+    $ntpcfg .= "\n";
+    
     /* Add PPS configuration */
     if (
         !empty($config['ntpd']['pps'])

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -200,6 +200,7 @@ function ntpd_configure_do($verbose = false)
         $ntpcfg .= '12';
     }
     $ntpcfg .= "\n";
+
     /* Add Max Clock Count */
     $ntpcfg .= "# Max number of associations\n";
     $ntpcfg .= 'tos maxclock ';

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -52,6 +52,7 @@ $copy_fields = [
     'noserve',
     'notrap',
     'orphan',
+    'maxclock',
     'peerstats',
     'statsgraph',
 ];
@@ -90,6 +91,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $input_errors = array();
     if (!empty($pconfig['orphan']) && ($pconfig['orphan'] < 0 || $pconfig['orphan'] > 15 || !is_numeric($pconfig['orphan']))) {
         $input_errors[] = gettext("Orphan mode must be a value between 0..15");
+    }
+    if (!empty($pconfig['maxclock']) && ($pconfig['maxclock'] < 0 || $pconfig['maxclock'] > 99 || !is_numeric($pconfig['maxclock']))) {
+        $input_errors[] = gettext("MaxClock must be a value between 0..99");
     }
     $prev_opt = !empty($a_ntpd['custom_options']) ? $a_ntpd['custom_options'] : "";
     if ($prev_opt != str_replace("\r\n", "\n", $pconfig['custom_options']) && !userIsAdmin($_SESSION['Username'])) {
@@ -354,6 +358,16 @@ include("head.inc");
                       </div>
                     </td>
                   </tr>
+                  <tr>
+                    <td><a id="help_for_maxclock" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Maxclock') ?></td>
+                    <td>
+                      <input name="maxclock" type="text" value="<?=$pconfig['maxclock']?>" placeholder="10" />
+                      <div class="hidden" data-for="help_for_maxclock">
+                        <?=gettext("(2-99)");?><br />
+                        <?=gettext("Specify the maximum number of servers retained by the server discovery schemes. The default is 10, which should typically be changed. This should be an odd number (to most effectively outvote falsetickers) typically two or three more than minclock (1), plus the number of pool entries. The pool entries must be added as maxclock, but not minclock, which also counts the pool entries themselves. For example, tos maxclock 11 with four pool lines would keep 7 associations."); ?>
+                      </div>
+                    </td>
+                  </tr>  
                   <tr>
                     <td><i class="fa fa-info-circle text-muted"></i> <?=gettext('NTP graphs') ?></td>
                     <td>


### PR DESCRIPTION
Per issue 5569 I made some proposed changes to the two files around NTP network servers. I broke out the changes in two phases. One is to simply parse the GUI entered servers to determine if they are a public pool server or not and set them correctly in the ntpd.conf file. Secondly to add setting in GUI to set maxcount. This tells ntpd how many concurrent servers to maintain. Due to the pool directive, status page will not show only the servers declared on the network tab (GPS,PPS unimpacted).  With the use of pool servers I felt it would be useful for users to set this if they wish.