### PR TITLE
Fix wireless - channels missing in 5Ghz and 2.4Ghz  

### DIFF
--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -265,11 +265,12 @@ function get_wireless_modes($interface)
     $cloned_interface = get_real_interface($interface);
     if ($cloned_interface) {
         $chan_list = "/sbin/ifconfig {$cloned_interface} list chan";
+        $column_fix = "sed 's/Channel/\\x0aChannel/2'";
         $stack_list = "/usr/bin/awk -F\"Channel \" '{ gsub(/\\*/, \" \"); print \$2 \"\\\n\" \$3 }'";
         $format_list = "/usr/bin/awk '{print \$5 \" \" \$6 \",\" \$1}'";
 
         $interface_channels = [];
-        exec("$chan_list | $stack_list | sort -u | $format_list 2>&1", $interface_channels);
+        exec("$chan_list | $column_fix | $stack_list | sort -u | $format_list 2>&1", $interface_channels);
 
         foreach ($interface_channels as $c => $interface_channel) {
             $channel_line = explode(",", $interface_channel);
@@ -310,11 +311,12 @@ function get_wireless_channel_info($interface)
     $cloned_interface = get_real_interface($interface);
     if ($cloned_interface) {
         $chan_list = "/sbin/ifconfig {$cloned_interface} list txpower";
+        $column_fix = "sed 's/Channel/\\x0aChannel/2'";
         $stack_list = "/usr/bin/awk -F\"Channel \" '{ gsub(/\\*/, \" \"); print \$2 \"\\\n\" \$3 }'";
         $format_list = "/usr/bin/awk '{print \$1 \",\" \$3 \" \" \$4 \",\" \$5 \",\" \$7}'";
 
         $interface_channels = [];
-        exec("$chan_list | $stack_list | sort -u | $format_list 2>&1", $interface_channels);
+        exec("$chan_list | $column_fix | $stack_list | sort -u | $format_list 2>&1", $interface_channels);
 
         foreach ($interface_channels as $channel_line) {
             $channel_line = explode(",", $channel_line);


### PR DESCRIPTION
Fix wireless channels missing in 802.11ng (2.4 Ghz) Add all the missing 802.11na channels (5Ghz)

The root cause was a problem in parsing the ifconfig output from channels - which we were reading only the first collumn instead of both.

I have created a ticket in the past about this: https://github.com/opnsense/core/issues/5765