### PR TITLE
Update dhcpd.inc to Allow Static Mapping to Not Assign Gateway to Client

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -1126,6 +1126,8 @@ EOD;
 
                 if (!empty($sm['gateway']) && $sm['gateway'] != "none" && (empty($dhcpifconf['gateway']) || $sm['gateway'] != $dhcpifconf['gateway'])) {
                     $dhcpdconf .= "  option routers {$sm['gateway']};\n";
+                } elseif ($sm['gateway'] == "none") {
+                    $dhcpdconf .= "  option routers no-gateway-assigned;\n";
                 }
 
                 $smdnscfg = "";


### PR DESCRIPTION
Apologies if there is anything wrong with this pull request - this is the first pull request I've done. Also note that I don't really know PHP (I just have a basic understanding of programming logic, and was googling stuff to figure out the syntax), so please double-check to ensure this doesn't mess anything unintended up.

See issue #6343 , particularly this post for an explanation of what I'm looking to do: https://github.com/opnsense/core/issues/6343#issuecomment-1437483299

**The problem's TL;DR:**
When creating a DHCP static mapping, the description of "Gateway" states that if you enter "none," it will not assign a gateway to that client (from the description: "Type "none" for no gateway assignment.") However, what this actually does is the same thing as leaving it blank - it omits the value from the client's static mapping in /var/dhcpd/etc/dhcpd.conf, which causes it to reference the pool's "option routers" entry, resulting in it assigning a gateway to the client anyway.


**Proposed solution:**
When looking through the dhcpd documentation, I did not see a valid value to put for "option routers" in a static mapping that would cause it to override the pool's "option routers" value to just leave it blank. In testing, though, I found that by putting an invalid hostname in for "option routers," it will not assign a hostname to the client pc (as it would need to resolve to an IP, then send that IP for the Gateway field on the client - since it cannot resolve it, it does not send an IP).

The change proposed in this pull request will make it so that if someone enters "none" for the Gateway value in a static mapping, it will add the line "option routers no-gateway-assigned;" to the static mapping's dhcpd.conf entry. As the chances of "no-gateway-assigned" resolving to an IP address in someone's environment would be essentially 0, I can't think of any issues with this. If you would like, this can be changed to any other equally-or-less-likely-to-already-be-used "hostname."


I have briefly (successfully) tested this on both a Windows-based and a Debian-based client, with OPNsense 23.1.3_4-amd64. Note that I did run into a problem with the "option domain-name-servers" being missing from pools at one point, but this appears to only have been when curl'd the dhcpd.inc from the Master branch - when I curl from the 23.1 branch and add just this change in, I do not have any issues.