### PR TITLE
Vxlan - added vxlanlocalport and vxlanremoteport

### DIFF
--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -97,7 +97,9 @@ function vxlan_configure_do($verbose = false, $device = null)
         $current_settings = [
             'vxlanid' => null,
             'vxlanlocal' => null,
+            'vxlanlocalport' => null,
             'vxlanremote' => null,
+            'vxlanremoteport' => null,
             'vxlangroup' => null,
         ];
 
@@ -109,7 +111,9 @@ function vxlan_configure_do($verbose = false, $device = null)
             $isChanged = false;
             $current_settings['vxlanid'] = $interfaces_details[$device_name]['vxlan']['vni'];
             $current_settings['vxlanlocal'] = explode(":", $interfaces_details[$device_name]['vxlan']['local'])[0];
+            $current_settings['vxlanlocalport'] = explode(":", $interfaces_details[$device_name]['vxlan']['localport'])[0];
             $current_settings['vxlanremote'] = explode(":", $interfaces_details[$device_name]['vxlan']['remote'])[0];
+            $current_settings['vxlanremoteport'] = explode(":", $interfaces_details[$device_name]['vxlan']['remoteport'])[0];
             if (!empty($interfaces_details[$device_name]['vxlan']['group'])) {
                 $current_settings['vxlangroup'] = explode(":", $interfaces_details[$device_name]['vxlan']['group'])[0];
             }
@@ -117,7 +121,7 @@ function vxlan_configure_do($verbose = false, $device = null)
         // gather settings, detect changes
         $ifcnfcmd = '/sbin/ifconfig %s';
         $ifcnfcmdp = array($device_name);
