### PR TITLE
system: start gateway monitors after firewall rules are in place

### DIFF
--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -98,8 +98,8 @@ plugins_configure('dhcp', true);
 plugins_configure('dhcrelay', true);
 plugins_configure('dns', true);
 
-plugins_configure('monitor', true, [null, true]);
 filter_configure_sync(true);
+plugins_configure('monitor', true, [null, true]);
 plugins_configure('vpn', true);
 plugins_configure('bootup', true);
 rrd_configure(true, true);


### PR DESCRIPTION
During bootup the gateway monitors were started before the firewall rules were finished setting up. Under some circumstances this could lead to incorrect data being reported by `dpinger` instances.

Closes #6862