### PR TITLE
Kea / Dhcp - DHCPv4 replacement [#6971], Add "IP Address" to KEA reservations Table

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv4Controller.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv4Controller.php
@@ -75,7 +75,7 @@ class Dhcpv4Controller extends ApiMutableModelControllerBase
 
     public function searchReservationAction()
     {
-        return $this->searchBase("reservations.reservation", ['subnet', 'hw_address', 'description'], "hw_address");
+        return $this->searchBase("reservations.reservation", ['subnet', 'ip_address', 'hw_address', 'description'], "hw_address");
     }
 
     public function setReservationAction($uuid)

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -107,6 +107,7 @@
                 <tr>
                   <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                   <th data-column-id="subnet" data-type="string">{{ lang._('Subnet') }}</th>
+                  <th data-column-id="ip_address" data-type="string">{{ lang._('IP Address') }}</th>
                   <th data-column-id="hw_address" data-type="string">{{ lang._('MAC') }}</th>
                   <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                   <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>


### PR DESCRIPTION
The device's IP address is missing from the KEA reservations table. See #6971 