### PR TITLE
Make the GUI interfaces selection actually honored by ntpd

### DIFF
--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -427,6 +427,7 @@ function ntpd_configure_do($verbose = false)
 
     if (is_array($interfaces) && count($interfaces)) {
         $ntpcfg .= "interface ignore all\n";
+        $ntpcfg .= "interface ignore wildcard\n";
         foreach ($interfaces as $interface) {
             if (!is_ipaddr($interface)) {
                 $interface = get_real_interface($interface);


### PR DESCRIPTION
Without the "interface ignore wildcard" directive, the service still listens on wildcard.