### PR TITLE
Allow setting UniFi Controller IP in Kea DHCP.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -86,4 +86,10 @@
         <type>text</type>
         <help>Boot filename to request</help>
     </field>
+    <field>
+        <id>subnet4.option_data.unifi_controller</id>
+        <label>UniFi Controller</label>
+        <type>text</type>
+        <help>IP address of your UniFi Controller</help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -83,6 +83,9 @@
                     <boot_file_name type="TextField">
                         <Mask>/^([^\n"])*$/u</Mask>
                     </boot_file_name>
+                    <unifi_controller type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </unifi_controller>
                 </option_data>
                 <pools type=".\KeaPoolsField">
                 </pools>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -83,8 +83,9 @@
                     <boot_file_name type="TextField">
                         <Mask>/^([^\n"])*$/u</Mask>
                     </boot_file_name>
-                    <unifi_controller type="TextField">
-                        <Mask>/^([^\n"])*$/u</Mask>
+                    <unifi_controller type="NetworkField">
+                        <NetMaskAllowed>N</NetMaskAllowed>
+                        <AddressFamily>ipv4</AddressFamily>
                     </unifi_controller>
                 </option_data>
                 <pools type=".\KeaPoolsField">

--- a/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
+++ b/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
@@ -49,6 +49,10 @@
 {% for od_attr in (subnet.option_data|list + option_data_defaults|list)|unique if subnet.option_data[od_attr]|length > 1 or od_attr in option_data_defaults %}
                     {
                         "name": "{{od_attr.replace('_','-')}}",
+{% if od_attr == 'unifi_controller' %}
+                        "space": "vendor-encapsulated-options-space",
+                        "code": 43,
+{% endif %}
                         "data": {{subnet.option_data[od_attr]|default(option_data_defaults[od_attr])|tojson}}
                     }{% if not loop.last %},{% endif +%}
 {% endfor %}

--- a/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
+++ b/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
@@ -47,6 +47,12 @@
                 "subnet": "{{subnet.subnet}}",
                 "option-data": [
 {% for od_attr in (subnet.option_data|list + option_data_defaults|list)|unique if subnet.option_data[od_attr]|length > 1 or od_attr in option_data_defaults %}
+{% if od_attr == 'unifi_controller' %}
+                    {
+                        "name": "vendor-encapsulated-options",
+                        "always-send": true
+                    },
+{% endif %}
                     {
                         "name": "{{od_attr.replace('_','-')}}",
 {% if od_attr == 'unifi_controller' %}

--- a/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
+++ b/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
@@ -33,6 +33,13 @@
                 "severity": "INFO"
             }
         ],
+        "option-def": [{
+          "name": "unifi-controller",
+          "code": 43,
+          "space": "vendor-encapsulated-options-space",
+          "type": "string",
+          "array": false
+        }],
         "subnet4": [
 {% for subnet in helpers.toList('OPNsense.Kea.dhcp4.subnets.subnet4') %}
             {

--- a/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
+++ b/src/opnsense/service/templates/OPNsense/Kea/kea-dhcp4.conf
@@ -35,9 +35,9 @@
         ],
         "option-def": [{
           "name": "unifi-controller",
-          "code": 43,
+          "code": 1,
           "space": "vendor-encapsulated-options-space",
-          "type": "string",
+          "type": "ipv4-address",
           "array": false
         }],
         "subnet4": [
@@ -57,9 +57,11 @@
                         "name": "{{od_attr.replace('_','-')}}",
 {% if od_attr == 'unifi_controller' %}
                         "space": "vendor-encapsulated-options-space",
-                        "code": 43,
-{% endif %}
+                        "code": 1,
+                        "data": "{{subnet.option_data[od_attr]}}"
+{% else %}
                         "data": {{subnet.option_data[od_attr]|default(option_data_defaults[od_attr])|tojson}}
+{% endif %}
                     }{% if not loop.last %},{% endif +%}
 {% endfor %}
                 ],


### PR DESCRIPTION
Tested using WireShark for my controller IP, 10.0.1.77 (`0x0a00014d`):

```wireshark
Option: (43) Vendor-Specific Information
  Length: 6
  Value: 01040a00014d
```
