### PR TITLE
Add word break in interface_statistics.widget.php

### DIFF
--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -143,7 +143,7 @@ $ifvalues = array(
         continue;
       } ?>
   <tr id="interface_statistics_widget_intf_<?= html_safe($ifdescr) ?>">
-    <td><strong><?= $ifname ?></strong></td>
+    <td style="word-break: break-word;"><strong><?= $ifname ?></strong></td>
 <?php $infcount = 0;
       while ($infcount++ < count($ifvalues)): ?>
     <td style="word-break: break-word;">&#126;</td>

--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -146,7 +146,7 @@ $ifvalues = array(
     <td><strong><?= $ifname ?></strong></td>
 <?php $infcount = 0;
       while ($infcount++ < count($ifvalues)): ?>
-    <td>&#126;</td>
+    <td style="word-break: break-word;">&#126;</td>
 <?php endwhile ?>
   </tr>
 <?php endforeach ?>


### PR DESCRIPTION
Afraid this issue persists even after the revamp from https://github.com/opnsense/core/pull/7019. This is literally illegible mess with large packet counts and multiple dashboard columns otherwise, that `toLocaleString()` does not help either.  

See example screenshots - the last one is after this fix.

![image](https://github.com/opnsense/core/assets/1075960/0a39eac8-e453-460e-91fc-65f1a8d5c65e)