-        foreach (array('vxlanid', 'vxlanlocal', 'vxlanremote', 'vxlangroup', 'vxlandev') as $param) {
+        foreach (array('vxlanid', 'vxlanlocal', 'vxlanlocalport', 'vxlanremote', 'vxlanremoteport', 'vxlangroup', 'vxlandev') as $param) {
             $value = '';
             if ($param == 'vxlandev') {
                 $intfnm = (string)$vxlan->$param;

--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -97,8 +97,8 @@ function vxlan_configure_do($verbose = false, $device = null)
         $current_settings = [
             'vxlanid' => null,
             'vxlanlocal' => null,
-            'vxlanlocalport' => null,
             'vxlanremote' => null,
+            'vxlanlocalport' => null,
             'vxlanremoteport' => null,
             'vxlangroup' => null,
         ];
@@ -110,18 +110,31 @@ function vxlan_configure_do($verbose = false, $device = null)
         } else {
             $isChanged = false;
             $current_settings['vxlanid'] = $interfaces_details[$device_name]['vxlan']['vni'];
-            $current_settings['vxlanlocal'] = $interfaces_details[$device_name]['vxlan']['local'];
-            $current_settings['vxlanlocalport'] = $interfaces_details[$device_name]['vxlan']['localport'];
-            $current_settings['vxlanremote'] = $interfaces_details[$device_name]['vxlan']['remote'];
-            $current_settings['vxlanremoteport'] = $interfaces_details[$device_name]['vxlan']['remoteport'];
-            if (!empty($interfaces_details[$device_name]['vxlan']['group'])) {
-                $current_settings['vxlangroup'] = $interfaces_details[$device_name]['vxlan']['group'];
+            $current_settings['vxlanlocal'] = explode(":", $interfaces_details[$device_name]['vxlan']['local'])[0];
+            $current_settings['vxlanremote'] = explode(":", $interfaces_details[$device_name]['vxlan']['remote'])[0];
+            $current_settings['vxlanlocalport'] = explode(":", $interfaces_details[$device_name]['vxlan']['local'])[1];
+
+            // extract vxlanremoteport from vxlanremote or vxlangroup
+            if (!empty($interfaces_details[$device_name]['vxlan']['remote'])) {
+                $vxlanRemoteParts = explode(":", $interfaces_details[$device_name]['vxlan']['remote']);
+                if (isset($vxlanRemoteParts[1])) {
+                    $current_settings['vxlanremoteport'] = $vxlanRemoteParts[1];
+                }
             }
+
+            if (empty($current_settings['vxlanremoteport']) && !empty($interfaces_details[$device_name]['vxlan']['group'])) {
+                $vxlangroupParts = explode(":", $interfaces_details[$device_name]['vxlan']['group']);
+                $current_settings['vxlangroup'] = $vxlangroupParts[0];
+                if (isset($vxlangroupParts[1])) {
+                    $current_settings['vxlanremoteport'] = $vxlangroupParts[1];
+                }
+            }
+
         }
         // gather settings, detect changes
         $ifcnfcmd = '/sbin/ifconfig %s';
         $ifcnfcmdp = array($device_name);
-        foreach (array('vxlanid', 'vxlanlocal', 'vxlanlocalport', 'vxlanremote', 'vxlanremoteport', 'vxlangroup', 'vxlandev') as $param) {
+        foreach (array('vxlanid', 'vxlanlocal', 'vxlanremote', 'vxlanlocalport', 'vxlanremoteport', 'vxlangroup', 'vxlandev') as $param) {
             $value = '';
             if ($param == 'vxlandev') {
                 $intfnm = (string)$vxlan->$param;

--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -110,12 +110,12 @@ function vxlan_configure_do($verbose = false, $device = null)
         } else {
             $isChanged = false;
             $current_settings['vxlanid'] = $interfaces_details[$device_name]['vxlan']['vni'];
-            $current_settings['vxlanlocal'] = explode(":", $interfaces_details[$device_name]['vxlan']['local'])[0];
-            $current_settings['vxlanlocalport'] = explode(":", $interfaces_details[$device_name]['vxlan']['localport'])[0];
-            $current_settings['vxlanremote'] = explode(":", $interfaces_details[$device_name]['vxlan']['remote'])[0];
-            $current_settings['vxlanremoteport'] = explode(":", $interfaces_details[$device_name]['vxlan']['remoteport'])[0];
+            $current_settings['vxlanlocal'] = $interfaces_details[$device_name]['vxlan']['local'];
+            $current_settings['vxlanlocalport'] = $interfaces_details[$device_name]['vxlan']['localport'];
+            $current_settings['vxlanremote'] = $interfaces_details[$device_name]['vxlan']['remote'];
+            $current_settings['vxlanremoteport'] = $interfaces_details[$device_name]['vxlan']['remoteport'];
             if (!empty($interfaces_details[$device_name]['vxlan']['group'])) {
-                $current_settings['vxlangroup'] = explode(":", $interfaces_details[$device_name]['vxlan']['group'])[0];
+                $current_settings['vxlangroup'] = $interfaces_details[$device_name]['vxlan']['group'];
             }
         }
         // gather settings, detect changes

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVxlan.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVxlan.xml
@@ -21,6 +21,13 @@
         </help>
     </field>
     <field>
+        <id>vxlan.vxlanlocalport</id>
+        <label>Source port</label>
+        <type>text</type>
+        <help>Define the source port. Default is 4789.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>vxlan.vxlanremote</id>
         <label>Remote address</label>
         <type>text</type>
@@ -28,6 +35,13 @@
           The interface can be configured in a unicast, or point-to-point, mode to create a tunnel between two hosts.
           This is the IP address of the remote end of the tunnel.
         </help>
+    </field>
+    <field>
+        <id>vxlan.vxlanremoteport</id>
+        <label>Remote port</label>
+        <type>text</type>
+        <help>Define the remote port. Default is 4789.</help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>vxlan.vxlangroup</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Interfaces/vxlans</mount>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>VXLAN configuration</description>
     <items>
         <vxlan type="ArrayField">
@@ -16,9 +16,17 @@
                 <Required>Y</Required>
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlanlocal>
+            <vxlanlocalport type="PortField">
+                <Required>Y</Required>
+                <default>4789</default>
+            </vxlanlocalport>
             <vxlanremote type="NetworkField">
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlanremote>
+            <vxlanremoteport type="PortField">
+                <Required>Y</Required>
+                <default>4789</default>
+            </vxlanremoteport>
             <vxlangroup type="NetworkField">
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlangroup>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.xml
@@ -16,17 +16,11 @@
                 <Required>Y</Required>
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlanlocal>
-            <vxlanlocalport type="PortField">
-                <Required>Y</Required>
-                <default>4789</default>
-            </vxlanlocalport>
+            <vxlanlocalport type="PortField"/>
             <vxlanremote type="NetworkField">
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlanremote>
-            <vxlanremoteport type="PortField">
-                <Required>Y</Required>
-                <default>4789</default>
-            </vxlanremoteport>
+            <vxlanremoteport type="PortField"/>
             <vxlangroup type="NetworkField">
                 <NetMaskAllowed>N</NetMaskAllowed>
             </vxlangroup>


### PR DESCRIPTION
I've chosen a pragmatic approach for this:

- Require the new fields not to be empty
- Fill them with the default value 4789
- Hide the "vxlanlocalport" and "vxlanremoteport" with advanced
- Always add them to all vxlan interfaces that are created
- Bumped the model version so existing configurations will be migrated to be with port numbers

If this approach is alright, I have tested it with unicast configuration and multicast group. Here's how it looks like in ifconfig:

```
vxlan1: flags=8802<BROADCAST,SIMPLEX,MULTICAST> metric 0 mtu 1450
        options=80020<JUMBO_MTU,LINKSTATE>
        ether 58:9c:fc:00:6d:6d
        groups: vxlan
        vxlan vni 12 local 192.168.3.1:4789 remote 192.168.3.2:4789
        media: Ethernet autoselect (autoselect <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
vxlan2: flags=8802<BROADCAST,SIMPLEX,MULTICAST> metric 0 mtu 1450
        options=80020<JUMBO_MTU,LINKSTATE>
        ether 58:9c:fc:10:ff:e0
        groups: vxlan
        vxlan vni 13 local 192.168.3.1:4785 remote 192.168.3.4:4785
        media: Ethernet autoselect (autoselect <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
vxlan3: flags=8802<BROADCAST,SIMPLEX,MULTICAST> metric 0 mtu 1450
        options=80020<JUMBO_MTU,LINKSTATE>
        ether 58:9c:fc:10:6e:52
        groups: vxlan
        vxlan vni 14 local 192.168.3.1:4785 group 227.0.0.1:4785
        media: Ethernet autoselect (autoselect <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
```
