### PR TITLE
Added configured host name to the page title

### DIFF
--- a/src/www/authgui.inc
+++ b/src/www/authgui.inc
@@ -327,7 +327,7 @@ function display_error_form($text)
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <title><?= gettext('Error') ?> | <?= $product->name() ?></title>
+    <title><?= gettext('Error') ?> | <?= $product->name() ?><?= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $config['system']['domain'])) ?></title>
 
     <link href="<?= cache_safe(get_themed_filename('/css/main.css')) ?>" rel="stylesheet">
     <link href="<?= cache_safe(get_themed_filename('/images/favicon.png')) ?>" rel="shortcut icon">
@@ -368,7 +368,7 @@ function display_login_form($Login_Error)
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <title><?= gettext('Login') ?> | <?= $product->name() ?></title>
+    <title><?= gettext('Login') ?> | <?= $product->name() ?><?= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $config['system']['domain'])) ?></title>
 
     <link href="<?= cache_safe(get_themed_filename('/css/main.css')) ?>" rel="stylesheet">
     <link href="<?= cache_safe(get_themed_filename('/images/favicon.png')) ?>" rel="shortcut icon">


### PR DESCRIPTION
When using password managers like KeePass, the page title is helpful in allowing the password manager to correctly identify the correct credentials to autofill the login form. By not including the host name in the page title, it is impossible for password managers to differentiate between multiple different OPNsense routers. This change adds the host name to the login page title in a format that is consistent with other pages throughout OPNsense and allows password managers to correctly identify the credentials required at login.