### PR TITLE
Update ET-Open to match Suricata 7.0

### DIFF
--- a/src/opnsense/scripts/suricata/metadata/rules/et-open.xml
+++ b/src/opnsense/scripts/suricata/metadata/rules/et-open.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset documentation_url="https://doc.emergingthreats.net/bin/view/Main/EmergingFAQ">
-    <location url="https://rules.emergingthreats.net/open/suricata-6.0/emerging.rules.tar.gz" prefix="ET open"/>
-    <version url="https://rules.emergingthreats.net/open/suricata-6.0/version.txt"/>
+    <location url="https://rules.emergingthreats.net/open/suricata-7.0/emerging.rules.tar.gz" prefix="ET open"/>
+    <version url="https://rules.emergingthreats.net/open/suricata-7.0/version.txt"/>
     <files>
         <file description="botcc.portgrouped" url="inline::rules/botcc.portgrouped.rules">botcc.portgrouped.rules</file>
         <file description="botcc" url="inline::rules/botcc.rules">botcc.rules</file>


### PR DESCRIPTION
Update the ruleset urls to match suricata 7.0. Currently there is no difference in the files provided.