### PR TITLE
IDS: Fixed old documentation URL of ruleset "ET open"

### DIFF
--- a/src/opnsense/scripts/suricata/metadata/rules/et-open.xml
+++ b/src/opnsense/scripts/suricata/metadata/rules/et-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset documentation_url="https://doc.emergingthreats.net/bin/view/Main/EmergingFAQ">
+<ruleset documentation_url="https://community.emergingthreats.net/t/frequently-asked-questions/56">
     <location url="https://rules.emergingthreats.net/open/suricata-7.0/emerging.rules.tar.gz" prefix="ET open"/>
     <version url="https://rules.emergingthreats.net/open/suricata-7.0/version.txt"/>
     <files>


### PR DESCRIPTION
doc.emergingthreats.net has its SSL certificate expired for over half a year.
Clicking https://doc.emergingthreats.net/bin/view/Main/EmergingFAQ leads to a browser warning "This is an unsafe connection". So not looking very trustworthy to install IDS rules from :wink: 

I thought of putting subpage https://rules.emergingthreatspro.com/OPEN_download_instructions.html as it targets more specific the instructions page. However, there is no navigation to go back to the top page.
As I user, clicking from OPNsense's "Ruleset details" dialog to get more information what rules I am going to download https://rules.emergingthreatspro.com helps me more.