### PR TITLE
src: resolve deprecation warnings for sre_constants

### DIFF
--- a/src/opnsense/scripts/suricata/queryAlertLog.py
+++ b/src/opnsense/scripts/suricata/queryAlertLog.py
@@ -33,7 +33,6 @@
 import sys
 import os.path
 import re
-import sre_constants
 import shlex
 import ujson
 sys.path.insert(0, "/usr/local/opnsense/site-python")
@@ -73,7 +72,7 @@ if __name__ == '__main__':
             filter_regexp = filter_regexp.lower()
             try:
                 data_filters_comp[filterField] = re.compile(filter_regexp)
-            except sre_constants.error:
+            except re.error:
                 # remove illegal expression
                 # del data_filters[filterField]
                 data_filters_comp[filterField] = re.compile('.*')

--- a/src/opnsense/scripts/syslog/queryLog.py
+++ b/src/opnsense/scripts/syslog/queryLog.py
@@ -33,7 +33,6 @@
 import sys
 import os.path
 import re
-import sre_constants
 import ujson
 import datetime
 import glob
@@ -82,7 +81,7 @@ if __name__ == '__main__':
                 # no wildcard operator, assume partial match
                 filter = ".*%s.*" % filter
             filter_regexp = re.compile(filter)
-        except sre_constants.error:
+        except re.error:
             # remove illegal expression
             filter_regexp = re.compile('.*')
 


### PR DESCRIPTION
On boot with python 3.11 a new deprecation warning appears:

```
configd.py	[e3c1a4e0-1dec-4667-a300-0ceff7926539] Script action stderr returned "b"/usr/local/opnsense/scripts/syslog/queryLog.py:36: DeprecationWarning: module 'sre_constants' is deprecated\n import sre_constants""
```

It's only used to have an exception class `sre_constants.error` it can be safely replaced with `re.error` since it is also imported from regex compiler there.