### PR TITLE
Add init7 mirror

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
@@ -92,6 +92,10 @@
             <url>http://mirror.wjcomms.co.uk/opnsense</url>
             <description>WJComms (HTTP, London, GB)</description>
         </mirror>
+        <mirror>
+            <url>https://mirror.init7.net/opnsense</url>
+            <description>init7 (HTTPS, Winterthur, CH)</description>
+        </mirror>
     </mirrors>
     <flavours allow_custom="true">
         <flavour has_subscription="true">


### PR DESCRIPTION
This PR adds the mirror that init7, a Swiss ISP, is running. See https://mirror.init7.net/.
I'm an init7 customer and not affiliated with them.