### PR TITLE
system: Handle empty DNS server gateway

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -237,6 +237,9 @@ function system_resolvconf_generate($verbose = false)
 
     /* setup static routes for DNS servers as configured */
     foreach ($routes as $host => $gateway) {
+        if (empty($gateway)) {
+            continue;
+        }
         system_host_route($host, $gateway);
     }
 


### PR DESCRIPTION
This PR fixes adds handling for empty DNS server gateway to fix ` /system_general.php: ROUTING: not a valid host gateway address: ''`.

In System -> Settings -> General a user can _optionally_ set a gateway for each DNS server. However, if no gateway is set for a DNS server the error above is thrown. This is caused by `system_host_route` being always called, even though there is no gateway set. If none is set, there's no need to setup a static route.