### PR TITLE
system: do not create an interface route without an address

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -672,6 +672,11 @@ function system_routing_configure($verbose = false, $interface = null, $monitor 
             continue;
         }
 
+        if (empty($ifdetails[$gateway['if']]['ipv4'][0])) {
+            log_msg("ROUTING: refusing to set interface route on addressless {$gateway['interface']}({$gateway['if']})", LOG_WARNING);
+            continue;
+        }
+
         system_interface_route($gateway, $routes);
     }
 


### PR DESCRIPTION
Similar to what default route handling already does.  In this case it's not logged as an error, because the condition is likely normal.