### PR TITLE
template: motd: drop X/Twitter for Reddit

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Auth/motd.in
+++ b/src/opnsense/service/templates/OPNsense/Auth/motd.in
@@ -5,5 +5,5 @@
 | Handbook:	https://docs.opnsense.org/   |       ))))))))   ((((((((
 | Forums:	https://forum.opnsense.org/  |         @@@///   \\\@@@
 | Code:		https://github.com/opnsense  |        @@@@         @@@@
-| Twitter:	https://twitter.com/opnsense |         @@@@@@@@@@@@@@@
+| X:		https://x.com/opnsense       |         @@@@@@@@@@@@@@@
 ----------------------------------------------

--- a/src/opnsense/service/templates/OPNsense/Auth/motd.in
+++ b/src/opnsense/service/templates/OPNsense/Auth/motd.in
@@ -1,9 +1,9 @@
-----------------------------------------------
-|      Hello, this is OPNsense %%CORE_SERIES_FW%%         |         @@@@@@@@@@@@@@@
-|                                            |        @@@@         @@@@
-| Website:	https://opnsense.org/        |         @@@\\\   ///@@@
-| Handbook:	https://docs.opnsense.org/   |       ))))))))   ((((((((
-| Forums:	https://forum.opnsense.org/  |         @@@///   \\\@@@
-| Code:		https://github.com/opnsense  |        @@@@         @@@@
-| X:		https://x.com/opnsense       |         @@@@@@@@@@@@@@@
-----------------------------------------------
+-------------------------------------------------
+|      Hello, this is OPNsense %%CORE_SERIES_FW%%            |         @@@@@@@@@@@@@@@
+|                                               |        @@@@         @@@@
+| Website:	https://opnsense.org/           |         @@@\\\   ///@@@
+| Handbook:	https://docs.opnsense.org/      |       ))))))))   ((((((((
+| Forums:	https://forum.opnsense.org/     |         @@@///   \\\@@@
+| Code:		https://github.com/opnsense     |        @@@@         @@@@
+| Reddit:	https://reddit.com/r/opnsense/  |         @@@@@@@@@@@@@@@
+-------------------------------------------------


### PR DESCRIPTION
It's quite controversial but things kind of change.

I recently pulled the 24.1 update, and noticed it was still mentioned as Twitter. 
Here's a patch to correctly refer to the product as of now, which is X.