### PR TITLE
Fully sanitize HTML ID avoiding CSS selector characters

### DIFF
--- a/src/www/widgets/widgets/services_status.widget.php
+++ b/src/www/widgets/widgets/services_status.widget.php
@@ -52,18 +52,23 @@ if (isset($_POST['servicestatusfilter'])) {
         function fetch_services() {
             ajaxGet('/api/core/service/search', {}, function(data, status) {
                 if (data['rows'] !== undefined) {
+                    let $table = $('#service_widget_table');
+                    let items = {};
+                    $table.find('tr[data-service-widget-id]').each(function() {
+                        let $item = $(this);
+                        items[$item.attr('data-service-widget-id')] = $item;
+                    });
                     $.each(data['rows'], function(key, value) {
-                        /* does not like the slash in the element id */
-                        value.key = value.id.split('/').join('__');
-                        let $item = $("#service_widget_id_" + value.key);
-                        if ($item.length == 0) {
-                            $item = $("<tr>").attr('id', "service_widget_id_" + value.key);
+                        let $item = items.hasOwnProperty(value.id) ? items[value.id] : null;
+                        if (!$item) {
+                            $item = $('<tr>').attr('data-service-widget-id', value.id);
                             $item.append($('<td/>'));
                             $item.append($('<td/>'));
-                            $item.append($('<td style="width:3em;;"/>'));
-                            $item.append($('<td style="width:5em; white-space: nowrap;"/>'));
+                            $item.append($('<td style="width: 3em;"/>'));
+                            $item.append($('<td style="width: 5em; white-space: nowrap;"/>'));
                             $item.hide();
-                            $("#service_widget_table").append($item);
+                            $table.append($item);
+                            items[value.id] = $item;
                         }
                         $item.find('td:eq(0)').text(value.name);
                         $item.find('td:eq(1)').text(value.description);


### PR DESCRIPTION
It's not just the slash character that causes problems, it's really any character that has special meaning in a CSS selector.

Better to handle all characters properly. This updated PR uses a data attribute instead and removes the need to make a key from the ID.

In my case, I noticed it with `in.tftpd` (from the `os-tftp` plugin) being repeated once more every time the widget would refreshed. This is because the dot ends the ID selector and starts a class selector, causing it to create a new row (and making me think it was creating more and more processes that would crash the system).