### PR TITLE
unbound: add support for wildcard domain lists

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -180,6 +180,9 @@
                 <Multiple>Y</Multiple>
                 <OptionValues>
                     <atf>Abuse.ch - ThreatFox IOC database</atf>
+                    <oisd0>OISD - Domain Blocklist Ads</oisd0>
+                    <oisd1>OISD - Domain Blocklist Big</oisd1>
+                    <oisd2>OISD - Domain Blocklist NSFW</oisd2>
                     <aa>AdAway List</aa>
                     <ag>AdGuard List</ag>
                     <bla0>Blocklist.site Abuse</bla0>

--- a/src/opnsense/scripts/unbound/blocklists/__init__.py
+++ b/src/opnsense/scripts/unbound/blocklists/__init__.py
@@ -48,7 +48,7 @@ class BaseBlocklistHandler:
         self.cur_bl_location = '/var/unbound/data/dnsbl.json'
 
         self.domain_pattern = re.compile(
-            r'^(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
+            r'^(\*\.){,1}(([\da-zA-Z_])([_\w-]{,62})\.){,127}(([\da-zA-Z])[_\w-]{,61})'
             r'?([\da-zA-Z]\.((xn\-\-[a-zA-Z\d]+)|([a-zA-Z\d]{2,})))$'
         )
 

--- a/src/opnsense/scripts/unbound/blocklists/default_bl.py
+++ b/src/opnsense/scripts/unbound/blocklists/default_bl.py
@@ -51,7 +51,7 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
     def get_blocklist(self):
         result = {}
         for blocklist, bl_shortcode in self._blocklists_in_config():
-            per_file_stats = {'uri': blocklist, 'skip': 0, 'blocklist': 0}
+            per_file_stats = {'uri': blocklist, 'skip': 0, 'blocklist': 0, 'wildcard': 0}
             for domain in self._domains_in_blocklist(blocklist):
                 if self._whitelist_pattern.match(domain):
                     per_file_stats['skip'] += 1
@@ -65,12 +65,16 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
                             else:
                                 result[domain]['duplicates'] = '%s' % bl_shortcode
                         else:
-                            result[domain] = {'bl': bl_shortcode, 'wildcard': False}
+                            if domain.startswith('*.'):
+                                result[domain[2:]] = {'bl': bl_shortcode, 'wildcard': True}
+                                per_file_stats['wildcard'] += 1
+                            else:
+                                result[domain] = {'bl': bl_shortcode, 'wildcard': False}
                     else:
                         per_file_stats['skip'] += 1
             syslog.syslog(
                 syslog.LOG_NOTICE,
-                'blocklist: %(uri)s (exclude: %(skip)d block: %(blocklist)d)' % per_file_stats
+                'blocklist: %(uri)s (exclude: %(skip)d block: %(blocklist)d wildcard: %(wildcard)d)' % per_file_stats
             )
 
         if self.cnf and self.cnf.has_section('include'):

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
@@ -1,6 +1,9 @@
 {%
   set predefined = {
       "aa": "https://adaway.org/hosts.txt",
+      "oisd0": "https://small.oisd.nl/domainswild",
+      "oisd1": "https://big.oisd.nl/domainswild",
+      "oisd2": "https://nsfw.oisd.nl/domainswild",
       "ag": "https://justdomains.github.io/blocklists/lists/adguarddns-justdomains.txt",
       "bla0": "https://blocklistproject.github.io/Lists/alt-version/abuse-nl.txt",
       "bla": "https://blocklistproject.github.io/Lists/alt-version/ads-nl.txt",
@@ -60,8 +63,6 @@ custom_{{loop.index}}={{uri}}
 [exclude]
 # exclude localhost entries
 default_pattern_1=.*localhost$
-# exclude non domain entries
-default_pattern_2=^(?![a-zA-Z_\d]).*
 {%    if not helpers.empty('OPNsense.unboundplus.dnsbl.whitelists')%}
 # user defined
 {%      for pattern in OPNsense.unboundplus.dnsbl.whitelists.split(',') %}


### PR DESCRIPTION
Also add 3 lists that contain wildcard domains. Removed the "exclude non domain entries" regex pattern since all domains are filtered through a larger domain pattern that now includes the wildcard symbol as well.