### PR TITLE
Remove dots from traffic chart

### DIFF
--- a/src/opnsense/www/js/widgets/Traffic.js
+++ b/src/opnsense/www/js/widgets/Traffic.js
@@ -65,6 +65,9 @@ export default class Traffic extends BaseWidget {
                         fill: true,
                         cubicInterpolationMode: 'monotone',
                         clip: 0
+                    },
+                    point: {
+                        radius: 0
                     }
                 },
                 scales: {


### PR DESCRIPTION
Just a minor cosmetic suggestion to remove the dots from the traffic chart so they only show when hovering.