### PR TITLE
Update ipsec.widget.php - Count user in "Overview" Tab and improve "Mobile Users" Tab

### DIFF
--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -68,19 +68,30 @@ foreach ($ipsec_status as $status_key => $status_value) {
         }
     }
 }
-// Initialize variable aggregated_data and loop through the ipsec_leases array to fetch the data for user, address and online status. Used later for div ipsec-mobile.
-$aggregated_data = array();
+// Initialize variable aggregated_data and loop through the ipsec_leases array to fetch the data for user, address and online status. Used later for div ipsec-mobile. Additionally count the unique_users in the same foreach loop, used for mobile_users count.
+$aggregated_data = [];
+$unique_users = [];
+
 foreach ($ipsec_leases as $lease) {
-    $user = $lease['user'];
-    $address = $lease['address'];
-    $online = $lease['online'];
     // For each unique user, initialize an empty array
-    if (!isset($aggregated_data[$user])) {
-        $aggregated_data[$user] = array();
+    if (!isset($aggregated_data[$lease['user']])) {
+        $aggregated_data[$lease['user']] = [];
     }
-    // Add the IP address to this user's array of addresses and connect it with the online status
-    $aggregated_data[$user][] = array('address' => $address, 'online' => $online);
+    // Add the lease data to this user's array of leases
+    $aggregated_data[$lease['user']][] = [
+        'address' => $lease['address'],
+        'online' => $lease['online']
+    ];
+    
+    // Count unique users in ipsec_leases array if lease is online
+    if ($lease['online']) {
+        $unique_users[$lease['user']] = true;
+    }
 }
+
+// Return the number of unique_users as mobile_users
+$mobile_users = count($unique_users);
+
 ?>
 <script>
     $(document).ready(function() {
@@ -145,18 +156,7 @@ foreach ($ipsec_leases as $lease) {
         </td>
         <td><?= (count($ipsec_tunnels) - $activetunnels); ?></td>
         <td>
-<?php
-    // Initialize variable unique_users
-    $unique_users = array();
-    foreach ($ipsec_leases as $lease) {
-        if ($lease['online']) {
-            // Count unique users in ipsec_leases array if lease is online
-            $unique_users[$lease['user']] = true;
-        }
-    }
-    // Return the number of unique_users as mobile_users
-    $mobile_users = count($unique_users);
-?>
+           <!-- mobile_users were counted in the earlier loop where data was aggregated -->
            <?=$mobile_users;?>
         </td>
       </tr>

--- a/src/www/widgets/widgets/ipsec.widget.php
+++ b/src/www/widgets/widgets/ipsec.widget.php
@@ -68,7 +68,19 @@ foreach ($ipsec_status as $status_key => $status_value) {
         }
     }
 }
-
+// Initialize variable aggregated_data and loop through the ipsec_leases array to fetch the data for user, address and online status. Used later for div ipsec-mobile.
+$aggregated_data = array();
+foreach ($ipsec_leases as $lease) {
+    $user = $lease['user'];
+    $address = $lease['address'];
+    $online = $lease['online'];
+    // For each unique user, initialize an empty array
+    if (!isset($aggregated_data[$user])) {
+        $aggregated_data[$user] = array();
+    }
+    // Add the IP address to this user's array of addresses and connect it with the online status
+    $aggregated_data[$user][] = array('address' => $address, 'online' => $online);
+}
 ?>
 <script>
     $(document).ready(function() {
@@ -134,15 +146,18 @@ foreach ($ipsec_status as $status_key => $status_value) {
         <td><?= (count($ipsec_tunnels) - $activetunnels); ?></td>
         <td>
 <?php
-        // count active mobile users
-        $mobile_users = 0;
-        foreach ($ipsec_leases as $lease) {
-            if ($lease['online']) {
-                ++$mobile_users;
-            }
+    // Initialize variable unique_users
+    $unique_users = array();
+    foreach ($ipsec_leases as $lease) {
+        if ($lease['online']) {
+            // Count unique users in ipsec_leases array if lease is online
+            $unique_users[$lease['user']] = true;
         }
-    ?>
-          <?=$mobile_users;?>
+    }
+    // Return the number of unique_users as mobile_users
+    $mobile_users = count($unique_users);
+?>
+           <?=$mobile_users;?>
         </td>
       </tr>
     </tbody>
@@ -176,28 +191,45 @@ foreach ($ipsec_status as $status_key => $status_value) {
     </tbody>
   </table>
 </div>
-<div id="ipsec-mobile" class="ipsec-tab-content" style="display:none;">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th><?= gettext('User');?></th>
-        <th><?= gettext('IP');?></th>
-        <th><?= gettext('Status');?></th>
-      </tr>
-    </thead>
-    <tbody>
-<?php
-    foreach ($ipsec_leases as $lease):?>
-      <tr>
-        <td><?=htmlspecialchars($lease['user']);?></td>
-        <td><?=htmlspecialchars($lease['address']);?></td>
-        <td>
-          <i class="fa fa-exchange fa-fw text-<?= $lease['online'] ?  "success" : 'danger' ?>"></i>
-        </td>
-      </tr>
 
-<?php
-    endforeach;?>
-    </tbody>
-  </table>
+<div id="ipsec-mobile" class="ipsec-tab-content" style="display:none;">
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th><?=gettext('User');?></th>
+            <th><?=gettext('IP');?></th>
+            <th><?=gettext('Status');?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php
+        // Generate the user and IP addresses table rows using the aggregated_data variable that was populated earlier
+        foreach ($aggregated_data as $user => $user_data):?>
+            <tr>
+                <td><?=htmlspecialchars($user);?></td>
+                <td>
+                    <table>
+                        <?php foreach($user_data as $lease): ?>
+                            <tr>
+                                <td><?=htmlspecialchars($lease['address']);?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </table>
+                </td>
+                <td>
+                    <table>
+                        <?php foreach($user_data as $lease):?>
+                            <tr>
+                                <td>
+                                    <!-- Show the online and offline status of each lease a user has. -->
+                                    <i class="fa fa-exchange fa-fw text-<?=$lease['online'] ? 'success' : 'danger' ?>"></i>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </table>
+                </td>
+            </tr>
+        <?php endforeach ?>
+        </tbody>
+    </table>
 </div>


### PR DESCRIPTION
https://github.com/opnsense/core/issues/6889

This change attempts to solve the problem of users having multiple IP addresses as leases and being counted per leased IP.
- Only "user" are counted now
- Each "user" can have several "lease"
- Each "lease" can have an individual online or offline status
- A user is online when at least one "lease" is "online = true"

The code can be tested with this sample data. It can be placed in line 46 and populates the variable $ipsec_leases = []

```
$ipsec_leases = array(
    array(
        'pool' => 'pool-roadwarrior-ipv4',
        'address' => '172.16.203.1',
        'online' => true,
        'user' => 'user1@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv4',
        'address' => '172.16.203.2',
        'online' => false,
        'user' => 'user2@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv4',
        'address' => '172.16.203.3',
        'online' => true,
        'user' => 'user3@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv4',
        'address' => '172.16.203.4',
        'online' => true,
        'user' => 'user5@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:1::1',
        'online' => false,
        'user' => 'user1@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:1::2',
        'online' => false,
        'user' => 'user1@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:1::3',
        'online' => true,
        'user' => 'user1@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:2::1',
        'online' => false,
        'user' => 'user2@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:2::2',
        'online' => false,
        'user' => 'user3@vpn1'
    ),
    array(
        'pool' => 'pool-roadwarrior-ipv6',
        'address' => 'fd00:abcd:1234:3::1',
        'online' => true,
        'user' => 'user4@vpn1'
    )
);
```
The result will look like this:

![grafik](https://github.com/opnsense/core/assets/79600909/38eba6b1-5a94-4a0d-87ed-573caa1d4643)

All users that have at least one online lease will be counted towards "Mobile Users". In the above sample data, user2@vpn1 has two offline leases, which means the user counts as not connected. All other users have at least one or multiple online leases, which makes them count as online.

![grafik](https://github.com/opnsense/core/assets/79600909/0d82d86e-3621-4d13-b7c1-3ab3f723a941)

I think this is the best variant, since it adds new functionality while also retaining all old functionality. :)