### PR TITLE
firewall: added presentation role to table on nat edit page

### DIFF
--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -528,7 +528,7 @@ $( document ).ready(function() {
         <section class="col-xs-12">
           <div class="content-box">
             <form method="post" name="iform" id="iform">
-              <table class="table table-striped opnsense_standard_table_form">
+              <table role="presentation" class="table table-striped opnsense_standard_table_form">
                 <tr>
                   <td style="width:22%"><?=gettext("Edit Redirect entry"); ?></td>
                   <td  style="width:78%; text-align:right">


### PR DESCRIPTION
Since this is not a data table, adding role="presentation" to remove extra screen reader announcements.