### PR TITLE
WireGuard: Add description for restart

### DIFF
--- a/src/opnsense/service/conf/actions.d/actions_wireguard.conf
+++ b/src/opnsense/service/conf/actions.d/actions_wireguard.conf
@@ -15,6 +15,7 @@ command:/usr/local/opnsense/scripts/Wireguard/wg-service-control.php
 parameters: restart %s
 type:script
 message: restart wireguard instance %s
+description:Restart WireGuard
 
 [configure]
 command:/usr/local/opnsense/scripts/Wireguard/wg-service-control.php


### PR DESCRIPTION
Sometime we need to restart wireguard during the night cause of ISP disruptions.
Can we have description to restart wireguard via cron? 