### PR TITLE
firewall/rules: fix floating rule display

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -771,7 +771,7 @@ $( document ).ready(function() {
                     } elseif (($rule->getInterface() == "" || strpos($rule->getInterface(), ",") !== false) && $selected_if == "FloatingRules") {
                         // floating type of rule and "floating" view
                         $is_selected = true;
-                    } elseif ($rule->getInterface() == "" || in_array($selected_if, explode(',', $rule->getInterface())) || in_array($rule->getInterface(), $ifgroups)) {
+                    } elseif ($rule->getInterface() == "" || !empty(array_intersect(array_merge([$selected_if], $ifgroups), explode(',', $rule->getInterface())))) {
                         // rule is floating or of group type and matches this interface
                         $is_selected = true;
                     }
@@ -836,7 +836,7 @@ $( document ).ready(function() {
                               <a style="cursor: pointer;" title="<?=html_safe(gettext('Affects all interfaces'));?>" data-placement='bottom' data-toggle="tooltip">
                                 <?=$intf_count;?>
                               </a>
-                          <?php elseif ($intf_count != '1' || $selected_if == 'FloatingRules'): ?>
+                          <?php elseif ($intf_count != '1' || $selected_if != $rule->getInterface() || $selected_if == 'FloatingRules'): ?>
                             <?= !empty($rule->getRawRule()['interfacenot']) ? '!' : '';?>
                             <a style="cursor: pointer;" class='interface_tooltip' data-interfaces="<?=$rule->getInterface();?>">
                               <?=$intf_count;?>


### PR DESCRIPTION
1. For a floating rule with a single interface group, the interface count and tooltip did not show when viewed from an interface rules page.

2. For a floating rule with an interface group and at least one other interface or interface group, the entire rule did not show when viewed from an interface rules page for which the interface is contained in one of the interface groups.