### PR TITLE
interfaces: split bring_down into dynamic and static parts #6852

### DIFF
--- a/src/etc/inc/console.inc
+++ b/src/etc/inc/console.inc
@@ -411,7 +411,7 @@ EOD;
         }
     } elseif (isset($config['interfaces']['lan'])) {
         unset($config['interfaces']['lan']['enable']);
-        interface_bring_down('lan');
+        interface_reset('lan');
 
         if (isset($config['dhcpd']['lan'])) {
             unset($config['dhcpd']['lan']);
@@ -447,7 +447,7 @@ EOD;
         }
     } elseif (isset($config['interfaces']['wan'])) {
         unset($config['interfaces']['wan']['enable']);
-        interface_bring_down('wan');
+        interface_reset('wan');
         unset($config['interfaces']['wan']);
     }
 
@@ -467,7 +467,7 @@ EOD;
     /* remove all other (old) optional interfaces */
     for (; isset($config['interfaces']['opt' . ($i + 1)]); $i++) {
         unset($config['interfaces']['opt' . ($i + 1)]['enable']);
-        interface_bring_down('opt' . ($i + 1));
+        interface_reset('opt' . ($i + 1));
         unset($config['interfaces']['opt' . ($i + 1)]);
     }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -818,9 +818,11 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
             break;
     }
 
-    if (!empty($ifcfg['ipaddrv6']) && !is_ipaddrv6($ifcfg['ipaddrv6'])) {
+    if ($reset) {
+        interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
+    } elseif (!empty($ifcfg['ipaddrv6']) && !is_ipaddrv6($ifcfg['ipaddrv6'])) {
         /* edge case: bring down a primary GUA, but not a link-local */
-        list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
+        list ($ip6) = _interfaces_primary_address6($interface, $ifconfig_details, false, false);
         if (!empty($ip6)) {
             mwexecf('/sbin/ifconfig %s inet6 %s delete', [$realifv6, $ip6]);
         }
@@ -851,8 +853,10 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
             break;
     }
 
-    if (!empty($ifcfg['ipaddr']) && !is_ipaddrv4($ifcfg['ipaddr'])) {
-        list ($ip4) = interfaces_primary_address($interface);
+    if ($reset) {
+        interfaces_addresses_flush($realif, 4, $ifconfig_details);
+    } elseif (!empty($ifcfg['ipaddr']) && !is_ipaddrv4($ifcfg['ipaddr'])) {
+        list ($ip4) = interfaces_primary_address($interface, $ifconfig_details);
         if (!empty($ip4)) {
             mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ip4]);
         }
@@ -861,11 +865,6 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
     /* clear stale state associated with this interface */
     mwexecf('/usr/local/sbin/ifctl -4c -i %s', $realif);
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
-
-    if ($reset) {
-        interfaces_addresses_flush($realif, 4, $ifconfig_details);
-        interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
-    }
 }
 
 function interface_suspend($interface)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -766,7 +766,7 @@ function interface_vip_bring_down($vip)
     }
 }
 
-function interface_bring_down($interface, $ifacecfg = false, $full = true, $reset = false)
+function interface_bring_down($interface, $ifacecfg = false, $reset = true)
 {
     global $config;
 
@@ -779,8 +779,6 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true, $rese
         $realifv6 = get_real_interface($interface, "inet6");
         $ifcfg = $config['interfaces'][$interface];
         $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
-        /* signal pppoe on demand to restart to retain behaviour */
-        $ifcfg['enable'] = !$reset;
     } else {
         $ifcfg = $ifacecfg['ifcfg'];
         $ppps = $ifacecfg['ppps'];
@@ -791,15 +789,6 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true, $rese
 
     $ifconfig_details = legacy_interfaces_details();
 
-    interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
-    if ($full == true) {
-        interfaces_addresses_flush($realif, 4, $ifconfig_details);
-        interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
-    }
-}
-
-function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps)
-{
     /*
      * hostapd and wpa_supplicant do not need to be running when the
      * interface is down.  They will also use 100% CPU if running after
@@ -845,7 +834,7 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
             if (!empty($ppps)) {
                 foreach ($ppps as $ppp) {
                     if ($ifcfg['if'] == $ppp['if']) {
-                        if (isset($ppp['ondemand']) && isset($ifcfg['enable'])) {
+                        if (isset($ppp['ondemand']) && !$reset) {
                             configdp_run('interface reconfigure', [$interface], true);
                         } else {
                             killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
@@ -872,6 +861,11 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     /* clear stale state associated with this interface */
     mwexecf('/usr/local/sbin/ifctl -4c -i %s', $realif);
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
+
+    if ($reset) {
+        interfaces_addresses_flush($realif, 4, $ifconfig_details);
+        interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
+    }
 }
 
 function interface_suspend($interface)
