### PR TITLE
unbound: fix typo in logger. create a pipe early in dnsbl_module.py

### DIFF
--- a/src/opnsense/scripts/unbound/logger.py
+++ b/src/opnsense/scripts/unbound/logger.py
@@ -188,7 +188,7 @@ class DNSReader:
         r_count = 0
         pipe_ready = False
         # give dnsbl_module.py some time to create a pipe
-        while r_count < 3 and not pipe_ready:
+        while not pipe_ready:
             try:
                 # open() will block until a query has been pushed down the fifo
                 self.fd = open(self.target_pipe, 'r')
@@ -196,8 +196,8 @@ class DNSReader:
             except InterruptedError:
                 self.close_logger()
             except OSError:
-                r_count =+ 1
-                if r_count == 3:
+                r_count += 1
+                if r_count > 10:
                     syslog.syslog(syslog.LOG_ERR, "Unable to open pipe. This is likely because Unbound isn't running.")
                     sys.exit(1)
                 time.sleep(1)

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
@@ -65,9 +65,9 @@ class ModuleContext:
         self.lock = Lock()
         self.pipe_buffer = deque(maxlen=100000) # buffer to hold qdata as long as a backend is not present
 
-        self.update_dnsbl(self.log_update_time)
         if self.stats_enabled:
             self.create_pipe_rdv()
+        self.update_dnsbl(self.log_update_time)
 
     def dnsbl_exists(self):
         return os.path.isfile(self.dnsbl_path) and os.path.getsize(self.dnsbl_path) > 0


### PR DESCRIPTION
Hi!
I'm very ashamed, perhaps the strangest typo on my end (I've never even used unary operators in real code).
as a result, the logger waits forever for the pipe ..
typo fix shows a dependence of the required waiting time on the size of the dnsbl (on a test vm with all lists enabled, it can reach up to 6 sec, so I set it to 10).
Besides of changing the order of actions in the `dnsbl_module.py` (first create a pipe, then load the json), using `Thread` to call load_dnsbl showed a good result.