### PR TITLE
GUI and SSH listener recommended on all interfaces in system_advanced_admin.php

### DIFF
--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -690,7 +690,7 @@ $(document).ready(function() {
               <tr>
                 <td><a id="help_for_webguiinterfaces" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Listen Interfaces') ?></td>
                 <td>
-                  <select id="webguiinterface" name="webguiinterfaces[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (recommended)')) ?>">
+                  <select id="webguiinterface" name="webguiinterfaces[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (not recommended)')) ?>">
 <?php foreach ($interfaces as $iface => $ifacename): ?>
                       <option value="<?= html_safe($iface) ?>" <?= !empty($pconfig['webguiinterfaces']) && in_array($iface, $pconfig['webguiinterfaces']) ? 'selected="selected"' : '' ?>><?= html_safe($ifacename) ?></option>
 <?php endforeach ?>
@@ -779,7 +779,7 @@ $(document).ready(function() {
               <tr>
                 <td><a id="help_for_sshinterfaces" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Listen Interfaces') ?></td>
                 <td>
-                  <select name="sshinterfaces[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (recommended)')) ?>">
+                  <select name="sshinterfaces[]" multiple="multiple" class="selectpicker" title="<?= html_safe(gettext('All (not recommended)')) ?>">
 <?php foreach ($interfaces as $iface => $ifacename): ?>
                       <option value="<?= html_safe($iface) ?>" <?= !empty($pconfig['sshinterfaces']) && in_array($iface, $pconfig['sshinterfaces']) ? 'selected="selected"' : '' ?>><?= html_safe($ifacename) ?></option>
 <?php endforeach ?>


### PR DESCRIPTION
In security terms it is not recomended to open the gui/ssh port on all interfaces, altough you still need a ACL entry to let traffic pass, we should not recommend this listener on ALL interfaces.

I strongly advice not to suggest opening admin port on ALL interfaces on a firewall product.