### PR TITLE
dashboard: widgets init next update after response

### DIFF
--- a/src/www/widgets/widgets/gateways.widget.php
+++ b/src/www/widgets/widgets/gateways.widget.php
@@ -114,8 +114,8 @@ $gateways = (new \OPNsense\Routing\Gateways())->gatewaysIndexedByName();
                         }
                     });
                 }
+                setTimeout(fetch_gateway_statuses, 5000);
             });
-            setTimeout(fetch_gateway_statuses, 5000);
         }
         fetch_gateway_statuses();
     });

--- a/src/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/www/widgets/widgets/interface_statistics.widget.php
@@ -88,28 +88,28 @@ $ifvalues = array(
     /**
      * update interface statistics
      */
-    setInterval(function update_statistics() {
-      ajaxGet('/api/interfaces/overview/interfacesInfo/1', {}, function(data, status) {
-        data.rows.map(function(interface_data) {
-          let stats = interface_data['statistics'];
-          let inbytes = format_field(parseInt(stats['bytes received']));
-          let outbytes = format_field(parseInt(stats['bytes transmitted']));
-          // fill in stats, use column index to determine td location
-          var item_index = $("#interface_statistics_widget_intf_" + interface_data['identifier']).index();
-          if (item_index != -1) {
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(1)").html(parseInt(stats['packets received']).toLocaleString());
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(2)").html(parseInt(stats['packets transmitted']).toLocaleString());
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(3)").html(inbytes);
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(4)").html(outbytes);
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(5)").html(stats['input errors']);
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(6)").html(stats['output errors']);
-              $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(7)").html(stats['collisions']);
-          }
+    function update_statistics() {
+        ajaxGet('/api/interfaces/overview/interfacesInfo/1', {}, function(data, status) {
+            data.rows.map(function(interface_data) {
+                let stats = interface_data['statistics'];
+                let inbytes = format_field(parseInt(stats['bytes received']));
+                let outbytes = format_field(parseInt(stats['bytes transmitted']));
+                // fill in stats, use column index to determine td location
+                var item_index = $("#interface_statistics_widget_intf_" + interface_data['identifier']).index();
+                if (item_index != -1) {
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(1)").html(parseInt(stats['packets received']).toLocaleString());
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(2)").html(parseInt(stats['packets transmitted']).toLocaleString());
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(3)").html(inbytes);
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(4)").html(outbytes);
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(5)").html(stats['input errors']);
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(6)").html(stats['output errors']);
+                    $("#interface_statistics_widget_intf_" + interface_data['identifier'] +" > td:eq(7)").html(stats['collisions']);
+                }
+            });
+            setTimeout(update_statistics, 5000);
         });
-      });
-
-      return update_statistics;
-    }(), 5000);
+    }
+    update_statistics();
 </script>
 
 <div id="interface_statistics-settings" class="widgetconfigdiv" style="display:none;">

--- a/src/www/widgets/widgets/log.widget.php
+++ b/src/www/widgets/widgets/log.widget.php
@@ -183,12 +183,11 @@ $nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? 
                 }).on('show.bs.popover', function() {
                     $(this).data("bs.popover").tip().css("max-width", "100%")
                 });
+                // schedule next fetch
+                var update_interval_ms = parseInt($("#filterlogentriesupdateinterval").val()) * 1000;
+                update_interval_ms = (isNaN(update_interval_ms) || update_interval_ms < 1000 || update_interval_ms > 60000) ? 5000 : update_interval_ms;
+                setTimeout(fetch_log, update_interval_ms);
             });
-
-            // schedule next fetch
-            var update_interval_ms = parseInt($("#filterlogentriesupdateinterval").val()) * 1000;
-            update_interval_ms = (isNaN(update_interval_ms) || update_interval_ms < 1000 || update_interval_ms > 60000) ? 5000 : update_interval_ms;
-            setTimeout(fetch_log, update_interval_ms);
         }
 
     });

--- a/src/www/widgets/widgets/services_status.widget.php
+++ b/src/www/widgets/widgets/services_status.widget.php
@@ -102,8 +102,8 @@ if (isset($_POST['servicestatusfilter'])) {
                         });
                     });
                 }
+                setTimeout(fetch_services, 5000);
             });
-            setTimeout(fetch_services, 5000);
         }
         fetch_services();
     });

--- a/src/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/www/widgets/widgets/traffic_graphs.widget.php
@@ -219,8 +219,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                   if (data.interfaces !== undefined) {
                       $( document ).trigger( "updateTrafficCharts", [ data ] );
                   }
+                  setTimeout(traffic_poller, 5000);
               });
-              setTimeout(traffic_poller, 5000);
           })();
         });
         // needed to display the widget settings menu


### PR DESCRIPTION
I'm having the problem that my OPNSENSE DEC2685 is running at 100% CPU usage every time I open the main web dashboard page.
I ignored the problem for a while, but now I'm starting to investigate it.

The main problem is that the widgets continuously request the APIs even if there is no response due to CPU overload.
Therefore, I think the best solution is to request new data after the previous request is answered.

I checked all widgets in the /src/www/widgets/widgets folder and made the change.
This behavior is already the case in the Wiregard widget.

<img width="547" alt="image" src="https://github.com/opnsense/core/assets/15692249/b6e2f796-ccf2-4b0d-82c7-4b6d167c1848">
