### PR TITLE
netflow: Fix incorrect interface index

### DIFF
--- a/src/etc/rc.d/netflow
+++ b/src/etc/rc.d/netflow
@@ -69,7 +69,7 @@ netflow_setup_interface()
     # determine (snmp) ifIndex
     ifIndex=0
     found=0
-    for item in $(/sbin/ifconfig -l); do
+    for item in $(/usr/local/sbin/ifinfo | grep "^Interface" | awk '{ print $2 }'); do
        let ifIndex = ifIndex + 1  > /dev/null 2>&1
        if [ "$item" = "$interface" ]; then
            found=1

--- a/src/etc/rc.d/netflow
+++ b/src/etc/rc.d/netflow
@@ -69,7 +69,7 @@ netflow_setup_interface()
     # determine (snmp) ifIndex
     ifIndex=0
     found=0
-    for item in $(/usr/local/sbin/ifinfo | grep "^Interface" | awk '{ print $2 }'); do
+    for item in $(/usr/local/sbin/ifinfo | awk '$1 == "Interface" { print $2 }'); do
        let ifIndex = ifIndex + 1  > /dev/null 2>&1
        if [ "$item" = "$interface" ]; then
            found=1

--- a/src/opnsense/scripts/netflow/lib/parse.py
+++ b/src/opnsense/scripts/netflow/lib/parse.py
@@ -30,6 +30,7 @@ import glob
 import tempfile
 import subprocess
 import os
+import re
 from lib.flowparser import FlowParser
 
 
@@ -40,11 +41,11 @@ class Interfaces(object):
         """ construct local interface mapping
         """
         self._if_index = dict()
-        sp = subprocess.run(['/sbin/ifconfig', '-l'], capture_output=True, text=True)
-        if_index = 1
-        for line in sp.stdout.split():
-            self._if_index["%s" % if_index] = line
-            if_index += 1
+        sp = subprocess.run(['/usr/local/sbin/ifinfo'], capture_output=True, text=True)
+        interfaces = re.findall(r"Interface ([^ ]+)", sp.stdout)
+
+        for index, interface in enumerate(interfaces, start=1):
+            self._if_index["%s" % index] = interface
 
     def if_device(self, if_index):
         """ convert index to device (if found)


### PR DESCRIPTION
This PR fixes an incorrect interface index used in Netflow.
Possibly related: https://forum.opnsense.org/index.php?topic=28555.msg138715#msg138715

## Background
I noticed this bug, because because my Netflow data (both `/var/log/flowd.log` and subsequently the SQLite DB created by the aggregator) contained incorrect interface index / name information.
Looking at `flowd-reader -v /var/log/flowd.log`, I see traffic from `pppoe0` (WAN) to `vtnet1` (LAN)
However, these flows are labled `in_if 11 out_if 2`, which map to `wg0` and `vtnet1` according to `ifconfig -l`.

All flows related to `pppoe0` are therefore wrongfully displayed and stored as `wg0` and vice-versa.

## Observations

It looks like `ifconfig -l` doesn't return the interfaces according to their actual interface index.
The current behavior will cause **`wg0` to have interface index 11 and `pppoe0` to have index 12**, because they're the 11th and and 12th item:
```
# ifconfig -l
vtnet0 vtnet1 vtnet2 vtnet3 vtnet4 enc0 lo0 pflog0 pfsync0 vtnet0_vlan7 wg0 pppoe0
```

However, if we ask `if_nametoindex` for a mapping between interface name and index, the results are different:
```
# # Demo application to print interface name and index
# cat interface-index.c
#include <sys/types.h>
#include <sys/socket.h>
#include <net/if.h>
#include <stdio.h>

int main(int argc, char *argv[]) {
    unsigned int index = if_nametoindex(argv[1]);
    printf("%s has index %d\n", argv[1], index);
}
# 
# # Compile it
# cc interface-index.c -o interface-index
# 
# # Print name and index of all interfaces
# for item in $(ifconfig -l); do ./interface-index $item; done
vtnet0 has index 1
vtnet1 has index 2
vtnet2 has index 3
vtnet3 has index 4
vtnet4 has index 5
enc0 has index 6
lo0 has index 7
pflog0 has index 8
pfsync0 has index 9
vtnet0_vlan7 has index 10
wg0 has index 12
pppoe0 has index 11
```
This shows, that **`wg0` actually has index 12 and `pppoe0` index 11**.

This result is also confirmed by `netstat`:
```
root@OPNsense:~ # netstat -I pppoe0 -f link
Name    Mtu Network       Address              Ipkts Ierrs Idrop    Opkts Oerrs  Coll
pppoe  1492 <Link#11>     pppoe0             6146899     0     0  2029358     0     0
root@OPNsense:~ # netstat -I wg0 -f link
Name    Mtu Network       Address              Ipkts Ierrs Idrop    Opkts Oerrs  Coll
wg0    1412 <Link#12>     wg0                   1144     0     0     4579     2     0
```
Netgraph seems to also use these interface indices and not the ordering from `ifconfig`.

## Suggested change
Because `ifconfig` seems to not return the interfaces in their actual order, we can use `ifinfo` instead, because it actually [loops](https://github.com/opnsense/ports/blob/599d27ab039375ca2f061fb458dda0c62f9f1c6c/opnsense/ifinfo/files/ifinfo.c#L98) over the interfaces their index order.