### PR TITLE
update traffic graph colors to be contrast and consistent in widget and traffic diagnostic

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/traffic.volt
@@ -159,7 +159,7 @@ POSSIBILITY OF SUCH DAMAGE.
                             frameRate: 30
                           },
                           colorschemes: {
-                            scheme: 'brewer.Paired12'
+                            scheme: 'tableau.Classic10'
                           }
                       }
                   }
@@ -257,7 +257,7 @@ POSSIBILITY OF SUCH DAMAGE.
                               frameRate: 30
                           },
                           colorschemes: {
-                              scheme: 'brewer.Paired12'
+                              scheme: 'tableau.Classic10'
                           }
                       }
                   }
@@ -382,11 +382,11 @@ POSSIBILITY OF SUCH DAMAGE.
             if (tmp !== null) {
                 selected_interfaces = tmp.split(',');
             }
-            let i = 1;
+            let i = 0;
             Object.keys(data.interfaces).forEach(function(intf) {
-                let colors = Chart.colorschemes.tableau.Tableau20.length;
-                let colorIdx = i - parseInt(i / colors) * colors;
-                data.interfaces[intf].color = Chart.colorschemes.tableau.Tableau20[colorIdx];
+                let colors = Chart.colorschemes.tableau.Classic10;
+                let colorIdx = i % colors.length;
+                data.interfaces[intf].color = colors[colorIdx];
 
                 let option = $("<option/>").attr("value", intf);
                 if (selected_interfaces.includes(intf)) {

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -173,7 +173,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                               frameRate: 30
                           },
                           colorschemes: {
-                              scheme: 'brewer.Paired12'
+                              scheme: 'tableau.Classic10'
                           }
                       }
                   }


### PR DESCRIPTION
default `brewer.Paired12` color scheme contains pairs very similar colors, so every two interfaces in list look very similar to each other, see image, where dataset1 and dataset2 are blue, dataset3 and dataset4 are green

![image](https://github.com/opnsense/core/assets/8658954/a04ef7be-ecde-41de-b887-b5b281c4f903)

to increase contrast between interface graphs I suggest to use `tableau.Classic10` which contains 10 very distinctive colors:

![image](https://github.com/opnsense/core/assets/8658954/f6543b36-d8a1-4dc6-9c95-4de4888ef239)

This should partially fix: [#6622](https://github.com/opnsense/core/issues/6622)

Another problem is that traffic widget and traffic diagnostic graphs are using different color schemes and indexes for the same interface, which is inconsistent and confusing, it is better to apply the same rules in both sections