### PR TITLE
proxy: allow more signs for username and password

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/proxy</mount>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <description>
         (squid) proxy settings
     </description>
@@ -243,14 +243,14 @@
                 <user type="TextField">
                     <default>username</default>
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z\._\-]){1,32}$/u</mask>
-                    <ValidationMessage>Username can be up to 32 signs long. Alphanumeric characters and also dot, dash and underscore allowed.</ValidationMessage>
+                    <mask>/^([0-9a-zA-Z\._\-%@]){1,128}$/u</mask>
+                    <ValidationMessage>Username can be up to 128 signs long. Alphanumeric characters and also dot, dash, percent sign (for URL escapes), at sign and underscore allowed.</ValidationMessage>
                 </user>
                 <password type="TextField">
                     <default>password</default>
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z\._\-]){1,32}$/u</mask>
-                    <ValidationMessage>Password can be up to 32 signs long. Alphanumeric characters and also dot, dash and underscore allowed.</ValidationMessage>
+                    <mask>/^([0-9a-zA-Z\._\-%]){1,128}$/u</mask>
+                    <ValidationMessage>Password can be up to 128 signs long. Alphanumeric characters and also dot, dash, percent sign (for URL escapes) and underscore allowed.</ValidationMessage>
                 </password>
                 <port type="PortField">
                     <Required>N</Required>


### PR DESCRIPTION
- eliminate the artificial limit of length and signs which does not exist in squid
- allow in particular `@` to support `first.last@mycompany.com` as username
- all other characters can be used via URL escaping (i.e. `%20` for spaces) but this also means `%` must be written as `%%`

see http://www.squid-cache.org/Doc/config/cache_peer/