### PR TITLE
OpenVPN instances: Add float option to support roaming clients

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -277,9 +277,9 @@
                         <float>float</float>
                         <passtos>passtos</passtos>
                         <persist-remote-ip>persist-remote-ip</persist-remote-ip>
-                        <route-nopull>route-nopull</route-nopull>
-                        <route-noexec>route-noexec</route-noexec>
                         <remote-random>remote-random</remote-random>
+                        <route-noexec>route-noexec</route-noexec>
+                        <route-nopull>route-nopull</route-nopull>
                     </OptionValues>
                 </various_flags>
                 <various_push_flags type="OptionField">

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -274,6 +274,7 @@
                     <OptionValues>
                         <client-to-client>client-to-client</client-to-client>
                         <duplicate-cn>duplicate-cn</duplicate-cn>
+                        <float>float</float>
                         <passtos>passtos</passtos>
                         <persist-remote-ip>persist-remote-ip</persist-remote-ip>
                         <route-nopull>route-nopull</route-nopull>


### PR DESCRIPTION
In the classic, legacy server variant there was an option called "dynamic_ip" which injected the options `persist-remote-ip` and `float` into the generated configuration file. In the modern variant `persist-remote-ip` is already available, but `float` isn't available anymore.

The OpenVPN `float` option is used to allow client to change IP addresses during an ongoing connection to allow roaming e.g. in mobile networks or changes in the client WiFi.

See https://github.com/opnsense/core/blob/d2ef070687d1a4077a818211db4ffd6a5eab69f6/src/etc/inc/plugins.inc.d/openvpn.inc#L872-L875