### PR TITLE
fix: :bug: Update field separator for Kea DHCP Subnet Form and Model

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -55,7 +55,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <separator>;</separator>
+        <separator>,</separator>
         <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -49,7 +49,7 @@
                     </domain_name_servers>
                     <domain_search type="HostnameField">
                         <IpAllowed>N</IpAllowed>
-                        <FieldSeparator>;</FieldSeparator>
+                        <FieldSeparator>,</FieldSeparator>
                         <AsList>Y</AsList>
                         <ValidationMessage>Please specify a valid list of domains</ValidationMessage>
                     </domain_search>


### PR DESCRIPTION
Fixes: #7417
Closes: #7417 

**Describe the bug**

When setting multiple search domains in Kea DHCP subnets, the configuration file /usr/local/etc/kea/kea-dhcp4.conf is written incorrectly.

The configuration file will be written as 
```json
                    {
                        "name": "domain-search",
                        "data": "first.domain;someother.domain"
                    },
```

This causes Kea to simply not report a search domain at all.

Based on the Kea documentation, I manually updated the file to this and restarted the service, which then behaved as expected.
```json
                    {
                        "name": "domain-search",
                        "data": "first.domain,someother.domain"
                    },
```


**To Reproduce**

Steps to reproduce the behavior:
1. Go to 'Services'
2. Click on 'Kea DHCP [new]'
3. Click on 'Kea DHCPv4'
4. Switch to the 'Subnets' tab
5. Configure a subnet with multiple search domains
6. Save and Restart Kea DHCP

**Expected behavior**

DHCP Clients on the configured subnet should get both search domains, but instead, they get none.

** Changes tested on my local instance **

OPNsense 24.1.6 (amd64).
Intel(R) Atom(TM) CPU C3758 @ 2.20GHz (4 cores, 4 threads)
Ethernet Controller I225-V and Ethernet Connection X553 10 GbE SFP+