### PR TITLE
Update main.scss iconspacer width

### DIFF
--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/main.scss
@@ -403,7 +403,7 @@ main.page-content.col-lg-12 {
             font-size: 20px;
           }
           &.__iconspacer {
-            width: 50px;
+            width: 60px;
             height: 30px;
             padding: 0px;
           }


### PR DESCRIPTION
Solve the problem of misaligned display of Chinese sidebar

**Before repair**
<img width="1142" alt="image" src="https://github.com/opnsense/core/assets/30649838/97bd15c5-056a-4459-a2fb-ab68bdd51192">


**Repair effect**
<img width="1275" alt="image" src="https://github.com/opnsense/core/assets/30649838/f3ca7056-57e4-49b0-8a3c-0bcd579995aa">
