### PR TITLE
parsing custom blocklist with wildcard domains

### DIFF
--- a/src/opnsense/scripts/unbound/blocklists/__init__.py
+++ b/src/opnsense/scripts/unbound/blocklists/__init__.py
@@ -48,7 +48,7 @@ class BaseBlocklistHandler:
         self.cur_bl_location = '/var/unbound/data/dnsbl.json'
 
         self.domain_pattern = re.compile(
-            r'^(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
+            r'^(\*\.){,1}(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
             r'?([\da-zA-Z]\.((xn\-\-[a-zA-Z\d]+)|([a-zA-Z\d]{2,})))$'
         )
 

--- a/src/opnsense/scripts/unbound/blocklists/default_bl.py
+++ b/src/opnsense/scripts/unbound/blocklists/default_bl.py
@@ -79,7 +79,10 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
                     entry = value.rstrip().lower()
                     if not self._whitelist_pattern.match(entry):
                         if self.domain_pattern.match(entry):
-                            result[entry] = {'bl': 'Manual', 'wildcard': False}
+                            if entry.startswith('*.'): # reformat wildcard domain
+                                result[entry[2:]] = {'bl': 'Manual', 'wildcard': True}
+                            else:
+                                result[entry] = {'bl': 'Manual', 'wildcard': False}
                 elif key.startswith('wildcard'):
                     entry = value.rstrip().lower()
                     if self.domain_pattern.match(entry):


### PR DESCRIPTION
Pull request to implement a small change to accommodate the feature i suggested in issue [#6888](https://github.com/opnsense/core/issues/6888).

Currently blocklist handler is already able tag a domain as wildcard with the property `'wildcard': True` for Unbound to pick up. I think it's trivial to add support for wildcard domains in the format `*.example.com` from custom blocklist with minimal change in logic.

New code only attempt to alter the parsing of custom blocklist and does not touch other inputs.