### PR TITLE
Better description for Safe Search

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
@@ -7,10 +7,10 @@
     </field>
     <field>
         <id>unbound.dnsbl.safesearch</id>
-        <label>Enable SafeSearch</label>
+        <label>Force SafeSearch</label>
         <type>checkbox</type>
         <style>safesearch</style>
-        <help>Enable the usage of SafeSearch on Google, DuckDuckGo, Bing, Qwant, PixaBay and YouTube</help>
+        <help>Force the usage of SafeSearch on Google, DuckDuckGo, Bing, Qwant, PixaBay and YouTube</help>
     </field>
     <field>
         <id>unbound.dnsbl.type</id>


### PR DESCRIPTION
'Enable Safe Search' doesn't do justice to what the option actually does, which is attempt to strictly enforce safe search. Byproducts of which include, but maybe not limited to, restrcting general usage of YouTube.

Once Safe Search is Enabled, YouTube operates in Restricted mode, as if any Google Account holder attempting to use YouTube is restricted by Google Workplace policy, or Family Policy. To my mind, Enabling and Forcing are different. I did not expect the Enabling of Safe Search in OpnSense to cause my YouTube content to be restricted like I'm 13 years old. It took me a little while to track the cause down. 'Enable' is a fairly soft word for what takes place inside OpnSense, whereas 'Force' is I believe more accurate.