### PR TITLE
Firewall / Aliases - Don't skip renamed aliases on cleanup

### DIFF
--- a/src/opnsense/scripts/filter/update_tables.py
+++ b/src/opnsense/scripts/filter/update_tables.py
@@ -125,7 +125,7 @@ if __name__ == '__main__':
 
     # cleanup removed aliases when reloading all
     if to_update is None:
-        registered_aliases = [alias.get_name() for alias in aliases if alias.is_managed()]
+        registered_aliases = [alias.get_name() for alias in aliases if (alias.is_managed() and alias.get_type() != 'external')]
         to_remove = list()
         to_remove_files = dict()
         for filename in glob.glob('/var/db/aliastables/*.txt'):


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=35903.0
reproducible

I apologize in advance if I missed something (quite complex logic ;) ).
Cleanup worked for renamed aliases on 22.7. I think registered_aliases did  not include aliases from 'pfctl -sT' with corresponding hash-files but not presented in config

Thanks!
