### PR TITLE
system: move default gateway switching to system_routing_configure()

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -151,7 +151,7 @@ function ifgroup_setup()
     }
 }
 
-function filter_configure_sync($verbose = false, $load_aliases = true, $switch_gw = true)
+function filter_configure_sync($verbose = false, $load_aliases = true)
 {
     global $config;
 
@@ -250,15 +250,6 @@ function filter_configure_sync($verbose = false, $load_aliases = true, $switch_g
         foreach ($config['nat']['rule'] as $rule) {
             $fw->registerForwardRule(600, $rule);
         }
-    }
-
-    if ($switch_gw && isset($config['system']['gw_switch_default'])) {
-        /*
-         * XXX When gateway switching is enabled we consider different default
-         * gateways.  Although this isn't the right spot for the feature (it's
-         * a monitoring/routing decision), we keep it here for historical reasons.
-         */
-        system_switch_route();
     }
 
     openlog("firewall", LOG_DAEMON, LOG_LOCAL4);

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -586,35 +586,11 @@ function system_default_route($gateway, $interface, $far = false)
     mwexecf('/sbin/route add -%s default %s', [$family, $gateway]);
 }
 
-function system_switch_route()
-{
-    $ifdetails = legacy_interfaces_details();
-    $gateways = new \OPNsense\Routing\Gateways($ifdetails);
-    $down_gateways = return_down_gateways();
-
-    if (!empty($down_gateways)) {
-        log_msg(sprintf('ROUTING: ignoring down gateways: %s', implode(', ', $down_gateways)), LOG_DEBUG);
-    }
-
-    foreach (['inet' => 'ipv4', 'inet6' => 'ipv6'] as $ipproto => $type) {
-        /* determine default gateway by considering monitor status */
-        $gateway = $gateways->getDefaultGW($down_gateways, $ipproto);
-        if ($gateway == null) {
-            continue;
-        }
-
-        if (empty($ifdetails[$gateway['if']][$type][0])) {
-            log_msg("ROUTING: refusing to set {$ipproto} gateway on addressless {$gateway['interface']}", LOG_ERR);
-            continue;
-        }
-
-        log_msg("ROUTING: switching to {$ipproto} default gateway on {$gateway['interface']}", LOG_INFO);
-        system_default_route($gateway['gateway'], $gateway['interface'], isset($gateway['fargw']));
-    }
-}
 
 function system_routing_configure($verbose = false, $interface = null, $monitor = true, $family = null)
 {
+    global $config;
+
     service_log('Setting up routes...', $verbose);
 
     if (!empty($interface)) {
@@ -625,19 +601,23 @@ function system_routing_configure($verbose = false, $interface = null, $monitor 
 
     $ifdetails = legacy_interfaces_details();
     $gateways = new \OPNsense\Routing\Gateways($ifdetails);
+    $down_gateways = isset($config['system']['gw_switch_default']) ? return_down_gateways() : [];
+
+    if (!empty($down_gateways)) {
+        log_msg(sprintf('ROUTING: ignoring down gateways: %s', implode(', ', $down_gateways)), LOG_DEBUG);
+    }
 
     foreach (['inet' => 'ipv4', 'inet6' => 'ipv6'] as $ipproto => $type) {
         if ($family !== null && $family !== $ipproto) {
             continue;
         }
 
-        /* determine default gateway without considering monitor status */
-        $gateway = $gateways->getDefaultGW([], $ipproto);
+        $gateway = $gateways->getDefaultGW($down_gateways, $ipproto);
         if ($gateway == null) {
             continue;
         }
 
-        if (empty($interface) || $interface == $gateway['interface']) {
+        if (isset($config['system']['gw_switch_default']) || empty($interface) || $interface == $gateway['interface']) {
             if (empty($ifdetails[$gateway['if']][$type][0])) {
                 log_msg("ROUTING: refusing to set {$ipproto} gateway on addressless {$gateway['interface']}", LOG_ERR);
                 continue;

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -86,11 +86,11 @@ system_hostname_configure(true);
 system_resolver_configure(true);
 system_syslog_start(true);
 
-filter_configure_sync(true, false, false); /* apply default policy before interface setup */
+filter_configure_sync(true, false); /* apply default policy before interface setup */
 interfaces_hardware(true);
 interfaces_configure(true);
 system_resolver_configure(true); /* adapts to runtime interface configuration */
-filter_configure_sync(true, true, false);
+filter_configure_sync(true);
 plugins_configure('early', true);
 system_routing_configure(true, null, false);
 
@@ -99,7 +99,7 @@ plugins_configure('dhcrelay', true);
 plugins_configure('dns', true);
 
 plugins_configure('monitor', true, [null, true]);
-filter_configure_sync(true, true, false);
+filter_configure_sync(true);
 plugins_configure('vpn', true);
 plugins_configure('bootup', true);
 rrd_configure(true, true);

--- a/src/etc/rc.syshook.d/monitor/10-dpinger
+++ b/src/etc/rc.syshook.d/monitor/10-dpinger
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2018-2019 Franco Fichtner <franco@opnsense.org>
+# Copyright (c) 2018-2023 Franco Fichtner <franco@opnsense.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,7 +34,7 @@ fi
 
 /usr/bin/logger -t dpinger "GATEWAY ALARM: ${GATEWAY} (Addr: ${2} Alarm: ${3} RTT: ${4}us RTTd: ${5}us Loss: ${6}%)"
 
-echo -n "Reloading filter: "
-/usr/local/bin/flock -n -E 0 -o /tmp/filter_reload_gateway.lock configctl filter reload skip_alias
+echo -n "Reloading routes: "
+/usr/local/bin/flock -n -E 0 -o /tmp/filter_reload_gateway.lock configctl routes configure
 
 exit 0


### PR DESCRIPTION
In an attempt to extract the default gateway switching out of filter_configure_sync() we actually move it to system_routing_configure() with minimal impact on current development state of things. Things to keep in mind:

1. The "down" interfaces are fetched and passed in this case.
2. When default gateway switching is active we ignore the user request for a specific interface if given. This way we save a hop between gateways of different interfaces in the original system_routing_configure() -> filter_configure_sync() flip-flop. Of note is that down gateways are thus never being used for the default route once gateway switching is enabled.
3. The monitor rc.syshook is easily ported over to rc.routing_configure call
4. Both system_routing_configure() and filter_configure_sync() are traditionally called in tandem in most situations making the impact of the change minimal as we also reach a few new points we haven't before.