### PR TITLE
Update VxLan.php - Add input validations to model

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
@@ -37,44 +37,51 @@ class VxLan extends BaseModel
     {
         $messages = parent::performValidation($validateFullModel);
 
+        // Initialize variables
         foreach ($this->vxlan->iterateItems() as $vxlan) {
-
             $vxlangroup = (string) $vxlan->vxlangroup;
             $vxlanremote = (string) $vxlan->vxlanremote;
             $vxlandev = (string) $vxlan->vxlandev;
 
-            // Validation 1: At least one of vxlangroup and vxlanremote must be populated, but not both.
-            if ((!empty($vxlangroup) && !empty($vxlanremote)) ||
-                (empty($vxlangroup) && empty($vxlanremote))) {
-                $messages->appendMessage(new Message(
-                    "Remote address -or- Multicast group has to be specified",
-                    "vxlan.vxlanremote",
-                    "GroupOrRemote"
-                ));
-                $messages->appendMessage(new Message(
-                    "Multicast group -or- Remote address has to be specified",
-                    "vxlan.vxlangroup",
-                    "GroupOrRemote"
-                ));
-            }
+            // Validate that values in Fields have been changed, prevents configuration save lockout when invalid data is present.
+            if ($validateFullModel ||
+                $vxlan->vxlangroup->isFieldChanged() ||
+                $vxlan->vxlanremote->isFieldChanged() ||
+                $vxlan->vxlandev->isFieldChanged()
+            ) {
+                // Validation 1: At least one of vxlangroup and vxlanremote must be populated, but not both.
+                if ((!empty($vxlangroup) && !empty($vxlanremote)) ||
+                    (empty($vxlangroup) && empty($vxlanremote))
+                ) {
+                    $messages->appendMessage(new Message(
+                        gettext("Remote address -or- Multicast group has to be specified"),
+                        "vxlan.vxlanremote",
+                        "GroupOrRemote"
+                    ));
+                    $messages->appendMessage(new Message(
+                        gettext("Multicast group -or- Remote address has to be specified"),
+                        "vxlan.vxlangroup",
+                        "GroupOrRemote"
+                    ));
+                }
 
-            // Validation 2: If vxlanremote is populated, vxlandev must be an empty string.
-             if (!empty($vxlanremote) && !empty($vxlandev)) {
-                $messages->appendMessage(new Message(
-                    "Remote address is specified, Device must be None",
-                    "vxlan.vxlandev",
-                    "DeviceRequirementForRemote"
-                    
-                ));
-            }
+                // Validation 2: If vxlanremote is populated, vxlandev must be an empty string.
+                if (!empty($vxlanremote) && !empty($vxlandev)) {
+                    $messages->appendMessage(new Message(
+                        gettext("Remote address is specified, Device must be None"),
+                        "vxlan.vxlandev",
+                        "DeviceRequirementForRemote"
+                    ));
+                }
 
-            // Validation 3: If vxlangroup is populated, vxlandev must not be an empty string.
-             if (!empty($vxlangroup) && empty($vxlandev)) {
-                $messages->appendMessage(new Message(
-                    "Multicast group is specified, a Device must also be specified",
-                    "vxlan.vxlandev",
-                    "DeviceRequirementForGroup"
-                ));
+                // Validation 3: If vxlangroup is populated, vxlandev must not be an empty string.
+                if (!empty($vxlangroup) && empty($vxlandev)) {
+                    $messages->appendMessage(new Message(
+                        gettext("Multicast group is specified, a Device must also be specified"),
+                        "vxlan.vxlandev",
+                        "DeviceRequirementForGroup"
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
[#6893](https://github.com/opnsense/core/issues/6893)

That was rather challenging for me. But I think I got it working the way it should.

Here's some screenshots with the results:

Requirement for either Remote address or Multicast group NOT to be empty:
![grafik](https://github.com/opnsense/core/assets/79600909/7e0a3263-7dcd-4e4f-b35c-3793a86b4ed0)

Requirement for both Remote address or Multicast group NOT to be populated at the same time:
![grafik](https://github.com/opnsense/core/assets/79600909/b3f31cf3-9a21-4b33-bedf-822afb2a472c)

Requirement for Device being set when Multicast group is populated:
![grafik](https://github.com/opnsense/core/assets/79600909/d4be978b-21f3-496a-a366-349c959d980b)

Requirement for Device being NONE when Remote address is populated:
![grafik](https://github.com/opnsense/core/assets/79600909/6e22e219-b130-42b4-a268-49965fb6d516)