@@ -881,7 +875,7 @@ function interface_suspend($interface)
 
 function interface_reset($interface, $ifacecfg = false)
 {
-    interface_bring_down($interface, $ifacecfg, true, true);
+    interface_bring_down($interface, $ifacecfg);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -766,42 +766,8 @@ function interface_vip_bring_down($vip)
     }
 }
 
-function interface_bring_down($interface = 'wan', $ifacecfg = false)
+function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps)
 {
-    global $config;
-
-    if (!isset($config['interfaces'][$interface]) || ($ifacecfg !== false && !is_array($ifacecfg))) {
-        return;
-    }
-
-    if ($ifacecfg === false) {
-        $realif = get_real_interface($interface);
-        $realifv6 = get_real_interface($interface, "inet6");
-        $ifcfg = $config['interfaces'][$interface];
-        $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
-    } else {
-        $ifcfg = $ifacecfg['ifcfg'];
-        $ppps = $ifacecfg['ppps'];
-        /* When $ifacecfg is passed, it should contain the original interfaces */
-        $realif = $ifacecfg['ifcfg']['realif'];
-        $realifv6 = $ifacecfg['ifcfg']['realifv6'];
-    }
-
-    $ifcfg['ipaddr'] = empty($ifcfg['ipaddr']) ? null : $ifcfg['ipaddr'];
-    $ifcfg['ipaddrv6'] = empty($ifcfg['ipaddrv6']) ? null : $ifcfg['ipaddrv6'];
-
-    if (isset($config['virtualip']['vip'])) {
-        foreach ($config['virtualip']['vip'] as $vip) {
-            if ($vip['interface'] == $interface && $vip['mode'] != 'carp') {
-                /**
-                 * only disable non carp aliases, net.inet.carp.ifdown_demotion_factor should do its work
-                 * when a carp interface goes down
-                 */
-                interface_vip_bring_down($vip);
-            }
-        }
-    }
-
     /*
      * hostapd and wpa_supplicant do not need to be running when the
      * interface is down.  They will also use 100% CPU if running after
@@ -818,7 +784,7 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
         plugins_configure('dhcp', false, ['inet6', $track6]);
     }
 
-    switch ($ifcfg['ipaddrv6']) {
+    switch ($ifcfg['ipaddrv6'] ?? 'none') {
         case 'slaac':
         case 'dhcp6':
             interface_dhcpv6_prepare($interface, $ifcfg, true);
@@ -831,8 +797,8 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
             break;
     }
 
-    /* may be required or not, but kept here for symmetry with IPv4 */
-    if (!empty($ifcfg['ipaddrv6'])) {
+    /* strip dynamic IPv6 addresses */
+    if (!is_ipaddrv6($ifcfg['ipaddrv6'] ?? 'none')) {
         /* edge case: bring down a primary GUA, but not a link-local */
         list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
         if (!empty($ip6)) {
@@ -840,7 +806,7 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
         }
     }
 
-    switch ($ifcfg['ipaddr']) {
+    switch ($ifcfg['ipaddr'] ?? 'none') {
         case 'ppp':
         case 'pppoe':
         case 'pptp':
@@ -848,11 +814,11 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
             if (!empty($ppps)) {
                 foreach ($ppps as $ppp) {
                     if ($ifcfg['if'] == $ppp['if']) {
-                        if (isset($ppp['ondemand']) && $ifacecfg === false) {
+                        if (isset($ppp['ondemand']) && isset($ifcfg['enable'])) {
                             configdp_run('interface reconfigure', [$interface], true);
-                            break;
+                        } else {
+                            killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
                         }
-                        killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
                         break;
                     }
                 }
@@ -865,8 +831,8 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
             break;
     }
 
-    /* required for static and dhcp (dhclient limitation) */
-    if (!empty($ifcfg['ipaddr'])) {
+    /* strip dynamic IPv4 addresses (also due to dhclient limitation) */
+    if (!is_ipaddrv4($ifcfg['ipaddr'] ?? 'none')) {
         list ($ip4) = interfaces_primary_address($interface);
         if (!empty($ip4)) {
             mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ip4]);
@@ -876,6 +842,85 @@ function interface_bring_down($interface = 'wan', $ifacecfg = false)
     /* clear stale state associated with this interface */
     mwexecf('/usr/local/sbin/ifctl -4c -i %s', $realif);
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
+}
+
+function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
+{
+    global $config;
+
+    if (isset($config['virtualip']['vip'])) {
+        foreach ($config['virtualip']['vip'] as $vip) {
+            /* XXX eventually bring down all as requested */
+            if ($vip['interface'] == $interface && $vip['mode'] != 'carp') {
+                /**
+                 * only disable non carp aliases, net.inet.carp.ifdown_demotion_factor should do its work
+                 * when a carp interface goes down
+                 */
+                interface_vip_bring_down($vip);
+            }
+        }
+    }
+
+    if (is_ipaddrv6($ifcfg['ipaddrv6'] ?? 'none')) {
+        /* edge case: bring down a primary GUA, but not a link-local */
+        list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
+        if (!empty($ip6)) {
+            mwexecf('/sbin/ifconfig %s inet6 %s delete', [$realifv6, $ip6]);
+        }
+    }
+
+    if (is_ipaddrv4($ifcfg['ipaddr'] ?? 'none')) {
+        list ($ip4) = interfaces_primary_address($interface);
+        if (!empty($ip4)) {
+            mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ip4]);
+        }
+    }
+}
+
+function interface_bring_down($interface, $ifacecfg = false, $full = true)
+{
+    global $config;
+
+    if (!isset($config['interfaces'][$interface]) || ($ifacecfg !== false && !is_array($ifacecfg))) {
+        return;
+    }
+
+    if ($ifacecfg === false) {
+        $realif = get_real_interface($interface);
+        $realifv6 = get_real_interface($interface, "inet6");
+        $ifcfg = $config['interfaces'][$interface];
+        $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
+        /* signal pppoe on demand to restart to retain behaviour */
+        $ifcfg['enable'] = true;
+    } else {
+        $ifcfg = $ifacecfg['ifcfg'];
+        $ppps = $ifacecfg['ppps'];
+        /* When $ifacecfg is passed, it should contain the original interfaces */
+        $realif = $ifacecfg['ifcfg']['realif'];
+        $realifv6 = $ifacecfg['ifcfg']['realifv6'];
+    }
+
+    interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
+    if ($full == true) {
+        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
+    }
+}
+
+function interface_suspend($interface)
+{
+    interface_bring_down($interface, false, false);
+}
+
+function interface_reset($interface)
+{
+    $toapplylist = [];
+
+    /* makes the passing of $ifacecfg automatic, but does not modify the cache */
+    if (file_exists('/tmp/.interfaces.apply')) {
+        $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
+    }
+
+    interface_bring_down($interface, $toapplylist[$interface] ?? false);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -766,6 +766,35 @@ function interface_vip_bring_down($vip)
     }
 }
 
+function interface_bring_down($interface, $ifacecfg = false, $full = true)
+{
+    global $config;
+
+    if (!isset($config['interfaces'][$interface]) || ($ifacecfg !== false && !is_array($ifacecfg))) {
+        return;
+    }
+
+    if ($ifacecfg === false) {
+        $realif = get_real_interface($interface);
+        $realifv6 = get_real_interface($interface, "inet6");
+        $ifcfg = $config['interfaces'][$interface];
+        $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
+        /* signal pppoe on demand to restart to retain behaviour */
+        $ifcfg['enable'] = true;
+    } else {
+        $ifcfg = $ifacecfg['ifcfg'];
+        $ppps = $ifacecfg['ppps'];
+        /* When $ifacecfg is passed, it should contain the original interfaces */
+        $realif = $ifacecfg['ifcfg']['realif'];
+        $realifv6 = $ifacecfg['ifcfg']['realifv6'];
+    }
+
+    interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
+    if ($full == true) {
+        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
+    }
+}
+
 function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps)
 {
     /*
@@ -856,35 +885,6 @@ function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
 
     if (!empty($ifcfg['ipaddr']) && is_ipaddrv4($ifcfg['ipaddr'])) {
         mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ifcfg['ipaddr']]);
-    }
-}
-
-function interface_bring_down($interface, $ifacecfg = false, $full = true)
-{
-    global $config;
-
-    if (!isset($config['interfaces'][$interface]) || ($ifacecfg !== false && !is_array($ifacecfg))) {
-        return;
-    }
-
-    if ($ifacecfg === false) {
-        $realif = get_real_interface($interface);
-        $realifv6 = get_real_interface($interface, "inet6");
-        $ifcfg = $config['interfaces'][$interface];
-        $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
-        /* signal pppoe on demand to restart to retain behaviour */
-        $ifcfg['enable'] = true;
-    } else {
-        $ifcfg = $ifacecfg['ifcfg'];
-        $ppps = $ifacecfg['ppps'];
-        /* When $ifacecfg is passed, it should contain the original interfaces */
-        $realif = $ifacecfg['ifcfg']['realif'];
-        $realifv6 = $ifacecfg['ifcfg']['realifv6'];
-    }
-
-    interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
-    if ($full == true) {
-        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
     }
 }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -793,6 +793,15 @@ function interface_reset($interface, $ifacecfg = false, $suspend = false)
         $realifv6 = $ifacecfg['ifcfg']['realifv6'];
     }
 
