### PR TITLE
Update head.inc to include meta tags for standalone/full-screen on Android & iOS

### DIFF
--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -41,7 +41,6 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-touch-fullscreen" content="yes">
 
     <title><?= $pagetitle ?></title>
 

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -39,6 +39,9 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <meta name="description" content="" />
     <meta name="copyright" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-touch-fullscreen" content="yes">
 
     <title><?= $pagetitle ?></title>
 


### PR DESCRIPTION
Add meta tags for Android and iOS to allow the WebUI to run in fullscreen/standalone mode on mobile browsers.

I have tested this by accessing my opnsense via ssh and editing /usr/local/www/head.inc to include this.

"App" now opens as a full screen app rather than a tab in the web browser.