### PR TITLE
Firewall: Aliases - read before write in alias table update to spare unneeded disk writes

### DIFF
--- a/src/opnsense/scripts/filter/update_tables.py
+++ b/src/opnsense/scripts/filter/update_tables.py
@@ -94,8 +94,20 @@ if __name__ == '__main__':
         # only try to replace the contents of this alias if we're responsible for it (know how to parse)
         if alias.get_parser():
             # when the alias or any of it's dependencies has changed, generate new
-            if alias_changed_or_expired or not os.path.isfile('/var/db/aliastables/%s.txt' % alias_name):
-                open('/var/db/aliastables/%s.txt' % alias_name, 'w').write('\n'.join(sorted(alias_content)))
+            alias_filename = '/var/db/aliastables/%s.txt' % alias_name
+            alias_file_exists = os.path.isfile(alias_filename)
+            if alias_changed_or_expired or not alias_file_exists:
+                new_alias_content = '\n'.join(sorted(alias_content))
+                if alias_file_exists:
+                    try:
+                        current_alias_content = open(alias_filename, 'r').read()
+                    except UnicodeDecodeError:
+                        current_alias_content = ""
+                else:
+                     current_alias_content = ""
+
+                if current_alias_content != new_alias_content:
+                    open(alias_filename, 'w').write(new_alias_content)
 
             # list current alias content when not trying to update a targetted list
             alias_pf_content = list(PF.list_table(alias_name)) if to_update is None else alias_content


### PR DESCRIPTION
Hi @AdSchellevis , this change relates to issue https://github.com/opnsense/core/issues/6596, and could perhaps be considered an additional optimization relating to the changes made in https://github.com/opnsense/core/commit/0e3d660e18c3b7e7fdefc6a9046ced6b60400500.

In the existing implementation, when the "Alias Resolve Interval" expires, `update_tables.py` will unconditionally rewrite affected alias entries, even if they haven't changed.  These modifications optimize this behavior so alias files will only be rewritten if the content is different than that on disk.  (This actually saves a significant number of extraneous writes on my system.)

I hope that this is helpful!