+    if (!$suspend) {
+        foreach (config_read_array('virtualip', 'vip') as $vip) {
+            if ($vip['interface'] == $interface) {
+                interface_vip_bring_down($vip);
+            }
+        }
+    }
+
+    /* cache ifconfig now that VIPs are handled */
     $ifconfig_details = legacy_interfaces_details();
 
     /*

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -797,7 +797,6 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
             break;
     }
 
-    /* strip dynamic IPv6 addresses */
     if (!empty($ifcfg['ipaddrv6']) && !is_ipaddrv6($ifcfg['ipaddrv6'])) {
         /* edge case: bring down a primary GUA, but not a link-local */
         list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
@@ -831,7 +830,6 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
             break;
     }
 
-    /* strip dynamic IPv4 addresses (also due to dhclient limitation) */
     if (!empty($ifcfg['ipaddr']) && !is_ipaddrv4($ifcfg['ipaddr'])) {
         list ($ip4) = interfaces_primary_address($interface);
         if (!empty($ip4)) {
@@ -861,19 +859,12 @@ function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
         }
     }
 
-    if (is_ipaddrv6($ifcfg['ipaddrv6'] ?? 'none')) {
-        /* edge case: bring down a primary GUA, but not a link-local */
-        list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
-        if (!empty($ip6)) {
-            mwexecf('/sbin/ifconfig %s inet6 %s delete', [$realifv6, $ip6]);
-        }
+    if (!empty($ifcfg['ipaddrv6']) && is_ipaddrv6($ifcfg['ipaddrv6'])) {
+        mwexecf('/sbin/ifconfig %s inet6 %s delete', [$realifv6, $ifcfg['ipaddrv6']]);
     }
 
-    if (is_ipaddrv4($ifcfg['ipaddr'] ?? 'none')) {
-        list ($ip4) = interfaces_primary_address($interface);
-        if (!empty($ip4)) {
-            mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ip4]);
-        }
+    if (!empty($ifcfg['ipaddr']) && is_ipaddrv4($ifcfg['ipaddr'])) {
+        mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ifcfg['ipaddr']]);
     }
 }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -798,7 +798,7 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     }
 
     /* strip dynamic IPv6 addresses */
