### PR TITLE
IDS: Add checkbox for exception-policy

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -92,6 +92,13 @@
         <help>With this option, you can set the size of the packets on your network. It is possible that bigger packets have to be processed sometimes. The engine can still process these bigger packets, but processing it will lower the performance.</help>
     </field>
     <field>
+        <id>ids.general.ignorePolicy</id>
+        <label>Ignore Policy Errors</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>With this option, when a protocol parser fails, it will just ignore the error which will mimic the default behavior in Suricata version 6 and below. Starting with Suricata 7, the default changed to drop affcted packets which might break e.g. services running on port 443 but not offering HTTPS protocol.</help>
+    </field>
+    <field>
         <id>ids.general.AlertLogrotate</id>
         <label>Rotate log</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -234,6 +234,10 @@
                 <Default>0</Default>
                 <Required>Y</Required>
             </LogPayload>
+            <ignorePolicy type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </ignorePolicy>
             <verbosity type="OptionField">
                 <BlankDesc>DEFAULT (0)</BlankDesc>
                 <OptionValues>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -735,9 +735,7 @@ pcap-file:
 # "yes" enables both detection and the parser, "no" disables both, and
 # "detection-only" enables protocol detection only (parser disabled).
 app-layer:
-{% if not helpers.empty('OPNsense.IDS.general.ignorePolicy') %}
-  error-policy: {% if OPNsense.IDS.general.ignorePolicy|default("0") == "1" %}ignore{% else %}auto{% endif %}ignore
-{% endif %}  
+  error-policy: {% if OPNsense.IDS.general.ignorePolicy|default("0") == "1" %}ignore{% else %}auto{% endif %}
   protocols:
     krb5:
       enabled: yes

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -736,7 +736,7 @@ pcap-file:
 # "detection-only" enables protocol detection only (parser disabled).
 app-layer:
 {% if not helpers.empty('OPNsense.IDS.general.ignorePolicy') %}
-  error-policy: ignore
+  error-policy: {% if OPNsense.IDS.general.ignorePolicy|default("0") == "1" %}ignore{% else %}auto{% endif %}ignore
 {% endif %}  
   protocols:
     krb5:

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -736,6 +736,7 @@ pcap-file:
 # "detection-only" enables protocol detection only (parser disabled).
 app-layer:
   error-policy: {% if OPNsense.IDS.general.ignorePolicy|default("0") == "1" %}ignore{% else %}auto{% endif %}
+  
   protocols:
     krb5:
       enabled: yes

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -735,6 +735,9 @@ pcap-file:
 # "yes" enables both detection and the parser, "no" disables both, and
 # "detection-only" enables protocol detection only (parser disabled).
 app-layer:
+{% if not helpers.empty('OPNsense.IDS.general.ignorePolicy') %}
+  error-policy: ignore
+{% endif %}  
   protocols:
     krb5:
       enabled: yes


### PR DESCRIPTION
Hi,

Suricata 7 added exeception policies:
https://docs.suricata.io/en/latest/configuration/exception-policies.html#exception-policies

When just upgrading to 24.1.2 there is no entry in suricata.yml which seems to activate this feature:
https://forum.suricata.io/t/my-traffic-gets-blocked-after-upgrading-to-suricata-7/3745

Two confirmations that when adding it to custom.yml it seems to work again in Suricata 6 behavior:
https://forum.opnsense.org/index.php?topic=38961.0
https://forum.opnsense.org/index.php?topic=38944.0

There might arise more problems e.g. when running openvpn on port 443 as it also does not speak https.

Nonetheless, in the official documentation it states that the default is ignore but it only seems to act like v6 when adding it explicitly, so maybe we can also set it to enabled by default, or just activate it in suricata.yml without a knob and let the decision up to you guys :)
https://docs.suricata.io/en/latest/configuration/exception-policies.html#exception-policies
