### PR TITLE
Fix misleading help text

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogLocal.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogLocal.xml
@@ -26,8 +26,8 @@
         <label>Id</label>
         <type>text</type>
         <help>IKE identity to use for authentication round.
-          When using certificate authentication.
-          The IKE identity must be contained in the certificate,
+          When using certificate authentication
+          the IKE identity must be contained in the certificate;
           either as the subject DN or as a subjectAltName
           (the identity will default to the certificate’s subject DN if not specified).
           Refer to https://docs.strongswan.org/docs/5.9/config/identityParsing.html for details on how


### PR DESCRIPTION
Confusing punctation would imply that the field is only relevant for certificate authentication.