### PR TITLE
OpenVPN Client Export: fix certificate list when CA specified

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -262,7 +262,9 @@ class OpenVPN extends BaseModel
                 }
                 // find caref
                 $this_caref = null;
-                if (isset(Config::getInstance()->object()->cert)) {
+                if (!empty((string)$node->ca)) {
+                    $this_caref = (string)$node->ca;
+                } else if (isset(Config::getInstance()->object()->cert)) {
                     foreach (Config::getInstance()->object()->cert as $cert) {
                         if (isset($cert->refid) && (string)$node->cert == $cert->refid) {
                             $this_caref = (string)$cert->caref;


### PR DESCRIPTION
When a different CA is specified for client certificate validation than the server certificate's CA, a wrong list of certificates is shown in the Client Export dialog.