### PR TITLE
Allow use of seperate CA for validation of OpenVPN clients

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -140,6 +140,12 @@
         <help>Select a certificate to use for this service.</help>
     </field>
     <field>
+        <id>instance.client_ca</id>
+        <label>CA Client Authentication</label>
+        <type>dropdown</type>
+        <help>Select a ca certificate for client validation</help>
+    </field>
+    <field>
         <id>instance.crl</id>
         <label>Certificate Revocation List</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -190,6 +190,12 @@
                     <Required>Y</Required>
                     <ValidationMessage>Please select a valid certificate from the list</ValidationMessage>
                 </cert>
+                <client_ca type="CertificateField">
+                    <Required>N</Required>
+                    <type>ca</type>
+                    <BlankDesc>None</BlankDesc>
+                    <ValidationMessage>Please select a valid ca from the list</ValidationMessage>
+                </client_ca>
                 <crl type="CertificateField">
                     <Required>N</Required>
                     <type>crl</type>


### PR DESCRIPTION
With the new OpenVPN interface of 23.7 the option to use a specific CA for verification of the client certificates is no longer available. 
This patch add the option to specify a specific user CA that should be used for authentication of the clients tls certificates. The setting is optional and if absent it falls back to using the CA of the server certificate for the OpenVPN `<ca>` option. If verification of client certificates is enabled and the server certificate doesn't include a CA and the CA client certificate doesn't exist an error is displayed. The CA server certificate which is currently in 23.7 is used as the `<ca>` option is instead defined as `<extra-certs>` to be able to complete its certificate chain.

Since the webpki develops to require or at least recommend separate CAs for server certificates and user certificates this option should still be available.