### PR TITLE
openvpn: add up and down scripts to vpn instance configs

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -499,6 +499,8 @@ class OpenVPN extends BaseModel
                 $options['proto'] = (string)$node->proto;
                 $options['verb'] = (string)$node->verb;
                 $options['verify-client-cert'] = (string)$node->verify_client_cert;
+                $options['up'] = '/usr/local/etc/inc/plugins.inc.d/openvpn/ovpn-linkup';
+                $options['down'] = '/usr/local/etc/inc/plugins.inc.d/openvpn/ovpn-linkdown';
 
                 foreach (
                     [


### PR DESCRIPTION
OpenVPN configs generated for new instances did not include instructions to call `ovpn-linkup` and `ovpn-linkdown`. Due to this `newip` would not trigger and `rc.newwanip` would not be called. For example this would lead to gateway monitors not starting.

Closes #6868