-    if (!is_ipaddrv6($ifcfg['ipaddrv6'] ?? 'none')) {
+    if (!empty($ifcfg['ipaddrv6']) && !is_ipaddrv6($ifcfg['ipaddrv6'])) {
         /* edge case: bring down a primary GUA, but not a link-local */
         list ($ip6) = _interfaces_primary_address6($interface, null, false, false);
         if (!empty($ip6)) {
@@ -832,7 +832,7 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     }
 
     /* strip dynamic IPv4 addresses (also due to dhclient limitation) */
-    if (!is_ipaddrv4($ifcfg['ipaddr'] ?? 'none')) {
+    if (!empty($ifcfg['ipaddr']) && !is_ipaddrv4($ifcfg['ipaddr'])) {
         list ($ip4) = interfaces_primary_address($interface);
         if (!empty($ip4)) {
             mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ip4]);

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -766,7 +766,7 @@ function interface_vip_bring_down($vip)
     }
 }
 
-function interface_bring_down($interface, $ifacecfg = false, $full = true)
+function interface_bring_down($interface, $ifacecfg = false, $full = true, $reset = false)
 {
     global $config;
 
@@ -780,13 +780,17 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true)
         $ifcfg = $config['interfaces'][$interface];
         $ppps = isset($config['ppps']['ppp']) ? $config['ppps']['ppp'] : [];
         /* signal pppoe on demand to restart to retain behaviour */
-        $ifcfg['enable'] = true;
+        $ifcfg['enable'] = !$reset;
     } else {
         $ifcfg = $ifacecfg['ifcfg'];
         $ppps = $ifacecfg['ppps'];
         /* When $ifacecfg is passed, it should contain the original interfaces */
         $realif = $ifacecfg['ifcfg']['realif'];
         $realifv6 = $ifacecfg['ifcfg']['realifv6'];
+    }
+
+    if ($reset && isset($ifcfg['enable']) && $ifacecfg === false) {
+        log_msg("interface_bring_down(): sloppy reconfiguration of $interface detected.", LOG_WARNING);
     }
 
     interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
