### PR TITLE
system: read before write of /etc/hosts and /etc/resolv.conf to spare unneeded disk writes

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -222,11 +222,20 @@ function system_resolvconf_generate($verbose = false)
         $resolvconf .= "search {$result}\n";
     }
 
-    $tempfile = tempnam('/tmp', 'resolv.conf');
-    file_put_contents($tempfile, $resolvconf);
-    chmod($tempfile, 0644);
-
-    rename($tempfile, '/etc/resolv.conf');
+    $fn_etc_resolvconf = '/etc/resolv.conf';
+    if (file_exists($fn_etc_resolvconf)) {
+        $old_csum = sha1_file($fn_etc_resolvconf);
+        $new_csum = sha1($resolvconf);
+    } else {
+        $old_csum = 0;
+        $new_csum = $old_csum + 1;
+    }
+    if ($old_csum != $new_csum) {
+        $tempfile = tempnam('/tmp', 'resolv.conf');
+        file_put_contents($tempfile, $resolvconf);
+        chmod($tempfile, 0644);
+        rename($tempfile, $fn_etc_resolvconf);
+    }
 
     /* setup static routes for DNS servers as configured */
     foreach ($routes as $host => $gateway) {
@@ -498,7 +507,17 @@ function system_hosts_generate($verbose = false)
         }
     }
 
-    file_put_contents('/etc/hosts', $hosts);
+    $fn_etc_hosts = '/etc/hosts';
+    if (file_exists($fn_etc_hosts)) {
+        $old_csum = sha1_file($fn_etc_hosts);
+        $new_csum = sha1($hosts);
+    } else {
+        $old_csum = 0;
+        $new_csum = $old_csum + 1;
+    }
+    if ($old_csum != $new_csum) {
+        file_put_contents($fn_etc_hosts, $hosts);
+    }
 
     service_log("done.\n", $verbose);
 }


### PR DESCRIPTION
This change relates to issue https://github.com/opnsense/core/issues/6596, and is a simple optimization that eliminates numerous unnecessary rewrites of the `/etc/resolv.conf` and `/etc/hosts` files.

My system receives lots of "new WAN IP" events (via both gateway router DHCP renewals, IPv6 RAs, etc.), when nothing actually changes (e.g., "No IP change detected").  OPNsense processing for these events end up calling `system_resolver_configure()`, which regenerates these files each time.

This commit simply compares the hashes of the contents of the existing `/etc/resolv.conf` and `/etc/hosts` files to hashes of the new file content, and will only write the files to disk if they don't exist, or if the new content is different.