### PR TITLE
unbound: Added cache-max-negative-ttl setting

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
@@ -326,6 +326,17 @@
         </help>
     </field>
     <field>
+        <id>unbound.advanced.cachemaxnegativettl</id>
+        <label>Maximum Negative TTL for RRsets and messages</label>
+        <type>text</type>
+        <help>
+            Configure a maximum Negative Time to live in seconds for RRsets and messages in the cache.
+            When the internal TTL expires the negative response cache item is expired.
+            This can be configured to force the resolver to query for data more often in case you wont
+            get a valid answer.
+        </help>
+    </field>
+    <field>
         <id>unbound.advanced.cacheminttl</id>
         <label>Minimum TTL for RRsets and messages</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -186,6 +186,8 @@
             </jostletimeout>
             <cachemaxttl type="NumericField">
             </cachemaxttl>
+            <cachemaxnegativettl type="NumericField">
+            </cachemaxnegativettl>
             <cacheminttl type="NumericField">
             </cacheminttl>
             <infrahostttl type="NumericField">

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/advanced.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/advanced.conf
@@ -31,6 +31,7 @@ log-local-actions: {{ set_boolean(OPNsense.unboundplus.advanced.loglocalactions)
 {{ set_numeric_value('outgoing-range', OPNsense.unboundplus.advanced.outgoingrange) }}
 {{ set_numeric_value('jostle-timeout', OPNsense.unboundplus.advanced.jostletimeout) }}
 {{ set_numeric_value('cache-max-ttl', OPNsense.unboundplus.advanced.cachemaxttl) }}
+{{ set_numeric_value('cache-max-negative-ttl', OPNsense.unboundplus.advanced.cachemaxnegativettl) }}
 {{ set_numeric_value('cache-min-ttl', OPNsense.unboundplus.advanced.cacheminttl) }}
 {{ set_numeric_value('infra-host-ttl', OPNsense.unboundplus.advanced.infrahostttl) }}
 infra-keep-probing: {{ set_boolean(OPNsense.unboundplus.advanced.infrakeepprobing) }}


### PR DESCRIPTION
See: https://forum.opnsense.org/index.php?topic=23747.0

Maximum negative TTL for cached records.
Useful if the cloud isn't as fast as you are.

For example, if you add records to CloudFlare it may take a few moments before the records are propagated.
If the negative TTL on that domain 1h, you need to flush your local cache (or wait an hour).

The setting forces a max TTL on negative responses (NXDOMAIN responses).

before:
```
> dig test.tcdn.nl     

...
;; QUESTION SECTION:
;test.tcdn.nl.			IN	A

;; AUTHORITY SECTION:
tcdn.nl.		3600	IN	SOA	donna.ns.cloudflare.com. dns.cloudflare.com. 2300657040 10000 2400 604800 3600
...
```

after added setting set to 30:
```
>dig test.tcdn.nl     

...
;; QUESTION SECTION:
;test.tcdn.nl.			IN	A

;; AUTHORITY SECTION:
tcdn.nl.		30	IN	SOA	donna.ns.cloudflare.com. dns.cloudflare.com. 2300657040 10000 2400 604800 3600
...
```

locally tested and working against 23.1.6