### PR TITLE
src: remove noodp and noydir, they do not serve any SEO purpose now

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -320,7 +320,7 @@ function display_error_form($text)
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="robots" content="noindex, nofollow, noodp, noydir" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="keywords" content="" />
     <meta name="description" content="" />
     <meta name="copyright" content="" />
@@ -360,7 +360,7 @@ function display_login_form($Login_Error)
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="robots" content="noindex, nofollow, noodp, noydir" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="keywords" content="" />
     <meta name="description" content="" />
     <meta name="copyright" content="" />

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="robots" content="noindex, nofollow, noodp, noydir" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="keywords" content="" />
     <meta name="description" content="" />
     <meta name="copyright" content="" />

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/htdocs_default/index.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-        <meta name="robots" content="noindex, nofollow, noodp, noydir" />
+        <meta name="robots" content="noindex, nofollow" />
         <meta name="keywords" content="" />
         <meta name="description" content="" />
         <meta name="copyright" content="" />

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -34,7 +34,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="robots" content="noindex, nofollow, noodp, noydir" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="keywords" content="" />
     <meta name="description" content="" />
     <meta name="copyright" content="" />


### PR DESCRIPTION
Ref: https://searchfacts.com/noodp-noydir-meta-tags/

I did learn this right now, and found all occurrences to remove them as the projects are long gone