### PR TITLE
Add Boot Environment Integration to OPNsense Web Interface

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/Api/GeneralController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/Api/GeneralController.php
@@ -1,0 +1,200 @@
+<?php
+/*
+ * Copyright (C) 2024 Sheridan Computers Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace OPNsense\BootEnvironments\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Base\UIModelGrid;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\BootEnvironments\BootEnvironments;
+class GeneralController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'general';
+    protected static $internalModelClass = '\OPNsense\BootEnvironments\General';
+
+    public function getAction()
+    {
+        // Check if we're only searching for a single record
+        $uri = explode("?", $_SERVER["REQUEST_URI"])[0];
+        $apiPath = '/api/bootenvironments/general/get/';
+
+        // request for new record?
+        if ($apiPath === $uri) {
+            $today = date("YmdHis");
+            return ['name' => 'BE'.$today];
+        } else if (substr($uri, 0, strlen($apiPath)) === $apiPath) {
+            // request for specific record?
+            $params = ltrim(str_replace($apiPath, '', $uri), '/');
+        }
+
+        $backEnd = new BackEnd();
+        $backResult = json_decode(trim($backEnd->configdRun('bootenvironments list')), true);
+        // only return valid json
+        if ($backResult !== null) {
+            // search for single record?
+            if (! empty($params)) {
+                foreach ($backResult as $result) {
+                    if ($result['uuid'] === $params) {
+                        return $result;
+                    }
+                }
+                return ['message' => 'Boot environment not found'];
+            }
+
+            // sort in order of creation
+            usort($backResult, function ($a, $b) use ($backResult) {
+                return strtotime($a['created']) - strtotime($b['created']);
+            });
+
+            // return all
+            return [
+                'status' => 'ok',
+                'path' => $params,
+                'rows' => $backResult,
+                'current' => 1,
+                'total' => count($backResult),
+                'rowCount' => 7,
+                'searchPhrase' => ''
+            ];
+        }
+        return ['message' => 'Unable to list boot environments'];
+    }
+
+    public function setAction()
+    {
+        if ($this->request->isPost() && $this->request->hasPost('bootenv')) {
+            $postVars = $this->request->getPost('bootenv') ?? [];
+
+            $uuid = $postVars['uuid'] ?? null;
+            $be = $this->findBootEnvironment($uuid);
+            if (empty($be)) {
+                return ['status' => 'error', 'message' => 'Boot environment not found'];
+            }
+
+            // check boot environment name
+            if ($be['name'] !== $postVars['name']) {
+                $backEnd = new BackEnd();
+                return json_decode(
+                    trim($backEnd->configdRun("bootenvironments rename {$be['name']} {$postVars['name']}")),
+                    true
+                );
+            }
+        }
+
+        return ['status' => 'error', 'message' => 'Unable to set boot environment'];
+    }
+
+    public function addBootEnvAction()
+    {
+        $response = ['status' => 'failed', 'result' => 'error'];
+        if ($this->request->isPost()) {
+            if ($this->request->hasPost('bootenv')) {
+                $bootenv = $this->request->getPost('bootenv');
+                $name = $bootenv['name'] ?? null;
+                $uuid = $bootenv['uuid'] ?? null;
+            }
+
+            $backEnd = new BackEnd();
+            if (empty($name) && empty($uuid)) {
+                // no name or uuid - create new environment
+                return($backEnd->configdRun("bootenvironments createquick"));
+            } else if (!empty($name) && !empty($uuid)) {
+                // we have a name and uuid, clone request?
+                $be = $this->findBootEnvironment($uuid);
+                if (empty($be)) {
+                    return ['status' => 'error', 'message' => 'Boot environment not found'];
+                }
+                if ($be['name'] !== $name) {
+                    $cloneFrom = $be['name'];
+                    return json_decode(
+                        trim($backEnd->configdRun("bootenvironments clone {$name} {$cloneFrom}")),
+                        true
+                    );
+                }
+            }
+            else {
+                // otherwise create as normal
+                return($backEnd->configdRun("bootenvironments create {$name}"));
+            }
+        }
+        return ['error' => 'Unable to add boot environment'];
+    }
+
+    public function delBootEnvAction($uuid): array
+    {
+        if (! $this->request->isPost()) {
+            $this->response->setStatusCode(405, 'Method Not Allowed');
+            $this->response->setHeader('Allow', 'POST');
+            return ['message' => 'Method not allowed'];
+        }
+
+        $be = $this->findBootEnvironment($uuid);
+        if (empty($be)) {
+            return ['status' => 'error', 'message' => 'Boot environment not found'];
+        }
+        $backEnd = new BackEnd();
+        return (json_decode(trim($backEnd->configdRun("bootenvironments destroy {$be['name']}")), true));
+    }
+
+    public function listAction()
+    {
+        return $this->getAction();
+    }
+
+    public function activateAction()
+    {
+        $response = ['status' => 'failed', 'result' => 'error'];
+        if ($this->request->isPost() && $this->request->hasPost('uuid') && !empty($this->request->getPost('uuid'))) {
+            $uuid = $this->request->getPost('uuid');
+            $be = $this->findBootEnvironment($uuid);
+            if (empty($be)) {
+                return ['status' => false, 'message' => 'Boot environment not found'];
+            }
+
+            $backEnd = new BackEnd();
+            $be_name = $be['name'];
+            return json_decode(trim($backEnd->configdRun("bootenvironments activate {$be_name}")), true);
+        }
+        return $response;
+    }
+
+    /**
+     * @param string $search uuid of boot environment to find
+     * @return array boot environment elements as an array, or null if not found
+     */
+    private function findBootEnvironment(string $search): array
+    {
+        $backEnd = new BackEnd();
+        $backResult = json_decode(trim($backEnd->configdRun("bootenvironments fetch --uuid {$search}")), true);
+        if ($backResult !== null) {
+            if ($backResult['uuid'] === $search) {
+                return $backResult;
+            }
+        }
+        return [];
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/GeneralController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/GeneralController.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright (C) 2024 Sheridan Computers Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace OPNsense\BootEnvironments;
+
+use OPNsense\Core\Backend;
+
+class GeneralController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $backEnd = new Backend();
+        $backResult = json_decode(trim($backEnd->configdRun('bootenvironments supported')), true);
+        if ($backResult === null or ! is_array($backResult)) {
+            $this->view->pick('OPNsense/BootEnvironments/unsupported');
+        }
+
+        $status = $backResult['status'] ?? null;
+        if ($status === 'OK') {
+            $this->view->pick('OPNsense/BootEnvironments/general');
+            $this->view->generalForm = $this->getForm('general');
+            return;
+        }
+
+        $this->view->pick('OPNsense/BootEnvironments/unsupported');
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/BootEnvironments/forms/general.xml
@@ -1,0 +1,12 @@
+<form>
+    <field>
+        <id>bootenv.uuid</id>
+        <label>UUID</label>
+        <type>hidden</type>
+    </field>
+    <field>
+        <id>bootenv.name</id>
+        <label>Name</label>
+        <type>text</type>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+    <page-system-bootenvironments>
+        <name>System: Boot Environments</name>
+        <patterns>
+            <pattern>ui/bootenvironments/*</pattern>
+            <pattern>api/bootenvironments/*</pattern>
+        </patterns>
+    </page-system-bootenvironments>
+</acl>

--- a/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.php
+++ b/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * Copyright (C) 2024 Sheridan Computers Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace OPNsense\BootEnvironments;
+
+use OPNsense\Base\BaseModel;
+
+class General extends BaseModel
+{
+}

--- a/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.xml
@@ -1,0 +1,16 @@
+<model>
+    <mount>//OPNsense/BootEnvironments/general</mount>
+    <description>
+        A mesh VPN that makes it easy to connect your devices, wherever they are.
+    </description>
+    <items>
+        <bootenv>
+            <uuid type="TextField">
+                <Required>N</Required>
+            </uuid>
+            <name type="TextField">
+                <Required>Y</Required>
+            </name>
+        </bootenv>
+    </items>
+</model>

--- a/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/BootEnvironments/general</mount>
     <description>
-        A mesh VPN that makes it easy to connect your devices, wherever they are.
+        Adds support for FreeBSD boot environments
     </description>
     <items>
         <bootenv>

--- a/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/BootEnvironments/Menu/Menu.xml
@@ -1,0 +1,7 @@
+<menu>
+    <System>
+        <BootEnvironments VisibleName="Boot Environments" cssClass="fa fa-database fa-fw">
+            <General VisibleName="General" url="/ui/bootenvironments/general"/>
+        </BootEnvironments>
+    </System>
+</menu>

--- a/src/opnsense/mvc/app/views/OPNsense/BootEnvironments/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/BootEnvironments/general.volt
@@ -1,0 +1,115 @@
+<script>
+    $(document).ready(function() {
+        // get be data
+        var be_get_data_map = {'frmGeneral':'/api/bootenvironments/general/get'};
+        // load initial data
+
+        let grid_env = $("#grid-env").UIBootgrid({
+            get: '/api/bootenvironments/general/get/',
+            set: '/api/bootenvironments/general/set/',
+            add: '/api/bootenvironments/general/addBootEnv/',
+            del: '/api/bootenvironments/general/delBootEnv/',
+            search: '/api/bootenvironments/general/list',
+            commands: {
+                activate_be: {
+                    method: function(event) {
+                        let uuid = $(this).data("row-id") !== undefined ? $(this).data("row-id") : '';
+                        ajaxCall('/api/bootenvironments/general/activate/', { uuid: uuid}, function(data, status){
+                            if (data.result) {
+                                BootstrapDialog.show({
+                                    title: "{{ lang._('Activation successful') }}",
+                                    type:BootstrapDialog.TYPE_INFO,
+                                    message: $("<div/>").text(data.result).html(),
+                                    cssClass: 'monospace-dialog',
+                                    buttons: [{
+                                        label: "{{ lang._('OK') }}",
+                                        cssClass: 'btn-primary',
+                                        action: function(dialog) {
+                                            dialog.close();
+                                        }
+                                    }]
+                                });
+                                $('#grid-env').bootgrid('reload');
+                            }
+                        }); 
+                    },
+                    classname: 'fa fa-fw fa-check',
+                    title: "{{ lang._('activate boot environment') }}",
+                    sequence: 10
+                },
+            },
+            options: {
+                selection: false,
+                multiSelect: false,
+                rowSelect: false,
+                formatters: {
+                    "commands": function (column, row) {
+                        let rowId = row.uuid;
+                        let elements = '<div class="break">'
+                        + '<button type="button" class="btn btn-xs btn-default command-activate_be bootgrid-tooltip" data-row-id="' + rowId + '" title="Activate"><span class="fa fa-fw fa-check"></span></button>'
+                        + '<button type="button" class="btn btn-xs btn-default command-edit bootgrid-tooltip" data-row-id="' + rowId + '"><span class="fa fa-fw fa-pencil"></span></button>' 
+                        + '<button type="button" class="btn btn-xs btn-default command-copy bootgrid-tooltip" data-row-id="' + rowId + '"><span class="fa fa-fw fa-clone"></span></button>';
+                        if (!row.virtual) {
+                            elements += '<button type="button" class="btn btn-xs btn-default command-delete bootgrid-tooltip" data-row-id="' + rowId + '"><span class="fa fa-fw fa-trash-o"></span></button>';
+                        }
+                        return elements + '</div>';
+                    }
+                }
+            }
+        });
+
+        $('#newBootEnvironment').SimpleActionButton({
+            onAction: function(data, status) {
+                $('#grid-env').bootgrid('reload');
+            }
+        });
+    });
+</script>
+<h1>Boot Environments</h1>
+
+<ul id="maintabs" class="nav nav-tabs" data-tabs="tabs">
+    <li id="beGeneral" class="active">
+        <a data-toggle="tab" href="#tab_general">{{ lang._('General') }}</a>
+    </li>
+</ul>
+
+<div class="tab-content content-box">
+    <div id="tab_general" class="tab-pane fade in active">
+        <table id="grid-env" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="frmGeneral">
+            <thead>
+                <tr>
+                    <th data-column-id="uuid" data-type="string" data-visible="false" data-identifier="true" data-sortable="false">{{ lang._('uuid') }}</th>
+                    <th data-column-id="name" data-type="string" data-visible="true" data-identifier="false" data-sortable="false">{{ lang._('Name') }}</th>
+                    <th data-column-id="active" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Active') }}</th>
+                    <th data-column-id="mountpoint" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Mountpoint') }}</th>
+                    <th data-column-id="size" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Size') }}</th>
+                    <th data-column-id="created" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Created') }}</th>
+                    <th data-column-id="commands" data-width="9em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="6"></td>
+                    <td>
+                        <button data-action="add" type="button" class="btn btn-xs btn-primary"><span class="fa fa-fw fa-plus"></span></button>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+</div>
+
+<section class="page-content-main">
+    <div class="content-box">
+        <button class="btn btn-primary __mt __mb __ml" id="newBootEnvironment"
+            data-endpoint='/api/bootenvironments/general/addBootEnv/'
+            data-label="{{ lang._('Quick Create') }}"
+            data-error-title="{{ lang._('Error creating boot environment.') }}"
+            type="button"
+        ></button>
+    </div>
+</section>
+
+{{ partial("layout_partials/base_dialog",['fields':generalForm,'id':'frmGeneral', 'label':lang._('Edit boot environment')])}}

--- a/src/opnsense/mvc/app/views/OPNsense/BootEnvironments/unsupported.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/BootEnvironments/unsupported.volt
@@ -1,0 +1,14 @@
+<div class="content-box">
+    <div class="container-fluid">
+        <h2><i class="fa fa-fw fa-warning"></i> Oops! It looks like you're using a UFS file system.</h2>
+        <p>
+            This plugin needs a ZFS file system to manage Boot Environments. Unfortunately, UFS
+            doesn't support this feature. To use Boot Environments, you'll need to switch to a
+            ZFS file system.
+        </p>
+        <p>
+            For more information on how to migrate to ZFS, please refer to our documentation
+            or support resources.
+        </p>
+    </div>
+</div>

--- a/src/opnsense/scripts/bootenvironments/be_activate.py
+++ b/src/opnsense/scripts/bootenvironments/be_activate.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, json
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('boot_environment_name', help='name')
+inputargs = parser.parse_args()
+
+if not bectl.activate_be(inputargs.boot_environment_name):
+    print(json.dumps({"status": "failed", "result": "An error ocurred whilst activating the boot environment"}))
+else:
+    print(json.dumps({"status": "ok", "result": 'Boot environment activated'}))

--- a/src/opnsense/scripts/bootenvironments/be_clone.py
+++ b/src/opnsense/scripts/bootenvironments/be_clone.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, json
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', help='name of boot environment to create', required=False)
+parser.add_argument('--from-source', help='boot environment to clone')
+
+inputargs = parser.parse_args()
+
+if inputargs.name is not None:
+    be_name=inputargs.name
+else:
+    be_name="test-{date:%Y%m%d%H%M%S}".format(date=datetime.datetime.now())
+
+be_source = inputargs.from_source
+
+if bectl.create_be(be_name, be_source):
+    print(json.dumps({"status": "ok", "result": "Boot environment created"}))
+else:
+    print(json.dumps({"status": "failed", "result": "Error: Could not create boot environment"}))

--- a/src/opnsense/scripts/bootenvironments/be_create.py
+++ b/src/opnsense/scripts/bootenvironments/be_create.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, datetime, json
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', help='name of boot environment to create', required=False)
+parser.add_argument('--from-source', help='boot environment to clone')
+inputargs = parser.parse_args()
+
+if inputargs.name is not None:
+    be_name=inputargs.name
+else:
+    be_name="BE-{date:%Y%m%d%H%M%S}".format(date=datetime.datetime.now())
+
+be_source = inputargs.from_source
+
+if bectl.create_be(be_name, be_source):
+    print(json.dumps({"status": "ok", "result": "Boot environment created"}))
+else:
+    print(json.dumps({"status": "failed", "result": "Error: Could not create boot environment"}))

--- a/src/opnsense/scripts/bootenvironments/be_destroy.py
+++ b/src/opnsense/scripts/bootenvironments/be_destroy.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, json
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('boot_environment_name', help='name')
+inputargs = parser.parse_args()
+
+if not bectl.destroy_be(inputargs.boot_environment_name):
+    print('{"status": "error", "error": "Boot environment destroyed."}')
+else:
+    print('{"status": "ok", "message": "Boot environment destroyed."}')

--- a/src/opnsense/scripts/bootenvironments/be_fetch.py
+++ b/src/opnsense/scripts/bootenvironments/be_fetch.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, json, hashlib, uuid
+
+def create_uuid_from_string(val: str) -> str:
+    hex_string = hashlib.md5(val.encode("UTF-8")).hexdigest()
+    return str(uuid.UUID(hex=hex_string))
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', help='name of boot environment to find', required = False)
+parser.add_argument('--uuid', help = 'uuid of boot environment', required = False)
+input_args = parser.parse_args()
+
+if input_args.name is None and input_args.uuid is None:
+    print('{"status": "failed", "error": "--name or --uuid must be specified"}')
+    exit(0)
+
+if input_args.name is not None:
+    match_on = "name"
+    search_term = input_args.name
+else:
+    match_on = "uuid"
+    search_term = input_args.uuid
+
+be_match = None
+boot_environments = bectl.get_be_list()
+for bootenv in boot_environments:
+    prop = bootenv.split("\t")
+    be = {
+        "uuid": create_uuid_from_string(prop[0]),
+        "name": prop[0],
+        "active": prop[1],
+        "mountpoint": prop[2],
+        "size": prop[3],
+        "created": prop[4]
+    }
+
+    if (be[match_on] == search_term):
+        be_match=be
+        break
+
+if be_match is not None:
+    print(json.dumps(be_match))
+else:
+    print('{"status": "failed"}')

--- a/src/opnsense/scripts/bootenvironments/be_list.py
+++ b/src/opnsense/scripts/bootenvironments/be_list.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, json, hashlib, uuid
+
+def create_uuid_from_string(val: str) -> str:
+    hex_string = hashlib.md5(val.encode("UTF-8")).hexdigest()
+    return str(uuid.UUID(hex=hex_string))
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parsed_be_list = []
+boot_environments = bectl.get_be_list()
+
+for bootenv in boot_environments:
+    prop = bootenv.split("\t")
+    be = {
+        "uuid": create_uuid_from_string(prop[0]),
+        "name": prop[0],
+        "active": prop[1],
+        "mountpoint": prop[2],
+        "size": prop[3],
+        "created": prop[4]
+    }
+
+    parsed_be_list.append(be)
+
+print(json.dumps(parsed_be_list))
+exit(0)

--- a/src/opnsense/scripts/bootenvironments/be_rename.py
+++ b/src/opnsense/scripts/bootenvironments/be_rename.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, argparse, json
+
+if not bectl.is_file_system_zfs():
+    print("Unsupported file system")
+    exit(0)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('be_source', help='name of boot environment to rename')
+parser.add_argument('be_dest', help='new name for boot environment')
+inputargs = parser.parse_args()
+
+be_source = inputargs.be_source
+be_dest = inputargs.be_dest
+if bectl.rename_be(be_source, be_dest):
+    print(json.dumps({"status": "ok", "result": "Boot environment renamed"}))
+else:
+    print(json.dumps({"status": "failed", "result": "Error: Could not rename boot environment"}))

--- a/src/opnsense/scripts/bootenvironments/be_supported.py
+++ b/src/opnsense/scripts/bootenvironments/be_supported.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import bectl, json
+
+if bectl.is_file_system_zfs() is not True:
+    print(json.dumps({"status": "failed", "result": "Error: Could not rename boot environment"}))
+else:
+    print(json.dumps({"status": "OK", "message": "File system is ZFS"}))

--- a/src/opnsense/scripts/bootenvironments/bectl.py
+++ b/src/opnsense/scripts/bootenvironments/bectl.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+"""
+    Copyright (c) 2024 Sheridan Computers Limited
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+from subprocess import Popen, run, PIPE
+
+def activate_be(be_name: str, t: bool = False) -> bool:
+    """
+    This function activate a BE.
+    :param be_name: Name of the BE to activate.
+    :param t: If True, the BE will be activated even if it is mounted.
+    """
+    option = '-t' if t else ''
+    cmd_list = ['bectl', 'activate', be_name]
+    if option == '-t':
+        cmd_list.insert(2, option)
+    bectl_process = run(cmd_list, stdout=PIPE)
+    return bectl_process.returncode == 0
+
+def create_be(new_be_name: str, non_active_be: str = None, recursive: bool = False) -> bool:
+    """
+    This function create a BE.
+    :param new_be_name: Name of the new BE.
+    :param non_active_be: Name of the non active BE.
+    :param recursive: If True, the BE will be created recursively.
+    """
+    cmd_list = ['bectl', 'create']
+    if recursive is True:
+        cmd_list.append('-r')
+    if non_active_be is not None:
+        cmd_list.append('-e')
+        cmd_list.append(non_active_be.strip())
+    cmd_list.append(new_be_name)
+    bectl_process = run(cmd_list)
+    return bectl_process.returncode == 0
+
+def destroy_be(be_name: str, F: bool = False, o: bool = False):
+    """
+    This function destroy a BE.
+    :param be_name: Name of the BE to destroy.
+    :param F: If True, the BE will be destroyed even if it is active.
+    :param o: If True, the BE will be destroyed even if it is mounted.
+    """
+    option = '-'
+    option += 'F' if F else ''
+    option += 'o' if o else ''
+    cmd_list = ['bectl', 'destroy', be_name]
+    if option != '-':
+        cmd_list.insert(2, option)
+    bectl_process = run(cmd_list)
+    return bectl_process.returncode == 0
+
+def rename_be(original_be_name: str, new_be_name: str):
+    """
+    This function rename a BE.
+    :param original_be_name: Name of the BE to rename.
+    :param new_be_name: New name of the BE.
+    """
+    cmd_list = ['bectl', 'rename', original_be_name, new_be_name]
+    bectl_process = run(cmd_list)
+    return bectl_process.returncode == 0
+
+def mount_be(be_name: str, path: str = None) -> str:
+    """
+    This function mounts the BE.
+    :param be_name: Name of the BE to mount.
+    :param path: The path where the BE will be mounted. If not provided,
+    a bectl will create a random one.
+    :return: The path where the BE is mounted.
+    """
+    cmd_list = ['bectl', 'mount', be_name]
+    cmd_list.append(path) if path else None
+    bectl_process = run(
+        cmd_list,
+        universal_newlines=True,
+        encoding='utf-8'
+    )
+    assert bectl_process.returncode == 0
+    return bectl_process.stdout.strip()
+
+def umount_be(be_name: str):
+    """
+    This function unmount the BE.
+    :param be_name: Name of the BE to unmount.
+    """
+    cmd_list = ['bectl', 'umount', be_name]
+    bectl_process = run(cmd_list)
+    return bectl_process.returncode == 0
+
+def get_be_list() -> list:
+    """
+    This function get the list of BEs.
+    :return: A list of BEs.
+    """
+    cmd_list = ['bectl', 'list', '-H']
+    bectl_output: Popen[str] = Popen(
+        cmd_list,
+        stdout=PIPE,
+        close_fds=True,
+        universal_newlines=True,
+        encoding='utf-8'
+    )
+    bectl_list = bectl_output.stdout.read().splitlines()
+    return bectl_list
+
+def is_file_system_zfs() -> bool:
+    """
+    This function check if the file system is zfs.
+    :return: True if the file system is zfs, False otherwise.
+    """
+    cmd_list = ['df', '-Tt', 'zfs', '/']
+    df_output = run(cmd_list, stdout=PIPE)
+    return df_output.returncode == 0

--- a/src/opnsense/service/conf/actions.d/actions_bootenvironments.conf
+++ b/src/opnsense/service/conf/actions.d/actions_bootenvironments.conf
@@ -1,0 +1,53 @@
+[list]
+command:/usr/local/opnsense/scripts/bootenvironments/be_list.py
+parameters:
+type:script_output
+message:Listing boot environments
+
+[create]
+command:/usr/local/opnsense/scripts/bootenvironments/be_create.py
+parameters: --name %s
+type:script_output
+message:Creating boot environment
+
+[clone]
+command:/usr/local/opnsense/scripts/bootenvironments/be_create.py
+parameters: --name %s --from-source %s
+type:script_output
+message:Cloning boot environment
+
+[createquick]
+command:/usr/local/opnsense/scripts/bootenvironments/be_create.py
+parameters:
+type:script_output
+message:Creating boot environment
+
+[activate]
+command:/usr/local/opnsense/scripts/bootenvironments/be_activate.py
+parameters: %s
+type:script_output
+message:Activating boot environment
+
+[destroy]
+command:/usr/local/opnsense/scripts/bootenvironments/be_destroy.py
+parameters: %s
+type:script_output
+message:Deleting boot environment
+
+[fetch]
+command:/usr/local/opnsense/scripts/bootenvironments/be_fetch.py
+parameters: %s %s
+type:script_output
+message:Fetching boot environment
+
+[rename]
+command:/usr/local/opnsense/scripts/bootenvironments/be_rename.py
+parameters: %s %s
+type:script_output
+message:Renaming boot environment
+
+[supported]
+command:/usr/local/opnsense/scripts/bootenvironments/be_supported.py
+parameters:
+type:script_output
+message:Checking if ZFS is supported


### PR DESCRIPTION
This pull request introduces a new feature to the OPNsense web interface, allowing users to manage FreeBSD boot environments directly within OPNsense. This integration provides an intuitive and seamless way for users to create, manage, and switch between boot environments, enhancing system management and recovery options.