### PR TITLE
setContentType in downloadAction on BackupController

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/BackupController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/BackupController.php
@@ -197,7 +197,7 @@ class BackupController extends ApiControllerBase
                         $hostname = $payload->system->hostname . "." . $payload->system->domain;
                     }
                     $target_filename = urlencode('config-' . $hostname . '-' . explode('/config-', $filename, 2)[1]);
-                    $this->response->setContentType('application/octet-stream');
+                    $this->response->setContentType('application/octet-stream', 'UTF-8');
                     $this->response->setRawHeader("Content-Disposition: attachment; filename=" . $target_filename);
                     $this->response->setRawHeader("Content-length: " . filesize($filename));
                     $this->response->setRawHeader("Pragma: no-cache");


### PR DESCRIPTION
setContentType now requires two parameters, not just one. The second parameter determines the encoding, i.e., UTF-8. Without this additional parameter, the call to downloadAction fails.

-=david=-

fixes #7654