### PR TITLE
webgui: prevent PHP session gc from running early

### DIFF
--- a/src/opnsense/service/templates/OPNsense/WebGui/php.ini
+++ b/src/opnsense/service/templates/OPNsense/WebGui/php.ini
@@ -31,3 +31,4 @@ log_errors=on
 error_log=/tmp/PHP_errors.log
 date.timezone="{{system.timezone|default('Etc/UTC')}}"
 session.save_path=/var/lib/php/sessions
+session.gc_maxlifetime={{system.webgui.session_timeout|default(240)|int * 60}}

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -151,6 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $newciphers = !empty($pconfig['ssl-ciphers']) ? implode(':', $pconfig['ssl-ciphers']) : '';
 
         $restart_webgui = $config['system']['webgui']['protocol'] != $pconfig['webguiproto'] ||
+            $config['system']['webgui']['session_timeout'] != $pconfig['session_timeout'] ||
             $config['system']['webgui']['port'] != $pconfig['webguiport'] ||
             $config['system']['webgui']['ssl-certref'] != $pconfig['ssl-certref'] ||
             $config['system']['webgui']['compression'] != $pconfig['compression'] ||


### PR DESCRIPTION
With the default PHP settings, there is a 1% chance for the session gc to trigger upon the start of a session, removing session files with modification times older than 24 minutes. This can cause sessions to timeout earlier than indicated by the webgui settings.