### PR TITLE
Fix IPsec key pair generator for 256 EC and add properer naming…

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/Api/KeyPairsController.php
@@ -137,7 +137,7 @@ class KeyPairsController extends ApiMutableModelControllerBase
             $attrs['private_key_type'] = OPENSSL_KEYTYPE_EC;
             switch ($size ?? '384') {
                 case '256';
-                    $attrs['curve_name'] = "secp256r1";
+                    $attrs['curve_name'] = "prime256v1";
                     break;
                 case '384';
                     $attrs['curve_name'] = "secp384r1";

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/key_pairs.volt
@@ -72,9 +72,9 @@
               <option data-type='rsa' value="3072">3072</option>
               <option data-type='rsa' value="4096">4096</option>
               <option data-type='rsa' value="8192">8192</option>
-              <option data-type='ecdsa' value="256">256</option>
-              <option data-type='ecdsa' value="384">384</option>
-              <option data-type='ecdsa' value="521">521</option>
+              <option data-type='ecdsa' value="256">NIST P-256</option>
+              <option data-type='ecdsa' value="384">NIST P-384</option>
+              <option data-type='ecdsa' value="521">NIST P-521</option>
           </select>
           <button id="keygen" type="button" class="btn btn-secondary" title="{{ lang._('Generate new.') }}" data-toggle="tooltip">
             <i class="fa fa-fw fa-gear"></i>


### PR DESCRIPTION
Key generation for the "256" EC does not work as the curve used in the generator code "secp256r1", does not exist in OpenSSL; it's called prime256v1 there.
Source: https://neuromancer.sk/std/nist/P-256

Also the names shown in the UI are ambiguous as there are several curves with 256, 384 or 521 bits. Renaming the drop-down list to "NIST P-256", "NIST P-384" and "NIST P-521" makes them uniquely identifiable.