### PR TITLE
Add local_port and remote_port to VPN: IPsec: Connections [new]

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogConnection.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogConnection.xml
@@ -91,6 +91,16 @@
         </help>
     </field>
     <field>
+        <id>connection.local_port</id>
+        <label>Local port</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help> 
+          Local UDP port for IKE communication. If the default of port 500 is used, 
+          automatic IKE port floating to port 4500 is used to work around NAT issues. 
+        </help>
+    </field>
+    <field>
         <id>connection.remote_addrs</id>
         <label>Remote addresses</label>
         <type>select_multiple</type>
@@ -104,6 +114,16 @@
           If FQDNs are assigned they are resolved every time a configuration lookup is done.
           If DNS resolution times out, the lookup is delayed for that time.
           To initiate a connection, at least one specific address or DNS name must be specified.
+        </help>
+    </field>
+    <field>
+        <id>connection.remote_port</id>
+        <label>Remote port</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>
+          Remote UDP port for IKE communication. If the default of port 500 is used, 
+          automatic IKE port floating to port 4500 is used to work around NAT issues.
         </help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -46,7 +46,6 @@
                 </local_addrs>
                 <local_port type="OptionField">
                     <Required>N</Required>
-                    <Default></Default>
                     <OptionValues>
                         <port500 value="">500 (default)</port500>
                         <port4500 value="4500">4500 (NAT-T)</port4500>
@@ -57,7 +56,6 @@
                 </remote_addrs>
                 <remote_port type="OptionField">
                     <Required>N</Required>
-                    <Default></Default>
                     <OptionValues>
                         <port500 value="">500 (default)</port500>
                         <port4500 value="4500">4500 (NAT-T)</port4500>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -44,9 +44,25 @@
                 <local_addrs type=".\IKEAdressField">
                     <Required>N</Required>
                 </local_addrs>
+                <local_port type="OptionField">
+                    <Required>N</Required>
+                    <Default></Default>
+                    <OptionValues>
+                        <port500 value="">500 (default)</port500>
+                        <port4500 value="4500">4500 (NAT-T)</port4500>
+                    </OptionValues>
+                </local_port>
                 <remote_addrs type=".\IKEAdressField">
                     <Required>N</Required>
                 </remote_addrs>
+                <remote_port type="OptionField">
+                    <Required>N</Required>
+                    <Default></Default>
+                    <OptionValues>
+                        <port500 value="">500 (default)</port500>
+                        <port4500 value="4500">4500 (NAT-T)</port4500>
+                    </OptionValues>
+                </remote_port>
                 <encap type="BooleanField">
                     <Default>0</Default>
                     <Required>Y</Required>


### PR DESCRIPTION
[#6818](https://github.com/opnsense/core/issues/6818)

I created new dropdown menus in the IPsec Connections Form. 
Users can select between port 500 (default) and port 4500 (NAT-T). I didn't create a free input field since other values have to be actually supported by the backend, and I didn't see the usecase for free choice.

I didn't upgrade the model version since I used the `elseif ((string)$attr == '')` in the Swanctl.php in order to skip the default value. I chose the default value as empty, because I didn't want to add local_port = 500 and remote_port = 500 explicitly to the configuration file, it's not needed since its the default even if its not specified. Thus I could maintain a non required field that won't need a migration since no config changes will be made when its implemented.

When a user enables advanced mode and chooses "4500 (NAT-T), the port gets added in the swanctl.conf.