### PR TITLE
MVC / ApiControllerBase: cached searchRecordSetBase wrapper

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
@@ -147,10 +147,6 @@ class ApiControllerBase extends ControllerRoot
         $records = [];
 
         if (is_callable($callback)) {
-            if (empty($cache_id) || empty($cache_ttl)) {
-                throw new \BadFunctionCallException('cache_id or cache_ttl arguments must be set');
-            }
-
             $cache = glob('/tmp/recordset.*');
             $obj_file = '/tmp/recordset.'. $cache_id . '.cache';
             $cache_file = null;


### PR DESCRIPTION
@AdSchellevis a quick POC for a cached version of searchRecordSetBase. Posted as a draft for discussion purposes, likely needs some cleaning up.

As a test I've plugged in the DHCPv4 leases overview in, which already required a filter function as well as a mechanism to alter the response before it was sent out back to the frontend, covering a large part of the use case.

On my end it significantly increases the responsiveness of bootgrid behaviour.