### PR TITLE
system: extend restore to be able to migrate

### DIFF
--- a/src/etc/inc/console.inc
+++ b/src/etc/inc/console.inc
@@ -51,9 +51,9 @@ function timeout($timer = 7)
     return $key;
 }
 
-function is_interface_mismatch()
+function is_interface_mismatch($locked = true)
 {
-    $patterns = array('^impossiblecontrolmatch$'); /* XXX */
+    $patterns = ['^impossiblecontrolmatch$'];
     $mismatch = false;
 
     foreach (plugins_devices() as $device) {
@@ -62,11 +62,10 @@ function is_interface_mismatch()
         }
     }
 
-    /* XXX we can match known devices names, much easier as soon as it is provided */
     $regex = '/' . implode('|', $patterns) . '/';
 
     foreach (legacy_config_get_interfaces(['virtual' => false]) as $ifname => $ifcfg) {
-        if (!empty($ifcfg['lock'])) {
+        if ($locked && !empty($ifcfg['lock'])) {
             /* Do not mismatch if any lock was issued */
             $mismatch = false;
             break;

--- a/src/etc/inc/plugins.inc.d/pf.inc
+++ b/src/etc/inc/plugins.inc.d/pf.inc
@@ -217,7 +217,7 @@ function pf_xmlrpc_sync()
     $result[] = array(
         'description' => gettext('Aliases'),
         'help' => gettext('Synchronize the aliases over to the other HA host.'),
-        'section' => 'OPNsense.Firewall.Alias',
+        'section' => 'aliases,OPNsense.Firewall.Alias',
         'id' => 'aliases',
         'services' => ['pf'],
     );

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -41,21 +41,13 @@ use OPNsense\Backup\Local;
 
 /**
  * restore config section
- * @param string $section_name config section name
+ * @param array $section_sets config section sets
  * @param string $new_contents xml content
  * @return bool status
  */
-function restore_config_section($section_name, $new_contents)
+function restore_config_section($section_sets, $new_contents)
 {
     global $config;
-
-    $sections = [];
-
-    foreach ($section_name as $section) {
-        $sections = array_merge($sections, explode(',', $section));
-    }
-
-    $sections = array_unique($sections);
 
     $tmpxml = '/tmp/tmpxml';
     $xml = null;
@@ -73,27 +65,76 @@ function restore_config_section($section_name, $new_contents)
 
     $restored = [];
 
-    foreach ($sections as $section) {
-        $old = &$config;
-        $new = &$xml;
+    foreach ($section_sets as $section_set) {
+        $sections = explode(',', $section_set);
+        $found = [];
 
-        $path = explode('.', $section);
-        $target = array_pop($path);
+        /* first find the existing sections from the set to be imported */
+        foreach ($sections as $section) {
+            $new = &$xml;
 
-        foreach ($path as $node) {
-            if (!isset($new[$node])) {
-                continue 2;
+            $path = explode('.', $section);
+            $target = array_pop($path);
+
+            foreach ($path as $node) {
+                if (!isset($new[$node])) {
+                    continue 2;
+                }
+                $new = &$new[$node];
             }
-            $new = &$new[$node];
-            if (!isset($old[$node])) {
-                $old[$node] = [];
+
+            if (isset($new[$target])) {
+                $found[] = $section;
             }
-            $old = &$old[$node];
         }
 
-        if (isset($new[$target])) {
-            $old[$target] = $new[$target];
-            $restored[] = $section;
+        /* keep current config and skip to next one considering this set failed */
+        if (!count($found)) {
+            continue;
+        }
+
+        /* secondly delete every old config section to be able to force a migration too */
+        foreach (array_diff($sections, $found) as $section) {
+            $old = &$config;
+
+            $path = explode('.', $section);
+            $target = array_pop($path);
+
+            foreach ($path as $node) {
+                if (!isset($old[$node])) {
+                    continue 2;
+                }
+                $old = &$old[$node];
+            }
+
+            if (isset($old[$target])) {
+                unset($old[$target]);
+            }
+        }
+
+        /* thirdly and lastly import the found sections */
+        foreach ($found as $section) {
+            $old = &$config;
+            $new = &$xml;
+
+            $path = explode('.', $section);
+            $target = array_pop($path);
+
+            foreach ($path as $node) {
+                if (!isset($new[$node])) {
+                    continue 2;
+                }
+                $new = &$new[$node];
+                if (!isset($old[$node])) {
+                    $old[$node] = [];
+                }
+                $old = &$old[$node];
+            }
+
+            if (isset($new[$target])) {
+                $old[$target] = $new[$target];
+                $restored[] = $section;
+            }
         }
     }
 

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -347,19 +347,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 }
             }
 
-            if ($do_reboot) {
-                if (is_interface_mismatch()) {
+            if (is_interface_mismatch(false)) {
+                $savemsg .= ' ' . sprintf(
+                    gettext(
+                        "Interfaces do not seem to match, please check the %sassignments%s now for missing devices."
+                    ),
+                    '<a href="/interfaces_assign.php">',
+                    '</a>'
+                );
+                if ($do_reboot) {
+                    $savemsg .= ' ' . gettext('Postponing reboot.');
                     $do_reboot = false;
-                    $savemsg .= ' ' . sprintf(
-                        gettext(
-                            "Postponing reboot as interfaces do not seem to match, please check %s assignments %s first and reboot manually."
-                        ),
-                        '<a href="/interfaces_assign.php">',
-                        '</a>'
-                    );
-                } else {
-                    $savemsg .= ' ' . gettext("The system is rebooting now. This may take one minute.");
                 }
+            }
+
+            if ($do_reboot) {
+                $savemsg .= ' ' . gettext("The system is rebooting now. This may take one minute.");
             }
         }
     } elseif (!empty($mode)){

--- a/src/www/diag_backup.php
+++ b/src/www/diag_backup.php
@@ -319,6 +319,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                         $do_reboot = true;
                     }
                     $config = parse_config();
+                    $flush = false;
                     if (!empty($pconfig['keepconsole'])) {
                         // restore existing console settings
                         foreach ($csettings as $fieldname => $fieldcontent) {
@@ -328,14 +329,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                                 $config['system'][$fieldname] = $fieldcontent;
                             }
                         }
+                        $flush = true;
                     }
-                    if (!empty($config['rrddata']) || !empty($pconfig['keepconsole'])){
-                        /* extract out rrd items, unset from $config when done */
-                        if (!empty($config['rrddata'])) {
-                            /* XXX we should point to the data... */
-                            rrd_import();
-                            unset($config['rrddata']);
-                        }
+                    if (!empty($config['rrddata'])) {
+                        /* XXX we should point to the data... */
+                        rrd_import();
+                        unset($config['rrddata']);
+                        $flush = true;
+                    }
+                    if ($flush) {
                         write_config();
                         convert_config();
                     }


### PR DESCRIPTION
Raising the bar with an official PR ;)

There are two parts:

1. consistent import per section "set" making sure nonexistent entries in the new config are cleared in the old one.
2. bring back "aliases" section to be able to migrate (doesn't work without 1.)