### PR TITLE
Update b.root-servers.net. Fixes #7115

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Unbound/core/root.min.hints
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/root.min.hints
@@ -1,92 +1,91 @@
-;       This file holds the information on root name servers needed to 
+;       This file holds the information on root name servers needed to
 ;       initialize cache of Internet domain name servers
 ;       (e.g. reference this file in the "cache  .  <file>"
-;       configuration file of BIND domain name servers). 
-; 
-;       This file is made available by InterNIC 
+;       configuration file of BIND domain name servers).
+;
+;       This file is made available by InterNIC
 ;       under anonymous FTP as
-;           file                /domain/named.cache 
+;           file                /domain/named.cache
 ;           on server           FTP.INTERNIC.NET
 ;       -OR-                    RS.INTERNIC.NET
-; 
-;       last update:     July 09, 2018 
-;       related version of root zone:     2018070901
-; 
-; FORMERLY NS.INTERNIC.NET 
+;
+;       last update:     December 20, 2023
+;       related version of root zone:     2023122001
+;
+; FORMERLY NS.INTERNIC.NET
 ;
 .                        3600000      NS    A.ROOT-SERVERS.NET.
 A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
 A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
-; 
-; FORMERLY NS1.ISI.EDU 
+;
+; FORMERLY NS1.ISI.EDU
 ;
 .                        3600000      NS    B.ROOT-SERVERS.NET.
-B.ROOT-SERVERS.NET.      3600000      A     199.9.14.201
-B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:200::b
-; 
-; FORMERLY C.PSI.NET 
+B.ROOT-SERVERS.NET.      3600000      A     170.247.170.2
+B.ROOT-SERVERS.NET.      3600000      AAAA  2801:1b8:10::b
+;
+; FORMERLY C.PSI.NET
 ;
 .                        3600000      NS    C.ROOT-SERVERS.NET.
 C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
 C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
-; 
-; FORMERLY TERP.UMD.EDU 
+;
+; FORMERLY TERP.UMD.EDU
 ;
 .                        3600000      NS    D.ROOT-SERVERS.NET.
 D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
 D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
-; 
+;
 ; FORMERLY NS.NASA.GOV
 ;
 .                        3600000      NS    E.ROOT-SERVERS.NET.
 E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
 E.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:a8::e
-; 
+;
 ; FORMERLY NS.ISC.ORG
 ;
 .                        3600000      NS    F.ROOT-SERVERS.NET.
 F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
 F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
-; 
+;
 ; FORMERLY NS.NIC.DDN.MIL
 ;
 .                        3600000      NS    G.ROOT-SERVERS.NET.
 G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
 G.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:12::d0d
-; 
+;
 ; FORMERLY AOS.ARL.ARMY.MIL
 ;
 .                        3600000      NS    H.ROOT-SERVERS.NET.
 H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
 H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
-; 
+;
 ; FORMERLY NIC.NORDU.NET
 ;
 .                        3600000      NS    I.ROOT-SERVERS.NET.
 I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
 I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
-; 
+;
 ; OPERATED BY VERISIGN, INC.
 ;
 .                        3600000      NS    J.ROOT-SERVERS.NET.
 J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
 J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
-; 
+;
 ; OPERATED BY RIPE NCC
 ;
 .                        3600000      NS    K.ROOT-SERVERS.NET.
 K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
 K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
-; 
+;
 ; OPERATED BY ICANN
 ;
 .                        3600000      NS    L.ROOT-SERVERS.NET.
 L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
 L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
-; 
+;
 ; OPERATED BY WIDE
 ;
 .                        3600000      NS    M.ROOT-SERVERS.NET.
 M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
 M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
-; End of file

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/root.min.hints
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/root.min.hints
@@ -89,3 +89,4 @@ L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
 .                        3600000      NS    M.ROOT-SERVERS.NET.
 M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
 M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file


### PR DESCRIPTION
See https://www.lacnic.net/6869/2/lacnic/lacnic-assigns-number-resources-to-the-usc_isi-dns-root-server. 

Refetched from  https://www.internic.net/domain/named.cache