### PR TITLE
VPN: IPsec: Connections: Pools add IP4_DNS and IP6_DNS Configuration Payloads

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogPool.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogPool.xml
@@ -18,5 +18,14 @@
           Accepts a single CIDR subnet defining the pool to allocate addresses from
         </help>
     </field>
-
+    <field>
+        <id>pool.dns</id>
+        <label>DNS</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>
+          DNS servers to push as configuration payload (RFC4306 3.15 - Value 3 and 10). Accepts multiple IPv4/IPv6 addresses.
+        </help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/PoolsDNSField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/PoolsDNSField.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (C) 2022 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\IPsec\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseField;
+use OPNsense\Base\Validators\CallbackValidator;
+use OPNsense\Firewall\Util;
+
+/**
+ * @package OPNsense\Base\FieldTypes
+ */
+class PoolsDNSField extends BaseField
+{
+    /**
+     * @var bool marks if this is a data node or a container
+     */
+    protected $internalIsContainer = false;
+
+    /**
+     * Get valid options, descriptions, and selected value
+     * @return array
+     */
+    public function getNodeData()
+    {
+        $result = [];
+        foreach (explode(',', $this->internalValue) as $ip) {
+            $result[$ip] = array("value" => $ip, "selected" => 1);
+        }
+        return $result;
+    }
+
+
+    public function getValidators()
+    {
+        $validators = parent::getValidators();
+        if ($this->internalValue != null) {
+            $validators[] = new CallbackValidator(["callback" => function ($data) {
+                $messages = [];
+                foreach (explode(",", $data) as $entry) {
+                    if (Util::isIpAddress($entry)) { // Only validate IP Addresses.
+                        continue;
+                    }
+                    $messages[] = sprintf(
+                        gettext('Entry "%s" is not a valid IPv4 or IPv6 address.'),
+                        $entry
+                    );
+                }
+                return $messages;
+            }
+            ]);
+        }
+        return $validators;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -328,6 +328,7 @@
                     <NetMaskRequired>Y</NetMaskRequired>
                     <ValidationMessage>Please specify a valid CIDR subnet.</ValidationMessage>
                 </addrs>
+                <dns type=".\PoolsDNSField"/>
             </Pool>
         </Pools>
         <VTIs>


### PR DESCRIPTION
https://github.com/opnsense/core/issues/6860

Small explanation what I did:
- I assessed that I needed to tokenize the input and to turn it into an array and to check if the input is an ipv4 or ipv6 address. I didn't know how to do it though, so I searched for clues how the Connections ``Local addresses`` did it, because I needed the same behavior.
- I found the ``IKEAdressField.php`` which almost did what I needed, and copied it to ``PoolsDNSField.php`` and changed it a little so it only accepts IP Addresses.
- Then I added a new field ``pools.dns`` to ``dialogPool.xml`` to accept the new DNS inputs in the WEB GUI.
- Last I added  ``<dns type=".\PoolsDNSField"/>`` to the ``<Pools>`` definition of ``Swanctl.xml``

At that point it just worked as expected, I can add multiple IPv4 and IPv6 addresses into each individual pool and they get saved as array in the swanctl.conf. On connection, they're pushed to the client as IKE configuration payload.