### PR TITLE
core/treeview - replace all &gt; and &lt;

### DIFF
--- a/src/opnsense/www/js/opnsense-treeview.js
+++ b/src/opnsense/www/js/opnsense-treeview.js
@@ -108,7 +108,7 @@ function update_tree(src_data, target)
             openedIcon: $('<i class="fa fa-minus-square-o"></i>'),
             onCreateLi: function(node, $li) {
                 let n_title = $li.find('.jqtree-title');
-                n_title.text(n_title.text().replace('&gt;','\>').replace('&lt;','\<'));
+                n_title.text(n_title.text().replaceAll('&gt;','\>').replaceAll('&lt;','\<'));
                 if (node.value !== undefined) {
                     $li.find('.jqtree-element').append(
                         '&nbsp; <strong>:</strong> &nbsp;' + node.value


### PR DESCRIPTION
This fixes some display issues in Firewall: Diagnostics: Statistics where there are more than one instance of > or < in the same line.

![image](https://github.com/opnsense/core/assets/108489988/6634aa80-fea4-4fea-92ed-376b814eaf0b)
