### PR TITLE
core/monit: make timeout required (as it has default)

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -226,14 +226,14 @@
          </path>
          <timeout type="IntegerField">
             <default>300</default>
-            <Required>N</Required>
+            <Required>Y</Required>
             <MinimumValue>1</MinimumValue>
             <MaximumValue>86400</MaximumValue>
             <ValidationMessage>Program Timeout needs to be an integer value between 1 and 86400</ValidationMessage>>
          </timeout>
          <starttimeout type="IntegerField">
             <default>30</default>
-            <Required>N</Required>
+            <Required>Y</Required>
             <MinimumValue>0</MinimumValue>
             <MaximumValue>86400</MaximumValue>
             <ValidationMessage>Start Delay needs to be an integer value between 0 and 86400</ValidationMessage>


### PR DESCRIPTION
Closes #6729