### PR TITLE
wireguard: different approach to bootup handling

### DIFF
--- a/src/etc/inc/plugins.inc.d/wireguard.inc
+++ b/src/etc/inc/plugins.inc.d/wireguard.inc
@@ -122,8 +122,23 @@ function wireguard_devices()
 
 function wireguard_prepare($device)
 {
-    mwexecf('/sbin/ifconfig wg create name %s', $device);
-    mwexecf('/sbin/ifconfig %s group wireguard', $device);
+    foreach ((new OPNsense\Wireguard\Server())->servers->server->iterateItems() as $node) {
+        if ($device != (string)$node->interface) {
+            continue;
+        }
+
+        /* deleting the stat file marks the interface for eventual reconfiguration */
+        @unlink((string)$node->statFilename);
+
+        if (!does_interface_exist($device)) {
+            mwexecf('/sbin/ifconfig wg create name %s', $device);
+            mwexecf('/sbin/ifconfig %s group wireguard', $device);
+        }
+
+        return $device;
+    }
+
+    return null;
 }
 
 function wireguard_configure()

--- a/src/opnsense/scripts/Wireguard/wg-service-control.php
+++ b/src/opnsense/scripts/Wireguard/wg-service-control.php
@@ -223,14 +223,7 @@ if (isset($opts['h']) || empty($args) || !in_array($args[0], ['start', 'stop', '
                         wg_start($node, $statHandle, $carp_if_flag);
                         break;
                     case 'configure':
-                        if (
-                            @md5_file($node->cnfFilename) != get_stat_hash($statHandle)['file'] ||
-                            !isset($ifdetails[(string)$node->interface]) || (
-                                // Interface has been setup, but without configuration
-                                empty($ifdetails[(string)$node->interface]['ipv4']) &&
-                                empty($ifdetails[(string)$node->interface]['ipv6'])
-                            )
-                        ) {
+                        if (@md5_file($node->cnfFilename) != get_stat_hash($statHandle)['file']) {
                             if (get_stat_hash($statHandle)['interface'] != wg_reconfigure_hash($node)) {
                                 // Fluent reloading not supported for this instance, make sure the user is informed
                                 syslog(


### PR DESCRIPTION
Since we used to allow IP configuration ands VIPs are a possibility we can avoid checking for missing IPs and simply delete the status hash file which will force an eventual reconfiguration.

While here avoid wireguard_prepare() from creating spurious devices when there is no need for it as it happens with manual invoke through "pluginctl -d wgX".  wg-service-control uses the same logic.