### PR TITLE
ipsec: Check ipsec config exists before using, closes #6411

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1270,7 +1270,7 @@ function ipsec_configure_do($verbose = false, $interface = '')
         set_single_sysctl('net.key.preferred_oldsa', '0');
     }
 
-    $ipseccfg = isset($config['ipsec']) ? $config['ipsec'] : [];
+    $ipseccfg = $config['ipsec'] ?? [];
     $a_phase1 = isset($config['ipsec']['phase1']) ? $config['ipsec']['phase1'] : [];
     $a_phase2 = isset($config['ipsec']['phase2']) ? $config['ipsec']['phase2'] : [];
     $a_client = isset($config['ipsec']['client']) ? $config['ipsec']['client'] : [];

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1270,7 +1270,7 @@ function ipsec_configure_do($verbose = false, $interface = '')
         set_single_sysctl('net.key.preferred_oldsa', '0');
     }
 
-    $ipseccfg = $config['ipsec'];
+    $ipseccfg = isset($config['ipsec']) ? $config['ipsec'] : [];
     $a_phase1 = isset($config['ipsec']['phase1']) ? $config['ipsec']['phase1'] : [];
     $a_phase2 = isset($config['ipsec']['phase2']) ? $config['ipsec']['phase2'] : [];
     $a_client = isset($config['ipsec']['client']) ? $config['ipsec']['client'] : [];


### PR DESCRIPTION
Looks like `$ipseccfg` is only used in the if condition just after this definition, and it is also wrapped in an `isset()`. This should catch when ipsec node doesn't exist in the config, set to an empty array, and then the following isset() will be looking for the named index in an empty array which will not be set.