### PR TITLE
Allow underscores in DNS names from DHCP leases

### DIFF
--- a/src/opnsense/scripts/dhcp/dnsmasq_watcher.py
+++ b/src/opnsense/scripts/dhcp/dnsmasq_watcher.py
@@ -49,7 +49,7 @@ def run_watcher(target_filename, default_domain, watch_file, service_pid):
     # initiate lease watcher and setup cache
     dhcpdleases = watchers.dhcpd.DHCPDLease(watch_file)
     cached_leases = dict()
-    hostname_pattern = re.compile("(?!-)[A-Z0-9-]*(?<!-)$", re.IGNORECASE)
+    hostname_pattern = re.compile("(?!-)[A-Z0-9-_]*(?<!-)$", re.IGNORECASE)
 
     # start watching dhcp leases
     last_cleanup = time.time()

--- a/src/opnsense/scripts/dhcp/unbound_watcher.py
+++ b/src/opnsense/scripts/dhcp/unbound_watcher.py
@@ -136,7 +136,7 @@ def run_watcher(target_filename, default_domain, watch_file, config):
     dhcpdleases = watchers.dhcpd.DHCPDLease(watch_file)
     cached_leases = dict()
     unbound_local_data = UnboundLocalData()
-    hostname_pattern = re.compile("(?!-)[A-Z0-9-]*(?<!-)$", re.IGNORECASE)
+    hostname_pattern = re.compile("(?!-)[A-Z0-9-_]*(?<!-)$", re.IGNORECASE)
 
     # start watching dhcp leases
     last_cleanup = time.time()


### PR DESCRIPTION
Currently DHCP leases with DNS names including underscores cause a warning "dhcpd leases: XXX_XXX not a valid hostname, ignoring" 

While these may not be true internet-valid hostnames according to IETF, many valid DNS names include underscores (e.g. _acme-challenge for ACME/letsencrypt validation, microsoft active directory names, SRV records, and manufacturer-default IP camera names, though I'm sure there are others). 

Blindly denying underscores for DNS records is likely to cause unforeseen issues, and I don't believe it's in our best interest to police names to that degree.