### PR TITLE
"bypass" keyword in suricata user defined rules

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
@@ -33,7 +33,7 @@
         <id>rule.bypass</id>
         <label>Bypass</label>
         <type>checkbox</type>
-        <help>Set bypass keyword, only used when in IPS mode.</help>
+        <help>Set bypass keyword. Increases traffic throughput. Suricata reads a packet, decodes it, checks it in the flow table. If the corresponding flow is local bypassed then it simply skips all streaming, detection and output and the packet goes directly out in IDS mode and to verdict in IPS mode.</help>
     </field>
     <field>
         <id>rule.description</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/dialogUserDefined.xml
@@ -30,6 +30,12 @@
         <help>Set action to perform here, only used when in IPS mode.</help>
     </field>
     <field>
+        <id>rule.bypass</id>
+        <label>Bypass</label>
+        <type>checkbox</type>
+        <help>Set bypass keyword, only used when in IPS mode.</help>
+    </field>
+    <field>
         <id>rule.description</id>
         <label>Description</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/IDS</mount>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <description>
         OPNsense IDS
     </description>
@@ -115,7 +115,7 @@
                 </action>
                 <bypass type="BooleanField">
                         <default>0</default>
-                        <Required>N</Required>
+                        <Required>Y</Required>
                 </bypass>
             </rule>
         </userDefinedRules>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -113,6 +113,10 @@
                         <pass>Pass</pass>
                     </OptionValues>
                 </action>
+                <bypass type="BooleanField">
+                        <default>0</default>
+                        <Required>N</Required>
+                </bypass>
             </rule>
         </userDefinedRules>
         <files>

--- a/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
+++ b/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
@@ -8,7 +8,10 @@
 {% if helpers.exists('OPNsense.IDS.userDefinedRules.rule') %}
 {%      for rule in helpers.toList('OPNsense.IDS.userDefinedRules.rule') %}
 {%          if rule.enabled|default('0') == '1' %}
-{{rule.action}}{% if rule.fingerprint|default('') != "" %} tls {% else %} ip {% endif %} {% if rule.source|default('') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {% if rule.bypass|default('0') == '1' %}bypass;{% endif %}{% if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif %} sid:{{
+{{rule.action}}{% if rule.fingerprint|default('') != ""
+      %} tls {% else %} ip {% endif %} {% if rule.source|default('') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {% if rule.bypass|default('0') == '1' %}bypass;{% endif %}{%
+      if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif
+      %} sid:{{
       4294967295 - loop.index
       }}; rev:1;)
 {%          endif %}

--- a/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
+++ b/src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules
@@ -8,10 +8,7 @@
 {% if helpers.exists('OPNsense.IDS.userDefinedRules.rule') %}
 {%      for rule in helpers.toList('OPNsense.IDS.userDefinedRules.rule') %}
 {%          if rule.enabled|default('0') == '1' %}
-{{rule.action}}{% if rule.fingerprint|default('') != ""
-      %} tls {% else %} ip {% endif %} {% if rule.source|default('') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {%
-      if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif
-      %} sid:{{
+{{rule.action}}{% if rule.fingerprint|default('') != "" %} tls {% else %} ip {% endif %} {% if rule.source|default('') != "" %} {{ rule.source }} {% else %} any {% endif %} any -> {% if rule.destination|default('') != "" %} {{ rule.destination }} {% else %} any {% endif %} any (msg:"{{rule.description.replace('"','\"')}}"; {% if rule.bypass|default('0') == '1' %}bypass;{% endif %}{% if rule.fingerprint|default('') != "" %} tls.fingerprint:"{{rule.fingerprint.lower()}}";{% endif %} sid:{{
       4294967295 - loop.index
       }}; rev:1;)
 {%          endif %}


### PR DESCRIPTION
Ref: #6744

Adds a new input field in `Services: Intrusion Detection: Administration: User defined` which adds `bypass;` keyword to `/usr/local/etc/suricata/opnsense.rules/OPNsense.rules`.

![grafik](https://github.com/opnsense/core/assets/79600909/761e207c-7844-4283-865a-61613dfe954b)

Rules are generated with the template `src/opnsense/service/templates/OPNsense/IDS/OPNsense.rules `and look like this when the checkbox is enabled:
`pass ip   10.0.0.0/8  any ->  10.0.0.0/8  any (msg:"bypass 10.0.0.0/8 to 10.0.0.0/8"; bypass; sid:1; rev:1;)`




