### PR TITLE
webgui + openssh: listen on IPv6 link-local addresses

### DIFF
--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -202,11 +202,6 @@ function openssh_configure_do($verbose = false, $interface = '')
     $listeners = array();
 
     foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
-        if ($info['scope']) {
-            /* link-local does not seem to be supported */
-            continue;
-        }
-
         if (!$info['bind']) {
             continue;
         }

--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -83,11 +83,6 @@ function webgui_configure_do($verbose = false, $interface = '')
     $listeners = count($interfaces) ? [] : ['0.0.0.0', '::'];
 
     foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
-        if ($info['scope']) {
-            /* link-local does not seem to be supported */
-            continue;
-        }
-
         if (!$info['bind']) {
             continue;
         }


### PR DESCRIPTION
WebGUI and SSH connections to link-local addresses only work if the listen interfaces are set to "All (recommended)". This PR allows link-local connections for specific listen interfaces, too. While selecting specific interfaces is only recommended for some use cases, explicitly excluding link-local addresses doesn't seem appropriate. Maybe there once was a bug which required this?