### PR TITLE
Fix typo: "second-level subdir" in helptext

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -167,7 +167,7 @@
                 <id>proxy.general.cache.local.l2</id>
                 <label>Number of second-level subdirectories</label>
                 <type>text</type>
-                <help>Enter the number of first-level subdirectories for the local cache (default is 256).</help>
+                <help>Enter the number of second-level subdirectories for the local cache (default is 256).</help>
                 <advanced>true</advanced>
             </field>
             <field>


### PR DESCRIPTION
Fix help-text error, should describe "second-level" instead "first level".

Reported-by: gecko_x2 (irc)
Signed-off-by: Sami Olmari <sami@olmari.fi>