### PR TITLE
ntpd: fix 'Soliciting pool server'

### DIFF
--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -399,18 +399,18 @@ function ntpd_configure_do($verbose = false)
     if (!empty($config['ntpd']['noquery'])) {
         $ntpaccess .= ' noquery';
     }
-    if (empty($config['ntpd']['nopeer'])) { /*note: this one works backwards */
-        $ntpaccess .= ' nopeer';
-    }
     if (empty($config['ntpd']['notrap'])) { /*note: this one works backwards */
         $ntpaccess .= ' notrap';
     }
     if (!empty($config['ntpd']['noserve'])) {
         $ntpaccess .= ' noserve';
     }
+    $ntpcfg .= "\nrestrict source {$ntpaccess}";
+    if (empty($config['ntpd']['nopeer'])) { /*note: this one works backwards */
+        $ntpaccess .= ' nopeer';
+    }
     $ntpcfg .= "\nrestrict default {$ntpaccess}";
     $ntpcfg .= "\nrestrict -6 default {$ntpaccess}";
-    $ntpcfg .= "\nrestrict source {$ntpaccess}";
     $ntpcfg .= "\n";
 
     /* A leapseconds file is really only useful if this clock is stratum 1 */


### PR DESCRIPTION
From ntp.conf man page:
if you want to use servers from a pool directive and also want to use nopeer by default, you'll want a restrict source ... line as well that does not include the nopeer directive.

This PR reorders ntpd.inc to remove `nopeer` from the `restrict source` line.

[Forum discussion](https://forum.opnsense.org/index.php?topic=35311.0)