### PR TITLE
dhcpd6: add scope to link-local DHCPv6 static mapping when creating route for delegated prefix

### DIFF
--- a/src/opnsense/scripts/dhcp/prefixes.php
+++ b/src/opnsense/scripts/dhcp/prefixes.php
@@ -87,7 +87,7 @@ foreach (plugins_run('static_mapping') as $map) {
 
         if (!empty($host['ipaddrv6'])) {
             /* we want static mapping to have a higher priority */
-            $duid_arr[$host['duid']]['address'] = $host['ipaddrv6'];
+            $duid_arr[$host['duid']]['address'] = is_linklocal($host['ipaddrv6']) ? $host['ipaddrv6'] . '%' . get_real_interface($host['interface']) : $host['ipaddrv6'];
         }
     }
 }


### PR DESCRIPTION
Allows prefix delegation to downstream routers which have an unnumbered WAN interface.
As discussed on the forum: https://forum.opnsense.org/index.php?topic=35724.msg174257#msg174257