### PR TITLE
Dashboard: New dashboard will not work with themes that use custom fonts, potential fix (not the best option)

### DIFF
--- a/src/opnsense/www/js/widgets/BaseGaugeWidget.js
+++ b/src/opnsense/www/js/widgets/BaseGaugeWidget.js
@@ -102,6 +102,8 @@ export default class BaseGaugeWidget extends BaseWidget {
                 id: 'custom_positioned_text',
                 beforeDatasetsDraw: (chart, _, __) => {
                     let data = chart.config.data.datasets[0].data;
+                    let bodyFamily = window.getComputedStyle(document.body, null).getPropertyValue('font-family');
+                    let headingFamily = window.getComputedStyle(document.querySelector('h1'), null).getPropertyValue('font-family');
                     if (data.length !== 0) {
                         let width = chart.width;
                         let height = chart.height;
@@ -113,7 +115,7 @@ export default class BaseGaugeWidget extends BaseWidget {
                         let secondaryText = _options.secondaryText(data, chart);
 
                         let fontSize = (height / divisor).toFixed(2);
-                        ctx.font = fontSize + "em SourceSansProSemiBold";
+                        ctx.font = fontSize + "em " + headingFamily;
                         ctx.textBaseline = "middle";
                         ctx.fillStyle = Chart.defaults.color;
 
@@ -124,7 +126,7 @@ export default class BaseGaugeWidget extends BaseWidget {
 
                         if (secondaryText) {
                             fontSize = (height / 90).toFixed(2);
-                            ctx.font = fontSize + "em SourceSansProRegular";
+                            ctx.font = fontSize + "em " + bodyFamily;
                             ctx.textBaseline = "middle";
                             ctx.fillStyle = Chart.defaults.color;
 


### PR DESCRIPTION
Through changing/designing the new template, I noticed fonts on new Dashboard Gauges do not work with the pre-set from the body. So, I modified the code to take the heading (H1, which is always present on the page) and body font for canvas rendering.  Works with 96% of browsers according to caniuse.com. 

This isn't the best solution, but would love to see this functionality in the new release. 

![image](https://github.com/user-attachments/assets/d2c3c433-8091-40ca-ac63-24c88c4a35d4)
