### PR TITLE
New IPSec configuration interface: XAuth PAM (group) constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /src/etc/pkg.conf
 /src/etc/pkg/**
 /src/etc/ssh/**
+/src/etc/strongswan.conf
+/src/etc/swanctl/**
 /src/lib/**
 /src/opnsense/changelog
 /src/www/wpad.dat

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.pyc
 *.sass-cache
 *.volt.php
+/src/etc/filter_geoip.conf
+/src/etc/filter_tables.conf
 /src/etc/php.ini
 /src/etc/php/**
 /src/etc/pkg.conf

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1,6 +1,7 @@
 <?php
 
 /*
+ * Copyright (C) 2023 GottemHams
  * Copyright (C) 2019 Pascal Mathis <mail@pascalmathis.com>
  * Copyright (C) 2016 Deciso B.V.
  * Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
@@ -969,7 +970,14 @@ function ipsec_write_strongswan_conf()
 
     $strongswanTree['charon']['plugins'] = [];
 
-    if (isset($a_client['enable'])) {
+    // The new-style VPN settings will take precedence over legacy ones
+    if ((new \OPNsense\IPsec\Swanctl())->getXAuthRestrictionsEnabled()) {
+        $strongswanTree['charon']['plugins']['xauth-pam'] = [
+            'pam_service' => 'ipsec',
+            'session' => 'no',
+            'trim_email' => 'yes'
+        ];
+    } elseif (isset($a_client['enable'])) {
         $net_list = [];
         if (isset($a_client['net_list'])) {
             foreach ($a_phase1 as $ph1ent) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/XauthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/XauthController.php
@@ -2,7 +2,6 @@
 
 /*
  * Copyright (C) 2023 GottemHams
- * Copyright (C) 2022 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,18 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OPNsense\IPsec;
+namespace OPNsense\IPsec\Api;
 
-class ConnectionsController extends \OPNsense\Base\IndexController
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+class XAuthController extends ApiMutableModelControllerBase
 {
-    public function indexAction()
-    {
-        $this->view->pick('OPNsense/IPsec/connections');
-        $this->view->formDialogConnection = $this->getForm('dialogConnection');
-        $this->view->formDialogLocal = $this->getForm('dialogLocal');
-        $this->view->formDialogRemote = $this->getForm('dialogRemote');
-        $this->view->formDialogChild = $this->getForm('dialogChild');
-        $this->view->formDialogPool = $this->getForm('dialogPool');
-        $this->view->formXauth = $this->getForm('xauth');
-    }
+    protected static $internalModelClass = '\OPNsense\IPsec\Swanctl';
+    protected static $internalModelName = 'swanctl';
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/xauth.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/xauth.xml
@@ -1,0 +1,22 @@
+<form>
+    <field>
+        <id>swanctl.XAuth.enabled</id>
+        <label>Enable</label>
+        <type>checkbox</type>
+        <help>Enable the below settings</help>
+    </field>
+    <field>
+        <id>swanctl.XAuth.database</id>
+        <label>Authentication database</label>
+        <type>select_multiple</type>
+        <help>Select Authentication database</help>
+    </field>
+    <field>
+        <id>swanctl.XAuth.enforceGroup</id>
+        <label>Enforce local group</label>
+        <type>select_multiple</type>
+        <help><![CDATA[Restrict access to users that are a member of least one of the selected (local) groups. <br/>
+        <b>NOTE:</b> please be aware that users which aren't administered locally will be denied when using this option.]]>
+        </help>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
@@ -1,6 +1,7 @@
 <?php
 
 /*
+ * Copyright (C) 2023 GottemHams
  * Copyright (C) 2022 Deciso B.V.
  * All rights reserved.
  *
@@ -268,5 +269,13 @@ class Swanctl extends BaseModel
             }
         }
         return $certrefs;
+    }
+
+    /**
+     * @return boolean XAuth restrictions enabled (auth database + group membership)
+     */
+    public function getXAuthRestrictionsEnabled()
+    {
+        return !empty((string)$this->XAuth->enabled);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Swanctl</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>OPNsense IPsec Connections</description>
     <items>
         <Connections>
@@ -437,5 +437,19 @@
                 </description>
             </SPD>
         </SPDs>
+        <XAuth>
+            <enabled type="BooleanField">
+                <default>0</default>
+                <Required>Y</Required>
+            </enabled>
+            <database type="AuthenticationServerField">
+                <Required>Y</Required>
+                <Multiple>Y</Multiple>
+            </database>
+            <enforceGroup type="AuthGroupField">
+                <Required>N</Required>
+                <Multiple>Y</Multiple>
+            </enforceGroup>
+        </XAuth>
     </items>
 </model>

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/connections.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/connections.volt
@@ -136,6 +136,7 @@
     <li class="active"><a data-toggle="tab" id="tab_connections" href="#connections">{{ lang._('Connections') }}</a></li>
     <li><a data-toggle="tab" href="#edit_connection" id="ConnectionDialog" style="display: none;"> </a></li>
     <li><a data-toggle="tab" href="#pools" id="tab_pools"> {{ lang._('Pools') }} </a></li>
+    <li><a data-toggle="tab" href="#xauth" id="tab_xauth"> {{ lang._('XAuth Settings') }} </a></li>
 </ul>
 <div class="tab-content content-box">
     <div id="connections" class="tab-pane fade in active">
@@ -327,6 +328,15 @@
           <hr/>
       </div>
     </div>
+    <div id="xauth" class="tab-pane fade in">
+      <div class="content-box" style="padding-bottom: 1.5em;">
+          {{ partial("layout_partials/base_form",['fields':formXauth,'id':'FormXauth','label':lang._('Edit XAuth Settings')])}}
+          <div class="col-md-12">
+              <hr />
+              <button class="btn btn-primary" id="saveAct_xauth" type="button"><b>{{ lang._('Apply') }}</b><i id="saveAct_xauth_progress"></i></button>
+          </div>
+      </div>
+    </div>
 </div>
 
 
@@ -336,3 +346,25 @@
 {{ partial("layout_partials/base_dialog",['fields':formDialogRemote,'id':'DialogRemote','label':lang._('Edit Remote')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogChild,'id':'DialogChild','label':lang._('Edit Child')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogPool,'id':'DialogPool','label':lang._('Edit Pool')])}}
+
+<script>
+$( document ).ready(function() {
+    var data_get_map = {'FormXauth':"/api/ipsec/xauth/get"};
+    mapDataToFormUI(data_get_map).done(function(data) {
+        formatTokenizersUI();
+        $('.selectpicker').selectpicker('refresh');
+    });
+
+    $("#saveAct_xauth").click(function() {
+        saveFormToEndpoint(url="/api/ipsec/xauth/set", formid='FormXauth', callback_ok=function() {
+            $("#saveAct_xauth_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/ipsec/service/reconfigure", sendData={}, callback=function(data, status) {
+                ajaxCall(url="/api/ipsec/service/status", sendData={}, callback=function(data, status) {
+                    updateServiceStatusUI(data['status']);
+                });
+                $("#saveAct_xauth_progress").removeClass("fa fa-spinner fa-pulse");
+            });
+        });
+    });
+});
+</script>


### PR DESCRIPTION
With the legacy interface we could restrict mobile users (or more likely, PAM auth in general) to certain groups. Since the new interface has you enabling XAuth on an individual remote authentication round, it makes sense to also have related settings somewhere in the vicinity. I chose a separate subtab under `Connections [new]`, since these **do affect all auth attempts** that go through Strongswan's `xauth-pam` plugin (`libcharon`'s actually though), similar to what it originally does. I did notice `swanctl.conf` allows a `groups` directive for the remote auth round, which could allow for round-specific group constraints. Unfortunately though, after messing around quite a bit with OPNsense's PAM module it seems like XAuth in general doesn't really support groups on its own. ;_;

The new-style VPN settings will take precedence over legacy ones (in some places) to try and avoid conflict. Of course this isn't 100%, since if you configure a legacy phase 1 or phase 2 then I've allowed OPNsense to still insert some config in `swanctl.conf`. But due to the overlap with the legacy mobile client settings I did make it skip a fair portion of it for **strongswan.conf**. It should still be possible to configure a VPN connection through the new interface in such a way that mobile clients can connect too. The original mobile settings are kinda insecure anyways I think, so this might even help move people to more secure settings (the new method doesn't insert any phase config itself, it only configures `charon` to interact with PAM).

Furthermore, the constraints shouldn't conflict with auth methods that aren't XAuth, since `charon` only uses OPNsense's `IPsec` auth service specifically when it's told to use the `xauth-pam` plugin. RADIUS, EAP, etc all have their own plugins so no problems there. :>

**Do note though** that I also mirrored the auth database setting, although I'm not entirely sure what the implications of it are. In my case I only have the local DB, but choosing something different might not even be relevant?