### PR TITLE
Kea: allow setting domain for DHCP clients

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -34,6 +34,12 @@
         <help>DNS servers to offer to the clients</help>
     </field>
     <field>
+        <id>subnet4.option_data.domain_name</id>
+        <label>Domain name</label>
+        <type>text</type>
+        <help>The domain name to offer to the client</help>
+    </field>
+    <field>
         <id>subnet4.option_data.ntp_servers</id>
         <label>NTP servers</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -62,6 +62,13 @@ class KeaDhcpv4 extends BaseModel
                     $subnet->option_data->domain_name_servers = $host_ip;
                     $subnet->option_data->ntp_servers = $host_ip;
                 }
+
+                // find system domain
+                $config = Config::getInstance()->object();
+                $domain = $config->system->domain;
+                if (!empty($domain)) {
+                    $subnet->option_data->domain_name = $domain;
+                }
             }
         }
         return parent::setNodes($data);

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -47,6 +47,9 @@
                         <AsList>Y</AsList>
                         <FieldSeparator>,</FieldSeparator>
                     </domain_name_servers>
+                    <domain_name type="HostnameField">
+                        <IpAllowed>N</IpAllowed>
+                    </domain_name>
                     <routers type="NetworkField">
                         <NetMaskAllowed>N</NetMaskAllowed>
                         <AddressFamily>ipv4</AddressFamily>


### PR DESCRIPTION
I know Kea is still in the very early stages, but this is a fairly important option to have for continuing evaluation.

I noticed while testing, the validation of `HostnameField` types will allow pretty much anything to be passed that matches `[0-9a-z.-]+` except really outrageous problems like 2 dots in a row. In particular, the `IpAllowed` flag [does nothing](https://github.com/opnsense/core/blob/master/src/opnsense/mvc/app/models/OPNsense/Base/Validators/HostValidator.php#L75) because `filter_var('10.1.2.3', FILTER_VALIDATE_DOMAIN)` does not return false.