### PR TITLE
unbound: discard-timeout

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
@@ -106,6 +106,18 @@
         </help>
     </field>
     <field>
+        <id>unbound.advanced.discardtimeout</id>
+        <label>Discard Timeout</label>
+        <type>text</type>
+        <help>
+	    The wait time in msec where recursion requests are dropped. This is to stop a large number of replies
+            from accumulating.
+            If 'Serve Expired Responses' is enabled it should be set greater than 'Client Expired Response Timeout'.
+            Otherwise, a value of 1900 msec is suggested.
+            The value 0 disables it. Default 1900 msec.
+        </help>
+    </field>
+    <field>
         <id>unbound.advanced.privatedomain</id>
         <label>Private Domains</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
@@ -111,10 +111,9 @@
         <type>text</type>
         <help>
 	    The wait time in msec where recursion requests are dropped. This is to stop a large number of replies
-            from accumulating.
-            If 'Serve Expired Responses' is enabled it should be set greater than 'Client Expired Response Timeout'.
-            Otherwise, a value of 1900 msec is suggested.
-            The value 0 disables it. Default 1900 msec.
+            from accumulating. If 'Serve Expired Responses' is enabled this field should be set greater than
+            'Client Expired Response Timeout', otherwise, these late responses will not update the cache.
+            The value 0 disables it. Default 1900. This setting may increase the "request queue exceeded" counter.
         </help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/unboundplus</mount>
     <description>Unbound configuration</description>
-    <version>1.0.10</version>
+    <version>1.0.9</version>
     <items>
         <general>
             <enabled type="BooleanField">

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/unboundplus</mount>
     <description>Unbound configuration</description>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -120,6 +120,7 @@
             <numqueriesperthread type="NumericField"/>
             <outgoingrange type="NumericField"/>
             <jostletimeout type="NumericField"/>
+            <discardtimeout type="NumericField"/>
             <cachemaxttl type="NumericField"/>
             <cachemaxnegativettl type="NumericField"/>
             <cacheminttl type="NumericField"/>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/advanced.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/advanced.conf
@@ -32,6 +32,7 @@ log-local-actions: {{ set_boolean(OPNsense.unboundplus.advanced.loglocalactions)
 {{ set_numeric_value('num-queries-per-thread', OPNsense.unboundplus.advanced.numqueriesperthread) }}
 {{ set_numeric_value('outgoing-range', OPNsense.unboundplus.advanced.outgoingrange) }}
 {{ set_numeric_value('jostle-timeout', OPNsense.unboundplus.advanced.jostletimeout) }}
+{{ set_numeric_value('discard-timeout', OPNsense.unboundplus.advanced.discardtimeout) }}
 {{ set_numeric_value('cache-max-ttl', OPNsense.unboundplus.advanced.cachemaxttl) }}
 {{ set_numeric_value('cache-max-negative-ttl', OPNsense.unboundplus.advanced.cachemaxnegativettl) }}
 {{ set_numeric_value('cache-min-ttl', OPNsense.unboundplus.advanced.cacheminttl) }}


### PR DESCRIPTION
Adds support for 'discard-timeout' to Unbound configuration.

This can be useful when using the option to serve expired responses.

The new option is added just below 'Jostle Timeout' within the advanced panel. 
I did consider adding it within the serve-expired section, however it's not strictly as tightly related and has more general applicability (as per unbound docs). I also removed once sentence (for help) which made no sense from the unbound docs, and clarified the exact labels used for related settings in the UI.

I tested with a 'live' install to ensure the panel worked, and the value was then placed into /var/unbound/advanced.conf

Based off master

Fixes #7493 
