### PR TITLE
Add next-server option to Kea

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -78,7 +78,7 @@
         <id>subnet4.next_server</id>
         <label>Next server</label>
         <type>text</type>
-        <help>Next server address or fqdn</help>
+        <help>Next server IP address</help>
     </field>
     <field>
         <id>subnet4.option_data.tftp_server_name</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -75,6 +75,12 @@
         <help>Specifies a list of RFC 868 time servers available to the client.</help>
     </field>
     <field>
+        <id>subnet4.next_server</id>
+        <label>Next server</label>
+        <type>text</type>
+        <help>Next server address or fqdn</help>
+    </field>
+    <field>
         <id>subnet4.option_data.tftp_server_name</id>
         <label>TFTP server</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -141,6 +141,7 @@ class KeaDhcpv4 extends BaseModel
             $record = [
                 'id' => $subnet_id++,
                 'subnet' => (string)$subnet->subnet,
+                'next-server' => (string)$subnet->next_server,
                 'option-data' => [],
                 'pools' => [],
                 'reservations' => []

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -36,8 +36,9 @@
                     <AddressFamily>ipv4</AddressFamily>
                     <Required>Y</Required>
                 </subnet>
-                <next_server type="TextField">
-                    <Mask>/^([^\n"])*$/u</Mask>
+                <next_server type="NetworkField">
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <AddressFamily>ipv4</AddressFamily>
                 </next_server>
                 <option_data_autocollect type="BooleanField">
                     <Default>1</Default>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -36,6 +36,9 @@
                     <AddressFamily>ipv4</AddressFamily>
                     <Required>Y</Required>
                 </subnet>
+                <next_server type="TextField">
+                    <Mask>/^([^\n"])*$/u</Mask>
+                </next_server>
                 <option_data_autocollect type="BooleanField">
                     <Default>1</Default>
                     <Required>Y</Required>


### PR DESCRIPTION
This PR aims to add the ``next-server`` (a.k.a. ``siaddr``) option to support PXE network booting with Kea
Fixes: #7189