### PR TITLE
ipsec: make Description in Connections Required

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Swanctl</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>OPNsense IPsec Connections</description>
     <items>
         <Connections>
@@ -98,7 +98,9 @@
                     <MinimumValue>0</MinimumValue>
                     <MaximumValue>1000</MaximumValue>
                 </keyingtries>
-                <description type="TextField"/>
+                <description type="TextField">
+                    <Required>Y</Required>
+                </description>
             </Connection>
         </Connections>
         <locals>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Swanctl</mount>
-    <version>1.0.1</version>
+    <version>1.0.0</version>
     <description>OPNsense IPsec Connections</description>
     <items>
         <Connections>


### PR DESCRIPTION
Hi,

it seems that when leaving the field empty, you have an empty dropdown list in authentication and children, it's a bit weird when you forget to fill in the field it's quite hard to find the error why you cannot link the newly created connection.

Happy if you find an alternative to this PR :)