### PR TITLE
Add response code REFUSED at Unbound blocklists

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dnsbl.xml
@@ -55,20 +55,22 @@
         </help>
     </field>
     <field>
+        <id>unbound.dnsbl.rcode</id>
+        <label>Return Response Code</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>
+            Use the DNS response code for entries in the blocklist.
+        </help>
+    </field>
+    <field>
         <id>unbound.dnsbl.address</id>
         <label>Destination Address</label>
         <type>text</type>
         <advanced>true</advanced>
         <help>
             Destination ip address for entries in the blocklist (leave empty to use default: 0.0.0.0).
-            Not used when "Return NXDOMAIN" is checked.
+            Only used when "Return Response Code" is "A".
         </help>
-    </field>
-    <field>
-        <id>unbound.dnsbl.nxdomain</id>
-        <label>Return NXDOMAIN</label>
-        <type>checkbox</type>
-        <advanced>true</advanced>
-        <help>Use the DNS response code NXDOMAIN instead of a destination address.</help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -226,11 +226,19 @@
                 <ValidationMessage>A valid domain must be specified.</ValidationMessage>
                 <MaskPerItem>Y</MaskPerItem>
             </wildcards>
+            <rcode type="OptionField">
+                <Default>1</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <opt1 value="REFUSED">REFUSED</opt1>
+                    <opt2 value="NXDOMAIN">NXDOMAIN</opt2>
+                    <opt3 value="NOERROR">A</opt3>
+                </OptionValues>
+            </rcode>
             <address type="NetworkField">
                 <NetMaskAllowed>N</NetMaskAllowed>
                 <AddressFamily>ipv4</AddressFamily>
             </address>
-            <nxdomain type="BooleanField"/>
         </dnsbl>
         <forwarding>
             <enabled type="BooleanField"/>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
@@ -1,4 +1,9 @@
 {%
+  set rcodes = {
+      "REFUSED": "REFUSED",
+      "NXDOMAIN": "NXDOMAIN",
+      "NOERROR": "NOERROR"
+  }
   set predefined = {
       "aa": "https://adaway.org/hosts.txt",
       "oisd0": "https://small.oisd.nl/domainswild",
@@ -40,7 +45,13 @@
 %}
 {%  if not helpers.empty('OPNsense.unboundplus.dnsbl.enabled') %}
 [settings]
-rcode={% if not helpers.empty('OPNsense.unboundplus.dnsbl.nxdomain') %}NXDOMAIN{%else%}NOERROR{%endif%}
+{%    if not helpers.empty('OPNsense.unboundplus.dnsbl.rcode') %}
+{%      if OPNsense.unboundplus.dnsbl.rcode in rcodes %}
+rcode={{ rcodes[OPNsense.unboundplus.dnsbl.rcode] }}
+{%      endif%}
+{%    else %}
+rcode={{ rcodes['REFUSED'] }}
+{%    endif%}
 
 address={{OPNsense.unboundplus.dnsbl.address|default('0.0.0.0')}}
 

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/blocklists.conf
@@ -4,6 +4,8 @@
       "NXDOMAIN": "NXDOMAIN",
       "NOERROR": "NOERROR"
   }
+%}
+{%
   set predefined = {
       "aa": "https://adaway.org/hosts.txt",
       "oisd0": "https://small.oisd.nl/domainswild",


### PR DESCRIPTION
Here is my PR for the addition of response code REFUSED at Unbound blocklists
Ref: #6027
Successfully tested on a live installation

https://github.com/opnsense/core/blob/master/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
- Since I was already doing this anyway, I added RCODE_SERVFAIL as well as RCODE_REFUSED, as this was used several times but was not defined.
- Pyflake shows even more undefined variables here, e.g. RR_TYPE_A, but I haven't looked into it any further...