### PR TITLE
API: reverse getArp resolve parameter behavior

### DIFF
--- a/src/opnsense/scripts/interfaces/list_arp.py
+++ b/src/opnsense/scripts/interfaces/list_arp.py
@@ -38,7 +38,7 @@ import watchers.dhcpd
 
 if __name__ == '__main__':
     # do we use reverse DNS lookup ?
-    arp_arg = '-an' if '-r' in sys.argv else '-a'
+    arp_arg = '-a' if '-r' in sys.argv else '-an'
 
     # index mac database (shipped with netaddr)
     macdb = dict()


### PR DESCRIPTION
Currently the `resolve` parameter for the [getArp](https://docs.opnsense.org/development/api/core/diagnostics.html#id5) API call performs the opposite behavior you'd expect. When the `resolve=yes` parameter is supplied `list_arp.py` _will not_ resolve hostnames, while `resolve=no` (the default) _will_ resolve them. 

If this behavior is intentional, disregard this PR.