### PR TITLE
firewall: added cell role to commands column on Nat page

### DIFF
--- a/src/www/firewall_nat.php
+++ b/src/www/firewall_nat.php
@@ -339,7 +339,7 @@ $( document ).ready(function() {
                       <th><?=gettext("IP");?></th>
                       <th><?=gettext("Ports");?></th>
                       <th><?=gettext("Description");?></th>
-                      <th class="text-nowrap">
+                      <th role="cell" class="text-nowrap">
                         <a href="firewall_nat_edit.php" class="btn btn-primary btn-xs" data-toggle="tooltip" title="<?= html_safe(gettext('Add')) ?>">
                           <i class="fa fa-plus fa-fw"></i>
                         </a>


### PR DESCRIPTION
Since the commands column is marked as a table header, screen readers will read the buttons every time a user navigates to a cell anywhere in that column. This causes a lot of extra speech output. Adding role="cell" to the commands column will suppress this.