@@ -893,16 +897,9 @@ function interface_suspend($interface)
     interface_bring_down($interface, false, false);
 }
 
-function interface_reset($interface)
+function interface_reset($interface, $ifacecfg = false)
 {
-    $toapplylist = [];
-
-    /* makes the passing of $ifacecfg automatic, but does not modify the cache */
-    if (file_exists('/tmp/.interfaces.apply')) {
-        $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
-    }
-
-    interface_bring_down($interface, $toapplylist[$interface] ?? false);
+    interface_bring_down($interface, $ifacecfg, true, true);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -789,13 +789,12 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true, $rese
         $realifv6 = $ifacecfg['ifcfg']['realifv6'];
     }
 
-    if ($reset && isset($ifcfg['enable']) && $ifacecfg === false) {
-        log_msg("interface_bring_down(): sloppy reconfiguration of $interface detected.", LOG_WARNING);
-    }
+    $ifconfig_details = legacy_interfaces_details();
 
     interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
     if ($full == true) {
-        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
+        interfaces_addresses_flush($realif, 4, $ifconfig_details);
+        interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
     }
 }
 
@@ -873,23 +872,6 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     /* clear stale state associated with this interface */
     mwexecf('/usr/local/sbin/ifctl -4c -i %s', $realif);
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
-}
-
-function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
-{
-    foreach (config_read_array('virtualip', 'vip') as $vip) {
-        if ($vip['interface'] == $interface) {
-            interface_vip_bring_down($vip);
-        }
-    }
-
-    if (!empty($ifcfg['ipaddrv6']) && is_ipaddrv6($ifcfg['ipaddrv6'])) {
-        mwexecf('/sbin/ifconfig %s inet6 %s delete', [$realifv6, $ifcfg['ipaddrv6']]);
-    }
-
-    if (!empty($ifcfg['ipaddr']) && is_ipaddrv4($ifcfg['ipaddr'])) {
-        mwexecf('/sbin/ifconfig %s delete %s', [$realif, $ifcfg['ipaddr']]);
-    }
 }
 
 function interface_suspend($interface)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -842,20 +842,11 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
 }
 
