### PR TITLE
rc: fix wrong order in service startup

### DIFF
--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -79,7 +79,7 @@ rc_enabled()
 	esac
 }
 
-rc_filenames="$(${RCORDER} /etc/rc.d/[a-z]* /usr/local/etc/rc.d/[a-z]* 2> /dev/null)"
+rc_filenames="$(${RCORDER} /etc/rc.d/* /usr/local/etc/rc.d/* 2> /dev/null)"
 rc_filenames_defer=
 rc_filenames_reverse=
 rc_filenames_skip=


### PR DESCRIPTION
So here's a fun one. In https://github.com/opnsense/plugins/issues/3811 it was reported that services start in the wrong order during system boot.

Looking at the affected services, everythings seems to look fine in `rcorder`:

```
root@opnsense:~ # rcorder /etc/rc.d/* /usr/local/etc/rc.d/* | grep -e haproxy -e zerotier
/usr/local/etc/rc.d/zerotier
/usr/local/etc/rc.d/haproxy
```

According to this output, ZeroTier should start before HAProxy, which is the correct order. However, during system boot this is not the case:

```
>>> Invoking start script 'freebsd'
...
Starting haproxy.
...
Starting zerotier.
...
```

After looking at the source code, I've noticed a minor difference in how OPNsense calls `rcorder`:

https://github.com/opnsense/core/blob/389b9d4839b2f387546d1755595358f2db9859e8/src/etc/rc.freebsd#L69

And indeed, when using this syntax, the wrong service order is returned:

```
root@opnsense:~ # rcorder /etc/rc.d/[a-z]* /usr/local/etc/rc.d/[a-z]* | grep -e haproxy -e zero
/usr/local/etc/rc.d/haproxy
/usr/local/etc/rc.d/zerotier
```

Interestingly, the `rcorder(8)` man page uses the [plain asterisk syntax](https://man.freebsd.org/cgi/man.cgi?query=rcorder&sektion=8&format=html). So my proposal is to change the syntax in OPNsense accordingly. :)