### PR TITLE
Firewall: fix issues with antilockout firewall rule

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -269,6 +269,7 @@
       <mediaopt/>
       <track6-interface>wan</track6-interface>
       <track6-prefix-id>0</track6-prefix-id>
+      <antilockout>true</antilockout>
     </lan>
   </interfaces>
   <dhcpd>

--- a/src/etc/inc/console.inc
+++ b/src/etc/inc/console.inc
@@ -383,6 +383,7 @@ EOD;
         config_read_array('interfaces', 'lan');
         $config['interfaces']['lan']['if'] = $lanif;
         $config['interfaces']['lan']['enable'] = true;
+        $config['interfaces']['lan']['antilockout'] = true;
 
         if ($new) {
             $config['interfaces']['lan']['ipaddr'] = '192.168.1.1';

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -94,9 +94,12 @@ function filter_core_get_antilockout()
         return [];
     }
 
-    $lockout_if = get_primary_interface_from_list(array_keys(legacy_config_get_interfaces(['virtual' => false])));
-    if (empty($lockout_if)) {
+    $lockout_ifs = array_keys(legacy_config_get_interfaces(['virtual' => false, 'enable' => true, 'antilockout' => true]));
+    if (empty($lockout_ifs)) {
+      $lockout_ifs = [get_primary_interface_from_list(array_keys(legacy_config_get_interfaces(['virtual' => false])))];
+      if (empty($lockout_ifs)) {
         return [];
+      }
     }
 
     /*
@@ -132,8 +135,7 @@ function filter_core_get_antilockout()
 
     sort($lockout_ports);
 
-    /* return a convenient one-entry array to iterate over for our callers */
-    return [$lockout_if => $lockout_ports];
+    return array_combine($lockout_ifs, array_fill(0, count($lockout_ifs), $lockout_ports));
 }
 
 /**

--- a/src/opnsense/scripts/shell/setaddr.php
+++ b/src/opnsense/scripts/shell/setaddr.php
@@ -542,6 +542,12 @@ if (console_prompt_for_yn('Restore web GUI access defaults?', 'n')) {
         unset($config['system']['webgui']['noantilockout']);
         $restart_webgui = true;
     }
+    if (isset($config['interfaces']['lan'])) {
+        $config['interfaces']['lan']['antilockout'] = true;
+        $restart_webgui = true;
+    } else {
+        echo "Could not enable anti lockout rule because no LAN interface was found.\n";
+    }
     if (isset($config['system']['webgui']['interfaces'])) {
         unset($config['system']['webgui']['interfaces']);
         $restart_webgui = true;

--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -420,6 +420,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     }
     $pconfig['enable'] = isset($a_interfaces[$if]['enable']);
     $pconfig['lock'] = isset($a_interfaces[$if]['lock']);
+    $pconfig['antilockout'] = isset($a_interfaces[$if]['antilockout']);
     $pconfig['blockpriv'] = isset($a_interfaces[$if]['blockpriv']);
     $pconfig['blockbogons'] = isset($a_interfaces[$if]['blockbogons']);
     $pconfig['gateway_interface'] = isset($a_interfaces[$if]['gateway_interface']);
@@ -596,6 +597,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     } elseif (empty($pconfig['enable'])) {
         if (isset($a_interfaces[$if]['enable'])) {
             unset($a_interfaces[$if]['enable']);
+        }
+        if (!empty($pconfig['antilockout'])) {
+            $a_interfaces[$if]['antilockout'] = true;
+        } elseif (isset($a_interfaces[$if]['antilockout'])) {
+            unset($a_interfaces[$if]['antilockout']);
         }
         if (!empty($pconfig['lock'])) {
             $a_interfaces[$if]['lock'] = true;
@@ -1013,6 +1019,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $new_config['descr'] = preg_replace('/[^a-z_0-9]/i', '', $pconfig['descr']);
             $new_config['enable'] = !empty($pconfig['enable']);
             $new_config['lock'] = !empty($pconfig['lock']);
+            $new_config['antilockout'] = !empty($pconfig['antilockout']);
             $new_config['spoofmac'] = $pconfig['spoofmac'];
 
             $new_config['blockpriv'] = !empty($pconfig['blockpriv']);
@@ -1759,6 +1766,19 @@ include("head.inc");
                         <td>
                           <input id="lock" name="lock" type="checkbox" value="yes" <?=!empty($pconfig['lock']) ? 'checked="checked"' : '' ?>/>
                           <?= gettext('Prevent interface removal') ?>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><a id="help_for_antilockout" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext('Antilockout') ?></td>
+                        <td>
+                          <input id="antilockout" name="antilockout" type="checkbox" value="yes" <?=!empty($pconfig['antilockout']) ? 'checked="checked"' : '' ?>/>
+                          <?= gettext('Enable antilockout firewall rule on this interface') ?>
+                          <div class="hidden" data-for="help_for_antilockout">
+                            <?= gettext(<<<EOD
+                                When this is checked, an anti lockout rule is generated which always permits access to the web GUI and SSH on this interface,
+                                regardless of the user-defined firewall rule set, unless the anti lockout feature is disabled in the advanced firewall settings.
+                                EOD); ?>
+                          </div>
                         </td>
                       </tr>
                       <tr>


### PR DESCRIPTION
This commit fixes two issues with the antilock firewall rule:
- the rule may randomly open ports on the WAN under certain circumstances
- the rule may select inactive interfaces

The issue is fixed by giving the user a choice for which interface the rule should apply for, default being LAN. The user is also being prevented from deleting/unassigning/disabling the currently selected interface.