-function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg, $any_vip = false)
+function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
 {
-    global $config;
-
-    if (isset($config['virtualip']['vip'])) {
-        foreach ($config['virtualip']['vip'] as $vip) {
-            /* XXX eventually bring down all as requested */
-            if ($vip['interface'] == $interface && ($vip['mode'] != 'carp' || $any_vip)) {
-                /**
-                 * only disable non carp aliases, net.inet.carp.ifdown_demotion_factor should do its work
-                 * when a carp interface goes down
-                 */
-                interface_vip_bring_down($vip);
-            }
+    foreach (config_read_array('virtualip', 'vip') as $vip) {
+        if ($vip['interface'] == $interface) {
+            interface_vip_bring_down($vip);
         }
     }
 
@@ -868,7 +859,7 @@ function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg, $an
     }
 }
 
-function interface_bring_down($interface, $ifacecfg = false, $full = true, $any_vip = false)
+function interface_bring_down($interface, $ifacecfg = false, $full = true)
 {
     global $config;
 
@@ -893,7 +884,7 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true, $any_
 
     interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
     if ($full == true) {
-        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg, $any_vip);
+        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
     }
 }
 
@@ -911,7 +902,7 @@ function interface_reset($interface)
         $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
     }
 
-    interface_bring_down($interface, $toapplylist[$interface] ?? false, true, true);
+    interface_bring_down($interface, $toapplylist[$interface] ?? false);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -766,7 +766,7 @@ function interface_vip_bring_down($vip)
     }
 }
 
-function interface_bring_down($interface, $ifacecfg = false, $reset = true)
+function interface_reset($interface, $ifacecfg = false, $suspend = false)
 {
     global $config;
 
@@ -774,6 +774,12 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
         return;
     }
 
+    /*
+     * The function formerly known as interface_bring_down() is largely intact,
+     * but its purpose was split between different use cases that it could not
+     * handle correctly not being aware of the caller's requirements.  Now we
+     * split between a suspend and reset mode in order to accomodate the need.
+     */
     if ($ifacecfg === false) {
         $realif = get_real_interface($interface);
         $realifv6 = get_real_interface($interface, "inet6");
@@ -818,7 +824,7 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
             break;
     }
 
