### PR TITLE
MVC: remove aria-hidden from base dialogs

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -55,7 +55,7 @@
     {% endif %}
 {% endfor %}
 
-<div class="modal fade" id="{{base_dialog_id}}" tabindex="-1" role="dialog" aria-labelledby="{{base_dialog_id}}Label" aria-hidden="true">
+<div class="modal fade" id="{{base_dialog_id}}" tabindex="-1" role="dialog" aria-labelledby="{{base_dialog_id}}Label">
     <div class="modal-backdrop fade in"></div>
     <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog_processing.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog_processing.volt
@@ -1,5 +1,5 @@
 <!-- Static Modal "Processing request", prevent user input while busy -->
-<div class="modal modal-static fade" id="processing-dialog" role="dialog" aria-hidden="true">
+<div class="modal modal-static fade" id="processing-dialog" role="dialog">
     <div class="modal-backdrop fade in"></div>
     <div class="modal-dialog">
         <div class="modal-content">


### PR DESCRIPTION
Aria-hidden attribute makes dialogs inaccessible for screen readers.