### PR TITLE
firewall: added presentation role to edit rules table

### DIFF
--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -779,7 +779,7 @@ include("head.inc");
                 <input name="after" type="hidden" value="<?=isset($after) ? $after :'';?>" />
                 <input type="hidden" name="floating" value="<?=$pconfig['floating'];?>" />
                 <div class="table-responsive">
-                  <table class="table table-striped opnsense_standard_table_form">
+                  <table role="presentation" class="table table-striped opnsense_standard_table_form">
                   <tr>
                     <td style="width:22%"><strong><?=gettext("Edit Firewall rule");?></strong></td>
                     <td style="width:78%;text-align:right">


### PR DESCRIPTION
For tables that are purely used for presentation as opposed to data, using the role="presentation" attribute prevents extra announcements from screen readers. For example, in this table, the Advanced and Show/Hide headers at the end of the table were being read on every cell when navigating with a screen reader.