### PR TITLE
Firewall Log Widget: Header Tweak

### DIFF
--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -237,7 +237,7 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
       <th data-column-id="interface" data-type="interface" class="text-center"><?= gettext('Interface') ?></th>
       <th data-column-id="src" data-type="source_address"><?= gettext('Source') ?></th>
       <th data-column-id="dst" data-type="destination_address"><?= gettext('Destination') ?></th>
-      <th data-column-id="dstport" data-type="destination_port"><?= gettext('Dest Port') ?></th>
+      <th data-column-id="dstport" data-type="destination_port"><?= gettext('Port') ?></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
"Interface" header makes column way wider then need be.
Abbreviate "Interface" with "I/F" to reduce unnecessary column width and line wrap.