### PR TITLE
mvc: improve field validation message handling

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
@@ -693,6 +693,24 @@ abstract class BaseField
     }
 
     /**
+     * @return string default validation message
+     */
+    protected function defaultValidationMessage()
+    {
+        return gettext('Validation failed.');
+    }
+
+    /**
+     * @return string current validation message
+     */
+    protected function getValidationMessage()
+    {
+        return $this->internalValidationMessage !== null ?
+            gettext($this->internalValidationMessage) :
+            $this->defaultValidationMessage();
+    }
+
+    /**
      * set Validation message ( for usage in model xml )
      * @param string $msg validation message (on failure)
      */

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
@@ -58,11 +58,6 @@ abstract class BaseListField extends BaseField
     protected $internalMultiSelect = false;
 
     /**
-     * @var string default validation message string
-     */
-    protected $internalValidationMessage = null;
-
-    /**
      * @return string validation message
      */
     protected function getValidationMessage()

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
@@ -58,16 +58,13 @@ abstract class BaseListField extends BaseField
     protected $internalMultiSelect = false;
 
     /**
-     * @return string validation message
+     * @inheritdoc
      */
-    protected function getValidationMessage()
+    protected function defaultValidationMessage()
     {
-        if ($this->internalValidationMessage == null) {
-            return gettext('option not in list');
-        } else {
-            return $this->internalValidationMessage;
-        }
+        return gettext('Option not in list.');
     }
+
     /**
      * select if multiple interfaces may be selected at once
      * @param $value boolean value 0/1
@@ -127,14 +124,16 @@ abstract class BaseListField extends BaseField
     {
         $validators = parent::getValidators();
         if ($this->internalValue != null) {
-            $domain = array_map('strval', array_keys($this->internalOptionList));
-            $this_message = $this->getValidationMessage();
+            $args = [
+                'domain' => array_map('strval', array_keys($this->internalOptionList)),
+                'message' => $this->getValidationMessage(),
+            ];
             if ($this->internalMultiSelect) {
                 // field may contain more than one option
-                $validators[] = new CsvListValidator(array('message' => $this_message, 'domain' => $domain));
+                $validators[] = new CsvListValidator($args);
             } else {
                 // single option selection
-                $validators[] = new InclusionIn(array('message' => $this_message, 'domain' => $domain));
+                $validators[] = new InclusionIn($args);
             }
         }
         return $validators;

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
@@ -58,7 +58,7 @@ abstract class BaseListField extends BaseField
     protected $internalMultiSelect = false;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function defaultValidationMessage()
     {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
@@ -54,18 +54,11 @@ class NetworkAliasField extends BaseListField
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    protected function getValidationMessage()
+    protected function defaultValidationMessage()
     {
-        if ($this->internalValidationMessage == null) {
-            return sprintf(
-                gettext("%s is not a valid source IP address or alias."),
-                (string)$this
-            );
-        } else {
-            return $this->internalValidationMessage;
-        }
+        return sprintf(gettext("%s is not a valid source IP address or alias."), (string)$this);
     }
 
     /**
@@ -102,7 +95,7 @@ class NetworkAliasField extends BaseListField
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function setMultiple($value)
     {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
@@ -54,7 +54,7 @@ class NetworkAliasField extends BaseListField
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function defaultValidationMessage()
     {
@@ -95,7 +95,7 @@ class NetworkAliasField extends BaseListField
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setMultiple($value)
     {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -173,7 +173,7 @@ class PortField extends BaseListField
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function defaultValidationMessage()
     {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -173,17 +173,13 @@ class PortField extends BaseListField
     }
 
     /**
-     * return validation message
+     * @inheritdoc
      */
-    protected function getValidationMessage()
+    protected function defaultValidationMessage()
     {
-        if ($this->internalValidationMessage == null) {
-            $msg = gettext('Please specify a valid port number (1-65535).');
-            if ($this->enableWellKnown) {
-                $msg .= ' ' . sprintf(gettext('A service name is also possible (%s).'), implode(', ', self::$wellknownservices));
-            }
-        } else {
-            $msg = $this->internalValidationMessage;
+        $msg = gettext('Please specify a valid port number (1-65535).');
+        if ($this->enableWellKnown) {
+            $msg .= ' ' . sprintf(gettext('A service name is also possible (%s).'), implode(', ', self::$wellknownservices));
         }
         return $msg;
     }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
@@ -43,11 +43,6 @@ class TextField extends BaseField
     protected $internalIsContainer = false;
 
     /**
-     * @var string default validation message string
-     */
-    protected $internalValidationMessage = "text validation error";
-
-    /**
      * @var null|string validation mask (regex)
      */
     protected $internalMask = null;
@@ -70,8 +65,10 @@ class TextField extends BaseField
         $validators = parent::getValidators();
         if ($this->internalValue != null) {
             if ($this->internalValue != null && $this->internalMask != null) {
-                $validators[] = new Regex(array('message' => $this->internalValidationMessage,
-                    'pattern' => trim($this->internalMask)));
+                $validators[] = new Regex([
+                    'message' => gettext($this->internalValidationMessage) ?? gettext('Text does not validate.'),
+                    'pattern' => trim($this->internalMask),
+                ]);
             }
         }
         return $validators;

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
@@ -57,6 +57,14 @@ class TextField extends BaseField
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function defaultValidationMessage()
+    {
+        return gettext('Text does not validate.');
+    }
+
+    /**
      * retrieve field validators for this field type
      * @return array returns Text/regex validator
      */
@@ -66,7 +74,7 @@ class TextField extends BaseField
         if ($this->internalValue != null) {
             if ($this->internalValue != null && $this->internalMask != null) {
                 $validators[] = new Regex([
-                    'message' => gettext($this->internalValidationMessage) ?? gettext('Text does not validate.'),
+                    'message' => $this->getValidationMessage(),
                     'pattern' => trim($this->internalMask),
                 ]);
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
@@ -57,7 +57,7 @@ class TextField extends BaseField
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function defaultValidationMessage()
     {


### PR DESCRIPTION
* defaultValidationMessage() provides the field default (because gettext() doesn't work on constants)
* $internalValidationMessage only provides the XML value if given (translated via lang.git)
* getValidationMessage() returns the preferred validation message correctly translated