### PR TITLE
Update suricata.yaml and remove two deprecated settings and add a few useful settings

### DIFF
--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -337,6 +337,13 @@ outputs:
       identity: "suricata"
       facility: local5
       level: Info
+      community-id: true
+      community-id-seed: 0
+      xff:
+        enabled: yes
+        mode: extra-data
+        deployment: reverse
+        header: X-Forwarded-For
       types:
         - alert:
 {%     if not helpers.empty('OPNsense.IDS.general.LogPayload') %}
@@ -344,8 +351,20 @@ outputs:
              payload-buffer-size: 4kb
              payload-printable: yes
 {%     endif %}
-             http: yes
-             tls: yes
+            metadata: yes
+            tagged-packets: yes
+        - http:
+            extended: yes
+        - dns:
+        - tls:
+            extended: yes
+        - files:
+            force-magic: no
+        - smtp:
+            extended: yes
+        - ftp:
+        - rdp:
+        - flow
 {% endif %}
 
   # deprecated - unified2 alert format for use with Barnyard2

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -353,18 +353,6 @@ outputs:
 {%     endif %}
             metadata: yes
             tagged-packets: yes
-        - http:
-            extended: yes
-        - dns:
-        - tls:
-            extended: yes
-        - files:
-            force-magic: no
-        - smtp:
-            extended: yes
-        - ftp:
-        - rdp:
-        - flow
 {% endif %}
 
   # deprecated - unified2 alert format for use with Barnyard2


### PR DESCRIPTION
Removes deprecated -http and -tls from types/alert, and adds useful default features for output

Example suricata.yaml config used for reference, it is version 7.x:
https://github.com/OISF/suricata/blob/main-7.0.x/suricata.yaml.in

I have successfully tested these (and more) settings, but I was using the /usr/local/etc/suricata/custom.yaml file and restarting the service to see it not error output about the deprecated settings. It is my understanding that the environment replaced the suricata.yaml setting with the custom.yaml setting.

The custom.yaml file does not work completely as expected btw, see here: https://forum.opnsense.org/index.php?topic=40955.msg200771

If that means I did not complete a successful test, please let me know, otherwise this should mean fewer errors and useful logs by default.