### PR TITLE
unbound: fix problematic migration of interfaces

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/general.xml
@@ -14,6 +14,8 @@
         <id>unbound.general.active_interface</id>
         <label>Network Interfaces</label>
         <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
         <help>
             Interface IP addresses used for responding to queries from clients.
             If an interface has both IPv4 and IPv6 IPs, both are used.
@@ -115,6 +117,8 @@
         <id>unbound.general.outgoing_interface</id>
         <label>Outgoing Network Interfaces</label>
         <type>select_multiple</type>
+        <allownew>true</allownew>
+        <style>tokenize</style>
         <advanced>true</advanced>
         <help>
             Utilize different network interfaces that Unbound will use to send queries to authoritative servers and receive their replies.

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/FieldTypes/UnboundInterfaceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/FieldTypes/UnboundInterfaceField.php
@@ -28,14 +28,14 @@
 
 namespace OPNsense\Unbound\FieldTypes;
 
-use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Base\FieldTypes\CSVListField;
 use OPNsense\Core\Config;
 
 /**
  * Class UnboundDomainField
  * @package OPNsense\Unbound\FieldTypes
  */
-class UnboundInterfaceField extends BaseListField
+class UnboundInterfaceField extends CSVListField
 {
     /**
      * Iterate over all interfaces in the configuration and only exclude
@@ -44,10 +44,11 @@ class UnboundInterfaceField extends BaseListField
     public function actionPostLoadingEvent()
     {
         $config = Config::getInstance()->object();
+        $list = [];
 
         foreach ($config->interfaces->children() as $key => $node) {
-            if ((empty($node->virtual) || $key == 'lo0') && !empty($node->enable)) {
-                $this->internalOptionList[$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
+            if (empty($node->virtual) && !empty($node->enable)) {
+                $list[$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
             }
         }
 
@@ -55,11 +56,13 @@ class UnboundInterfaceField extends BaseListField
             if (!empty($setting) && empty((string)$setting->disable)) {
                 $key = 'ovpn' . substr($mode, 8, 1) . (string)$setting->vpnid;
                 $type = substr($mode, 8, 6);
-                $this->internalOptionList[$key] = "OpenVPN {$type} (" . (!empty($setting->description) ?
+                $list[$key] = "OpenVPN {$type} (" . (!empty($setting->description) ?
                     (string)$setting->description : (string)$setting->vpnid) . ")";
             }
         }
 
-        natcasesort($this->internalOptionList);
+        natcasesort($list);
+
+        $this->setSelectOptions($list);
     }
 }


### PR DESCRIPTION
This pertains to migration of `active_interface` and `outgoing_interface` from legacy configuration to model. It's easy to reproduce by adding a nonexistent interface there and trying to migrate it, because...

Interfaces may not be available or disabled.  We can still give a hint with the tokenizer/type-ahead but we have to accept the old configuration or else the migration will always fail as long as bad values are stored.  CSV field will allow these arbitrary values and deletion thereof if needed even if we do not follow a strict UX pattern here.

Also remove the Loopback from the selection.  It is always added automatically to prevent the user breaking local resolving.

All ideas welcome.