### PR TITLE
Fix issue with route add command

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -687,7 +687,7 @@ function system_routing_configure($verbose = false, $interface = null, $monitor 
                     mwexec("/sbin/route delete {$cmd}", true);
                     if ($fargw) {
                         mwexecf('/sbin/route delete -%s %s -interface %s ', [$ipproto, $gatewayip, $interfacegw], true);
-                        mwexecf('/sbin/route add %s -%s -interface %s', [$ipproto, $gatewayip, $interfacegw], true);
+                        mwexecf('/sbin/route add -%s %s -interface %s', [$ipproto, $gatewayip, $interfacegw], true);
                     } elseif (is_linklocal($gatewayip) && strpos($gatewayip, '%') === false) {
                         $gatewayip .= "%{$interfacegw}";
                     }


### PR DESCRIPTION
The hyphen was added in the wrong place causing the 'route add' command to error out. This was causing it to run

`route add inet -'IP' 'GW'`

when it should be

`route add -inet 'IP ' GW'`

Reference: https://github.com/opnsense/core/pull/6580#issue-1729389899