### PR TITLE
Add Uptime API Endpoint

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
@@ -185,4 +185,13 @@ class SystemController extends ApiControllerBase
 
         return ["status" => "failed"];
     }
+
+    public function uptimeAction()
+    {
+        if ($this->request->isGet()) {
+            $backend = new Backend();
+	        $uptime = trim($backend->configdRun('system uptime'));
+            return $uptime;
+        }
+    }
 }

--- a/src/opnsense/service/conf/actions.d/actions_system.conf
+++ b/src/opnsense/service/conf/actions.d/actions_system.conf
@@ -96,3 +96,9 @@ command:/usr/bin/vmstat
 parameters: -m -z --libxo json
 type:script_output
 message:show vmstat
+
+[uptime]
+command:uptime
+parameters:
+type:script_output
+message:system uptime


### PR DESCRIPTION
The purpose of this pull request is to add the uptime of OPNsense accessible with the API Endpoint /api/core/system/uptime