### PR TITLE
Removed unique constraint on Virtual IP addresses

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vip.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vip.xml
@@ -24,12 +24,6 @@
             <subnet type=".\VipNetworkField">
                 <!--required, but validated in model -->
                 <Required>N</Required>
-                <Constraints>
-                    <check001>
-                        <ValidationMessage>Address already assigned.</ValidationMessage>
-                        <type>UniqueConstraint</type>
-                    </check001>
-                </Constraints>
             </subnet>
             <subnet_bits type=".\VipNetworkField">
                 <!--required, but validated in model -->


### PR DESCRIPTION
In IPv6 deployment scenarios, using `fe80::1/10` is an easy circumvention of the lack of [tokenized interface identifiers](https://datatracker.ietf.org/doc/id/draft-chown-6man-tokenised-ipv6-identifiers-02.txt) across multiple subnets and makes remembering a gateway address *much* easier. As `fe80::1` is a link-local address and Opnsense/BSD already use [zone identifiers](https://www.rfc-editor.org/rfc/rfc6874) to separate link-local addresses on individual interfaces, there shouldn't be a problem assigning this address to multiple interfaces.

However, the OpnSense model blocks me from assigning this address as a virtual IP to multiple interfaces:

![image](https://github.com/opnsense/core/assets/1315327/06b7d65f-e6bf-4253-b01c-3cb31142b052)

This PR removes the constraint in the model to not be able to have the same virtual IP assigned to multiple interfaces.

Tested on OPNsense 23.1.9-amd64 using the following config:

![image](https://github.com/opnsense/core/assets/1315327/e92c1cc0-ae74-4d1f-82e1-f8b524d4bffe)

Yields the following `ifconfig` output:

<pre>
igb0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	description: Internal (lan)
	options=4800028<VLAN_MTU,JUMBO_MTU,NOMAP>
	ether f4:90:ea:00:bd:54
	inet6 fe80::f690:eaff:fe00:bd54%igb0 prefixlen 64 scopeid 0x1
	inet6 2001:1c00:2503:a600:f690:eaff:fe00:bd54 prefixlen 64
	<b>inet6 fe80::1%igb0 prefixlen 10 scopeid 0x1</b>
	inet 10.100.0.1 netmask 0xffffff00 broadcast 10.100.0.255
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
[...]
vlan0.0.2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	description: DMZ (opt1)
	options=4000000<NOMAP>
	ether f4:90:ea:00:bd:54
	inet 10.100.2.1 netmask 0xffffff00 broadcast 10.100.2.255
	inet6 fe80::f690:eaff:fe00:bd54%vlan0.0.2 prefixlen 64 scopeid 0x9
	inet6 2001:1c00:2503:a602:f690:eaff:fe00:bd54 prefixlen 64
        <b>inet6 fe80::1%vlan0.0.2 prefixlen 10 scopeid 0x9</b>
	groups: vlan
	vlan: 2 vlanproto: 802.1q vlanpcp: 0 parent interface: igb0
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
[...]
vlan0.0.5: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	description: Guest (opt2)
	options=4000000<NOMAP>
	ether f4:90:ea:00:bd:54
	inet6 fe80::f690:eaff:fe00:bd54%vlan0.0.5 prefixlen 64 scopeid 0xb
	inet6 2001:1c00:2503:a605:f690:eaff:fe00:bd54 prefixlen 64
	<b>inet6 fe80::1%vlan0.0.5 prefixlen 10 scopeid 0xb</b>
	inet 10.100.5.1 netmask 0xffffff00 broadcast 10.100.5.255
	groups: vlan
	vlan: 5 vlanproto: 802.1q vlanpcp: 0 parent interface: igb0
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
[...]
</pre>

and the following `netstat -rn` output:

<pre>
[...]
Internet6:
Destination                       Gateway                       Flags     Netif Expire
default                           fe80::201:5cff:fe70:9446%igb1 UG         igb1
::1                               link#5                        UHS         lo0
[...]
fe80::/10                         link#1                        U          igb0
fe80::%igb0/64                    link#1                        U          igb0
<b>fe80::1%igb0                      link#1                        UHS         lo0</b>
fe80::f690:eaff:fe00:bd54%igb0    link#1                        UHS         lo0
fe80::%igb1/64                    link#2                        U          igb1
fe80::f690:eaff:fe00:bd55%igb1    link#2                        UHS         lo0
fe80::%lo0/64                     link#5                        U           lo0
fe80::1%lo0                       link#5                        UHS         lo0
fe80::%vlan0.0.2/64               link#9                        U      vlan0.0.
<b>fe80::1%vlan0.0.2                 link#9                        UHS         lo0</b>
fe80::f690:eaff:fe00:bd54%vlan0.0.2 link#9                      UHS         lo0
fe80::%vlan0.0.316/64             link#10                       U      vlan0.0.
fe80::f690:eaff:fe00:bd54%vlan0.0.316 link#10                   UHS         lo0
fe80::%vlan0.0.5/64               link#11                       U      vlan0.0.
<b>fe80::1%vlan0.0.5                 link#11                       UHS         lo0</b>
fe80::f690:eaff:fe00:bd54%vlan0.0.5 link#11                     UHS         lo0
</pre>

Tested with a Linux client:

```bash
mtak@gen1:~$ sudo ip -6 r d default via fe80::f690:eaff:fe00:bd54 dev eth0
mtak@gen1:~$ sudo ip -6 r a default via fe80::1 dev eth0
mtak@gen1:~$ ping6 -n google.com
PING google.com(2a00:1450:400e:802::200e) 56 data bytes
64 bytes from 2a00:1450:400e:802::200e: icmp_seq=1 ttl=118 time=10.8 ms
64 bytes from 2a00:1450:400e:802::200e: icmp_seq=2 ttl=118 time=20.1 ms
```