### PR TITLE
interfaces: allow multiple ip addresses in dhcp reject from validation and improve help text

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3180,7 +3180,7 @@ EOD;
         $dhclientconf .= "  supersede interface-mtu 0;\n";
     }
 
-    if (is_ipaddrv4($wancfg['dhcprejectfrom'])) {
+    if (isset($wancfg['dhcprejectfrom'])) {
         $dhclientconf .= "  reject {$wancfg['dhcprejectfrom']};\n";
     }
 
@@ -3291,7 +3291,7 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif)
     if (empty($wancfg['dhcphonourmtu'])) {
         $dhclientconf .= "\tsupersede interface-mtu 0;\n";
     }
-    if (is_ipaddrv4($wancfg['dhcprejectfrom'])) {
+    if (isset($wancfg['dhcprejectfrom'])) {
         $dhclientconf .= "\treject {$wancfg['dhcprejectfrom']};\n";
     }
     if (isset($wancfg['dhcpvlanprio'])) {

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -327,6 +327,28 @@ function get_wireless_channel_info($interface)
     return $wireless_channels;
 }
 
+/**
+ * @return true if $value is a comma separated list of valid dotted IPv4
+ * addresses, or false otherwise.
+ *
+ * Spaces around the IPv4 addresses are allowed.
+ */
+function is_ipaddrlistv4($value)
+{
+    if (!is_string($value)) {
+        return false;
+    }
+
+    $list = explode(',', $value);
+    foreach ($list as $item) {
+        $trimmed_item = trim($item);
+        if (!is_ipaddrv4($trimmed_item)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 $ifdescrs = legacy_config_get_interfaces(['virtual' => false]);
 $hwifs = array_keys(get_interface_list());
 
@@ -845,8 +867,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (!empty($pconfig['alias-subnet']) && !is_numeric($pconfig['alias-subnet'])) {
             $input_errors[] = gettext("A valid alias subnet bit count must be specified.");
         }
-        if (!empty($pconfig['dhcprejectfrom']) && !is_ipaddrv4($pconfig['dhcprejectfrom'])) {
-            $input_errors[] = gettext("A valid alias IP address must be specified to reject DHCP Leases from.");
+        if (!empty($pconfig['dhcprejectfrom']) && !is_ipaddrlistv4($pconfig['dhcprejectfrom'])) {
+            $input_errors[] = gettext("A valid IP address or comma separated IP address list must be specified to reject DHCP Leases from.");
         }
 
         if ($pconfig['gateway'] != "none" || $pconfig['gatewayv6'] != "none") {
@@ -2289,7 +2311,7 @@ include("head.inc");
                           <td>
                             <input name="dhcprejectfrom" type="text" id="dhcprejectfrom" value="<?=htmlspecialchars($pconfig['dhcprejectfrom']);?>" />
                             <div class="hidden" data-for="help_for_dhcprejectfrom">
-                              <?=gettext("If there is a certain upstream DHCP server that should be ignored, place the IP address or subnet of the DHCP server to be ignored here."); ?>
+                              <?=gettext("If there are certain upstream DHCP servers that should be ignored, place the comma separated list of IP addresses of the DHCP servers to be ignored here."); ?>
                               <?=gettext("This is useful for rejecting leases from cable modems that offer private IPs when they lose upstream sync."); ?>
                             </div>
                           </td>


### PR DESCRIPTION
Fixes an issue with the help text for `Reject Leases From` in the Interfaces page, where according to the help text, the `Reject Leases From` value can be an IP address or a subnet, however in reality subnets are not supported by the dhclient version that opnsense uses (but lists of IP addresses are).

This MR updates the help text and the validation to match what dhclient accepts.