-    if ($reset) {
+    if (!$suspend) {
         interfaces_addresses_flush($realifv6, 6, $ifconfig_details);
     } elseif (!empty($ifcfg['ipaddrv6']) && !is_ipaddrv6($ifcfg['ipaddrv6'])) {
         /* edge case: bring down a primary GUA, but not a link-local */
@@ -836,7 +842,7 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
             if (!empty($ppps)) {
                 foreach ($ppps as $ppp) {
                     if ($ifcfg['if'] == $ppp['if']) {
-                        if (isset($ppp['ondemand']) && !$reset) {
+                        if (isset($ppp['ondemand']) && $suspend) {
                             configdp_run('interface reconfigure', [$interface], true);
                         } else {
                             killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
@@ -853,7 +859,7 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
             break;
     }
 
-    if ($reset) {
+    if (!$suspend) {
         interfaces_addresses_flush($realif, 4, $ifconfig_details);
     } elseif (!empty($ifcfg['ipaddr']) && !is_ipaddrv4($ifcfg['ipaddr'])) {
         list ($ip4) = interfaces_primary_address($interface, $ifconfig_details);
@@ -869,12 +875,14 @@ function interface_bring_down($interface, $ifacecfg = false, $reset = true)
 
 function interface_suspend($interface)
 {
-    interface_bring_down($interface, false, false);
-}
-
-function interface_reset($interface, $ifacecfg = false)
-{
-    interface_bring_down($interface, $ifacecfg);
+    /*
+     * Suspend uses a subset of interface_reset() to avoid
+     * stripping all the static addresses already in use.
+     * This helps to retain routes and gateway information
+     * also relevant when reloading the packet filter for
+     * e.g. NAT rules generation.
+     */
+    interface_reset($interface, false, true);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -842,14 +842,14 @@ function interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $p
     mwexecf('/usr/local/sbin/ifctl -6c -i %s', $realifv6);
 }
 
-function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
+function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg, $any_vip = false)
 {
     global $config;
 
     if (isset($config['virtualip']['vip'])) {
         foreach ($config['virtualip']['vip'] as $vip) {
             /* XXX eventually bring down all as requested */
-            if ($vip['interface'] == $interface && $vip['mode'] != 'carp') {
+            if ($vip['interface'] == $interface && ($vip['mode'] != 'carp' || $any_vip)) {
                 /**
                  * only disable non carp aliases, net.inet.carp.ifdown_demotion_factor should do its work
                  * when a carp interface goes down
@@ -868,7 +868,7 @@ function interface_bring_down_static($interface, $realif, $realifv6, $ifcfg)
     }
 }
 
-function interface_bring_down($interface, $ifacecfg = false, $full = true)
+function interface_bring_down($interface, $ifacecfg = false, $full = true, $any_vip = false)
 {
     global $config;
 
@@ -893,7 +893,7 @@ function interface_bring_down($interface, $ifacecfg = false, $full = true)
 
     interface_bring_down_dynamic($interface, $realif, $realifv6, $ifcfg, $ppps);
     if ($full == true) {
-        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg);
+        interface_bring_down_static($interface, $realif, $realifv6, $ifcfg, $any_vip);
     }
 }
 
@@ -911,7 +911,7 @@ function interface_reset($interface)
         $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
     }
 
-    interface_bring_down($interface, $toapplylist[$interface] ?? false);
+    interface_bring_down($interface, $toapplylist[$interface] ?? false, true, true);
 }
 
 function interfaces_ptpid_used($ptpid)

--- a/src/etc/rc.linkup
+++ b/src/etc/rc.linkup
@@ -61,7 +61,7 @@ function handle_argument_group($action, $device)
     switch ($action) {
         case 'stop':
             log_msg(sprintf("DEVD: Ethernet detached event for %s(%s)", $interface, $device));
-            interface_bring_down($interface);
+            interface_suspend($interface);
             break;
         case 'start':
             log_msg(sprintf("DEVD: Ethernet attached event for %s(%s)", $interface, $device));

--- a/src/etc/rc.syshook.d/carp/20-ppp
+++ b/src/etc/rc.syshook.d/carp/20-ppp
@@ -52,7 +52,7 @@ if (!empty($a_hasync['disconnectppps'])) {
                 if ($ppp['if'] == $interface['if']) {
                     log_msg("{$iface} is connected to ppp interface {$ifkey} set new status {$type}");
                     if ($type == 'BACKUP') {
-                        interface_bring_down($ifkey);
+                        interface_suspend($ifkey);
                     } else {
                         interface_ppps_configure($ifkey);
                     }

--- a/src/opnsense/scripts/interfaces/ifctl.sh
+++ b/src/opnsense/scripts/interfaces/ifctl.sh
@@ -135,7 +135,7 @@ if [ "${DO_COMMAND}" = "-c" ]; then
 		done
 	done
 
-        # legacy behaviour originating from interface_bring_down()
+        # XXX legacy behaviour originating from interface_bring_down()
 	/usr/sbin/arp -d -i ${IF} -a
 
 	exit 0

--- a/src/opnsense/scripts/interfaces/ifctl.sh
+++ b/src/opnsense/scripts/interfaces/ifctl.sh
@@ -135,7 +135,7 @@ if [ "${DO_COMMAND}" = "-c" ]; then
 		done
 	done
 
-        # XXX legacy behaviour originating from interface_bring_down()
+        # XXX legacy behaviour originating from interface_reset()
 	/usr/sbin/arp -d -i ${IF} -a
 
 	exit 0

--- a/src/opnsense/scripts/shell/setaddr.php
+++ b/src/opnsense/scripts/shell/setaddr.php
@@ -584,7 +584,7 @@ write_config(sprintf('%s configuration from console menu', $interface));
 echo "done.\n";
 
 system_resolver_configure(true);
-interface_bring_down($interface);
+interface_reset($interface);
 interface_configure(true, $interface, true);
 filter_configure_sync(true);
 

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -572,7 +572,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             if (file_exists('/tmp/.interfaces.apply')) {
                 $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
                 foreach ($toapplylist as $ifapply => $ifcfgo) {
-                    interface_reset($ifapply, $ifcfgo);
+                    interface_reset($ifapply, $ifcfgo, isset($ifcfgo['enable']));
                     interface_configure(false, $ifapply, true);
                 }
 

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -572,7 +572,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             if (file_exists('/tmp/.interfaces.apply')) {
                 $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
                 foreach ($toapplylist as $ifapply => $ifcfgo) {
-                    interface_reset($ifapply);
+                    interface_reset($ifapply, $ifcfgo);
                     interface_configure(false, $ifapply, true);
                 }
 

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -569,12 +569,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (!is_subsystem_dirty('interfaces')) {
             $intput_errors[] = gettext("You have already applied your settings!");
         } else {
-            clear_subsystem_dirty('interfaces');
-
             if (file_exists('/tmp/.interfaces.apply')) {
                 $toapplylist = unserialize(file_get_contents('/tmp/.interfaces.apply'));
                 foreach ($toapplylist as $ifapply => $ifcfgo) {
-                    interface_bring_down($ifapply, $ifcfgo);
+                    interface_reset($ifapply);
                     interface_configure(false, $ifapply, true);
                 }
 
@@ -585,8 +583,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 }
                 rrd_configure();
             }
+
+            clear_subsystem_dirty('interfaces');
+            @unlink('/tmp/.interfaces.apply');
         }
-        @unlink('/tmp/.interfaces.apply');
         if (!empty($ifgroup)) {
             header(url_safe('Location: /interfaces.php?if=%s&group=%s', array($if, $ifgroup)));
         } else {

--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -158,7 +158,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             // no validation errors, delete entry
             unset($config['interfaces'][$id]['enable']);
-            interface_bring_down($id);
+            interface_reset($id);
 
             if (isset($config['dhcpd'][$id])) {
                 unset($config['dhcpd'][$id]);
@@ -244,8 +244,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               if (!is_array($ifdev) && ($ifname == 'lan' || $ifname == 'wan' || substr($ifname, 0, 3) == 'opt')) {
                   $reloadif = false;
                   if (!empty($config['interfaces'][$ifname]['if']) && $config['interfaces'][$ifname]['if'] != $ifdev) {
-                      interface_bring_down($ifname);
-                      /* Mark this to be reconfigured in any case. */
+                      interface_reset($ifname);
                       $reloadif = true;
                   }
                   $config['interfaces'][$ifname]['if'] = $ifdev;

--- a/src/www/status_interfaces.php
+++ b/src/www/status_interfaces.php
@@ -38,7 +38,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($_POST['submit'] == 'remote') {
             configdp_run('interface reconfigure', array($interface));
         } elseif (!empty($_POST['status']) && $_POST['status'] == 'up') {
-            interface_bring_down($interface);
+            interface_suspend($interface);
         } else {
             interface_configure(false, $interface, true);
         }


### PR DESCRIPTION
Add new variants interface_suspend() and interface_reset() in order to test the new variants once for rc.linkup and interfaces.php. Temporary file read isn't optimal but it avoids tainting callers with additional arguments that might be wrong...  Later we can switch individual use from interface_bring_down() to the one or the other and refactor again if it is no longer called directly.

I'm entirely unsure about the PPP on demand primer, but in general it would make sense to avoid it when the interface is disabled. The historic way of doing it is priming it for reconfiguration on 'bring-down' so that it can be back up when the line is required.