### PR TITLE
Can we please leave out the time delimiter ('T') too?  Better human readability.

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -87,7 +87,7 @@
                     },
                     timestamp: function (column, row) {
                         if (row[column.id] && row[column.id].includes('.')) {
-                            return row[column.id].split('.')[0];
+                            return row[column.id].split('.')[0].replace('T', ' ');
                         }
                         return row[column.id];
                     }


### PR DESCRIPTION
Leave out delimiter ('T') from UI last updated time display for better readability.  Run together strings are less readable for we mere mortals.