### PR TITLE
LAGG interfaces: Fix bug with reported number of flapping ports

### DIFF
--- a/src/etc/inc/interfaces.lib.inc
+++ b/src/etc/inc/interfaces.lib.inc
@@ -410,7 +410,7 @@ function legacy_interfaces_details($intf = null)
             $result[$current_interface]['laggstatistics'] = [];
             $next_line = $ifconfig_data[$lineid + 1];
             $result[$current_interface]['laggstatistics']['active ports'] = trim(explode(":", $next_line)[1]);
-            $next_line = $ifconfig_data[$lineid + 1];
+            $next_line = $ifconfig_data[$lineid + 2];
             $result[$current_interface]['laggstatistics']['flapping'] = trim(explode(":", $next_line)[1]);
         } elseif (preg_match("/laggport: (.*)\Wflags=\d+<(.*)> state=\d+<(.*)>$/", $line, $matches)) {
             if (empty($result[$current_interface]['laggport'])) {


### PR DESCRIPTION
The current OPNsense code displays the same number for active ports and flapping ports in the interfaces overview page. The displayed flapping count does not match the output of `ifconfig -v <interface>`.

This looks like it was a simple copy/paste error in the code and the fix is very simple.

This was reported on the forum at https://forum.opnsense.org/index.php?topic=30098.0