### PR TITLE
firewall/alias: Fix progress bar default value

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -572,7 +572,7 @@
 <div id="aliases_stat"  title="{{ lang._('Current Tables Entries/Firewall Maximum Table Entries') }}">
     <div class="col-xs-1"><i class="fa fa-fw fa-info-circle"></i></div>
     <div id="entries_bar" class="progress" style="text-align: center;">
-        <div id="room_left" class="progress-bar" role="progressbar" aria-valuenow="0%" aria-valuemin="0" aria-valuemax="100" style="width: 23%;z-index: 0;"></div>
+        <div id="room_left" class="progress-bar" role="progressbar" aria-valuenow="0%" aria-valuemin="0" aria-valuemax="100" style="width: 0%; z-index: 0;"></div>
         <span class="state_text" style="position:absolute;right:0;left:0;">
         <span>{{ lang._('loading data..') }}</span>
         </span>


### PR DESCRIPTION
This PR fixes the progress bar default value.

I argue that if the actual number of entries hasn't been loaded yet, there's no reason to show `23%` per default. Additionally, this results in a flashy progress bar, even though there's no actual progress.

This is best visible when (re)loading the Firewall Alias page.

Before:

https://user-images.githubusercontent.com/46975855/232329685-40434a58-141c-4e93-a91f-4be61b722d17.mp4

After:

https://user-images.githubusercontent.com/46975855/232329702-fbb67fcd-9722-4acf-adbd-ab8f2f84ab67.mp4

