### PR TITLE
Demo of volt framework using Dnsmasq

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Plugin.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Plugin.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * Copyright (C) 2015 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Dnsmasq;
+
+/**
+ * Class PluginIndexController extends Core's OPNsense\Base\IndexController.
+ *
+ * All controllers for this plugin, should extend from this one.
+ *
+ *
+ *
+ *
+ *
+ * @package OPNsense\Dnsmasq
+ */
+class Plugin
+{
+    /**
+     * Array for this plugin's settings.
+     *
+     * @var array $settings
+     */
+    protected $settings = array();
+
+    /**
+     * Array for this plugin's settings.
+     *
+     * @var array $settings
+     */
+    protected $plugin_ini = '/usr/local/opnsense/data/dnsmasq/plugin.ini';
+
+    /**
+     * Array for this plugin's settings.
+     *
+     * @var array $settings
+     */
+    public function __construct()
+    {
+        // Set values for the protected settings array.
+        $this->settings = [
+            // The common name of the plugin.
+            'plugin_name' => 'dnsmasq',
+            // A safe name to use in DOM id's.
+            'plugin_safe_name' => 'dnsmasq',
+            // A common (stylized) label for the plugin.
+            'plugin_label' => 'Dnsmasq DNS',
+            // The service name that this plugin has.
+            'plugin_service_name' => 'dnsmasq',
+            // The name of the configd module for this plugin.
+            'plugin_configd_name' => 'dnsmasq',
+            // The name of the log directory, assumed to be in /var/log
+            'plugin_log_dir_name' => 'dnsmasq'
+        ];
+    }
+
+    /**
+     * Function to get the settings out of the class.
+     *
+     * @var array $settings
+     */
+    public function getSettings()
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Returns the name of the configd for this plugin.
+     *
+     * @var array $settings
+     */
+    public function getConfigdName()
+    {
+        $ini = parse_ini_file($this->plugin_ini, true);
+        if (array_key_exists('plugin', $ini)) {
+            if (array_key_exists('configd_name', $ini['plugin'])) {
+                return $ini['plugin']['configd_name'];
+            }
+        }
+    }
+
+    /**
+     * Function to retreive the xml form data for a form of a given name.
+     *
+     * This function will parse an XML file to be located at a specific path,
+     * the convention being the following:
+     * /usr/local/opnsense/mvc/app/contorllers/OPNsense/<Pluginname>/forms/
+     *
+     * All that is to be passed in is the file name itself, the file extension is assumed.
+     *
+     * XXX Can't use the original derived path for the $filename because this file isn't located
+     * alongside the forms directory anymore. Need to find another dynamic approach to doing it.
+     *
+     * @param $formname
+     * @return array
+     * @throws \Exception
+     */
+    public function getFormXml($formname)
+    {
+        $class_info = new \ReflectionClass($this);
+
+        // XXX Need to fix this so it's dynamic based on the caller (not $this)
+        //$filename = dirname($class_info->getFileName()) . '/forms/' . $formname . '.xml';
+
+        $filename = __DIR__ . '/forms/' . $formname . '.xml';
+        if (file_exists($filename)) {
+            $formXml = simplexml_load_file($filename);
+            if ($formXml === false) {
+                //$formXml = '<pre>XML file ' . $filename . ' is invalid.</pre>';
+                throw new \Exception('form xml ' . $filename . ' not valid');
+            }
+        } else {
+            // Set an empty XML document to return since we don't have an XML to parse.
+            $formXml = simplexml_load_string('<root></root>');
+        }
+        return $formXml;
+    }
+
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/PluginIndexController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/PluginIndexController.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (C) 2015 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Dnsmasq;
+use OPNsense\Core\Backend;
+use OPNsense\Dnsmasq\Plugin;
+
+
+/**
+ * Class PluginIndexController extends Core's OPNsense\Base\IndexController.
+ *
+ * All controllers for this plugin, should extend from this one.
+ *
+ *
+ *
+ *
+ *
+ * @package OPNsense\Dnsmasq
+ */
+class PluginIndexController extends \OPNsense\Base\IndexController
+{
+
+    /**
+     * Function to call the indexAction() for any page, and create a UI endpoint for it.
+     *
+     * UI endpoint (example):
+     * `/ui/dnscryptproxy/settings`
+
+     * This function is to be inherited by all of the controllers, and it will then dynamically
+     * derive the names of the forms out of Phalcon instead of needing to statically define an indexAction()
+     * for each page individually.
+     *
+     * indexAction() is analogous to index.html, it's the default if no API action is provided.
+     */
+    public function indexAction()
+    {
+        // Pull the name of this api from the Phalcon view to use in further calls.
+        //$this_api_name = $this->view->getNamespaceName();
+        // This also may be acceptible but probably less reliable.
+        $this_api_name = $this->router->getMatches()[1];            // "about"
+
+        $plugin = new Plugin;
+        $form_xml = $plugin->getFormXml($this_api_name);
+
+        $this->view->setVars(
+            [
+                // Derive the API path from the UI path of the view, swapping out the leading "/ui/" for "/api/".
+                // This is crude, but it will work until I discover a more reliable way to do it in the view.
+                // XXX Unused?
+                //'plugin_version' => $this->invokeConfigdRun('plugin_version'),  // "2.0.45.1"
+                //'dnscrypt_proxy_version' => $this->invokeConfigdRun('version'), // "2.0.45"
+                'plugin_api_path' => preg_replace("/^\/ui\//", "/api/", $this->router->getMatches()[0]),
+                'this_xml' => $form_xml,
+                // example: controllers/OPNsense/Dnsmasq/forms/settings.xml
+                //'data_get_map' => $form_xml->xpath('model')
+            ]
+        );
+        // Since the directory structure of OPNsense's plugins isn't conducive to automatically loading the template,
+        // pick the specific template we want to load. Relative to /usr/local/opnsense/mvc/app/views, no file extension
+
+        $this->view->pick('OPNsense/Dnsmasq/' . $this_api_name);
+        // reference: views/OPNsense/Dnsmasq/settings.volt
+
+    }
+
+    /**
+     * This is a special function which is executed after routing by XXX
+     * @param $formname
+     * @return array
+     * @throws \Exception
+     */
+    public function afterExecuteRoute($dispatcher)
+    {
+        // Create plugin object to get some settings for in the view.
+        $plugin = new Plugin;
+
+        // Set in the view our plugin settings.
+        $this->view->setVars($plugin->getSettings());
+
+        // We derive the plugin_api_name from the namespace of this PHP class.
+        // This assumes that the namespace will be something like: OPNsense\Dnsmasq
+        $plugin_api_name = preg_replace('/^.*\\\/','',strtolower($this->router->getNamespaceName()));
+
+        // Set the plugin_name in the view.
+        $this->view->setVar('plugin_api_name', $plugin_api_name);
+    }
+
+
+
+
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/SettingsController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+    OPNsense® is Copyright © 2022 by Deciso B.V.
+    Copyright (C) 2022 agh1467@protonmail.com
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Dnsmasq;
+
+
+/**
+ * An IndexController-based class that creates an endpoint to display the setting page in the UI.
+ *
+ * @package OPNsense\Dnsmasq
+ */
+class SettingsController extends PluginIndexController
+{
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/settings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/settings.xml
@@ -1,0 +1,178 @@
+<model title="Settings" name="settings" endpoint="settings">
+    <box>
+        <header id="general_options" label="General Options"/>
+        <field id="enable" type="onoff" label="Enable">
+        </field>
+        <field id="listen_port" type="text" label="Listen Port">
+            <help> The port used for responding to DNS queries. It should normally be left blank unless another service needs to bind to TCP/UDP port 53.</help>
+        </field>
+        <field id="network_interfaces" type="select_multiple" label="Network Interfaces">
+            <help>Interface IPs used by Dnsmasq for responding to queries from clients. If an interface has both IPv4 and IPv6 IPs, both are used. Queries to other interface IPs not selected below are discarded. The default behavior is to respond to queries on every available IPv4 and IPv6 address.</help>
+        </field>
+        <field id="bind_mode" type="checkbox" label="Bind Mode">
+            <help>If this option is set, Dnsmasq will only bind to the interfaces containing the IP addresses selected above, rather than binding to all interfaces and discarding queries to other addresses. This option does not work with IPv6. If set, Dnsmasq will not bind to IPv6 addresses.</help>
+        </field>
+        <field id="DNSSEC" type="checkbox" label="DNSSEC">
+            <help></help>
+        </field>
+        <field id="dhcp_registration" type="checkbox" label="DHCP Registration">
+            <help> If this option is set, then machines that specify their hostname when requesting a DHCP lease will be registered in Dnsmasq, so that their name can be resolved.</help>
+        </field>
+        <field id="dhcp_domain_override" type="text" label="DHCP Domain Override">
+            <help> The domain name to use for DHCP hostname registration. If empty, the default system domain is used. Note that all DHCP leases will be assigned to the same domain. If this is undesired, static DHCP lease registration is able to provide coherent mappings.</help>
+        </field>
+        <field id="static_dhcp" type="checkbox" label="Static DHCP">
+            <help> If this option is set, then DHCP static mappings will be registered in Dnsmasq, so that their name can be resolved. You should also set the domain in System: General setup to the proper value.</help>
+        </field>
+        <field id="prefer_dhcp" type="checkbox" label="Prefer DHCP">
+            <help> If this option is set, then DHCP mappings will be resolved before the manual list of names below. This only affects the name given for a reverse lookup (PTR).</help>
+        </field>
+        <header id="dns_query_forwarding" label="DNS Query Forwarding"/>
+        <field id="dns_query_query_servers_sequentially" type="checkbox" label="Query DNS servers sequentially ">
+            <help> If this option is set, Dnsmasq will query the DNS servers sequentially in the order specified (System: General Setup: DNS Servers), rather than all at once in parallel.</help>
+        </field>
+        <field id="dns_query_forwarding_require_domain" type="checkbox" label="Require domain">
+            <help> If this option is set, Dnsmasq will not forward A or AAAA queries for plain names, without dots or domain parts, to upstream name servers. If the name is not known from /etc/hosts or DHCP then a "not found" answer is returned.</help>
+        </field>
+        <field id="dns_query_forwarding_private_lookups" type="checkbox" label="Do not forward private reverse lookups">
+            <help> If this option is set, Dnsmasq will not forward reverse DNS lookups (PTR) for private addresses (RFC 1918) to upstream name servers. Any entries in the Domain Overrides section forwarding private "n.n.n.in-addr.arpa" names to a specific server are still forwarded. If the IP to name is not known from /etc/hosts, DHCP or a specific domain override then a "not found" answer is immediately returned. </help>
+        </field>
+        <separator/>
+        <field id="no_hosts_lookup" type="checkbox" label="No Hosts Lookup">
+            <help>Do not read hostnames in /etc/hosts.</help>
+        </field>
+        <field id="log_queries" type="checkbox" label="Log Queries">
+            <help>Log the results of DNS queries.</help>
+        </field>
+        <field id="Maximum concurrent queries" type="text" label="Maximum concurrent queries">
+            <help>Set the maximum number of concurrent DNS queries. On configurations with tight resources, this value may need to be reduced.</help>
+        </field>
+        <field id="Cache Size" type="text" label="Cache Size">
+            <help>Set the size of the cache. Setting the cache size to zero disables caching. Please note that huge cache size impacts performance.</help>
+        </field>
+        <field id="Local DNS entry TTL" type="text" label="Local DNS entry TTL">
+            <help>This option allows a time-to-live (in seconds) to be given for local DNS entries, i.e. /etc/hosts or DHCP leases. This will reduce the load on the server at the expense of clients using stale data under some circumstances. A value of zero will disable client-side caching.</help>
+        </field>
+    </box>
+    <box>
+        <bootgrid id="host_overrides" label="Host Overrides">
+            <help>Entries in this section override individual results from the forwarders. Use these for changing DNS results or for adding custom DNS records.</help>
+            <columns>
+                <column id="host" width="" sortable="false">Host</column>
+                <column id="domain" width="" sortable="false">Domain</column>
+                <column id="ip" width="" sortable="false">IP</column>
+                <column id="description" width="" sortable="false">Description</column>
+            </columns>
+            <api>
+                <search>/api/dnsmasq/settings/bootgrid/search</search>
+                <get>/api/dnsmasq/settings/bootgrid/get</get>
+                <set>/api/dnsmasq/settings/bootgrid/set</set>
+                <add>/api/dnsmasq/settings/bootgrid/add</add>
+                <del>/api/dnsmasq/settings/bootgrid/del</del>
+                <info>/api/dnsmasq/settings/info</info>
+                <toggle>/api/dnsmasq/settings/bootgrid/toggle</toggle>
+                <import>/api/dnsmasq/settings/importgrid</import>
+                <export>/api/dnsmasq/settings/bootgrid/export</export>
+            </api>
+            <row_count>20,50,100,200,500,1000,-1</row_count>
+            <dialog node="host_overrides">
+                <label>Edit Override</label>
+                <field id="enabled" label="Enabled" type="checkbox">
+                    <help>Enable or disable this override.</help>
+                </field>
+                <field id="host" label="Host" type="text">
+                    <help>Name of the host, without domain part e.g. myhost</help>
+                    <hint>myhost</hint>
+                </field>
+                <field id="domain" label="Domain" type="text">
+                    <hint>example.com</hint>
+                    <help>Domain of the host e.g. example.com</help>
+                </field>
+                <field id="ip_address" label="IP Address" type="text">
+                    <hint>192.168.100.100</hint>
+                    <help>IP address of the host e.g. 192.168.100.100 or fd00:abcd::1</help>
+                </field>
+                <field id="description" label="Description" type="text">
+                    <help>You may enter a description here for your reference (not parsed).</help>
+                </field>
+                <bootgrid id="override_aliases" label="Override Aliases">
+                    <help>Enter additional names for this host.</help>
+                    <columns>
+                        <column id="host" width="5em" sortable="false">Host</column>
+                        <column id="domain" width="90em" sortable="false">Domain</column>
+                        <column id="description" width="90em" sortable="false">Description</column>
+                    </columns>
+                    <api>
+                        <search>/api/dnsmasq/settings/bootgrid/search</search>
+                        <get>/api/dnsmasq/settings/bootgrid/get</get>
+                        <set>/api/dnsmasq/settings/bootgrid/set</set>
+                        <add>/api/dnsmasq/settings/bootgrid/add</add>
+                        <del>/api/dnsmasq/settings/bootgrid/del</del>
+                        <info>/api/dnsmasq/settings/info</info>
+                        <toggle>/api/dnsmasq/settings/bootgrid/toggle</toggle>
+                    </api>
+                    <dialog node="aliases">
+                        <label>Edit Aliases</label>
+                        <field id="Host" label="Enabled" type="text">
+                            <help>This will enable or disable the blocklist entry.</help>
+                        </field>
+                        <field id="domain" label="Domain" type="text">
+                            <help></help>
+                            <hint>*.example.com</hint>
+                        </field>
+                        <field id="description" label="Description" type="text">
+                            <style></style>
+                            <help></help>
+                        </field>
+                    </dialog>
+                </bootgrid>
+            </dialog>
+        </bootgrid>
+    </box>
+    <box>
+        <bootgrid id="domain_overrides" label="Domain Overrides">
+            <help>Entries in this area override an entire domain, and subdomains, by specifying an authoritative DNS server to be queried for that domain.</help>
+            <columns>
+                <column id="domain" width="11em" sortable="false">Domain</column>
+                <column id="ip_address" width="5em" sortable="false">IP Address</column>
+                <column id="port" width="90em" sortable="false">Port</column>
+                <column id="source_ip" width="5em" sortable="false">Source IP</column>
+                <column id="description" width="90em" sortable="false">Description</column>
+            </columns>
+            <api>
+                <search>/api/dnsmasq/settings/bootgrid/search</search>
+                <get>/api/dnsmasq/settings/bootgrid/get</get>
+                <set>/api/dnsmasq/settings/bootgrid/set</set>
+                <add>/api/dnsmasq/settings/bootgrid/add</add>
+                <del>/api/dnsmasq/settings/bootgrid/del</del>
+                <info>/api/dnsmasq/settings/info</info>
+                <toggle>/api/dnsmasq/settings/bootgrid/toggle</toggle>
+                <import>/api/dnsmasq/settings/importgrid</import>
+                <export>/api/dnsmasq/settings/bootgrid/export</export>
+            </api>
+            <row_count>20,50,100,200,500,1000,-1</row_count>
+            <dialog node="entries">
+                <label>Edit Domain Override</label>
+                <field id="domain" label="Domain" type="text">
+                    <help>Domain to override (NOTE: this does not have to be a valid TLD!) e.g. test or mycompany.localdomain or 1.168.192.in-addr.arpa</help>
+                    <hint>*.example.com</hint>
+                </field>
+                <field id="ip_address" label="IP Address" type="text">
+                    <style></style>
+                    <help>IP address of the authoritative DNS server for this domain e.g. 192.168.100.100 Or enter # for an exclusion to pass through this host/subdomain to standard nameservers instead of a previous override. Or enter ! for lookups for this host/subdomain to NOT be forwarded anywhere.</help>
+                </field>
+                <field id="port" label="Port" type="text">
+                    <style></style>
+                    <help>Specify a non standard port number here, leave blank for default</help>
+                </field>
+                <field id="source_ip" label="Source IP" type="text">
+                    <style></style>
+                    <help>Source IP address for queries to the DNS server for the override domain. Leave blank unless your DNS server is accessed through a VPN tunnel.</help>
+                </field>
+                <field id="description" label="Description" type="text">
+                    <help>You may enter a description here for your reference (not parsed).</help>
+                </field>
+            </dialog>
+        </bootgrid>
+    </box>
+</model>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
@@ -1,10 +1,7 @@
 <menu>
     <Services>
         <Dnsmasq VisibleName="Dnsmasq DNS" cssClass="fa fa-tags fa-fw">
-          <Settings order="10" url="/services_dnsmasq.php">
-            <Hosts url="/services_dnsmasq_edit.php*" visibility="hidden"/>
-            <Domains url="/services_dnsmasq_domainoverride_edit.php*" visibility="hidden"/>
-          </Settings>
+          <Settings order="10" url="/ui/dnsmasq/settings"/>
           <LogFile VisibleName="Log File" order="50" url="/ui/diagnostics/log/core/dnsmasq"/>
         </Dnsmasq>
     </Services>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -1,0 +1,37 @@
+{##
+ #
+ # OPNsense® is Copyright © 2022 – 2018 by Deciso B.V.
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+{##
+ # This is the template for the about page.
+ #
+ # Variables sent in by the controller:
+ # plugin_name            string  name of this plugin, used for API calls
+ # plugin_version         string  version of this plugin
+ # dnscrypt_proxy_version string  version of dnscrypt-proxy
+ # this_form              array   the form XML in an array
+ #}
+{% extends 'plugin_main.volt' %}

--- a/src/opnsense/mvc/app/views/_macros.volt
+++ b/src/opnsense/mvc/app/views/_macros.volt
@@ -1,0 +1,432 @@
+{#
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{##
+ #
+ #
+ #
+ # @xml SimpleXMLObject the XML data to look through for tabs
+ #}
+{%  macro build_tab_headers(xml, lang, params) %}
+{%          for tab_element in xml.tab %}
+{%              if loop.first %}
+{# Create unordered list for the tabs, and try to pick an active tab, only on the first loop. #}
+<ul class="nav nav-tabs" role="tablist" id="maintabs">
+{# If we have no params['active_tab'] defined, if we have no subtabs, pick self, else pick first subtab. #}
+{%                  if params['active_tab']|default('') == '' %}
+{%                      if !(tab_element.subtab) %}
+{%                          set params['active_tab'] = tab_element['id']|default() %}
+{%                      else %}
+{%                          set params['active_tab'] = tab_element.subtab[0]['id']|default() %}
+{%                      endif %}
+{%                  endif %}
+{%              endif %}
+{# If we have subtabs, then let's accommodate them. #}
+{%              if tab_element.subtab %}
+{# We need to look forward to understand if one of our subtabs is the assigned params['active_tab'] from the form. #}
+{%                  set active_subtab = false %}
+{%                  for node in tab_element.xpath('subtab/@id') %}
+{%                      if node.__toString() == params['active_tab'] %}
+{%                          set active_subtab = true %}
+{%                      endif %}
+{%                  endfor %}
+{# Since we have a subtab, we need to accommodate it with an appropriate dropdown button to display the menu. #}
+{# If one of our subtabs is params['active_tab'], then we need to set this tab as active also. #}
+<li role="presentation" class="dropdown{% if active_subtab == true %} active{% endif %}">
+  <a data-toggle="dropdown"
+     href="#"
+     class="dropdown-toggle
+            pull-right
+            visible-lg-inline-block
+            visible-md-inline-block
+            visible-xs-inline-block
+            visible-sm-inline-block"
+     role="button">
+    <b><span class="caret"></span></b>
+  </a>
+{# The onclick sets the tab to be selected when the tab itself is clicked. #}
+{# If one is defined in the XML, then use that, else pick the first subtab. #}
+{%                  set tab_onclick = tab_element['on_click']|default(tab_element.subtab[0]['id']) %}
+  <a data-toggle="tab"
+     onclick="$('#subtab_item_{{ tab_onclick }}').click();"
+     class="visible-lg-inline-block
+            visible-md-inline-block
+            visible-xs-inline-block
+            visible-sm-inline-block"
+     style="border-right:0px;">
+{# This is the parent tab of the subtabs #}
+     <b>{{ lang._('%s')|format(tab_element['description']) }}</b>
+  </a>
+  <ul class="dropdown-menu" role="menu">
+{# Now we specify each subtab, iterate through the subtabs for this tab if present. #}
+{%                  for subtab_element in tab_element.subtab %}
+{%                      if loop.first %}
+{# Assume the first subtab should be active if no params['active_tab'] is set. #}
+{%                          if params['active_tab'] == '' %}
+{%                              set params['active_tab'] = subtab_element['id']|default() %}
+{%                          endif %}
+{%                      endif %}
+<li class="{% if params['active_tab'] == subtab_element['id'] %}active{% endif %}">
+    <a data-toggle="tab"
+       id="subtab_item_{{ subtab_element['id'] }}"
+       href="#subtab_{{ subtab_element['id'] }}"
+       style="{{ get_xml_prop(subtab_element, 'style') }}">
+        {{ lang._('%s')|format(subtab_element['description']) }}
+    </a>
+</li>
+{%                  endfor %}
+    </ul>
+  </li>
+{%              else %} {# No subtabs, standard tab, no dropdown#}
+<li {% if params['active_tab'] == tab_element['id'] %} class="active" {% endif %}>
+  <a data-toggle="tab"
+     id="tab_header_{{ tab_element['id'] }}"
+     href="#tab_{{ tab_element['id'] }}"
+     style="{{ get_xml_prop(tab_element, 'style') }}">
+    <b>{{ lang._('%s')|format(tab_element['description']) }}</b>
+  </a>
+</li>
+{%              endif %}
+{%              if loop.last %}
+{# Close the unordered list only on the last loop. #}
+</ul>
+{%              endif %}
+{%          endfor %}
+{%  endmacro %}
+
+
+{##
+ # This function builds box contents for each defined box in the XML. Similar
+ # to tabs. Supports individual model definitions for each box with base_table.
+ #
+ #}
+{%  macro build_field_contents(xml, lang, params) %}
+{#  Since we have only fields, call the partial directly,
+    we'll just put them in one box for now. It looks OK.
+    Supports model definition via the root XML element. #}
+<div class="content-box">
+{{              partial("layout_partials/base_table",[
+                    'this_part':xml,
+                    'lang': lang,
+                    'params': params
+                ]) }}
+</div>
+{%  endmacro %}
+
+
+{#/*
+ #   This function is used throughout to provide support for getting values from xml nodes from either the attributes
+ #   or a sub-element style definition. This allows for flexibility and backwards compatibility in the XML.
+ #   This shouldn't be used for retreving ALL properties, but only those properties which should be allowed to be defined
+ #   in either style.
+ #
+ #   XML attributes have certain restrictions such as no duplicate definitions.
+ #   XML sub-elements do allow duplicates.
+ #
+ */#}
+{% macro get_xml_prop(xml, property_name, required = false) %}
+{# The below volt return doesn't work correctly because of the object->variable_name call. Doing it in PHP instead. #}
+{# {%     return (xml[property_name]|default(xml.property_name)).__toString() %} #}
+<?php $xml_prop = ((empty($xml[$property_name]) ? ($xml->$property_name) : ($xml[$property_name])))->__toString(); ?>
+{%     if required %}
+{%         if xml_prop == '' %}
+{# XXX Needs to be wrapped in a lang call, but lang() isn't passed in currently. Needs rework. #}
+{%                  set throw_msg = "Element '"~ property_name ~ "' undefined or empty in:" %}
+<?php $throw_msg .= chr(0x0A) . var_export($xml, true); ?>
+<?php throw new \Phalcon\Mvc\View\Exception($throw_msg); ?>
+{%         endif %}
+{%     endif %}
+{%     return xml_prop %}
+{% endmacro %}
+
+{#/*
+ # Function to get the id of a given XML field element.
+ #
+ # This function provides backwards compatibility between the legacy model.field_id style,
+ # while supporting the newer approach of defining the model in the XML itself.
+/*#}
+{%  macro get_field_id(xml, model, lang, params = null) %}
+{%      if xml.getName() == 'field' %}
+{# Only operate on <field> XML elements. #}
+{%          set field_id = get_xml_prop(xml, 'id') %}
+{# Grab the id of the field from either the attr or sub-element. #}
+{%          if field_id != '' %}
+{# We have a field id at least. #}
+{%              if model != '' %}
+{# A model defined in the xml, that's the new style, let's use that.
+  Technically the feild id could still have a model name in it like modelname.fieldname, but it won't break anything. #}
+{%                  set this_field_id = model ~ "." ~ field_id %}
+{%              else %}
+{# No model defined, let's see if the <id> contains a period to signify the model name instead (legay). #}
+{%                  if '.' in field_id %}
+{%                      set this_field_id = field_id %}
+{%                  else %}
+{%                      set throw_msg = lang._("Element <id> missing model specification (Example: <id>model.id</id>):") %}
+{%                  endif %}
+{%              endif %}
+{%          else %}
+{%              set throw_msg = lang._("Element missing <id> sub-element definition (Example: <id>model.id</id>):") %}
+{%          endif  %}
+{%      endif %}
+{%      if throw_msg is defined %}
+{# We've got a throw message so one of the evaluations above failed, throw to inform the Crash Reporter. #}
+<?php $throw_msg .= chr(0x0A) . var_export($xml, true); ?>
+<?php throw new \Phalcon\Mvc\View\Exception($throw_msg); ?>
+{%      else %}
+{# Return this_field_id, which is hopefully defined at this point. #}
+{%          return this_field_id %}
+{%      endif %}
+{%  endmacro %}
+
+{##
+ # This function builds box contents for each defined box in the XML. Similar
+ # to tabs. Supports individual model definitions for each box with base_table.
+ #
+ #}
+{%  macro build_container_contents(xml, lang, params = null) %}
+{%      if xml.getName() == 'box' %}
+<section class="col-xs-12">
+    <div class="content-box">
+{{              partial("layout_partials/base_table",[
+                    'this_part':xml,
+                    'lang': lang,
+                    'params': params
+                ]) }}
+    </div>
+</section>
+{%      elseif xml.getName() == 'buttons' %}
+<section class="page-content-main">
+    <div class="content-box">
+            <br>
+{{  partial("layout_partials/rows/buttons",[
+            'this_node': xml,
+            'lang': lang,
+            'params': params
+]) }}<br><br><br>{# XXX Replace these brs with some style padding instead. #}
+    </div>
+</section>
+{%      endif %}
+{%  endmacro %}
+
+
+
+{##
+ # This macro builds a page using the form data as input.
+ #
+ # This is a super macro that builds pages with or without tabs, the tab
+ # headers, tab contents, and the bootgrid_dialogs all at once.
+ #
+ # This is to save on having to put all of these commands in the main volt, and
+ # to put the div definition in the right place on the page.
+ #
+ # this_page SimpleXMLObject from which to build the page
+ #}
+
+{%  macro build_tab_content(xml, lang, params) %}
+{# Use the name of the element to specify the prefix, this will be 'tab' or 'subtab' #}
+<div id="{{ xml.getName() }}_{{ xml['id'] }}"
+     class="tab-pane fade in{% if params['active_tab'] == xml['id'] %} active{% endif %}">
+{{              partial("layout_partials/base_table",[
+                    'this_part': xml,
+                    'lang': lang,
+                    'params': params
+                ]) }}
+</div>
+{%  endmacro %}
+
+
+{%  macro build_xml_part(xml, lang, params = null) %}
+{%      set tab_count = 0 %}
+{# {%      for xml_element in xml if xml_element.getName() != 'tab' %} #}
+{%      for xml_element in xml %}
+{%          if tab_count != 0 and xml_element.getName() != 'tab' %}
+{# Iterating from something that was tabs, to something that's not tabs, so reset the tab counter, and close the tab box. #}
+{%              set tab_count = 0 %}
+</div>
+{%          endif %}
+{%          if xml_element.getName() == 'tab' %}
+{%              set tab_count += 1 %}
+{%              if tab_count == 1 %}
+{{                  build_tab_headers(xml, lang, params) }}
+{# Building tabs, so let's open the tab box div. #}
+<div class="tab-content content-box tab-content">
+{%              endif %}
+{%              if xml_element.subtab %}
+{# Instead of iterating through elements, checking against getName(), we'll just assume that only subtabs are children of tabs. #}
+{# All other elements will be ignored. #}
+{%                  for subtab in xml_element.subtab %}
+{{                      build_tab_content(subtab, lang, params) }}
+{%                  endfor %}
+{%              else %}
+{{                  build_tab_content(xml_element, lang, params) }}
+{%              endif %}
+{%          elseif xml_element.getName() == 'box' %}
+{# If there are tabs here, we need to build them now. #}
+{{                  build_container_contents(xml_element, lang, params) }}
+{%          elseif xml_element.getName() == 'field' %}
+{# XXX Fields should be treated as a group like tabs are, and grouped into a box automatically. #}
+{# XXX field contents function currently expects to be passed xml.field, and pass that on to base_table #}
+{# XXX Base table then draws the table and iterates through all of the fields. It's not going to work for this approach. #}
+{# XXX {%  for node in this_part %}
+{# XXX We'll need to not use base_table.  Maybe draw the table ourselves, and call the field type in here? #}
+{# If there are tabs here, we need to build them now. #}
+{{                  build_field_contents(xml_element, lang, params) }}
+{%          elseif xml_element.getName() == 'model' %}
+{{                build_xml(xml_element, lang, params) }}
+{%          else %}{# Catch all other element types. #}
+{{                  build_container_contents(xml_element, lang, params) }}
+{%          endif %}
+{%      endfor %}
+{%  endmacro %}
+
+
+{%  macro build_form(xml, lang, params = null) %}
+
+{# {%      for this_form in xml.xpath('//*/form') %} #}
+{# Include a hidden apply changes field which becomes visible when the configuration changes without applying. #}
+{%         include "layout_partials/floating/apply_changes.volt" %}
+{# {%      endfor %} #}
+
+{# {%                  set this_id = get_xml_prop(xml, 'id') %} #}
+{%                  set params['model'] = get_xml_prop(xml, 'name') %}
+{%                  set params['model_endpoint'] = get_xml_prop(xml, 'endpoint') %}
+{%                  set params['title'] = get_xml_prop(xml, 'title') %}
+{# Since this is a form element, we need to go deeper. Pass params since we've maybe added a few things. #}
+{# XXX Do we need this _in_form variable? #}
+{%                  if params['_in_form'] is not defined %}
+{# Set a flag, so if we return here, we'll know we're in a form. #}
+{%                      set params['_in_form'] = true %}
+{%                      if params['model'] != '' and params['model_endpoint'] != '' %}
+{# XXX Figure out if data-title should be required. #}
+{# Open up the HTML form element. #}
+<form id="frm_{{ params['model'] }}"
+      class="form-inline"
+      data-title="{{ params['title'] }}"
+      data-model="{{ params['model'] }}"
+      data-model-endpoint="{{ params['model_endpoint'] }}">
+{%                      else %}
+{# XXX Try to throw here inform the user of missing definition. #}
+{# {%                          break %} #}
+{%                      endif %}
+{%                  else %}
+{# XXX Try to throw here with some PHP instead of break. #}
+{# {%                      break %} #}
+{%                  endif %}
+{{                  build_xml_part(xml, lang, params) }}
+{%                  if params['_in_form'] == true %}
+{# Close the HTML form element that was opened earlier. #}
+</form>
+{# Set our flag to false so we'll know we're not in a form if we return. #}
+{%                      set params['_in_form'] = false %}
+{%                      set params['model'] = '' %}
+{%                      set params['model_endpoint'] = '' %}
+{%                      set params['title'] = '' %}
+{%                  endif %}
+{%  endmacro %}
+
+{#
+ # This function is the starting function for processing an XML.
+ #
+ #}
+{%  macro build_xml(xml, lang, params = null) %}
+{%      if xml %}
+{%          if params['active_tab'] is empty %}
+{%              set params['active_tab'] = get_xml_prop(xml, 'activetab') %}
+{%          endif %}
+{%          if xml.getName() == 'model' %}
+{{              build_form(xml, lang, params) }}
+{%          else %}
+{{              build_xml_part(xml.children(), lang, params) }}
+{%          endif %}
+{# After we've closed the form for the model, we'll be safe to build
+   any dialogs for this model (which also include form elements).
+Since they're defined within the model, let's assume that their belong to it. #}
+{%      for bootgrid in xml.xpath('//*/bootgrid[dialog]') %}
+{{          partial("layout_partials/bootgrid_dialog",[
+                    'this_grid':bootgrid,
+                    'lang': lang,
+                    'params': params
+                ]) }}
+{%      endfor %}
+
+
+
+{#  # Conditionally display buttons at the bottom of the page. #}
+{%          if xml.button %}
+<section class="page-content-main">
+{# Alert class used to get padding to look good.
+   Maybe there is another class that can be used. #}
+  <div class="alert alert-info" role="alert">
+{%              for button_element in xml.button %}
+{%                  if button_element['type']|default('primary') in ['primary', 'group' ] %} {# Assume primary if not defined #}
+{%                      if button_element['type']|default('') == 'primary' and
+                           button_element['action'] %}
+    <button class="btn btn-primary"
+            id="btn_{{ plugin_safe_name }}_{{ button_element['action'] }}"
+            type="button">
+      <i class="{{ button_element['icon']|default('') }}"></i>
+      &nbsp
+      <b>{{ lang._('%s') | format(button_element.__toString()) }}</b>
+      <i id="btn_{{ plugin_safe_name }}_progress"></i>
+    </button>
+{%                      elseif button_element['type'] == 'group' %}
+{#  We set our own style here to put the button in the right place. #}
+    <div class="btn-group"
+         {{ (button_element['id']|default('') != '') ?
+             'id="'~button_element['id']~'"' : '' }}>
+      <button type="button"
+              class="btn btn-default dropdown-toggle"
+              data-toggle="dropdown">
+        <i class="{{ button_element['icon'] }}"></i>
+        &nbsp
+        <b>{{ lang._('%s') | format(button_element['label']) }}</b>
+        <i id="btn_{{ plugin_safe_name }}_progress"></i>
+        &nbsp
+        <i class="caret"></i>
+      </button>
+{%                          if button_element.dropdown %}
+      <ul class="dropdown-menu" role="menu">
+{%                              for dropdown_element in button_element.dropdown %}
+        <li>
+          <a id="drp_{{ plugin_safe_name }}_{{ dropdown_element['action'] }}">
+            <i class="{{ button_element['icon'] }}"></i>
+            &nbsp
+            {{ lang._('%s') | format(dropdown_element.__toString()) }}
+          </a>
+        </li>
+{%                              endfor %}
+      </ul>
+{%                          endif %}
+    </div>
+{%                      endif %}
+{%                  endif %}
+{%              endfor %}
+  </div>
+</section>
+{%      endif %}
+{%    endif %}
+{%  endmacro %}

--- a/src/opnsense/mvc/app/views/_script.volt
+++ b/src/opnsense/mvc/app/views/_script.volt
@@ -1,0 +1,213 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ # }
+
+{##
+ # This is a partial used to populate the <script> section of a page.
+ #
+ # Expects to have in the environment (scope) an array by the name of this_form.
+ # This should contain an array of form XML data, created by the controller using
+ # getForm().
+ #
+ # Expects to have all macros available in the environment.
+ # views/OPNsense/<Pluginname>/_macros.volt
+ #
+ # Includes several universal functions, and attachments for convenience.
+ #
+ # All comments encapsulated in Javascript friendly notation so JS syntax
+ # highlighting works correctly.
+ #}
+
+    function saveForm(form, dfObj, this_callback_ok, this_callback_fail){
+        var this_frm = form;
+        var frm_id = this_frm.attr("id");
+        var frm_title = this_frm.attr("data-title");
+        var frm_model = this_frm.attr("data-model");
+
+{#/*    # It's possible for a form to exist without a data-model, exclude them. */#}
+        if (frm_model) {
+            var api_url="/api/{{ plugin_api_name }}/" + frm_model + "/set";
+            saveFormToEndpoint(
+                url=api_url,
+                formid=frm_id,
+                callback_ok=
+                    function(data, status){
+                        dfObj.resolve();
+                        this_callback_ok();
+                    },
+                false,
+                callback_fail=
+                    function(data, status){
+                        dfObj.reject();
+                        this_callback_fail();
+                    }
+            );
+        } else {
+                dfObj.reject();
+                this_callback_fail();
+        }
+    }
+
+
+    function ajaxDataDialog(data, dialog_title){
+        if (data['message'] != '' ) {
+            var message = data['message']
+        } else {
+            var message = JSON.stringify(data)
+        }
+        BootstrapDialog.show({
+            type:BootstrapDialog.TYPE_WARNING,
+            title: dialog_title,
+            message: message,
+            draggable: true
+        });
+    }
+
+{#/*
+     * standard data mapper to map json request data to forms on this page
+     * @param data_get_map named array containing form names and source url's to get data from {'frm_example':"/api/example/settings/get"};
+     * @param server_params parameters to send to server
+     * @return promise object, resolves when all are loaded
+     */#}
+    function mapDataToUI(server_params) {
+        const dfObj = new $.Deferred();
+
+{#/*    // calculate number of items for deferred object to resolve */#}
+        let elements = $('[data-model-name][data-model-endpoint]');
+
+        if (server_params === undefined) {
+            server_params = {};
+        }
+
+        const collected_data = {};
+        elements.each(function(index) {
+            let model_name = $( this ).data('model-name');
+            let model_endpoint = "/api/{{ plugin_api_name }}/" + $( this ).data('model-endpoint');
+            let element = $(this);
+            ajaxGet(model_endpoint,server_params , function(data, status) {
+                if (status === "success") {
+{#*/                    // related form found, load data */#}
+                        setFormData(element.attr('id'), data);
+                        collected_data[element.attr('id')] = data;
+                }
+                if (index === elements.length - 1) {
+                    dfObj.resolve(collected_data);
+                }
+            });
+        });
+
+        return dfObj;
+    }
+
+
+
+{#/*
+    # Save event handlers for all defined forms
+    # This uses jquery selector to match all button elements with id starting with "save_frm_" */#}
+    $('a[id^="drp_frm_"][id$="_save"],button[id^="btn_frm_"][id$="_save"]').each(function(){
+        $(this).click(function() {
+            const dfObj = new $.Deferred();
+            var this_frm = $(this).closest("form");
+            if ($(this).attr('type') == "button") {
+                var this_btn = $(this);
+            } else {
+                var this_btn = $(this).closest('div').find('button').first();
+            }
+
+            busyButton(this_btn);
+
+            saveForm(this_frm, dfObj);
+
+            clearButtonAndToggle(this_btn)
+
+            return dfObj;
+        });
+    });
+
+
+{#/*
+    # Perform save and reconfigure for single form. */#}
+    $('a[id^="drp_frm_"][id$="_save_apply"],button[id*="btn_frm_"][id$="_save_apply"]').click(function() {
+        const saveObj = new $.Deferred();
+        const reconObj = new $.Deferred();
+        var this_btn = $(this);
+        var this_frm = $(this).closest("form");
+        busyButton(this_btn);
+        saveForm(this_frm, saveObj, reconfigureService, [this_btn, reconObj, clearButtonAndToggle, [this_btn]]);
+
+        return { saveObj, reconObj };
+    });
+
+
+{#/*
+    # Save event handler for the Save All button.
+    # The ID should be unique and derived from the form data. */#}
+    $('a[id^="drp_{{ plugin_safe_name }}_save"],button[id="btn_{{ plugin_safe_name }}_save_all"]').click(function() {
+        const dfObj = new $.Deferred();
+        if ($(this).attr('type') == "button") {
+            var this_btn = $(this);
+        } else {
+            var this_btn = $(this).closest('div').find('button').first();
+        }
+{#/*    # Turn on the spinner animation for the button to indicate activity. */#}
+        busyButton(this_btn);
+        var models = $('form[id^="frm_"][data-model]').map(function() {
+{#          # Create a deferred object to pass to the function and wait on. #}
+            const model_dfObj = new $.Deferred();
+            saveForm($(this), model_dfObj);
+            return model_dfObj
+        });
+        $.when(...models.get()).then(function() {
+            dfObj.resolve();
+        });
+{#/*    # Clear the button state, and trigger an Apply toggle check. */#}
+        clearButtonAndToggle(this_btn)
+
+        return dfObj;
+    });
+
+{#/*
+    # Save event handler for the Save and Apply All button.
+    # The ID should be unique and derived from the form data. */#}
+    $('a[id^="drp_{{ plugin_safe_name }}_save_apply_all"],button[id="btn_{{ plugin_safe_name }}_save_apply_all"]').click(function() {
+        const reconObj = new $.Deferred();
+        var this_btn = $(this);
+
+        busyButton(this_btn);
+
+        var models = $('form[id^="frm_"][data-model]').map(function() {
+{#          # Create a deferred object to pass to the function and wait on. #}
+            const model_dfObj = new $.Deferred();
+            saveForm($(this), model_dfObj);
+            return model_dfObj
+        });
+        $.when(...models.get()).then(function() {
+{#/*        # when done, disable progress animation. */#}
+            reconfigureService(this_btn, reconObj, clearButtonAndToggle, [this_btn]);
+            dfObj.resolve();
+        });
+        return recon_dfObj;
+    });

--- a/src/opnsense/mvc/app/views/_styles.volt
+++ b/src/opnsense/mvc/app/views/_styles.volt
@@ -1,0 +1,41 @@
+{#
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+<style>
+{# This is a style for displaying log files.
+   It will respect whitespace and use a fixed-width font
+   for better readability. Has some extra stuff to do wrapping. #}
+    .logs {
+        white-space: pre-wrap;       /* Since CSS 2.1 */
+        white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+        white-space: -pre-wrap;      /* Opera 4-6 */
+        white-space: -o-pre-wrap;    /* Opera 7 */
+        word-wrap: break-word;       /* Internet Explorer 5.5+ */
+        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+        font-size: small;
+    }
+</style>

--- a/src/opnsense/mvc/app/views/js/data_get_map.volt
+++ b/src/opnsense/mvc/app/views/js/data_get_map.volt
@@ -1,0 +1,39 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ ##}
+{#/*
+    Populate data_get_map for use in mapDataToFormUI() function later. */#}
+var data_get_map = {
+{%  if this_xml.getName() == 'model' %}
+    'frm_{{ this_xml['name'] }}': '/api/{{ plugin_api_name }}/{{ this_xml['endpoint'] }}/get'
+{%  else %}
+{%  for model in this_xml.xpath('//*/model') %}
+{%      if model['name'] and model['endpoint'] %}
+    'frm_{{ model['name'] }}': '/api/{{ plugin_api_name }}/{{ model['endpoint'] }}/get'
+{%      endif %}
+{%  endfor %}
+{%  endif %}
+};

--- a/src/opnsense/mvc/app/views/js/functions.volt
+++ b/src/opnsense/mvc/app/views/js/functions.volt
@@ -1,0 +1,261 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ # #}
+{#/*
+    # Toggle function is for enabling or disabling field(s)
+    # This will disable an entire row (make things greyed out)
+    # takes care of at least text boxes, checkboxes, and dropdowns.
+    # It uses the *= wildcard, so take care with the field name.
+    # Field should be the id of an object or the prefix/suffix
+    # for a set of objects.
+*/#}
+function toggle (id, type, toggle) {
+    var efield = $.escapeSelector(id);
+    if (type == "field") {
+{#/*        # This might need further refinement, selects the row matching field id,
+        # uses .find() to select descendants, .addBack() to select itself. */#}
+        var selected_row = $('tr[id=row_' + efield + ']')
+        var selected = selected_row.find('div,[id*=' + efield + '],[data-id*=' + efield + '],[name*=' + efield + '],[class^="select-box"],[class^="btn"],[class^="search-field"],ul[class^="tokens-container"]').addBack();
+        if (toggle == "disabled") {
+{#/*            # Disable entire row related to a field */#}
+            selected.addClass("disabled");
+            selected.prop({
+                "readonly": true,
+                "disabled": true
+            });
+{#/*            # This element needs to be specially hidden because it is for some reason
+            # hidden when tokenizer creates the element. This is the target element
+            # <li class="token-search" style="width: 15px; display: none;"><input autocomplete="off"></li> */#}
+            selected.find('li[class="token-search"]').hide();
+{#/*            # Disable the Clear All link below dropdown boxes,
+            # the toggle column on grids (Enabled column),
+            # and the tokens in a tokenized field. */#}
+            selected.find('a[id^="clear-options_"],[class*="command-toggle"],li[class="token"]').css("pointer-events","none");
+            $('input[id=' + efield + ']').trigger("change");
+        } else if (toggle == "enabled") {
+{#/*            # Disable entire row related to a field */#}
+            selected.removeClass("disabled");
+            selected.prop({
+                "readonly": false,
+                "disabled": false
+            });
+{#/*            # This element needs to be specially shown because it is for some reason
+            # hidden when tokenizer creates the element. This is the target element
+            # <li class="token-search" style="width: 15px; display: none;"><input autocomplete="off"></li>*/#}
+            selected.find('li[class="token-search"]').show();
+{#/*            # Enable the Clear All link below dropdown boxes,
+            # the toggle column on grids (Enabled column),
+            # and the tokens in a tokenized field.*/#}
+            selected.find('a[id^="clear-options_"],[class*="command-toggle"],li[class="token"]').css("pointer-events","auto");
+{#/*            # Trigger a field change to trigger a toggle of any dependent fields (i.e. fields that this field enables) */#}
+            var selected_field = $('input[id=' + efield + ']')
+            $('input[id=' + efield + ']').trigger("change");
+        } else if (toggle == "hidden") {
+{#/*            # Do a nice fade out with a hide once done,
+            # and add dummy row for striping. */#}
+            selected_row.fadeOut(400, function() {
+                selected_row.after('<tr class="dummy_row" style="display: none"></tr>');
+            });
+        } else if (toggle == "visible") {
+{#/*            # Do a nice fade in instead of a show() pop */#}
+            selected_row.fadeIn(200, function() {
+                selected_row.next("tr[class=dummy_row]").remove();
+            });
+        }
+    } else if (["tab", "box"].includes(type)) {
+        if (toggle == "hidden") {
+{#/*            # Use a fadeOut instead of hide() for a nice effect. */#}
+            $("#" + efield).fadeOut();
+        } else if (toggle == "visible") {
+{#/*            # Use a fadeIn instead of show() for a nice effect. */#}
+            $("#" + efield).fadeIn();
+        }
+    } else if (["button"].includes(type)) {
+        if (toggle == "hidden") {
+            $("button[id=" + efield + "]").hide();
+        } else if (toggle == "visible") {
+            $("button[id=" + efield + "]").show();
+        }
+    } else {
+{#/* Catch all for any other types, just try all the things and maybe something will work.. */#}
+        var selected = $(type + '[id=' + efield + "]");
+        if (toggle == "hidden") {
+            selected.hide();
+        } else if (toggle == "visible") {
+            selected.show();
+        } else if (toggle == "enabled") {
+            selected.addClass("disabled");
+            selected.prop({
+                "readonly": true,
+                "disabled": true
+            });
+        } else if (toggle == "disabled") {
+            selected.removeClass("disabled");
+            selected.prop({
+                "readonly": false,
+                "disabled": false
+            });
+        }
+    }
+}
+
+{#/*
+ # =====================================================================================================================
+ # Button Functions
+ # =====================================================================================================================
+*/#}
+{#/* Make a button look busy, and disable it to prevent extra clicks. */#}
+function busyButton(this_btn) {
+    this_btn.find('[id$="_progress"]').addClass("fa fa-spinner fa-pulse");
+    this_btn.addClass("disabled");
+}
+{#/* Make a button clear from busy state, re-enable it. */#}
+function clearButton(this_btn) {
+    this_btn.find('[id$="_progress"]').removeClass("fa fa-spinner fa-pulse");
+    this_btn.removeClass("disabled");
+}
+{#/* Make a button clear from busy state, re-enable it, includes toggle for Apply Changes visibility. */#}
+function clearButtonAndToggle(this_btn) {
+    clearButton(this_btn);
+    toggleApplyChanges();
+}
+
+{#/*
+ # =====================================================================================================================
+ # Configuration Activities
+ # =====================================================================================================================
+*/#}
+{#/*
+ # This function is designed to take a selected form DOM, a defferred object, and supports callbacks for pass and fail.
+ #
+ # This uses the selctor method and relies on the HTML data. Since we have XML data to drive the model, I'm not sure
+ # this approach is necessary anymore.
+ #
+ # For example as we have the data_get_map, a data_set_map could be created just the same. It could be referenced by model name.
+ #
+*/#}
+    function saveForm(form, dfObj, this_callback_ok, this_callback_fail){
+        var this_frm = form;
+        var frm_id = this_frm.attr("id");
+        var frm_title = this_frm.attr("data-title");
+        var frm_model = this_frm.attr("data-model");
+
+{#/*    # It's possible for a form to exist without a data-model, exclude them. */#}
+        if (frm_model) {
+            var api_url="/api/{{ plugin_api_name }}/" + frm_model + "/set";
+            saveFormToEndpoint(
+                url=api_url,
+                formid=frm_id,
+                callback_ok=
+                    function(data, status){
+                        dfObj.resolve();
+                        if (typeof this_callback_ok === "function") {
+                            this_callback_ok();
+                        }
+                    },
+                false,
+                callback_fail=
+                    function(data, status){
+                        dfObj.reject();
+                        if (typeof this_callback_fail === "function") {
+                            this_callback_fail();
+                        }
+                    }
+            );
+        } else {
+                dfObj.reject();
+                this_callback_fail();
+        }
+    }
+
+{#/*
+    # Basic function to save the form, and reconfigure after saving
+    # displays a dialog if there is some issue */#}
+function saveFormAndReconfigure(element){
+    const dfObj = new $.Deferred();
+    var this_frm = $(element).closest("form");
+    var frm_id = this_frm.attr("id");
+    var frm_title = this_frm.attr("data-title");
+    var frm_model = this_frm.attr("data-model");
+    var api_url="/api/{{ plugin_api_name }}/" + frm_model + "/set";
+
+{#/*    # set progress animation when saving */#}
+    $("#" + frm_id + "_progress").addClass("fa fa-spinner fa-pulse");
+
+    saveFormToEndpoint(url=api_url, formid=frm_id, callback_ok=function(){
+        ajaxCall(url="/api/{{ plugin_api_name }}/service/reconfigure", sendData={}, callback=function(data,status){
+{#/*            # when done, disable progress animation. */#}
+            $("#" + frm_id + "_progress").removeClass("fa fa-spinner fa-pulse");
+
+            if (status != "success" || data['status'] != 'ok' ) {
+                ajaxDataDialog(data, frm_title);
+            } else {
+                ajaxCall(url="/api/{{ plugin_api_name }}/service/status", sendData={}, callback=function(data,status) {
+                    updateServiceStatusUI(data['status']);
+                    dfObj.resolve();
+                });
+            }
+        });
+    });
+    return dfObj;
+}
+
+{#/*
+ # =====================================================================================================================
+ # Service Activities
+ # =====================================================================================================================
+*/#}
+{#/* XXX Needs description. */#}
+{#/* XXX This is probably a button activity, and the reconfigure activity could probably be broken out. */#}
+function reconfigureService(button, dfObj, callback_after, params){
+    var frm_title = '{{ plugin_label }}';
+
+    busyButton(button);
+
+    var api_url = "/api/{{ plugin_api_name }}/service/reconfigure";
+    ajaxCall(url=api_url, sendData={}, callback=function(data, status){
+        if (status != "success" || data['status'] != 'ok' ) {
+            ajaxDataDialog(data, frm_title);
+        } else {
+            if (callback_after !== undefined) {
+                callback_after.apply(this, params);
+            }
+            var api_url = "/api/{{ plugin_api_name }}/service/status";
+            ajaxCall(url=api_url, sendData={}, callback=function(data, status) {
+                updateServiceStatusUI(data['status']);
+                dfObj.resolve();
+            });
+        }
+    });
+    return dfObj;
+}
+
+
+{#/*
+ # =====================================================================================================================
+ # UI Activities
+ # =====================================================================================================================
+*/#}

--- a/src/opnsense/mvc/app/views/layout_partials/base_table.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_table.volt
@@ -1,0 +1,91 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{##
+ # This partial is for building a form, including all fields. It's called
+ # by other volt scipts and to build tabs, and boxes. The array 'this_part'
+ # should be the tab, or box (or possibly other structure) being drawn.
+ #
+ # This is called by the following functions:
+ # _macros::build_tabs()
+ # _macros::
+ #
+ # The array named "this_part" should contain:
+ #
+ # this_part['id']          : 'id' attribute on 'tab' element in form XML,
+ #                            intended to be unique on the page
+ # this_part['description'] : 'description' attribute on 'tab' element in form XML
+ #                            used as 'data-title' to set on form HTML element
+ # this_part.field          : array of fields on this tab
+ #}
+
+{%  set help = this_part.xpath('//*/field/help') ? true : false %}
+{%  set advanced = this_part.xpath('//*/field/advanced') ? true : false %}
+
+{# This partial may be called by base_dialog, and it will define a different 'model' when called.
+   This will set a 'model' to params['model'] in the case it's not overriden. #}
+{% if model is not defined  %}
+{%     if params['model'] is defined %}
+{%         set model = params['model'] %}
+{%     else %}
+{%         set model = '' %}
+{%     endif %}
+{% endif %}
+
+{# Start building the table for the fields. #}
+<div class="table-responsive">
+    <table class="table table-striped table-condensed">
+        <colgroup>
+            <col class="col-md-3"/>
+            <col class="col-md-{{ 12-3-msgzone_width|default(4) }}"/>
+            <col class="col-md-{{ msgzone_width|default(5) }}"/>
+        </colgroup>
+        <tbody>
+{# Draw the help row if we have to draw the help or advanced switch. #}
+{%  if advanced or help %}
+{%      include "layout_partials/rows/help_or_advanced.volt" %}
+{%  endif %}
+{# Here we iterate through the children in order rather than use the this_part.field
+   in order to keep the order when a model definition may be present. #}
+{%  for node in this_part %}
+{%      set node_type = node.getName() %}
+{%      if node_type not in ['style','label'] %}
+{# Ignore some elements which aren't actually row types. #}
+{# Now call the appropriate partial for that row type. #}
+{{  partial("layout_partials/rows/" ~ node_type,[
+            'this_node': node,
+            'model': model,
+            'lang': lang,
+            'params': params
+]) }}
+{%      endif %}
+
+{%  endfor %}
+            </tbody>
+        </thead>
+    </table>
+</div>

--- a/src/opnsense/mvc/app/views/layout_partials/bootgrid_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/bootgrid_dialog.volt
@@ -1,0 +1,99 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{##
+ # Builds input dialog for bootgrids, uses the following parameters (as associative array):
+ #
+ # this_grid['target']              :   id of the dialog's parent field.
+ # this_grid.dialog          :   array dialog defined for the bootgrid
+ # this_grid.dialog['label'] :   Label for the dialog
+ # this_grid.dialog['field'] :   array of fields for this dialog
+ #
+ # msgzone_width, hasSaveBtn https://github.com/opnsense/core/commit/4c736c65060c926ecc9eb7539b93454559e9d2d4
+ #}
+{%      set this_grid_id = get_xml_prop(this_grid, 'id') %}
+{%      set dialog_elements = this_grid.dialog %}
+{%      set dialog_label = get_xml_prop(dialog_elements, 'label') %}
+{#      Find if there are help supported or advanced field on this page #}
+{%      set dialog_help = false %}
+{%      set dialog_advanced = false %}
+
+{# Grab the node from the dialog element. #}
+{%      set grid_id = get_xml_prop(this_grid, 'id') %}
+{# <?php $model = explode(".", $grid_id)[1]; ?> #}
+
+{%  set help = this_grid.xpath('//*/field/help') ? true : false %}
+{%  set advanced = this_grid.xpath('//*/field/advanced') ? true : false %}
+
+{# The id here has to match the same value as is populated in data-editDialog attribute on the bootgrid table. #}
+<div class="modal fade"
+     id="bootgrid_dialog_{{ this_grid_id }}"
+     tabindex="-1"
+     role="dialog"
+     aria-labelledby="{{ this_grid_id }}_Label"
+     aria-hidden="true">
+    <div class="modal-backdrop fade in"></div>
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button"
+                        class="close"
+                        data-dismiss="modal"
+                        aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title"
+                    id="{{ this_grid_id }}_Label">
+                    {{ dialog_label|default('Edit') }}
+                </h4>
+            </div>
+            <div class="modal-body">
+{#              Must match what's defined in data-editDialog attribute on bootgrid table: params['set']+uuid, 'frm_' + editDlg, function(){ #}
+                <form id="frm_bootgrid_dialog_{{ this_grid_id }}">
+{{      partial("layout_partials/base_table",[
+                'this_part': this_grid.dialog.children(),
+                'model': grid_id,
+                'lang': lang,
+                'params': params
+]) }}
+                </form>
+            </div>
+            <div class="modal-footer">
+{# XXX Need to comment where this flag is set from. #}
+{%      if hasSaveBtn|default('true') == 'true' %}
+                <button type="button" class="btn btn-default" data-dismiss="modal">{{ lang._('Cancel') }}</button>
+                <button type="button" class="btn btn-primary" id="btn_bootgrid_dialog_{{ this_grid_id }}_save">{{ lang._('Save') }} <i id="btn_bootgrid_dialog_{{ this_grid_id }}_save_progress" class=""></i></button>
+{%      else %}
+                <button type="button" class="btn btn-default" data-dismiss="modal">{{ lang._('Close') }}</button>
+{%      endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+{# Clean up the node value as it shouldn't leave this dialog. #}
+{%      set params['node'] = '' %}

--- a/src/opnsense/mvc/app/views/layout_partials/components/help_icon.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/components/help_icon.volt
@@ -1,0 +1,46 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{# Requires:
+    this_element - the xml element being evaluated (usually a field)
+    this_element_id - the id of the elment the help is for
+    this_element_label - the label to use for the element.
+#}
+{# XXX Leaning towards not using this. XXX }
+<div class="control-label" id="control_label_{{ this_element_id }}">
+{%  if this_element.help %}
+{# Add the help icon if help is defined. #}
+    <a id="help_for_{{ this_element_id }}"
+       href="#"
+       class="showhelp">
+        <i class="fa fa-info-circle"></i>
+    </a>
+{%      else %}
+{# Add a "muted" help icon which does nothing. #}
+    <i class="fa fa-info-circle text-muted"></i>
+{%      endif %}
+    <b>{{ get_xml_prop(this_parameter, 'description', true) }}</b>
+</div>

--- a/src/opnsense/mvc/app/views/layout_partials/components/help_text.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/components/help_text.volt
@@ -1,0 +1,33 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{# Requires:
+    help_id - id of the element that the help text is for.
+    help_text - the help text itself.
+#}
+<div class="hidden" data-for="help_for_{{ help_id }}">
+    <small>{{ lang._('%s')|format(help_text) }}</small>
+</div>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/checkbox.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/checkbox.volt
@@ -1,0 +1,123 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # This partial is for the checkbox field type.
+ #
+ # This creates a simple HTML checkbox that the user can click to select an item.
+ #
+ # The value for this field will get translated as checked = 1, or unchecked = 0.
+ #
+ # This field support field control.
+ #
+ # Example usage in form XML:
+ # <field>
+ #     <id>enabled</id>
+ #     <label>Enable DNSCrypt Proxy</label>
+ #     <help>This will enable the dnscrypt-proxy service.</help>
+ #     <type>checkbox</type>
+ # </field>
+ #
+ # Compatible model field types:
+ # BooleanField
+ # TextField
+ # IntegerField
+ #
+ # Intended to be used with BooleanField type in the model:
+ # <enabled type="BooleanField">
+ #     <required>Y</required>
+ #     <default>0</default>
+ # </enabled>
+ #
+ # Example partial call from another volt template:
+ # {{      partial("OPNsense/Dnscryptproxy/layout_partials/fields/checkbox",[
+ #                 'this_field': this_node,
+ #                 'this_field_id': this_field_id,
+ #                 'lang': lang,
+ #                 'params': params
+ # ]) }}
+ #
+ # List of objects expected in the environment:
+ #  this_field     : (SimpleXMLObject) a field XML node
+ #  this_field_id  : (String) the id of the field
+ #
+ # The field id could be derived from this_field, but it's already acquired earlier by rows/field.volt, so it's just
+ # assumed to be passed in to save a little work.
+#}
+<input
+    type="checkbox"
+    class="{{ this_field.style|default('') }}"
+    id="{{ this_field_id }}"
+>
+{# =================================================================================================================== #}
+<script>
+{#/*
+ # =============================================================================
+ # checkbox, radio, dropdown: toggle functionality
+ # =============================================================================
+ # A toggle function for checkboxes, radio buttons, and dropdown menus.
+ # XXX This function is mostly the same for four types of fields, and maybe this could be separated into a function.
+ # XXX Maybe it could be called toggle_control().
+ # After thinking about this, i don't think that a javascript function would offer much advantage. We'd have to create
+ # a variable (array) stuff it with the info from the XML, then just pass the variable to the function, and it would
+ # have to iterate through it, and also deal with the logic. This would also include the the logic of the state
+ # conditions (checked = true/false for checkboxes, but something different for dropdowns and radio buttons).
+ # This approach seems less work, even though it's mostly the same code 4 times.
+ # XXX We could also turn this back into a macro, and simply call the macro here.
+*/#}
+{%  if this_field.control %}
+{%      if this_field.control.action %}
+{#/*  Attach to the element associated with the field id,
+    or the text field associated with the radio buttons */#}
+    $("#" + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/*  This prevents the field from acting out if it is in a disabled state. */#}
+        if ($(this).hasClass("disabled") == false) {
+{#/*  This pulls the on_set key values out of all of the field's attributes,
+    and then creates an array of the unique values. */#}
+{%          set on_set_values_xml = this_field.control.xpath('action/@on_set') %}
+{%          set value_list = [] %}
+{%          set value_list_array = [] %}
+{%          for xml_node in on_set_values_xml %}
+<?php $value_list_array[] = $xml_node->__toString() ?>
+{%          endfor %}
+<?php $value_list = array_unique($value_list_array); ?>
+{#/*  Iterate through the values we found to start building our if blocks.  */#}
+{%              for on_set in value_list %}
+            if ($(this).prop("checked") == {{ on_set }} ) {
+{#/*  Iterate through the fields only if the "on_set" value matches that of the current for loop's "on_set" variable. */#}
+{%                  for target_field in this_field.control.action if target_field['on_set'] == on_set %}
+{#/*  We use the field's value so we don't have to have a line of code for each version, check first that they're OK. */#}
+{%                      if target_field['do_state'] in [ "disabled", "enabled", "hidden", "visible" ] %}
+                toggle("{{ target_field }}", "{{ target_field['type'] }}", "{{ target_field['do_state'] }}");
+{%                      endif %}
+{%                  endfor %}
+            }
+{%              endfor %}
+        }
+    });
+{%      endif %}
+{%  endif %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/command.volt.unused
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/command.volt.unused
@@ -1,0 +1,243 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # Template for a command button which executes a pre-defined command (with optional input from the user).
+ #
+ # Allows for specifying an API endpoint to call when pressed, allowing for output to be returned to the user.
+ #
+ # This is called primarily by form_input_tr.volt for building input fields for each row of the form table.
+ #
+ # Expects two variables to be present in the environment (these will be provided when called by form_input_tr.volt):
+ # this_field           A SimpleXMLElement of the field to be rendered.
+ # this_field_id        The id of the given field (in the form: modelname.field_id).
+ #
+ # XML field element definition:
+ # /field                                   The <field> XML element as a SimpleXMLElement object.
+ # /field/function                          Optional, specify what function to use for the command.
+ # /field/readonly                          (Only for function: field) Set the field as read-only
+ # /field/hint                              (Only for function: field) Provide a hint to display to the user what to type into the field. XXX maybe mention placeholder?
+ # /field/separator                         (Only for function: selectpicker) Defines the separator for selectpicker XXX <-- needs elaborated, something to do with selectpicker function
+ # /field/style                             Specify a pre-defined CSS style to use for this field.
+ # /field/width                             Width of XXX
+ # /field/size                              Size of XXX
+ # /field/output                            Default: false, Boolean, display output (true) or not (false).
+ # /field/buttons                           Sub-element containing button elements.
+ # /field/buttons/button['id']              Unique identifier for the button
+ # /field/buttons/button['type']            The type of button that it is, used for SimpleActionButton functionality.
+ # /field/buttons/button['label']           Label to be used for displaying to the user.
+ # /field/buttons/button['endpoint']        (Only for button type: SimpleActionButton) API endpoint to call for that button.
+ # /field/buttons/button['error-title']     (Only for button type: SimpleActionButton) The title of the error window.
+ # /field/buttons/button['service-widget']  (Only for button type: SimpleActionButton) XXX Needs definition.
+ #
+ #
+ # Example Usage in an XML (with comments for clarity):
+ # <!-- intput functionality -->
+ # <field>
+ #   <id>hostname</id>
+ #   <label>Hostname</label>
+ #   <type>command</type>
+ #   <function>field</function>       <!-- options: input, selectpicker, field -->
+ #   <function>input</function>
+ #   <buttons>
+ #     <button id="resolve" type="SimpleActionButton">
+ #       <label>Logout</label>
+ #       <endpoint>/api/dnscryptproxy/diagnostics/command/resolve</endpoint>
+ #       <error-title>Command execution error occurred.</error-title>
+ #       <service-widget></service-widget> <!-- Name of the service for use with updateServiceControlUI -->
+ #     </button>
+ #   </buttons>
+ #   <output>resolve_command</output> <!-- id of output field to display command output -->
+ # </field>
+ #
+ # <!-- selectpicker selectpicker functionality -->
+ # <field>
+ #   <id>config_view</id>
+ #   <label>View dnscrypt-proxy Configuration</label>
+ #   <type>command</type>
+ #   <function>selectpicker</function>
+ #   <api>/api/dnscryptproxy/diagnostics/command/config-view</api>
+ #   <options>
+ #     <option>dnscrypt-proxy.toml</option>
+ #     <option>allowed-ips-internal.txt</option>
+ #     <option>allowed-ips-manual.txt</option>
+ #     <!-- additional option definitions ... --->
+ #   </options>
+ #   <output>config_view_output</output>
+ #   <button_label>View</button_label>
+ #   </field>
+ #
+ # Example Model definition:
+ # Not applicable.
+ #
+ # This template can be either included, or called via partial. For which should be used review:
+ # https://docs.phalcon.io/5.0/en/volt#partial-vs-include
+ #
+ # Example include call in a Volt Template:
+ # {% include "OPNsense/Dnscryptproxy/layout_partials/fields/command.volt" %}
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/command",
+ #            [
+ #                'this_field':this_field,
+ #                'this_field_id':this_field_id
+ #             ]
+ #    )
+ # }}
+ #
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+{# Built-in: input field for the user to enter in values to send to the command. #}
+{%  if this_field.function == "input" %}
+    <input id="inpt_{{ this_field_id }}_command"
+           class="form-control {{ this_field.style }}"
+           type="text"
+           size="{{this_field.size|default("36")}}"
+           style="height: 34px;
+                  padding-left:11px;
+                  display: inline;"/>
+{# XXX     ^^^^ Migrate this style to CSS #}
+{# Built-in: selectpicker (dropdown box) with various selections #}
+{%  elseif this_field.function == "selectpicker" %}
+    <select id="{{ this_field_id }}"
+            class="selectpicker {{ this_field.style }}"
+            data-size="{{ this_field.size|default(10) }}"
+            data-width="{{ this_field.width|default("334px") }}"
+            data-live-search="true"
+            {{ this_field.separator is defined ?
+            'data-separator="'~this_field.separator~'"' : '' }}>
+{%      for option in this_field.options.option %}
+                    <option value="{{ lang._('%s')|format(option) }}">
+                        {{ lang._('%s')|format(option) }}
+                    </option>
+{%      endfor %}
+                </select>
+{# Built-in: creates XXX #}
+{%  elseif this_field.function == "field" %}
+    <input id="{{ this_field_id }}"
+           class="form-control {{ this_field.style }}"
+           type="text"
+           size="{{ this_field.size|default("50") }}"
+           {{ this_field.readonly ?
+           'readonly="readonly"' : '' }}
+           {{ (this_field.hint) ?
+           'placeholder="'~this_field.hint~'"' : '' }}
+            style="height: 34px;
+                   display: inline-block;
+                   width: 161px;
+                   vertical-align: middle;
+                   margin-left: 3px;">
+{# XXX      ^^^^ style can probably go into CSS #}
+{%  endif %}
+{%  if this_field.buttons %}
+{%      for button in this_field.buttons.children() %}
+{# Support both id defined as an attribute, as well as a sub-element (legacy), flatten to string, may be empty. #}
+{%          set button_id = (button['id']|default(button.id)).__toString() %}
+{# XXX Maybe do error handling here later. #}
+{%          if button_id != "" %}
+{# Support both label defined as an attribute, as well as a sub-element (legacy), flatten to string, may be empty. #}
+{%              set button_label = (button['label']|default(button.label)).__toString() %}
+{# https://forum.phalcon.io/discussion/19045/accessing-object-properties-whose-name-contain-a-hyphen-in-volt
+   Below we reference some variables which have dashes in their names, Volt has no built-in way to do this.
+   Using PHP to do this for now until I figure a way to get in commands to the compiler. #}
+    <button id="btn_{{ this_field_id }}_{{ button_id }}_command"
+            class="btn btn-primary"
+            type="button"
+{%              if button['type'] == "SimpleActionButton" %}
+            data-label="{{ button_label }}"
+            data-endpoint="{{ button.endpoint }}"
+            data-error-title="<?php echo $button->{'error-title'}; ?>"
+            data-service-widget="<?php echo $button->{'service-widget'}; ?>"
+{%              endif %}
+    >
+{# If SimpleActionButton no label or progress spinner, since that will be provided by SimpleActionButton. #}
+{%              if button['type'] != "SimpleActionButton" %}
+        <b>{{ lang._('%s')|format(button_label) }}</b>
+        <i id="btn_{{ this_field_id }}_{{ button_id }}_command_progress"></i>
+{%              endif %}
+    </button>
+{%          endif %}
+{%      endfor %}
+{%  endif %}
+<script>
+{#/*
+ # =============================================================================
+ # command: attachments for command field types
+ # =============================================================================
+ # Attaches to the command button sets up the classes and
+ # defines the API to be called when clicked
+*/#}
+{% if this_field.buttons %}
+{%     for button in this_field.buttons.children() %}
+{%         set button_id = this_field_id~'_'~get_xml_prop(button, 'id') %}
+/*
+{{ get_xml_prop(button, 'id') }}
+*/
+{%         if button_id != "" %}
+{# Support both label defined as an attribute, as well as a sub-element (legacy), flatten to string, may be empty. #}
+{%              set button_label = get_xml_prop(button, 'label') %}
+$('#btn_{{ button_id }}_command').click(function(){
+    var command_input;
+{%              if this_field.function == "input" %}
+    command_input = $("#inpt_" + $.escapeSelector("{{ this_field_id }}_command")).val();
+{%              elseif this_field.function == "selectpicker" %}
+    command_input = $("button[data-id=" + $.escapeSelector("{{ this_field_id }}")).attr('title');
+{%              endif %}
+{#/*
+{%              if this_field.output.__toString() == "true" %}
+//        $('#pre_{{ this_field_id }}_command_output').text("Executing...");
+{%              endif %}
+*/#}
+    $("#btn_{{ button_id }}_command_progress").addClass("fa fa-spinner fa-pulse");
+{%              if button.endpoint %}
+    ajaxCall(url='{{ button.endpoint }}', sendData={'command_input':command_input}, callback=function(data,status) {
+        if (data['status'] != "ok") {
+{%                  if this_field.output.__toString() == "true" %}
+            $('#pre_{{ this_field_id }}_command_output').text(data['status']);
+{%                  endif %}
+        } else {
+{%                  if this_field.output %}
+            $('#pre_{{ this_field_id }}_command_output').text(data['response']);
+{%                  endif %}
+        }
+        toggle("tr_{{ this_field_id }}_command_output", 'tr','visible' );
+        $("#btn_{{ button_id }}_command_progress").removeClass("fa fa-spinner fa-pulse");
+    });
+{%              endif %}
+});
+{%          endif %}
+{%      endfor %}
+{%  endif %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/dropdown.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/dropdown.volt
@@ -1,0 +1,70 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # This partial is for the dropdown field type.
+ #
+ # This partial is used by rows/fields.volt.
+ #
+ # Example usage in XML:
+ # <field>
+ #     <id>server_selection_method</id>
+ #     <label>Server selection method</label>
+ #     <type>dropdown</type>
+ #     <help>Select to use manual server selection options, instead of ... </help>
+ # </field>
+ #
+ # Compatible model field types:
+ # OptionField
+ # JsonKeyValueStoreField
+ #
+ # Intended to be used with OptionField type in the model:
+ # <server_selection_method type="OptionField">
+ #     <required>Y</required>
+ #     <default>0</default>
+ #     <Multiple>N</Multiple>
+ #     <OptionValues>
+ #         <option value="0">Automatic</option>
+ #         <option value="1">Manual</option>
+ #     </OptionValues>
+ #     <ValidationMessage>A server selection method must be selected.</ValidationMessage>
+ # </server_selection_method>
+ #
+ # Example partial call from another volt template:
+ # {{      partial("OPNsense/Dnscryptproxy/layout_partials/fields/dropdown",[
+ #                 'this_field': this_node,
+ #                 'this_field_id': this_field_id,
+ #                 'lang': lang,
+ #                 'params': params
+ # ]) }}
+ #
+ # List of objects expected in the environment:
+ #  this_field     : (SimpleXMLObject) a field XML node
+ #  this_field_id  : (String) the id of the field
+ #
+ # This field is structured very similarly to the select_multiple field, so a combined template is called instead.
+#}
+{% include "layout_partials/fields/select_multiple_dropdown.volt" %}

--- a/src/opnsense/mvc/app/views/layout_partials/fields/hidden.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/hidden.volt
@@ -1,0 +1,66 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # This partial is for the checkbox field type.
+ #
+ # This simply creates an input box for a string, but hides it from displaying on the page. This field is intended to
+ # be used when a value is stored in the config, but shouldn't be displayed to the user, or is used programmatically to
+ # perform some activity on the page. This allows for the value to be stored and/or modified without the user changing
+ # it directly via the UI.
+ #
+ # This partial is used by layout_partials/rows/fields.volt.
+ #
+ # Example usage in form XML:
+ # <field>
+ #     <id>query_log.enabled</id>
+ #     <type>checkbox</type>
+ #     <hidden>true</hidden>
+ # </field>
+ #
+ # No specific model field type is intended for this field, it will work with any type which returns a string.
+ # Such as IntegerField, BooleanField, TextField.
+ #
+ # Example partial call from another volt template:
+ # {{      partial("OPNsense/Dnscryptproxy/layout_partials/fields/hidden",[
+ #                 'this_field': this_node,
+ #                 'this_field_id': this_field_id,
+ #                 'lang': lang,
+ #                 'params': params
+ # ]) }}
+ #
+ # List of objects expected in the environment:
+ #  this_field     : (SimpleXMLObject) a field XML node
+ #  this_field_id  : (String) the id of the field
+ #
+ # The field id could be derived from this_field, but it's already acquired earlier by rows/field.volt, so it's just
+ # assumed to be passed in to save a little work.
+#}
+<input
+    type="hidden"
+    id="{{ this_field_id }}"
+    class="{{ this_field.style|default('') }}"
+>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/info.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/info.volt
@@ -1,0 +1,63 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # This partial is for the info field type.
+ #
+ # This will simply statically display the value of the setting.
+ #
+ # The user will not be able to edit the field.
+ #
+ # Example usage in form XML:
+ # <field>
+ #     <id>first_time_setup</id>
+ #     <label>First Time Setup</label>
+ #     <type>info</type>
+ #     <help>Help text.</help>
+ # </field>
+ #
+ # No specific model field type is intended for this field, it will work with any type which returns a string.
+ # Such as IntegerField, BooleanField, TextField.
+ #
+ # Example partial call from another volt template:
+ # {{      partial("OPNsense/Dnscryptproxy/layout_partials/fields/info",[
+ #                 'this_field': this_node,
+ #                 'this_field_id': this_field_id,
+ #                 'lang': lang,
+ #                 'params': params
+ # ]) }}
+ #
+ # List of objects expected in the environment:
+ #  this_field     : (SimpleXMLObject) a field XML node
+ #  this_field_id  : (String) the id of the field
+ #
+ # The field id could be derived from this_field, but it's already acquired earlier by rows/field.volt, so it's just
+ # assumed to be passed in to save a little work.
+ #}
+<span
+    class="{{ this_field.style }}"
+    id="{{ this_field_id }}">
+</span>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/managefile.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/managefile.volt
@@ -1,0 +1,329 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # This is a partial for an 'onoff' field, which is very similar to a radio button
+ # with the 'button-group' built-in style, however, only includes two pre-defined
+ # buttons: On, Off
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'this_field_id':this_field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # this_field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+        <input
+            id="{{ this_field_id }}"
+            type="text"
+            class="form-control hidden">
+            {{ (this_field.style|default('') == "classic") ?
+            '<label id="lbl_'~this_field.id~'"></label><br>' : '' }}
+        <label class="input-group-btn form-control"
+               style="display: inline;">
+            <label class="btn btn-default"
+                   id="btn_{{ this_field_id }}_select"
+{# XXX replace this with a builtin functionality. #}
+{%      if this_field.style == "classic" %}
+                    style="
+                        padding: 2px;
+                        padding-bottom: 3px;
+                        width: 100%;"
+{%      endif %}>
+{# XXX Figure out how to attach a tooltip here #}
+{# if we're using classic style, don't add icons. field may be overloaded,
+    supposed to be css class(es) for other fields #}
+{# XXX should be replaced with "builtin" functionality. #}
+{%      if this_field.style|default("") != "classic" %}
+                <i class="fa fa-fw fa-folder-o"
+                   id="inpt_{{ this_field_id }}_icon">
+                </i>
+                <i id="inpt_{{ this_field_id }}_progress">
+                </i>
+{%      endif %}
+                <input
+                    type="file"
+                    class="form-control
+                        {{ (this_field.style|default("") != "classic") ?
+                            'hidden' : '' }}"
+                    for="{{ this_field_id }}"
+                    accept="text/plain">
+            </label>
+        </label>
+{%      if this_field.style|default("") != "classic" %}
+{# if we're using classic style, no need to display this box
+   Explicit style is used here for alignment with the downloadbox
+   button, and matching the size of the button.
+   This input element gets no id to prevent getFormData() from
+   picking it up, using 'for' attr to identify. #}
+{# XXX should replace with a pre-built/built-in style. #}
+        <input
+            class="form-control"
+            type="text"
+            readonly=""
+            for="{{ this_field_id }}"
+            style="height: 34px;
+                   display: inline-block;
+                   width: 161px;
+                   vertical-align: middle;
+                   margin-left: 3px;"
+        >
+{%      endif %}
+{# This if statement is just to get the spacing between the
+   download/upload buttons to be consistent #}
+{# XXX should replace with a pre-built/built-in style. #}
+{%      if this_field.style|default("") == "classic" %}
+        &nbsp
+{%      endif %}
+        <button
+            class="btn btn-default"
+            type="button"
+            id="btn_{{ this_field_id }}_upload"
+            title="{{ lang._('%s')|format('Upload selected file')}}"
+            data-toggle="tooltip"
+        >
+            <i class="fa fa-fw fa-upload"></i>
+        </button>
+        <button
+            class="btn btn-default"
+            type="button"
+            id="btn_{{ this_field_id }}_download"
+            title="{{ lang._('%s')|format('Download')}}"
+            data-toggle="tooltip"
+        >
+            <i class="fa fa-fw fa-download"></i>
+        </button>
+        <button
+            class="btn btn-danger"
+            type="button"
+            id="btn_{{ this_field_id }}_remove"
+            title="{{ lang._('%s')|format('Remove')}}"
+            data-toggle="tooltip"
+        >
+            <i class="fa fa-fw fa-trash-o"></i>
+        </button>
+
+
+<script>
+{#/* =============================================================================
+ # managefile: file selection
+ # =============================================================================
+ # Catching when a file is selected for upload.
+ #
+ # Requires creation of "this_namespace" object earlier in script.
+ #
+ # I think this mostly came from the Web Proxy plugin.
+*/#}
+{%  if this_field.api.upload %}
+$("input[for=" + $.escapeSelector("{{ this_field_id }}") + "][type=file]").change(function(evt) {
+{#/*      Check browser compatibility */#}
+    if (window.File && window.FileReader && window.FileList && window.Blob) {
+         var file_event = evt.target.files[0];
+{#/*     If a file has been selected, let's get the content and file name. */#}
+        if (file_event) {
+            var reader = new FileReader();
+            reader.onload = function(readerEvt) {
+{#/*            Store these in our namespace for use in the upload function.
+                This namespace was created at the beginning of the script section. */#}
+                this_namespace.upload_file_content = readerEvt.target.result;
+                this_namespace.upload_file_name = file_event.name;
+{#/*                  Set the value of the input box we created to store the file name. */#}
+                if ($("label[id='lbl_" + $.escapeSelector("{{ this_field_id }}") + "']").length){
+                    $("label[id='lbl_" +
+                      $.escapeSelector("{{ this_field_id }}") +
+                      "']").text("{{ lang._('Current') }}: " +
+                      this_namespace.upload_file_name);
+                } else {
+                    $("#" + $.escapeSelector("{{ this_field_id }}") +
+                      ",input[for=" + $.escapeSelector("{{ this_field_id }}") +
+                      "][type=text]").val(this_namespace.upload_file_name);
+                }
+            };
+{#/*        Actually get the file, explicitly reading as text. */#}
+            reader.readAsText(file_event);
+        }
+    } else {
+{#/*    Maybe do something else if support isn't available for this API. */#}
+        alert("{{ lang._('Your browser does not appear to support the HTML5 File API.') }}");
+    }
+});
+{#/* Attach to the ready event for the field to trigger and update to the value of the visible elements. */#}
+$('#' + $.escapeSelector('{{ this_field_id }}')).change(function(e){
+    var file_name = $('#' + $.escapeSelector('{{ this_field_id }}')).val();
+{#/*      Modern style */#}
+    if ($('label[id="lbl_' + $.escapeSelector('{{ this_field_id }}') + '"]').length) {
+        $('label[id="lbl_' + $.escapeSelector('{{ this_field_id }}') + '"]').text("Current: " + file_name);
+    }
+{#/*      Classic style */#}
+    if ($('input[for="' + $.escapeSelector('{{ this_field_id }}') + '"][type=text]').length) {
+        $('input[for="' + $.escapeSelector('{{ this_field_id }}') + '"][type=text]').val(file_name);
+    }
+});
+{%  endif %}
+{#/*
+ # =============================================================================
+ # managefile: file upload
+ # =============================================================================
+ # Upload activity of the selected file.
+ #
+ # Requires creation of "this_namespace" object earlier in script.
+*/#}
+{%  if this_field.api.upload %}
+$("#btn_" + $.escapeSelector("{{ this_field_id }}" + "_upload")).click(function(){
+{#/* Check that we have the file content. */#}
+    if (this_namespace.upload_file_content) {
+        ajaxCall("{{ field.api.upload }}", {'content': this_namespace.upload_file_content,'target': '{{ this_field_id }}'}, function(data,status) {
+            if (data['error'] !== undefined) {
+{#/*                      error saving */#}
+                    stdDialogInform(
+                        "{{ lang._('Status') }}: " + data['status'],
+                        data['error'],
+                        "{{ lang._('OK') }}",
+                        function(){},
+                        "warning"
+                    );
+            } else {
+{#/*            Clear the file content since we're done, then save, reload, and tell user. */#}
+                this_namespace.upload_file_content = null;
+                saveFormAndReconfigure($("#btn_" + $.escapeSelector("{{ this_field_id }}" + "_upload")));
+                stdDialogInform(
+                    "{{ lang._('File Upload') }}",
+                    "{{ lang._('Upload of ') }}"+ this_namespace.upload_file_name + "{{ lang._(' was successful.') }}",
+                    "Ok"
+                );
+{#/*            No error occurred, so let set the setting for storage in the config. */#}
+                $("#" + $.escapeSelector("{{ this_field_id }}")).val(this_namespace.upload_file_name);
+            }
+        });
+    }
+});
+{%  endif %}
+{#/*
+ # =============================================================================
+ # managefile: file download
+ # =============================================================================
+ # Download activity of the file that was uploaded.
+*/#}
+{%  if this_field.api.download %}
+$("#btn_" + $.escapeSelector("{{ this_field_id }}") + "_download").click(function(){
+    window.open('{{ this_field.api.download }}/{{ this_field_id }}');
+{#/*    # Use blur() to force the button to lose focus.
+        # This addresses a UI bug where after clicking the button, and after dismissing
+        # the save dialog (either save or cancel), upon returning to the browser window
+        # the button lights up, and displays the tooltip. It then gets stuck like that
+        # after the user clicks somewhere in the browser window.
+        # This appears to only happen on the download activity. */#}
+    $(this).blur()
+});
+{%          endif %}
+{#/*
+ # =============================================================================
+ # managefile: file remove
+ # =============================================================================
+ # Removing a file that was uploaded.
+ #
+ # Dialog structure came from the web proxy plugin.
+*/#}
+{%  if this_field.api.remove %}
+$("#btn_" + $.escapeSelector("{{ this_field_id }}") + "_remove").click(function() {
+    BootstrapDialog.show({
+        type:BootstrapDialog.TYPE_DANGER,
+        title: "{{ lang._('Remove File') }} ",
+        message: "{{ lang._('Are you sure you want to remove this file?') }}",
+        buttons: [{
+            label: "{{ lang._('Yes') }}",
+            cssClass: 'btn-primary',
+            action: function(dlg){
+                dlg.close();
+                ajaxCall("{{ this_field.api.remove }}", {'field': '{{ this_field_id }}'}, function(data,status) {
+                    if (data['error'] !== undefined) {
+                        stdDialogInform(
+                            data['error'],
+                            "{{ lang._('API Returned:') }}\n" + data['status'],
+                            "{{ lang._('OK') }}",
+                            function(){},
+                            "warning"
+                        );
+                    } else {
+                        if ($("label[id='lbl_" + $.escapeSelector("{{ this_field_id }}") + "']").length){
+                            $("label[id='lbl_" + $.escapeSelector("{{ this_field_id }}") + "']").text("{{ lang._('Current: ') }}");
+                        } else {
+                            $("#" + $.escapeSelector("{{ this_field_id }}") +
+                              ",input[for=" + $.escapeSelector("{{ this_field_id }}") +
+                              "][type=text]").val("");
+                        }
+                        saveFormAndReconfigure($("#btn_" + $.escapeSelector("{{ this_field_id }}") + "_remove"));
+                        stdDialogInform(
+                            "{{ lang._('Remove file') }}",
+                            "{{ lang._('Remove file was successful.') }}",
+                            "{{ lang._('Ok') }}"
+                        );
+                    }
+                });
+            }
+        }, {
+            label: "{{ lang._('No') }}",
+            action: function(dlg){
+                dlg.close();
+            }
+        }]
+    });
+});
+{%  endif %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/onoff.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/onoff.volt
@@ -1,0 +1,183 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ # -----------------------------------------------------------------------------
+ #}
+
+{#
+ # This is a partial for an 'onoff' field.
+ #
+ # This field is very similar to a radio button with the 'button-group' built-in style,
+ # however, only includes two pre-defined buttons: On, Off
+ #
+ # The same button could be defined manually as a radio button, but this is just a shortcut.
+ #
+ # This field supports field control.
+ #
+ # Example usage in an form XML:
+ # <field>
+ #   <id>enabled</id>
+ #   <label>Enable DNSCrypt Proxy</label>
+ #   <help>This will enable the dnscrypt-proxy service.</help>
+ #   <type>onoff</type>
+ # </field>
+ #
+ # Example usage in form XML (with controls):
+ # <field>
+ #     <id>blocked_names_enabled</id>
+ #     <type>onoff</type>
+ #     <label>Enable Blocked Names</label>
+ #     <help>Control the blacklist functionality.</help>
+ #     <control>
+ #         <action on_set="1" type="field" do_state="enabled">settings.blocked_names_type</action>
+ #         <action on_set="1" type="field" do_state="enabled">settings.blocked_names_logging</action>
+ #         <action on_set="0" type="field" do_state="disabled">settings.blocked_names_type</action>
+ #         <action on_set="0" type="field" do_state="disabled">settings.blocked_names_file_external</action>
+ #         <action on_set="0" type="field" do_state="disabled">settings.blocked_names_file_manual</action>
+ #         <action on_set="0" type="field" do_state="disabled">settings.blocked_names_logging</action>
+ #         <action on_set="0" type="field" do_state="disabled">blocked_names_internal_entries</action>
+ #     </control>
+ # </field>
+ #
+ # Compatible model field types:
+ # BooleanField
+ # TextField
+ # IntegerField
+ #
+ # Intended to be used with a BooleanField in the model:
+ # <blocked_names_enabled type="BooleanField">
+ #     <required>Y</required>
+ #     <default>0</default>
+ # </blocked_names_enabled>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/onoff",[
+ #     'this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ #
+ #}
+
+{# We define a hidden input to hold the
+   value of the setting from the config #}
+<input type="text"
+       class="form-control hidden"
+       id="{{ this_field_id }}"
+       readonly="readonly">
+<div class="btn-group btn-group-xs" data-toggle="buttons">
+{%  for this_key, this_value in [ 'On': 1 , 'Off': 0 ] %}
+  <label class="btn btn-default">
+    <input type="radio"
+           name="rdo_{{ this_field_id }}"
+           value="{{ this_value }}"/>
+{# Use non-breakable spaces to give the label some breathing room. #}
+             &nbsp;{{ lang._('%s')|format (this_key) }}&nbsp;
+  </label>
+{%  endfor %}
+</div>
+<script>
+{#/* =============================================================================
+  # field control
+  # ==============================================================================
+  # This will attach a change event which will call the toggle function based
+  # on the configuration specified in the XML for this field.
+  # An example control structure for an on/off switch:
+  # <control>
+  #   <action on_set="1" type="field" do_state="enabled">settings.listen_addresses</action>
+  #   <action on_set="0" type="field" do_state="disabled">settings.listen_addresses</action>
+  # </control>
+  # XXX Maybe add support for attr/sub-element definition style.
+*/#}
+{%  if this_field.control %}
+{%      if this_field.control.action %}
+{#/* Attach to the element associated with the field id,
+     or the text field associated with the radio buttons */#}
+    $("#" + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/* This prevents the field from acting out if it is in a disabled state. */#}
+        if ($(this).hasClass("disabled") == false) {
+{#/* This pulls the on_set key values out of all of the field's attributes,
+    and then creates an array of the unique values. */#}
+{%              set on_set_values_xml = this_field.control.xpath('action/@on_set') %}
+{#/* {%              set value_list = [] %} */#}
+{#/* {%              set value_list_array = [] %} */#}
+{%              for xml_node in on_set_values_xml %}
+<?php $value_list_array[] = $xml_node->__toString() ?>
+{%              endfor %}
+<?php $value_list = array_unique($value_list_array); ?>
+{#/*  Iterate through the values we found to start building our if blocks. */#}
+{%                  for on_set in value_list %}
+{#/*  Start if statments looking at different value based on field type */#}
+            if ($(this).val() == "{{ on_set }}") {
+{#/*  Iterate through the fields only if the "on_set" value
+      matches that of the current for loop's "on_set" variable. */#}
+{%                  for target_field in this_field.control.action if target_field['on_set'] == on_set %}
+{#/*  We use the field's value so we don't have to have a line
+      of code for each version, check first that they're OK. */#}
+{%                      if target_field['do_state'] in [ "disabled", "enabled", "hidden", "visible" ] %}
+                toggle("{{ target_field }}", "{{ target_field['type'] }}", "{{ target_field['do_state'] }}");
+{%                      endif %}
+{%                  endfor %}
+            }
+{%              endfor %}
+        }
+    });
+{%      endif %}
+{%  endif %}
+{#/*
+ # =============================================================================
+ # radio: click activity
+ # =============================================================================
+ # Click event for radio type objects
+ # Store which radio button was selected, since this value will be dynamic depending on which radio button is clicked.
+ # This looks a bit strange because all of the radio input tags have the same name attribute,
+ # and differ in the content of the surrounding <label> tag, and value attribute. So when this is clicked,
+ # it sets the value of the field to be the same as the value of the radio button that was selected.
+ # Then we trigger a change event to set any enable/disabled fields.
+*/#}
+    $('input[name=rdo_' + $.escapeSelector("{{ this_field_id }}") + ']').parent('label').click(function () {
+        $('#' + $.escapeSelector("{{ this_field_id }}")).val($(this).children('input').val());
+        $('#' + $.escapeSelector("{{ this_field_id }}")).trigger("change");;
+    });
+{#/* =============================================================================
+ # radio: change activity
+ # =============================================================================
+ # Change function which updates the values of the approprite radio button.
+ */#}
+    $('#' + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/*    # Set whichever radiobutton accordingly, may already be selected.
+        # This covers the initial page load situation. */#}
+        var field_value = $('#' + $.escapeSelector("{{ this_field_id }}")).val();
+{#/*    This catches the first pass, if change event is initiated before the
+        value of the target field is set by mapDataToFormUI() */#}
+        if (field_value != "") {
+            $('input[name=rdo_' + $.escapeSelector("{{ this_field_id }}") + '][value=' + field_value + ']').parent('label').addClass("active");
+        }
+    });
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/password.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/password.volt
@@ -1,0 +1,35 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+<input
+    type="password"
+    autocomplete="new-password"
+    class="form-control {{ this_field.style|default('') }}"
+    size="{{ this_field.size|default("43") }}"
+    id="{{ this_field_id }}"
+    {{ this_field.readonly|default(false) ?
+        'readonly="readonly"' : '' }}
+>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/radio.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/radio.volt
@@ -1,0 +1,181 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # This is a partial for an 'onoff' field, which is very similar to a radio button
+ # with the 'button-group' built-in style, however, only includes two pre-defined
+ # buttons: On, Off
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+{# We define a hidden input to hold the
+   value of the setting from the config #}
+{# XXX Size shouldn't matter for this hidden field. #}
+        <input
+            type="text"
+            class="form-control hidden"
+            size="{{ this_field.size|default("50") }}"
+            id="{{ this_field_id }}"
+            readonly="readonly"
+        >
+{# Figure out if we should use a builtin style or legacy. #}
+{%      if this_field.builtin in [ 'legacy', 'button-group' ] %}
+{%          set builtin = this_field.builtin %}
+{%      else %}
+{%          set builtin = 'legacy' %}
+{%      endif %}
+{%      if builtin == 'legacy' %}
+        <div class="radio">
+{%      elseif builtin == 'button-group' %}
+        <div class="btn-group btn-group-xs" data-toggle="buttons">
+{%      endif %}
+{%      for this_button in this_field.buttons.button|default({}) %}
+{%          if builtin == 'legacy' %}
+            <label>
+{%          elseif builtin == 'button-group' %}
+            <label class="btn btn-default">
+{%          endif %}
+                <input type="radio"
+                       name="rdo_{{ this_field_id }}"
+                       value="{{ this_button['value'] }}"/>
+{# Use non-breakable spaces to give the label some breathing room. #}
+                &nbsp;{{ lang._('%s')|format (this_button) }}&nbsp;
+            </label>
+{%      endfor %}
+        </div>
+
+<script>
+{#/*
+ # =============================================================================
+ # checkbox, radio, dropdown: toggle functionality
+ # =============================================================================
+ # A toggle function for checkboxes, radio buttons, and dropdown menus.
+ # XXX This function is mostly the same for four types of fields, and maybe this could be separated into a function.
+ # XXX Maybe it could be called toggle_control().
+*/#}
+{%  if this_field.control %}
+{%      if this_field.control.action %}
+{#/*  Attach to the element associated with the field id,
+    or the text field associated with the radio buttons */#}
+$("#" + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/*  This prevents the field from acting out if it is in a disabled state. */#}
+    if ($(this).hasClass("disabled") == false) {
+{#/*  This pulls the on_set key values out of all of the field's attributes,
+and then creates an array of the unique values. */#}
+{%          set on_set_values_xml = this_field.control.xpath('action/@on_set') %}
+{%          set value_list = [] %}
+{%          set value_list_array = [] %}
+{%          for xml_node in on_set_values_xml %}
+<?php $value_list_array[] = $xml_node->__toString() ?>
+{%          endfor %}
+<?php $value_list = array_unique($value_list_array); ?>
+{#/*  Iterate through the values we found to start building our if blocks. */#}
+{%          for on_set in value_list %}
+{#/*  Start if statments looking at different value based on field type */#}
+        if ($(this).val() == "{{ on_set }}") {
+{#/*  Iterate through the fields only if the "on_set" value matches that of the current for loop's "on_set" variable. */#}
+{%              for target_field in this_field.control.action if target_field['on_set'] == on_set %}
+{#/*  We use the field's value so we don't have to have a line of code for each version, check the data from the XML is acceptible. */#}
+{%                  if target_field['do_state'] in [ "disabled", "enabled", "hidden", "visible" ] %}
+            toggle("{{ target_field }}", "{{ target_field['type'] }}", "{{ target_field['do_state'] }}");
+{%                  endif %}
+{%              endfor %}
+        }
+{%          endfor %}
+    }
+});
+{%      endif %}
+{%  endif %}
+{#/*
+ # =============================================================================
+ # radio: click activity
+ # =============================================================================
+ # Click event for radio type objects
+ # Store which radio button was selected, since this value will be dynamic depending on which radio button is clicked.
+ # This looks a bit strange because all of the radio input tags have the same name attribute,
+ # and differ in the content of the surrounding <label> tag, and value attribute. So when this is clicked,
+ # it sets the value of the field to be the same as the value of the radio button that was selected.
+ # Then we trigger a change event to set any enable/disabled fields.
+*/#}
+$('input[name=rdo_' + $.escapeSelector("{{ this_field_id }}") + ']').parent('label').click(function () {
+    $('#' + $.escapeSelector("{{ this_field_id }}")).val($(this).children('input').val());
+    $('#' + $.escapeSelector("{{ this_field_id }}")).trigger("change");;
+});
+{#/*
+ # =============================================================================
+ # radio: change activity
+ # =============================================================================
+ # Change function which updates the values of the approprite radio button.
+*/#}
+$('#' + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/*    # Set whichever radiobutton accordingly, may already be selected.
+    # This covers the initial page load situation. */#}
+    var field_value = $('#' + $.escapeSelector("{{ this_field_id }}")).val();
+{#/*    This catches the first pass, if change event is initiated before the
+    value of the target field is set by mapDataToFormUI() */#}
+    if (field_value != "") {
+        $('input[name=rdo_' + $.escapeSelector("{{ this_field_id }}") + '][value=' + field_value + ']').parent('label').addClass("active");
+    }
+});
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/select_multiple.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/select_multiple.volt
@@ -1,0 +1,27 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{% include "layout_partials/fields/select_multiple_dropdown.volt" %}

--- a/src/opnsense/mvc/app/views/layout_partials/fields/select_multiple_dropdown.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/select_multiple_dropdown.volt
@@ -1,0 +1,187 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#
+ # This partial is for use with both select_multiple and dropdown field types.
+ #
+ # These field types can be used in three primary ways:
+ # 1. Dropdwon - A dropdown box, with a pre-determined selection for the user to select one item from.
+ # 2. Select Multple (Select Picker) - Similar to the dropdown, but allows multiple selection
+ # 3. Select Multple (Tokenize) - No menu is provided, but a box with "tokenized" items is displayed.
+ #                                This allows the user to add or remove items from the list.
+ #
+ # This field support field control.
+ #
+ # Example dropdown (single selectpicker) usage in XML:
+ # <field>
+ #     <id>server_selection_method</id>
+ #     <label>Server selection method</label>
+ #     <type>dropdown</type>
+ #     <help>Select to use manual server selection options, instead of ... </help>
+ # </field>
+ #
+ # Example select_multiple (multiple selectpicker) usage in XML:
+ # <field>
+ #     <id>server_names</id>
+ #     <label>Server Names</label>
+ #     <type>select_multiple</type>
+ #     <style>selectpicker</style>
+ #     <allownew>false</allownew>
+ #     <help>Explicitely define which servers to use. With servers ... </help>
+ # </field>
+ #
+ # Example select_multiple (tokenizer)
+ # <field>
+ #     <id>listen_addresses</id>
+ #     <label>Listen Addresses</label>
+ #     <hint>127.0.0.1:5353, [::1]:5353</hint>
+ #     <help>Set the IP address and port combinations this service should ... </help>
+ #     <style>tokenize</style>
+ #     <allownew>true</allownew>
+ #     <type>select_multiple</type>
+ # </field>
+ #
+ # dropdown and select_multiple (selectpicker) are intended to be used with OptionField type in the model:
+ # <server_selection_method type="OptionField">
+ #     <required>Y</required>
+ #     <default>0</default>
+ #     <Multiple>N</Multiple>
+ #     <OptionValues>
+ #         <option value="0">Automatic</option>
+ #         <option value="1">Manual</option>
+ #     </OptionValues>
+ #     <ValidationMessage>A server selection method must be selected.</ValidationMessage>
+ # </server_selection_method>
+ #
+ # select_multiple (tokenize) is intended to be used with a list field type like CSVListField in the model:
+ # <listen_addresses type="CSVListField">
+ #     <required>Y</required>
+ #     <default>127.0.0.1:5353,[::1]:5353</default>
+ #     <Multiple>Y</Multiple>
+ # </listen_addresses>
+ #
+ # Example partial call from another volt template:
+ # {{      partial("OPNsense/Dnscryptproxy/layout_partials/fields/select_multiple",[
+ #                 'this_field': this_node,
+ #                 'this_field_id': this_field_id,
+ #                 'lang': lang,
+ #                 'params': params
+ # ]) }}
+ #
+ # List of objects expected in the environment:
+ #  this_field     : (SimpleXMLObject) a field XML node
+ #  this_field_id  : (String) the id of the field
+ #
+ # This field is structured very similarly to the select_multiple field, so a combined template is called instead.
+#}
+
+{% set this_field_style = get_xml_prop(this_field, 'style')|default('selectpicker') %}
+{% set this_field_type = get_xml_prop(this_field, 'type', true) %}
+<select
+    id="{{ this_field_id }}"
+    class="{{ this_field_style }}"
+    {{ this_field_type == 'select_multiple' ? 'multiple' : '' }}
+    data-width="{{ this_field.width|default("334px") }}"{# XXX Could this default be defined in a central location? #}
+    data-allownew="{{ this_field.allownew|default('false') }}"
+    data-sortable="{{ this_field.sortable|default('false') }}"
+    data-live-search="{{ this_field.search|default('true') }}"
+    data-actions-box="{{ this_field.actions_box|default('false') }}"
+    {{ this_field.title is defined ? 'title="' ~ this_field.title ~ '"' : '' }}
+    {{ this_field.max_options is defined ? 'data-max-options="' ~ this_field.max_options ~ '"' : '' }}
+    {{ this_field.header is defined ? 'data-header="' ~ this_field.header ~ '"' : '' }}
+    {{ this_field.hint is defined ? 'data-hint="' ~ this_field.hint ~ '"' : '' }}
+    {{ this_field.size is defined ? 'data-size="' ~ this_field.size ~ '"' : '' }}
+    {{ this_field.selected_text_format is defined ? 'data-selected-text-format="' ~ this_field.selected_text_format ~ '"' : '' }}
+    {{ this_field.separator is defined ? 'data-separator="' ~ this_field.separator ~ '"' : '' }}
+></select>
+{{ this_field_style != "tokenize" ? '<br />' : '' }}
+<a href="#"
+   class="text-danger"
+   id="clear-options_{{ this_field_id }}">
+    <i class="fa fa-times-circle"></i>
+    <small>{{ lang._('%s')|format('Clear All') }}</small>
+</a>
+{%  if this_field_style == "tokenize" %}
+&nbsp;&nbsp;
+<a href="#"
+   class="text-danger"
+   id="copy-options_{{ this_field_id }}">
+    <i class="fa fa-copy"></i>
+    <small>{{ lang._('%s')|format('Copy') }}</small>
+</a>
+&nbsp;&nbsp;
+{#  This doesn't seem to work, returns error:
+Uncaught TypeError: navigator.clipboard is undefined #}
+<a href="#"
+   class="text-danger"
+   id="paste-options_{{ this_field_id }}"
+   style="display:none">
+    <i class="fa fa-paste"></i>
+    <small>{{ lang._('%s')|format('Paste') }}</small>
+</a>
+{%  endif %}
+
+<script>
+{#/*
+ # =============================================================================
+ # toggle functionality
+ # =============================================================================
+ # A toggle function for checkboxes, radio buttons, and dropdown menus.
+*/#}
+{%  if this_field.control %}
+{%      if this_field.control.action %}
+{#/*  Attach to the element associated with the field id,
+      or the text field associated with the radio buttons */#}
+    $("#" + $.escapeSelector("{{ this_field_id }}")).change(function(e){
+{#/*  This prevents the field from acting out if it is in a disabled state. */#}
+        if ($(this).hasClass("disabled") == false) {
+{#/*  This pulls the on_set key values out of all of the field's attributes,
+      and then creates an array of the unique values. */#}
+{%                  set on_set_values_xml = this_field.control.xpath('action/@on_set') %}
+{%                  set value_list = [] %}
+{%                  set value_list_array = [] %}
+{%                  for xml_node in on_set_values_xml %}
+<?php $value_list_array[] = $xml_node->__toString() ?>
+{%                  endfor %}
+<?php $value_list = array_unique($value_list_array); ?>
+{#/*  Iterate through the values we found to start building our if blocks. */#}
+{%                  for on_set in value_list %}
+{#/*  Start if statments looking at different value based on field type */#}
+            if ($(this).val() == "{{ on_set }}") {
+{#/*  Iterate through the fields only if the "on_set" value matches that of the current for loop's "on_set" variable. */#}
+{%                      for target_field in this_field.control.action if target_field['on_set'] == on_set %}
+{#/*  We use the field's value so we don't have to have a line of code for each version, check first that they're OK. */#}
+{%                          if target_field['do_state'] in [ "disabled", "enabled", "hidden", "visible" ] %}
+                toggle("{{ target_field }}", "{{ target_field['type'] }}", "{{ target_field['do_state'] }}");
+{%                          endif %}
+{%                      endfor %}
+            }
+{%                  endfor %}
+        }
+    });
+{%      endif %}
+{%  endif %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/startstoptime.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/startstoptime.volt
@@ -1,0 +1,134 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # This is a partial for a 'startstoptime' field
+ # XXX Needs description
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+{# The structure and elements mostly came from the original
+   firewall_schedule_edit.php #}
+{# We define a hidden input to hold the
+   value of the setting from the config #}
+{%      if (this_field.start_hour_id is defined and
+            this_field.start_min_id is defined and
+            this_field.stop_hour_id is defined and
+            this_field.stop_min_id is defined) %}
+{# Make the background inherit from the row. #}
+            <table style="background-color: inherit;">
+                <tr>
+                    <td>{{ lang._('%s')|format('Start Time') }}</td>
+                    <td>{{ lang._('%s')|format('Stop Time') }}</td>
+                </tr>
+                <tr>
+{%          for time, ids in {
+                    "start":[
+                        this_field.start_hour_id,
+                        this_field.start_min_id
+                    ],
+                    "stop":[
+                        this_field.stop_hour_id,
+                        this_field.stop_min_id
+                    ]
+                } %}
+                    <td>
+                        <div>
+{# Original div used input-group class, but this causes z-index issues with the dropdown menu
+   appearing behind boxes below it. So it's been removed. #}
+{# These <select> elements will trigger dropdown boxes getting added. #}
+                            <select
+                                class="selectpicker form-control"
+                                data-width="55"
+                                data-size="10"
+                                data-live-search="true"
+                                id="{{ ids[0] }}"
+                            ></select>
+{# The setFormData() assumes all <selects> are backed by an array datatype like an OptionField type in the model.
+   When retreiving the data through the search API, it expects to receive an array. That array should
+   be the OptionValues described in the model. It will then sift through the array, and locate any
+   with the selected=>1 and mark them as such. When this field is erroneously backed by a
+   non-array type field, it results in one option being added to the list:
+   # <option value="resolve" selected="selected"></option>
+   This is a result of a "bug" in jQuery in the .each() function. Attempting to iterate through
+   an empty string will result in only the word 'resolve' being returned.
+   The following javascript code demonstrates this behavior:
+   #  var r = 0;
+   #  var str = '';
+   #  for (r in str) {
+   #     console.log(r);
+   #  } #}
+                            <select
+                                class="selectpicker form-control"
+                                data-width="55"
+                                data-size="10"
+                                data-live-search="true"
+                                id="{{ ids[1] }}"
+                            ></select>
+                        </div>
+                    </td>
+{%          endfor %}
+                </tr>
+            </table>
+{%      endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/fields/status.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/status.volt
@@ -1,0 +1,98 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # This is a partial for an 'onoff' field, which is very similar to a radio button
+ # with the 'button-group' built-in style, however, only includes two pre-defined
+ # buttons: On, Off
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+<span id="{{ this_field_id }}"
+      class="label-default label {{ this_field.style }}">
+        <i id="span_{{ this_field_id }}_progress" class="fa fa-spinner fa-pulse"></i>&nbsp;
+    {{ this_field.values['default'] }}
+</span>
+
+<script>
+$('span[id=' + $.escapeSelector("{{ this_field_id }}") + ']').change(function(e){
+    var field_value = $(this).text();
+{#/*    # This catches the first pass, if change event is initiated before the
+        # value of the target field is set by mapDataToFormUI() */#}
+    if (field_value != "") {
+{%              if field.values %}
+{%                  for this_value in field.values.children() %}
+{%                      if this_value['match'] == 'regex' %}
+        if (field_value.match(new RegExp('{{ this_value.__toString() }}'))) {
+{%                      else %}
+        if (field_value == '{{ this_value.__toString() }}') {
+{%                      endif %}
+            $(this).addClass('label-{{ this_value.getName() }}')
+            $(this).children('i').removeClass('fa fa-spinner fa-pulse');
+        }
+{%                  endfor %}
+{%              endif %}
+   }
+});
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/text.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/text.volt
@@ -1,0 +1,36 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+<input
+    type="text"
+    class="form-control {{ this_field.style }}"
+    size="{{ this_field.size|default("50") }}"
+    id="{{ this_field_id }}"
+    {{ this_field.readonly ?
+        'readonly="readonly"' : '' }}
+    {{ (this_field.hint) ?
+        'placeholder="'~this_field.hint~'"' : '' }}
+>

--- a/src/opnsense/mvc/app/views/layout_partials/fields/textbox.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/fields/textbox.volt
@@ -1,0 +1,35 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+<textarea
+    class="{{ this_field.style|default('') }}"
+    rows="{{ this_field.height|default("5") }}"
+    id="{{ this_field_id }}"
+    {{ this_field.readonly|default(false) ?
+        'readonly="readonly"' : '' }}
+    {{ this_field.hint is defined ?
+        'placeholder="'~this_field.hint~'"' : '' }}
+></textarea>

--- a/src/opnsense/mvc/app/views/layout_partials/floating/apply_changes.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/floating/apply_changes.volt
@@ -1,0 +1,146 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # XXX Need description updates
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+{#/* XXX This won't work for multiple models on the same page. This may need to support multiple models. */#}
+{#/* Look into the attachments, and see how the id's will need to change to support multiple models.
+  we can then loop through and include for each model in the XML in build_xml().
+  We could do a couple of things:
+  1. Multiple buttons, one for each model.
+  2. Single button, for all models, detects when at least one is dirty, and saves all model data (regardless of state).
+
+  The second option is more challenging as it requires evaluating all of the models, first, and then deciding the outcome after.
+  The current approach uses a direct callback. I think we'll have to do deferred objects, and build an array to figure it out. */#}
+{# Add hidden apply changes box, shown when configuration changed, but unsaved. #}
+<div class="col-xs-12" id="alt_{{ params['plugin_safe_name'] }}_apply_changes" style="display: none;">
+    <div class="alert alert-info"
+         id="alt_{{ params['plugin_safe_name'] }}_apply_changes_info"
+         style="min-height: 65px;">
+        <form method="post">
+            <button type="button"
+                    id="btn_{{ params['plugin_safe_name'] }}_apply_changes"
+                    class="btn btn-primary pull-right">
+                <b>Apply changes</b>
+                <i id="btn_{{ params['plugin_safe_name'] }}_apply_changes_progress" {# Progress spinner to activate when applying changes. #}
+                   class=""></i>
+            </button>
+        </form>
+        <div style="margin-top: 8px;">
+            {{ lang._('The %s configuration has been changed. You must apply the changes in order for them to take effect.')|format(params['plugin_label']) }}
+        </div>
+    </div>
+</div>
+
+
+<script>
+{#/*
+ # This is a toggle function to show or hide the Apply Changes section at the top of the page.
+*/#}
+$( document ).ready(function() {
+{#/* Toggle the apply changes message for when the config is dirty/clean. */#}
+    toggleApplyChanges();
+});
+
+function toggleApplyChanges(){
+    const dfObj = new $.Deferred();
+{#/*
+    # Function to check if the config is dirty and display the Apply Changes box/button */#}
+    var api_url = "/api/{{ params['plugin_api_name'] }}/settings/state";
+    ajaxCall(url=api_url, sendData={}, callback=function(data,status){
+{#/*            # when done, disable progress animation. */#}
+        if ('state' in data) {
+            var apply_field = "alt_{{ params['plugin_api_name'] }}_apply_changes";
+            if (data['state'] == "dirty"){
+{#                  # Do a slide down for a clean entrance, then scroll to show the box. #}
+                $("#" + apply_field).slideDown(1000);
+                var element = document.getElementById(apply_field);
+                const y = element.getBoundingClientRect().top + window.scrollY;
+                window.scroll({
+                  top: (y - 140),
+                  behavior: 'smooth'
+                });
+            } else if (data['state'] == "clean" ){
+{#                  # Do a slide up for a clean exit. #}
+                $("#" + apply_field).slideUp(1000);
+            }
+        }
+        dfObj.resolve();
+    });
+    return dfObj;
+}
+{#/*
+    # Apply event handler for the Apply Changes button.
+    # The ID should be unique. */#}
+$('button[id="btn_{{ params['plugin_api_name'] }}_apply_changes"]').click(function() {
+    const dfObj = new $.Deferred();
+    var this_btn = $(this);
+    busyButton(this_btn);
+    reconfigureService(this_btn, dfObj, clearButtonAndToggle, [this_btn]);
+    return dfObj;
+});
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/prefixes/form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/prefixes/form.volt
@@ -1,0 +1,33 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ # -----------------------------------------------------------------------------
+ #}
+<form id="frm_{{ this_id }}"
+      class="form-inline"
+      data-title="{{ params['title'] }}"
+      data-model-name="{{ params['model'] }}"
+      data-model-endpoint="{{ params['model_endpoint'] }}">

--- a/src/opnsense/mvc/app/views/layout_partials/rows/bootgrid.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/bootgrid.volt
@@ -1,0 +1,480 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{##
+ # This is a partial for building the bootgrid HTML table row.
+ #
+ # This is called by base_form.volt for field types 'bootgrid'
+ #
+ # Expects to receive an array by the name of this_field.
+ #
+ # The following keys may be used in this partial:
+ #
+ # this_field.id             : target for this bootgrid
+ # this_field['type']              : type of input or field. Valid types are:
+ #           bootgrid                bootgrid field
+ # this_field.api.add        : API for bootgrid to add entries
+ # this_field.api.del        : API for bootgrid to delete entries
+ # this_field.api.set        : API for bootgrid to set entries (edit/update)
+ # this_field.api.get        : API for bootgrid to get entries (edit/read)
+ # this_field.api.toggle     : API for bootgrid to toggle entries (enable/disable)
+ # this_field.api.export     : API for bootgrid to export entries
+ # this_field.api.import     : API for bootgrid to import entries
+ # this_field.api.clear      : API for clearing log files from the bootgrid
+ # this_field['columns']['column'] : array of columns for the bootgrid
+ # this_field['dialog']            : array containing the fields for the dialog
+ # this_field.label             : attribute label (visible text)
+ # this_field.help              : help text
+ # this_field['advanced']          : property "is advanced", only display in advanced mode
+ # this_field.style             : css class to add
+ #}
+{%    set this_node_id = get_xml_prop(this_node, 'id', true) %}
+{%    set this_node_label = get_xml_prop(this_node, 'label') %}
+{#      Create a safe id derived from the bootgrid id, escaping periods. #}
+{# XXX Macro this advanced/help section. #}
+<tr id="row_{{ this_node_id }}"
+    {{ this_node['advanced']|default(false) ? 'data-advanced="true"' : '' }}
+>
+    <td colspan="3">
+{%      if this_node_label %}
+        <div class="control-label" id="control_label_{{ this_node_id }}">
+{%          if this_node.help %}
+            <a
+                id="help_for_{{ this_node_id }}"
+                href="#"
+                class="showhelp"
+            >
+                    <i class="fa fa-info-circle"></i>
+            </a>
+{%          elseif this_node.help|default(false) == false %}
+            <i class="fa fa-info-circle text-muted"></i>
+{%          endif %}
+            <b>{{ lang._('%s')|format(this_node_label) }}</b>
+        </div>
+{%          if this_node.help|default(false) %}
+        <div class="hidden" data-for="help_for_{{ this_node_id }}">
+            <small>{{ lang._('%s')|format(this_node.help) }}</small>
+        </div>
+{%          endif %}
+{%      endif %}
+{# data-editDialog value must match button values on the edit dialog.
+   The bootgrid plugin uses it like:
+   $("#btn_"+editDlg+"_save").unbind('click');
+   $("#"+editDlg).modal('hide');
+   so this means that the dialog can't have
+   a . (or other unsafe) in the name since
+   it isn't escaped before using the var in a selector
+   in opnsense_bootgrid_plugin.js #}
+        <table id="bootgrid_{{ this_node_id }}"
+               class="table
+                      table-condensed
+                      table-hover
+                      table-striped
+                      table-responsive
+                      bootgrid-table"
+               data-editDialog="{{ this_node.dialog|default(false) ? 'bootgrid_dialog_' ~ this_node_id : '' }}">
+            <thead>
+                <tr>
+{%      if this_node.api.toggle %}
+                    <th data-column-id="enabled"
+                        data-width="0em"
+                        data-type="string"
+                        data-formatter="rowtoggle">
+                        {{ lang._('%s')|format('Enabled') }}
+                    </th>
+{%      endif %}
+{%      for column in this_node.columns.column %}
+{%          set data_formatter = "" %}
+                    <th
+                        data-type="{{ column['type']|default('string') }}"
+                        data-visible="{{ column['visible']|default('true') }}"
+                        data-visible-in-selection="{{ column['visible-in-selection']|default('true') }}"
+                        data-sortable="{{ column['sortable']|default('true') }}"
+                        {{ (column['id']|default('') != '') ?
+                            'data-column-id="'~column['id']~'"' : '' }}
+                        {{ (column['size']|default('') != '') ?
+                            'data-size="'~column['size']~'"' : '' }}
+                        {{ (column['data-formatter']|default('') != '') ?
+                            'data-formatter="'~column['data-formatter']~'"' : '' }}
+                        {{ (column['width']|default('') != '') ?
+                            'data-width="'~column['width']~'"' : '' }}
+                        {{ (column['width']|default('') != '') ?
+                            'width="'~column['width']~'"' : '' }}>
+                        {{ lang._('%s')|format(column|default('')) }}
+                    </th>
+{%          if loop.last %}
+                {% set last_row_index = loop.index0 %}
+{%          endif %}
+{%      endfor %}
+{# Automatically add command column if all APIs are defined, use commandsWithInfo if info API is defined. #}
+{%      if this_node.api.del and
+           this_node.api.set and
+           this_node.api.get and
+           this_node.api.add %}
+                    <th
+                        data-column-id="commands"
+                        data-formatter="{{ (this_node.api.info) ? 'commandsWithInfo' : 'commands' }}"
+                        data-sortable="false"
+                        data-width="{{ (this_node.api.info) ? '9em' : '7em' }}">
+                        {{ lang._('%s')|format('Commands') }}
+                    </th>
+{%      endif %}
+{# Column to house the UUID of each row in the table.
+   Hidden from the user by default, but can be made visible in the column select box in the top right. #}
+                    <th
+                        data-column-id="uuid"
+                        data-type="string"
+                        data-identifier="true"
+                        data-visible="false"
+                        data-visible-in-selection="true">
+                        {{ lang._('%s')|format('ID') }}
+                    </th>
+                </tr>
+            </thead>
+            <tbody
+{# XXX other places this is usually the style field. #}
+{%      if this_node.class|default('') != '' %}
+{#              # This is for if another class is specified in the form data. #}
+                class="{{ this_node.class }}"
+{%      endif %}
+{%      if this_node.style|default('') != '' %}
+{#              # This is for if another style is specified in the form data. #}
+                style="{{ this_node.style }}"
+{%      endif %}
+            ></tbody>
+            <tfoot>
+                <tr>{# Start a new row for our buttons. #}
+{%      if this_node.api.add or
+           this_node.api.del %}
+{#  We use the index from the foreach loop above
+    to put the commands one column after the last field. #}
+                    <td colspan="{{ (last_row_index + 1) }}"></td>
+                    <td>
+{%          if this_node.api.add %}
+                        <button
+                            data-action="add"
+                            type="button"
+                            class="btn btn-xs btn-default"
+                        >
+                            <span class="fa fa-plus"></span>
+                        </button>
+{%          endif %}
+{%          if this_node.api.del %}
+                        <button
+                            data-action="deleteSelected"
+                            type="button"
+                            class="btn btn-xs btn-default"
+                        >
+                            <span class="fa fa-trash-o"></span>
+                        </button>
+{%          endif %}
+                    </td>
+{%      endif %}
+{%      if this_node.api.import or
+           this_node.api.export %}
+                </tr>
+{# Close the previous row, and start a new one.
+   This still looks good even when there isn't an add/del button. #}
+                <tr>
+{# We use the index from the foreach loop above
+   to put the commands one column after the last field. #}
+                    <td colspan="{{ (last_row_index + 1) }}"></td>
+                    <td>
+{%          if this_node.api.export %}
+                        <button id="btn_bootgrid_{{ this_node_id }}_export"
+                                data-toggle="tooltip"
+                                title="{{ lang._('%s')|format('Download') }}"
+                                type="button"
+                                class="btn btn-md btn-default pull-right"
+                                style="margin-left: 6px;">
+                            <span class="fa fa-cloud-download"></span>
+                        </button>
+{%          endif %}
+{%          if this_node.api.import %}
+                        <button id="btn_bootgrid_{{ this_node_id }}_import"
+                                data-toggle="tooltip"
+                                title="{{ lang._('%s')|format('Upload') }}"
+                                type="button"
+                                class="btn btn-md btn-default pull-right">
+                            <span class="fa fa-cloud-upload"></span>
+                        </button>
+{%          endif %}
+                    </td>
+{%      endif %}
+                </tr>
+            </tfoot>
+        </table>
+{%      if this_node.api.clear %}
+        <div class="alert alert-info" role="alert" style="min-height: 65px;">
+            <form method="post">
+                <button type="button"
+                        id="btn_bootgrid_{{ this_node_id }}_clear"
+                        class="btn btn-danger pull-right"
+                        >
+                        <i class="fa fa-fw fa-trash-o"></i>
+                        &nbsp{{ lang._('Clear Log') }}
+                </button>
+            </form>
+            <div style="margin-top: 8px;">
+                {{ lang._('This log can be cleared using the button on the right.') }}
+            </div>
+        </div>
+{%      endif %}
+    </td>
+</tr>
+<script>
+{#/* =============================================================================
+ # bootgrid: UIBootgrid attachments (API definition)
+ # =============================================================================
+ # Builds out the UIBootgrid attachments according to form definition
+*/#}
+{#/* These UIBootgrid calls must execute in document.ready()
+     otherwise they will result in a 403 permission denied due to CSRF token missing. */#}
+{% if this_node.api and this_node.api.children() %}
+$( document ).ready(function() {
+    $('#' + 'bootgrid_' + $.escapeSelector("{{ this_node_id }}")).UIBootgrid({
+{%              for api in this_node.api.children()|default([]) %}
+        '{{ api.getName() }}':'{{ api }}/{{ this_node_id }}/',
+{%              endfor %}
+        'options':{
+            'selection':
+{%-             if (this_node.builtin == 'logs') -%}
+                    false
+{%-             else -%}
+                    {{- this_node.columns['selection']|default('false') }}
+{%-             endif %}
+{%              if this_node.row_count %},
+            'rowCount':[{{ this_node.row_count }}]
+{%              endif %}
+{%              if this_node.grid_options %},
+            {{- this_node.grid_options }}
+{%              endif %}
+        }
+    });
+});
+{% endif %}
+{#/*
+ # Create an event hanlder for whenever a create/update/delete call is made to the bootgrid API.
+     This isn't truly ideal but was the first successful method I've discovered.
+*/#}
+{%  if this_node.api.add or this_node.api.set or this_node.api.del  %}
+    $(document).on("ajaxSuccess", function(event, jqxhr, settings) {
+
+        if ((
+{%      for api in this_node.xpath('api/*[self::add or self::set or self::del]')|default([]) %}
+                settings.url.startsWith('{{ api }}/{{ this_node_id }}/'){% if not loop.last %} ||{%  endif %}
+
+{%      endfor %}
+            )) {
+{#/*        Run the toggle for the apply changes pane. Won't show if config isn't dirty. */#}
+            if (typeof toggleApplyChanges === "function") {
+                toggleApplyChanges();
+            }
+        }
+    });
+{%  endif %}
+{#/*
+ # =============================================================================
+ # bootgrid: import button
+ # =============================================================================
+ # Allows importing a list into a field
+{# XXX This import function is probably not exclusive to bootgrids, but could be useful in other contexts. */#}
+{%  if this_node.api.import %}
+{%      set this_node_label = get_xml_prop(this_node, 'label', true) %}
+{#/*
+ # Mostly from the Firewall alias plugin
+ #  Since base_dialog() only has buttons for Save, Close, and Cancel,
+ #  we build our own dialog using some wrapper functions, and
+ #  perform validation on the data to be imported. */#}
+    $('#btn_bootgrid_' + $.escapeSelector("{{ this_node_id }}") + '_import').click(function(){
+        let $msg = $("<div/>");
+        let $imp_file = $("<input type='file' id='btn_bootgrid_{{ this_node_id }}_select' />");
+        let $table = $("<table class='table table-condensed'/>");
+        let $tbody = $("<tbody/>");
+        $table.append(
+          $("<thead/>").append(
+            $("<tr>").append(
+              $("<th/>").text('{{ lang._('Source') }}')
+            ).append(
+              $("<th/>").text('{{ lang._('Message') }}')
+            )
+          )
+        );
+        $table.append($tbody);
+        $table.append(
+          $("<tfoot/>").append(
+            $("<tr/>").append($("<td colspan='2'/>").text(
+              "{{ lang._('Errors were encountered, no records were imported.') }}"
+            ))
+          )
+        );
+
+        $imp_file.click(function(){
+{#/*        # Make sure upload resets when new file is provided
+            # (bug in some browsers) */#}
+            this.value = null;
+        });
+        $msg.append($imp_file);
+        $msg.append($("<hr/>"));
+        $msg.append($table);
+        $table.hide();
+{#/*      # Show the dialog to the user for importing. */#}
+        BootstrapDialog.show({
+          title: "{{ lang._('Import %s')|format(this_node_label) }}",
+          message: $msg,
+          type: BootstrapDialog.TYPE_INFO,
+          draggable: true,
+          buttons: [{
+              label: '<i class="fa fa-cloud-upload" aria-hidden="true"></i>',
+              action: function(sender){
+                  $table.hide();
+                  $tbody.empty();
+                  if ($imp_file[0].files[0] !== undefined) {
+                      const reader = new FileReader();
+                      reader.readAsBinaryString($imp_file[0].files[0]);
+                      reader.onload = function(readerEvt) {
+                          let import_data = null;
+                          try {
+                              import_data = JSON.parse(readerEvt.target.result);
+                          } catch (error) {
+                              $tbody.append(
+                                $("<tr/>").append(
+                                  $("<td>").text("*")
+                                ).append(
+                                  $("<td>").text(error)
+                                )
+                              );
+                              $table.show();
+                          }
+                          if (import_data !== null) {
+                              ajaxCall("{{ this_node.api.import }}", {'data': import_data,'target': '{{ this_node_id }}' }, function(data,status) {
+                                  if (data.validations !== undefined) {
+                                      Object.keys(data.validations).forEach(function(key) {
+                                          $tbody.append(
+                                            $("<tr/>").append(
+                                              $("<td>").text(key)
+                                            ).append(
+                                              $("<td>").text(data.validations[key])
+                                            )
+                                          );
+                                      });
+                                      $table.show();
+                                  } else {
+                                      std_bootgrid_reload('bootgrid_{{ this_node_id }}')
+                                      sender.close();
+                                  }
+                              });
+                          }
+                      }
+                  }
+              }
+          },{
+             label: "{{ lang._('Cancel') }}",
+             action: function(sender){
+                sender.close();
+             }
+           }]
+        });
+    });
+{%  endif %}
+{#/*
+ # =============================================================================
+ # bootgrid: export button
+ # =============================================================================
+ # Allows exporting a list out for external storage or manupulation
+ #
+ # Mostly came from the firewall plugin.
+*/#}
+{%  if this_node.api.export %}
+    $("#btn_bootgrid_{{ this_node_id }}_export").click(function(){
+{#      Make ajax call to URL. #}
+        return $.ajax({
+            type: 'GET',
+            url: "{{ this_node.api.export }}",
+            complete: function(data,status) {
+                if (data) {
+                    var output_data = '';
+                    var ext = '';
+                    try {
+                        var response = jQuery.parseJSON(data);
+                        output_data = JSON.stringify(data, null, 2);
+                        ext = 'json';
+
+                    } catch {
+                        // Assume text
+                        output_data = data['responseText'];
+                        ext = 'txt';
+                    }
+                    let a_tag = $('<a></a>').attr('href','data:application/json;charset=utf8,' + encodeURIComponent(output_data))
+                        .attr('download','{{ this_node_id }}_export.' + ext).appendTo('body');
+
+                    a_tag.ready(function() {
+                        if ( window.navigator.msSaveOrOpenBlob && window.Blob ) {
+                            var blob = new Blob( [ output_data ], { type: "text/csv" } );
+                            navigator.msSaveOrOpenBlob( blob, '{{ this_node_id }}_export.' + ext );
+                        } else {
+                            a_tag.get(0).click();
+                        }
+                    });
+                }
+            },
+            data: { "target": "{{ this_node_id }}"}
+        });
+    });
+{%  endif %}
+{#/*
+ #=============================================================================
+ # bootgrid: clear button
+ # =============================================================================
+ # Allows clearing the log file that the bootgrid is displaying the contents of.
+ #
+*/#}
+{%  if this_node.api.clear %}
+    $("#btn_bootgrid_{{ this_node_id }}_clear").click(function(){
+        event.preventDefault();
+        BootstrapDialog.show({
+            type: BootstrapDialog.TYPE_DANGER,
+            title: "{{ lang._('Log') }}",
+            message: "{{ lang._('Do you really want to flush this log?') }}",
+            buttons: [{
+                label: "{{ lang._('No') }}",
+                action: function(dialogRef) {
+                    dialogRef.close();
+                }
+            }, {
+                label: "{{ lang._('Yes') }}",
+                action: function(dialogRef) {
+                    ajaxCall("{{ this_node.api.clear }}", {}, function(){
+                        dialogRef.close();
+                        $('#bootgrid_{{ this_node_id }}').bootgrid('reload');
+                    });
+                }
+            }]
+        });
+    });
+{%  endif %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/buttons.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/buttons.volt
@@ -1,0 +1,256 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{# old button
+<tr>
+    <td colspan="3">
+        <button
+            class="btn btn-primary" id="{{ node_id|default('') }}"
+            data-label="{{ lang._('%s') | format(node_label) }}"
+{# /usr/local/opnsense/www/js/opnsense_ui.js:SimpleActionButton() #}
+{# These fields are expected by the SimpleActionButton() to label, and attach click event. #}{#
+            data-endpoint="{{ node.api|default('') }}"
+            data-error-title="{{ lang._('%s') | format(node.error|default('')) }}"
+            data-service-widget="{{node.widget|default('')}}"
+            type="button"
+        ></button>
+    </td>
+</tr>
+#}
+{# XXX could we just assume that if dropdowns are defined that we'll be using a group? probably
+   We could assume button group if dropdown exists. We'd need to consider a few things if so.
+   Such as specification conflicts like specifying action=primary while having dropdowns.
+   Maybe throw, or silently ignore?
+   What about different button types? Are there other kinds other than "droptdown-toggle"?
+   For now will go with explicit.
+   Also button can be type="SimpleActionButton", which should be a primary style button.
+ #}
+{#
+ # Built-in buttons:
+    Save
+        Only saves the configuration, it doesn't reconfigure the service.
+    Save and Apply
+        Do save, and also reconfigure the service.
+    Save Actions (both above buttons in a drop down)
+        A group dropdown button, which offers the two above options in a dropwdown list.
+    Apply
+        This applies a save config. This is similar to what is present on the Firewall/Alias page.
+
+    Save button notes XXX
+        For dynamic creation and assignment as a built-in, the save function is going to locate the nearist parent form,
+        thus, the label, and button ids will actually have to get their info from the <model> definition. These are already
+        carried into the partial in params[].
+ #}
+{#
+<?php
+$string = <<<XML
+<button type="group" icon="fa fa-floppy-o" label="Save Sources Settings" id="save_actions">
+    <dropdown action="save" icon="fa fa-floppy-o">Save Only</dropdown>
+    <dropdown action="save_apply" icon="fa fa-floppy-o">Save and Apply</dropdown>
+</button>
+XML;
+$xml = simplexml_load_string($string);
+?>
+#}
+<tr>
+    <td colspan="3">
+{#              # We set our own style here to put the button in a place that looks good. #}
+        <div class="col-md-12">
+{%  for this_button in this_node.button %}
+{%      set this_button_id = get_xml_prop(this_button, 'id', true) %}
+{%      set this_button_type = get_xml_prop(this_button, 'type')|default('primary') %}{# Assume primary if not defined #}
+{%      set this_button_label = get_xml_prop(this_button, 'label', true) %}
+{%      set this_button_style = get_xml_prop(this_button, 'style') %}
+{%      set this_button_icon = this_button['icon']|default('') %}
+{%      if this_button_type in ['primary', 'group' ] %}
+{%          if this_button_type == 'primary' %}
+{# Action is required for primary buttons. #}
+{%              set this_button_action = get_xml_prop(this_button, 'action', true) %}
+{%          endif %}
+{%          if this_button_type == 'group' %}
+    <div class="btn-group"
+         id="{{ this_button_id }}">
+        <button type="button"
+                class="btn dropdown-toggle{{ this_button_style != '' ? " " ~ this_button_style : ' btn-default' }}"
+                data-toggle="dropdown">
+{%          elseif this_button_type == 'primary' %}
+    <button id="btn_{{ this_button_id }}_{{ this_button_action }}"
+            type="button"
+            class="btn{{ this_button_style != '' ? " " ~ this_button_style : ' btn-primary' }}"
+{%                  if this_button_action == 'SimpleActionButton' %}
+{%                      set this_button_endpoint = get_xml_prop(this_button, 'endpoint', true) %}
+            data-label="{{ this_button_label }}"
+            data-endpoint="{{ this_button_endpoint }}"
+            data-error-title="{{ this_button.error_title }}"
+            {{ this_button.service_widget is defined ?
+            'data-service-widget="' ~ this_button.service_widget ~ '"' : '' }}
+{%                  endif %}
+    >
+{%          endif %}
+        <i class="{{ this_button_icon }}"></i>
+        &nbsp<b>{{ lang._('%s') | format(this_button_label) }}</b>&nbsp
+        <i id="btn_{{ this_button_id }}_progress"></i>
+{%          if this_button_type == 'group' %}
+        <i class="caret"></i>
+{%          endif %}
+        </button>
+{%          if this_button_type == 'group' %}
+{%              if this_button.dropdown %}
+            <ul class="dropdown-menu" role="menu">
+{%                  for this_dropdown in this_button.dropdown %}
+                <li>
+                    <a id="drp_{{ this_button_id }}_{{ this_dropdown['action'] }}">
+                        <i class="{{ this_dropdown['icon'] }}"></i>
+                        &nbsp{{ lang._('%s') | format(this_dropdown['label']|default(this_dropdown[0])) }}
+                    </a>
+                </li>
+{%                  endfor %}
+            </ul>
+{%              endif %}
+{%          endif %}
+{%          if this_button_type == 'group' %}
+    </div>{# close the button group div #}
+{%          endif %}
+{%      endif %}
+{%  endfor %}
+        </div>{# clode div for style override #}
+    </td>
+</tr>
+
+
+<script>
+{#/*
+ # =============================================================================
+ # buttons: process any buttons accordingly for this field.
+ # =============================================================================
+ # Mainly for attaching SimpleActionButton function/event.
+ #
+ # XXX I don't really like how the confirm_dialog built-in is located here. Maybe it should be a function by itself,
+ # and stored in js/funcitons.volt for now. All we'd need to do here is pass it the values from the XML,
+ # title, message, and the selected button (this_button).
+*/#}
+{#/* Re-running through the buttons to create scripts. This keeps the javascript separate from the HTML above. */#}
+{%  for this_button in this_node.button %}
+{%      set this_button_action = get_xml_prop(this_button, 'action') %}
+{%      set this_button_id = get_xml_prop(this_button, 'id', true) %}
+{%      if this_button_action == 'SimpleActionButton' %}
+        let this_button = $('button[id="btn_' + $.escapeSelector('{{ this_button_id }}') + '_SimpleActionButton"]')
+    this_button.SimpleActionButton({
+{#/*    We're defining onPreAction here in order to display a confirm dialog
+        before executing the button's API call. */#}
+        onPreAction:
+{%          if this_button['builtin'] == 'confirm_dialog' %}
+        function () {
+{#/*        We create a defferred object here to hold the function
+            from completing before input is received from the user. */#}
+            const dfObj = new $.Deferred();
+{#/*        stdDialogConfirm() doesn't return the result, i.e. cal1back
+            If the user clicks cancel it doesn't execute callback(), so
+            so it never comes back to this function. There is no way to
+            clean up the spinner on the button if the user clicks cancel.
+            So we're using the wrapper BootstrapDialog.confirm() directly. */#}
+            BootstrapDialog.confirm({
+                title: '{{ lang._('%s')|format(this_button.confirm_title) }} ',
+                message: '{{ lang._('%s')|format(this_button.confirm_message) }}',
+                type: BootstrapDialog.TYPE_WARNING,
+                btnOKLabel: '{{ lang._('Yes') }}',
+                callback: function (result) {
+                    if (result) {
+{#/*                    User answered yes, we can resolve dfObj now. */#}
+                        dfObj.resolve();
+                    } else {
+{#/*                    User answered no, clean up the spinner added by SimpleActionButton(), and then do nothing. */#}
+                        this_button.find('.reload_progress').removeClass("fa fa-spinner fa-pulse");
+                    }
+                }
+            });
+{#/*        This is used to prevent the function from completeing before
+            getting input from the user first. Only gets returned after
+            the dialog box has been dismissed. */#}
+            return dfObj;
+        }
+{%          else %}
+            {{ this_button.onpreaction|default('undefined') }}
+{%          endif %}
+,
+        onAction: {{ this_button.onaction|default('undefined') }}
+    });
+{%      endif %}
+{#/* XXX This is really specific to how the save/save and apply button is intended to be structured.
+     These definitely need to be changed to functions so that they're more flexible. This whole section is very specific. */#}
+{%          for this_dropdown in this_button.dropdown %}
+/*
+{{ dump(this_dropdown) }}
+*/
+{%              set this_dropwdown_action = get_xml_prop(this_dropdown, 'action', true) %}
+{%              if this_dropwdown_action == 'save_form' %}
+        $('a[id="drp_' + $.escapeSelector('{{ this_button_id }}') + '_save_form"]').click(function() {
+            const dfObj = new $.Deferred();
+            if ($(this).attr('type') == "button") {
+                var this_btn = $(this);
+            } else {
+                var this_btn = $(this).closest('div').find('button').first();
+            }
+{#/*    # Turn on the spinner animation for the button to indicate activity. */#}
+            busyButton(this_btn);
+            var models = $('form[id^="frm_"][data-model]').map(function() {
+{#          # Create a deferred object to pass to the function and wait on. #}
+            const model_dfObj = new $.Deferred();
+            saveForm($(this), model_dfObj);
+            return model_dfObj
+            });
+            $.when(...models.get()).then(function() {
+                dfObj.resolve();
+            });
+{#/*    # Clear the button state, and trigger an Apply toggle check. */#}
+            clearButtonAndToggle(this_btn)
+
+            return dfObj;
+        });
+{%              elseif this_dropwdown_action == 'save_form_apply' %}
+        $('a[id="drp_' + $.escapeSelector('{{ this_button_id }}') + '_save_form_apply"]').click(function() {
+        const reconObj = new $.Deferred();
+        var this_btn = $(this);
+
+        busyButton(this_btn);
+
+        var models = $('form[id^="frm_"][data-model]').map(function() {
+{#          # Create a deferred object to pass to the function and wait on. #}
+            const model_dfObj = new $.Deferred();
+            saveForm($(this), model_dfObj);
+            return model_dfObj
+        });
+        $.when(...models.get()).then(function() {
+{#/*        # when done, disable progress animation. */#}
+            reconfigureService(this_btn, reconObj, clearButtonAndToggle, [this_btn]);
+            dfObj.resolve();
+        });
+        return recon_dfObj;
+    });
+{%              endif %}
+{%          endfor %}
+{%  endfor %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/command.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/command.volt
@@ -1,0 +1,209 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{%  set this_node_id = get_xml_prop(this_node, 'id', true) %}
+{%  set this_node_description = get_xml_prop(this_node, 'label') %}
+{{ partial("OPNsense/Dnscryptproxy/layout_partials/rows/header",[
+        'this_node': this_node,
+        'lang': lang
+]) }}
+{# XXX Maybe add a header with the description value from the <command> element. #}
+{#      Create a safe id derived from the bootgrid id, escaping periods. #}
+{# XXX Make safe_id procedure a macro. #}
+{# XXX Maybe close previous table and open new if the colspan appraoch doesn't pan out. #}
+<?php $safe_id = preg_replace('/\./','_',$this_node_id); ?>
+{%  for this_parameter in this_node.parameters.parameter %}
+{%      set this_parameter_id = safe_id ~ "_" ~ get_xml_prop(this_parameter, 'id', true) %}
+{%      set this_parameter_type = get_xml_prop(this_parameter, 'type', true) %}
+{%      set this_parameter_style = get_xml_prop(this_parameter, 'style') %}
+{%      set this_parameter_size = get_xml_prop(this_parameter, 'size') %}
+<tr id="row_{{ this_parameter_id }}"
+    {{ this_node['advanced']|default(false) ? 'data-advanced="true"' : '' }}>
+{# ----------------------- Column 1 - Item label ---------------------------- #}
+    <td colspan="1">
+        <div class="control-label" id="control_label_{{ this_field_id }}">
+{%      if this_parameter.help %}
+{# Add the help icon if help is defined. #}
+            <a id="help_for_{{ this_parameter_id }}"
+                       href="#"
+                       class="showhelp">
+                        <i class="fa fa-info-circle"></i>
+                    </a>
+{%      else %}
+{# Add a "muted" help icon which does nothing. #}
+                    <i class="fa fa-info-circle text-muted"></i>
+{%      endif %}
+                    <b>{{ get_xml_prop(this_parameter, 'label') }}</b>
+        </div>
+    </td>
+{# ------------------- Column 2 - Type + help message. ---------------- #}
+    <td colspan="2">
+{# Built-in: input field for the user to enter in values to send to the command. #}
+{%      if this_parameter_type == "text" %}
+    <input id="inpt_{{ this_parameter_id }}_command"
+           class="form-control {{ this_parameter_style }}"
+           type="text"
+           size="{{this_parameter_size|default("36")}}"
+           style="height: 34px;
+                  padding-left:11px;
+                  display: inline;"/>
+{# XXX     ^^^^ Migrate this style to CSS #}
+{# Built-in: selectpicker (dropdown box) with various selections #}
+{%      elseif this_parameter_type == "selectpicker" %}
+    <select id="{{ this_parameter_id }}"
+            class="selectpicker {{ this_parameter.style }}"
+            data-size="{{ this_parameter.size|default(10) }}"
+            data-width="{{ this_parameter.width|default("334px") }}"
+            data-live-search="true"
+            {{ this_parameter.separator is defined ?
+            'data-separator="'~this_parameter.separator~'"' : '' }}>
+{%          for option in this_parameter.options.option %}
+                    <option value="{{ lang._('%s')|format(option) }}">
+                        {{ lang._('%s')|format(option) }}
+                    </option>
+{%          endfor %}
+                </select>
+{# Built-in: creates XXX I don't know what this is here for. #}
+{%      elseif this_parameter_type == "field" %}
+    <input id="{{ this_parameter_id }}"
+           class="form-control {{ this_parameter.style }}"
+           type="text"
+           size="{{ this_parameter.size|default("50") }}"
+           {{ this_parameter.readonly ?
+           'readonly="readonly"' : '' }}
+           {{ (this_parameter.hint) ?
+           'placeholder="'~this_parameter.hint~'"' : '' }}
+            style="height: 34px;
+                   display: inline-block;
+                   width: 161px;
+                   vertical-align: middle;
+                   margin-left: 3px;">
+{# XXX      ^^^^ style can probably go into CSS #}
+{%      endif %}
+{%      if this_parameter.help %}
+        <div class="hidden" data-for="help_for_{{ this_parameter_id }}">
+            <small>{{ lang._('%s')|format(this_parameter.help) }}</small>
+        </div>
+{%      endif %}
+    </td>
+</tr>
+<tr>
+    <td colspan="1">{# Intentionally left blank #}</td>
+    <td colspan="2">
+{%      for button in this_node.buttons.button %}
+{%          set button_id = get_xml_prop(button, 'id', true) %}
+{%          set button_label = get_xml_prop(button, 'label', true) %}
+{# https://forum.phalcon.io/discussion/19045/accessing-object-properties-whose-name-contain-a-hyphen-in-volt
+   Below we reference some variables which have dashes in their names, Volt has no built-in way to do this.
+   Using PHP to do this for now until I figure a way to get in commands to the compiler. #}
+    <button id="btn_{{ this_node_id }}_{{ button_id }}_command"
+            class="btn btn-primary"
+            type="button"
+{%              if button['action'] == "SimpleActionButton" %}
+            data-label="{{ button_label }}"
+            data-endpoint="{{ button.endpoint }}"
+            data-error-title="<?php echo $button->{'error-title'}; ?>"
+            data-service-widget="<?php echo $button->{'service-widget'}; ?>"
+{%              endif %}
+    >
+{# If SimpleActionButton no label or progress spinner, since that will be provided by SimpleActionButton. #}
+{%              if button['type'] != "SimpleActionButton" %}
+        <b>{{ lang._('%s')|format(button_label) }}</b>
+        <i id="btn_{{ this_node_id }}_{{ button_id }}_command_progress"></i>
+{%              endif %}
+    </button>
+{%      endfor %}
+    </td>
+</tr>
+{%  endfor %}
+
+
+
+
+{#
+ # Command Output area.
+ #}
+{%  if this_node.output is true %}
+<tr>
+    <td colspan="3">
+        <pre
+            id="pre_{{ this_node_id }}_command_output"
+            style="white-space: pre-wrap;"
+        >{{ this_node.placeholder_text|default('') }}</pre>
+    </td>
+</tr>
+{%  endif %}
+
+
+
+<script>
+{#/*
+ # =============================================================================
+ # command: attachments for command field types
+ # =============================================================================
+ # Attaches to the command button sets up the classes and
+ # defines the API to be called when clicked
+*/#}
+{%  for button in this_node.buttons.button %}
+{%      set button_id = this_node_id~'_'~get_xml_prop(button, 'id', true) %}
+{%      set button_label = get_xml_prop(button, 'label') %}
+$('#btn_{{ button_id }}_command').click(function(){
+    var command_input = [];
+{%      for this_parameter in this_node.parameters.parameter %}
+{%          set this_parameter_id = safe_id ~ "_" ~ get_xml_prop(this_parameter, 'id', true) %}
+{%          set this_parameter_type = get_xml_prop(this_parameter, 'type', true) %}
+{%          set this_parameter_style = get_xml_prop(this_parameter, 'style') %}
+{%          set this_parameter_size = get_xml_prop(this_parameter, 'size') %}
+{%          if this_parameter_type == "text" %}
+    command_input.push($("#inpt_" + $.escapeSelector("{{ this_parameter_id }}_command")).val());
+{%          elseif this_parameter_type == "selectpicker" %}
+    command_input = [ $("button[data-id=" + $.escapeSelector("{{ this_parameter_id }}")).attr('title') ];
+{%          endif %}
+{#/* XXX Probably not needed.
+{%              if this_node.output.__toString() == "true" %}
+//        $('#pre_{{ this_node_id }}_command_output').text("Executing...");
+{%              endif %}
+*/#}
+    $("#btn_{{ button_id }}_command_progress").addClass("fa fa-spinner fa-pulse");
+{%          if button.endpoint %}
+    ajaxCall(url='{{ button.endpoint }}', sendData={'command_input':command_input}, callback=function(data,status) {
+        if (data['status'] != "ok") {
+{%              if this_node.output.__toString() == "true" %}
+            $('#pre_{{ this_node_id }}_command_output').text(data['status']);
+{%              endif %}
+        } else {
+{%              if this_node.output %}
+            $('#pre_{{ this_node_id }}_command_output').text(data['response']);
+{%              endif %}
+        }
+{#         toggle("tr_{{ this_node_id }}_command_output", 'tr','visible' ); #}
+        $("#btn_{{ button_id }}_command_progress").removeClass("fa fa-spinner fa-pulse");
+    });
+{%          endif %}
+});
+{%      endfor %}
+{%  endfor %}
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/field.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/field.volt
@@ -1,0 +1,145 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ # -----------------------------------------------------------------------------
+ #}
+{##-
+ # This is a partial for building an HTML table row within a tab (form).
+ #
+ # This gets called by base_form.volt, and base_dialog.volt.
+ #
+ # Expects to receive an array by the name of this_field.
+ #
+ # The following keys may be used in this partial:
+ #
+ # this_field.id                : unique id of the attribute
+ # this_field.type              : type of input or field. Valid types are:
+ #           text                    single line of text
+ #           password                password field for sensitive input. The contents will not be displayed.
+ #           textbox                 multiline text box
+ #           checkbox                checkbox
+ #           dropdown                single item selection from dropdown
+ #           select_multiple         multiple item select from dropdown
+ #           hidden                  hidden fields not for user interaction
+ #           info                    static text (help icon, no input or editing)
+ #           command                 command button, with optional input field
+ #           radio                   radio buttons
+ #           managefile              upload/download/remove box for a file
+ #           startstoptime           time input for a start time, and stop time.
+ # this_field.label             : attribute label (visible text)
+ # this_field.size              : size (width in characters) attribute if applicable
+ # this_field.height            : height (length in characters) attribute if applicable
+ # this_field.help              : help text
+ # this_field.advanced          : property "is advanced", only display in advanced mode
+ # this_field.hint              : input control hint
+ # this_field.style             : css class to add
+ # this_field.width             : width in pixels if applicable
+ # this_field.allownew          : allow new items (for list) if applicable
+ # this_field.readonly          : if true, input fields will be readonly
+ # this_field.start_hour_id     : id for the start hour field
+ # this_field.start_min_id      : id for the start minute field
+ # this_field.stop_hour_id      : id for the stop hour field
+ # this_field.stop_min_id       : id for the stop minute field
+ # this_field['button_label']      : label for the command button
+ # this_field['input']             : boolean field to enable input on command field
+ # this_field['buttons']['button'] : array of buttons for radio button field
+ #}
+{# Set the field id supporting both attribute and legacy sub-element definition, giving preference to the attr method.
+   This flattens it out to a string, regardless of which one is selected.
+   Subsequent <id> sub element definitions beyond the first are ignored.
+   Multple attributes of the same name aren't possible as it's invalid XML syntax and will throw. #}
+{%  set this_field_id = get_field_id(this_node, model, lang, params) %}
+{# {%  set field_id = (this_field['id']|default(this_field.id)).__toString() %} #}
+{%  set this_field_label = get_xml_prop(this_node, 'label') %}
+{%  set this_field_type = get_xml_prop(this_node, 'type') %}
+{# This should catch the conditions of no id's defined in both attr and sub-elements. #}
+{# XXX Maybe xpath can be used to do this test? and test for other required conditions throughout the XML. #}
+{#
+{%  if this_field_id|length == 0 %}
+{# Error handling, throw will get caught by Crash Reporter and displayed to the user.
+{% set msg = lang._("Element <field> missing 'id' definition in XML:") %}
+<?php $msg .= chr(0x0A) . var_export($this_field, true); ?>
+<?php throw new \Phalcon\Mvc\View\Exception($msg); ?>
+{%  else %}
+{%     if params['model'] %}
+{# Prepend the model (if defined) onto the field id since it will be needed by mapDataToFormUI.
+{%         set this_field_id = params['model']~'.'~field_id %}
+{%     else %}
+{%         set this_field_id = field_id %}
+{%     endif %}
+#}
+{# Set up the help, and advanced text settings for this field's row. #}
+<tr id="row_{{ this_field_id }}"
+    {{ this_node.advanced ? 'data-advanced="true"' : '' }}
+    {{ this_node.hidden ? 'style="display: none;"' : '' }}>
+{# ----------------------- Column 1 - Item label ---------------------------- #}
+    <td>
+        <div class="control-label" id="control_label_{{ this_field_id }}">
+{%      if this_node.help %}
+{# Add the help icon if help is defined. #}
+            <a id="help_for_{{ this_field_id }}"
+               href="#"
+               class="showhelp">
+                <i class="fa fa-info-circle"></i>
+            </a>
+{%      else %}
+{# Add a "muted" help icon which does nothing. #}
+                <i class="fa fa-info-circle text-muted"></i>
+{%      endif %}
+                <b>{{ this_field_label }}</b>
+        </div>
+    </td>
+{# ------------------- Column 2 - Item field + help message. ---------------- #}
+    <td>
+{# Call the partial for the given field type. #}
+{# We pass in this_field_id because it's prepared earlier (before the row is created,
+   and we don't want to have to put that code in each field volt. #}
+{{      partial("layout_partials/fields/" ~ this_field_type,[
+                'this_field': this_node,
+                'this_field_id': this_field_id,
+                'lang': lang,
+                'params': params
+]) }}
+{# If help is defined, add it after the field definition so it will appear below it. #}
+{%      if this_node.help %}
+        <div
+            class="hidden"
+            data-for="help_for_{{ this_field_id }}"
+        >
+            <small>{{ lang._('%s')|format(this_node.help) }}</small>
+        </div>
+{%      endif %}
+    </td>
+{# ------------ Column 3 - Help block to display validation messages ------- #}
+{# Add a span to be used by the validator to dispay messages to the user when a validation error occurs. #}
+    <td>
+        <span
+            class="help-block"
+            id="help_block_{{ this_field_id }}"
+        ></span>
+    </td>
+</tr>
+{# {%  endif %} #}

--- a/src/opnsense/mvc/app/views/layout_partials/rows/header.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/header.volt
@@ -1,0 +1,48 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#              close table and start new one with header #}
+{%  set node_label = get_xml_prop(this_node, 'label') %}
+{%  set node_id = get_xml_prop(this_node, 'id') %}
+<tr {% if this_node.advanced|default(false)=='true' %} data-advanced="true"{% endif %}>
+    <th colspan="3">
+        <h2>
+{%              if this_node.help %}
+            <a id="help_for_hdr_{{ node_id }}" href="#" class="showhelp">
+                <i class="fa fa-info-circle"></i>
+            </a>
+{%              elseif this_node.help|default(false) == false %}
+            <i class="fa fa-info-circle text-muted"></i>
+{%              endif %}
+            {{ lang._('%s')|format(node_label) }}
+    </h2>
+{%              if this_node.help %}
+            <div class="hidden" data-for="help_for_hdr_{{ node_id }}">
+                <small>{{ lang._('%s')|format(this_node.help) }}</small>
+            </div>
+{%              endif %}
+    </th>
+</tr>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/help_or_advanced.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/help_or_advanced.volt
@@ -1,0 +1,91 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # XXX Need description update
+ #
+ # Example Usage in an XML:
+ #  <field>
+ #      <id>status</id>
+ #      <label>dnscrypt-proxy status</label>
+ #      <type>status</type>
+ #      <style>label-opnsense</style>
+ #      <labels>
+ #          <success>clean</success>
+ #          <danger>dirty</danger>
+ #      </labels>
+ #  </field>
+ #
+ # Example Model definition:
+ #  <status type=".\PluginStatusField">
+ #      <configdcmd>dnscryptproxy state</configdcmd>
+ #  </status>
+ #
+ # Example partial call in a Volt tempalte:
+ # {{ partial("OPNsense/Dnscryptproxy/layout_partials/fields/status",[
+ #     this_field':this_field,
+ #     'field_id':field_id
+ # ]) }}
+ #
+ # Expects to be passed
+ # field_id         The id of the field, includes model name. Example: settings.enabled
+ # this_field       The field itself.
+ # this_field.style A style to use by default.
+ #
+ # Available CSS styles to use:
+ # label-primary
+ # label-success
+ # label-info
+ # label-warning
+ # label-danger
+ # label-opnsense
+ # label-opnsense-sm
+ # label-opnsense-xs
+ #}
+
+<tr>
+    <td style="text-align:left">
+{%  if advanced %}
+        <a href="#">
+            <i class="fa fa-toggle-off text-danger"
+               id="show_advanced_{{ model }}">
+            </i>
+        </a> <small>{{ lang._('advanced mode') }}</small>
+{#  XXX     ^ Not sure if this space is neccessary. #}
+{%  endif %}
+    </td>
+    <td colspan="2" style="text-align:right">
+{%  if help %}
+        <small>{{ lang._('full help') }}</small>
+        <a href="#">
+            <i class="fa fa-toggle-off text-danger"
+               id="show_all_help_frm_{{ model }}">
+            </i>
+        </a>
+{%  endif %}
+    </td>
+</tr>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/separator.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/separator.volt
@@ -1,0 +1,47 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+{#              close table and start new one with header #}
+{# close the table that was started earlier, start a new table, and put an empty row #}
+        </tbody>
+    </table>
+</div>
+<!-- Table Separator -->
+<div class="table-responsive">
+    <table class="table table-striped table-condensed">
+        <colgroup>  {# We need to define again the column groups #}
+            <col class="col-md-3"/>
+            <col class="col-md-4"/>
+            <col class="col-md-5"/>
+        </colgroup>
+        <thead>
+            <tr>
+                <th colspan="3"> {# This header should span all three columns #}
+                    <br> {# This is just an empty header to create a visual space #}
+                </th>
+            </tr>
+        </thead>
+        <tbody>

--- a/src/opnsense/mvc/app/views/layout_partials/rows/span_content.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/rows/span_content.volt
@@ -1,0 +1,31 @@
+{##
+ # OPNsense® is Copyright © 2022 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+<tr>
+    <td colspan="3">
+        {{ node.content|default('') }}
+    </td>
+</tr>

--- a/src/opnsense/mvc/app/views/plugin_main.volt
+++ b/src/opnsense/mvc/app/views/plugin_main.volt
@@ -1,0 +1,117 @@
+{##
+ #
+ # OPNsense® is Copyright © 2022 – 2018 by Deciso B.V.
+ # Copyright (C) 2022 agh1467@protonmail.com
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ # 2.  Redistributions in binary form must reproduce the above copyright notice,
+ #     this list of conditions and the following disclaimer in the documentation
+ #     and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+{##
+ # This is the main template for this plugin, and service as the base for all
+ # of its pages. All of the other volt templates extend this one, allowing
+ # for easy updates, and a consistent user experience.
+ #
+ # There are variables that should be provided in the view.
+ # These are commonly set in the calling controller.
+ #
+ # Variables:
+ # plugin_safe_name string           a safe name for the plugin
+ #                                   that doesn't include any unusual characters.
+ # plugin_label     string           a plain language label for the plugin
+ #                                   for use in dialog titles, and such
+ # this_xml         SimpleXMLObject  this is the SimpleXMLObject of the form to render
+ #                                   commonly set by the calling controller
+ #}
+
+<?php ob_start(); ?>
+{# Include javascript functions for use throughout. #}
+<script>
+{% include "js/functions.volt" %}
+
+{% block data_get_map %}
+{% include "js/data_get_map.volt" %}
+{% endblock %}
+</script>
+
+{# Pull in our macro definitions. #}
+{% include "_macros.volt" %}
+{# Define some styles. #}
+{% include "_styles.volt" %}
+
+{% block body %}
+{# Build the entire page including:
+    tab headers,
+    tabs content (include fields and bootgrids),
+    and all bootgrid dialogs #}
+{{ build_xml(this_xml, lang, [
+    'plugin_api_name': plugin_api_name,
+    'plugin_safe_name': plugin_safe_name,
+    'plugin_label':plugin_label]) }}
+{% endblock %}
+
+<script>
+$( document ).ready(function() {
+
+{#/*
+    Add in any dynamic script content, functions, and other stuff. */#}
+{%   include "_script.volt" %}
+
+{#/* If no dialog message is defined, skip loading the dialog box at all. Maybe not the best place for this. */#}
+{%  if this_xml['loading_dialog_msg'] %}
+{#/*
+    Conditionally display this dialog only if we actually have data to load in mapDataToFormUI() */#}
+    if ($('[data-model][data-model-endpoint]').length) {
+        BootstrapDialog.show({
+            title: 'Loading settings',
+            closable: false,
+            message:
+                '{{ lang._('%s') | format(this_xml['loading_dialog_msg']) }}' +
+                '&nbsp&nbsp<i class="fa fa-cog fa-spin"></i>'
+            });
+    }
+{%  endif %}
+
+{% block script %}
+{% endblock %}
+
+{#/*
+    # Adds a hash tag to the URL for tabs, for example: http://opnsense/ui/plugin/settings#subtab_schedules
+    # update history on tab state and implement navigation From the firewall plugin */#}
+    if (window.location.hash != "") {
+        $('a[href="' + window.location.hash + '"]').click();
+    }
+
+    $('.nav-tabs a').on('shown.bs.tab', function (e) {
+        history.pushState(null, null, e.target.hash);
+    });
+
+{#/*
+    # Update the service controls any time the page is loaded.
+    # This makes a call to /api/{{ plugin_api_name }}/service/status */#}
+    updateServiceControlUI('{{ plugin_api_name }}');
+
+});
+</script>
+
+{# Clean up the blank lines in html output, probably inefficient, but makes things look nice when debugging. #}
+<?php  echo join("\n", array_filter(array_map(function ($i) { $o = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "", $i); if (!empty(trim($o))) {return $o;} }, explode("\n", ob_get_clean()))));  ?>


### PR DESCRIPTION
**Disclaimer: Only for demonstration purposes for the front-end volt template framework. Not ready for merge, looking for feedback regarding improvements, or different ways to do any part of this framework. It still needs lots of polish. There's comments for a lot of things, some of the comments may be incorrect. Some are just comments/questions/ideas for myself.**

I wanted to see if a conversation could be started around the Phalcon volt framework, there hasn't been any significant work on the framework for many years. Since MVC work is planned for the upcoming roadmap, this might be an appropriate time to talk about it. In working on my plugin for dnscrypt-proxy, I've built a framework based on the original one in Core. I've included the framework adapted to Core and an example of usage targeting the Dnsmasq plugin.

The main goal I had in building this framework was to reduce the need to write HTML, PHP, or Javascript directly. I didn't like the fact that I had to do this with early iterations of the dnscrypt-proxy plugin, jumping from file to file changing variable names and DOM element ids and attributes so everything matched was a huge headache, so I strived to eliminate the need to do it at all. I think this framework heavily embraces the spirit of MVC. It's intended to make it easier to rapidly develop a plugin, taking the labor out of rendering a page to look right (with the advantage of keeping styles uniform across the OPNsense UI). It keeps everything in sync, as well as makes it easy to expand the framework to render different kinds of things (e.g. rows/fields) on the page.

Here is a summary of some of the things that are done differently from the current Core framework:
1. The most major change is that the form XML is not converted to an array. After much deliberation and contemplation, I saw little value is this because it was incredibly inhibiting to flexibility of rending content on the page based on content/structure of the XML. With each new element or concept, the array needed to be changed to accommodate what was already in the XML structure. This is entirely skipped, and the XML is used as a SimpleXMLElement object instead.
2. Instead of using just partials to render, there is extensive utilization of several features of Phalcon, namely includes/partials/macros/extends/blocks. These allow for the framework to lay a solid foundation, without a plugin developer re-building from scratch each page. All that needs to happen is inherit the right files, and the plugin will build itself. The use of blocks allow for overriding specific sections of the base templates with their own blocks. Additionally, the extensive use of partials allows for easy expansion of the framework by simply adding a new file.
3. Instead of manually designing a bootgrid in HTML, creating the UIBootgrid call, defining the APIs, etc. Bootgrids are rendered entirely automatically. Bootgrid dialogs are rendered automatically. It is even possible to render bootgrids within bootgrid dialogs (see the Host Overrides dialog box). There are some logistical hurdles to overcome for this to be a successful application, but just as a proof of concept it is possible and easy to do.
4. It adds support for different kinds of 'containers' beyond tabs/subtabs, to include boxes. It also supports rendering without any containers, just fields (it just puts them in a box currently). It supports multiple tabs, multiple sets of tabs, multiple models, multiple boxes, etc. It's designed to be driven by the XML in a dynamic way with some specific restrictions (related mostly to the model or tabs, etc).
5. Also, there is some flexibility for where things are defined. In the Dnsmasq form XML, there is extensive use of element attributes, instead of defining named sub-elements for these things. This is flexible and backwards compatible. There are two macros which are mostly used to get these: get_xml_prop(), and get_field_id()
6. Also introduced is throwing in the volt for error handling. If, for example, a field has no id defined (as either an attribute or sub-element), it will throw, and return the element missing the id so it's easy to see where and what the problem is. (Kudos to whoever build the crash reporter, it's amazing, 10/10 would recommend throwing).
7. Not demonstrated here, but is noted in some of the comments for the fields, is the concept of what I'm kind of calling "field control," where activities with a field can have actions. For example, checking a box for a setting may enable or disable another field (or fields) on the page. It's flexible and dynamic and would work for fields which have a known state like checkboxes, dropdowns, radio buttons, etc.
8. Includes an "apply changes" box which can appear when saving a config without applying it. I think this will be very helpful in making the user experience uniform across the UI since currently this apply button may appear in multiple places throughout using OPNsense. If this box were to be used universally it would always appear in the same place. It would need much consideration to be universally usable though as noticed in the comment with it.

In this example for Dnsmasq, there is 0 static HTML, PHP, or Javascript. Everything is written automatically by the framework from the form XML.

To see more of the framework in action, I use most features of it in the dnscrypt-proxy plugin (I do need to update it though, what's in the repo isn't the latest), since it was what drove the need for many of them. This is just an example of the front-end parts, there are more parts for the back-end such as API functionality which I also built with the intention of making them available in Core for all plugins to use.

You should be able to try it out with the following command, then browse to Services->Dnsmasq DNS->Settings:
`opnsense-patch -a agh1467 443dd9fc9dd7845f9a4b403fbc0e64bb0c3aa402`

This will _not_ clobber the existing partials, and shouldn't impact any other functionality. It lives alongside the current framework, and is only used if called directly by using the build_xml() macro.

Future ideas:
* Making it possible for plugins to override, and include new, fields or rows (or even containers) of their own.