### PR TITLE
interfaces: require PPP interface to be in up state

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1239,6 +1239,9 @@ EOD;
         @unlink('/var/spool/lock/LCK..' . basename($port));
     }
 
+    /* precaution for post-start 'up' check */
+    legacy_interface_flags($interface, 'down');
+
     /* fire up mpd */
     mwexecf(
         '/usr/local/sbin/mpd5 -b -d /var/etc -f %s -p %s -s ppp %s',

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1250,7 +1250,6 @@ EOD;
 
     /* wait for functional device */
     $i = 0;
-    $interface_is_up = false;
     while ($i < 30) {
         if (does_interface_exist($ppp['if'], 'up')) {
             $interface_is_up = true;

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1251,10 +1251,10 @@ EOD;
     /* wait for functional device */
     $i = 0;
     while ($i < 30) {
+        sleep(1);
         if (does_interface_exist($ppp['if'], 'up')) {
             break;
         }
-        sleep(1);
         $i++;
     }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1252,7 +1252,6 @@ EOD;
     $i = 0;
     while ($i < 30) {
         if (does_interface_exist($ppp['if'], 'up')) {
-            $interface_is_up = true;
             break;
         }
         sleep(1);

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1259,7 +1259,7 @@ EOD;
         $i++;
     }
 
-    if ($i >= 30) {
+    if ($i >= $max) {
         log_msg("interface_ppps_configure() waiting threshold exceeded - device {$interface} is still not up", LOG_WARNING);
     }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1261,7 +1261,7 @@ EOD;
     }
 
     if (!$interface_is_up) {
-        log_msg("Waiting threshold exceeded - interface $interface is still not UP in interface_ppps_configure().", LOG_WARNING);
+        log_msg("interface_ppps_configure() waiting threshold exceeded - device {$interface} is still not up", LOG_WARNING);
     }
 
     switch ($ppp['type']) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1248,15 +1248,20 @@ EOD;
     /* appease netgraph by setting the correct node name */
     shell_safe('/usr/sbin/daemon -f /usr/local/opnsense/scripts/interfaces/ppp-rename.sh %s %s %s', [$interface, $ifcfg['if'], $ppp['type']]);
 
-    /* wait for up to 10 seconds for the interface to appear (ppp(oe)) */
+    /* wait for up to 30 seconds for the interface to appear in UP state (ppp(oe)) */
     $i = 0;
-    while ($i < 10) {
-        exec("/sbin/ifconfig " . escapeshellarg($ppp['if']) . " 2>&1", $out, $ret);
-        if ($ret == 0) {
+    $interface_is_up = false;
+    while ($i < 30) {
+        if (does_interface_exist($ppp['if'], 'up')) {
+            $interface_is_up = true;
             break;
         }
         sleep(1);
         $i++;
+    }
+
+    if (!$interface_is_up) {
+        log_msg("Waiting threshold exceeded - interface $interface is still not UP in interface_ppps_configure().", LOG_WARNING);
     }
 
     switch ($ppp['type']) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1249,6 +1249,7 @@ EOD;
     shell_safe('/usr/sbin/daemon -f /usr/local/opnsense/scripts/interfaces/ppp-rename.sh %s %s %s', [$interface, $ifcfg['if'], $ppp['type']]);
 
     /* wait for functional device */
+    $max = 30;
     $i = 0;
     while ($i < 30) {
         sleep(1);

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1248,7 +1248,7 @@ EOD;
     /* appease netgraph by setting the correct node name */
     shell_safe('/usr/sbin/daemon -f /usr/local/opnsense/scripts/interfaces/ppp-rename.sh %s %s %s', [$interface, $ifcfg['if'], $ppp['type']]);
 
-    /* wait for up to 30 seconds for the interface to appear in UP state (ppp(oe)) */
+    /* wait for functional device */
     $i = 0;
     $interface_is_up = false;
     while ($i < 30) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1240,7 +1240,7 @@ EOD;
     }
 
     /* precaution for post-start 'up' check */
-    legacy_interface_flags($interface, 'down');
+    legacy_interface_flags($interface, 'down', false);
 
     /* fire up mpd */
     mwexecf(

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1258,7 +1258,7 @@ EOD;
         $i++;
     }
 
-    if (!$interface_is_up) {
+    if ($i >= 30) {
         log_msg("interface_ppps_configure() waiting threshold exceeded - device {$interface} is still not up", LOG_WARNING);
     }
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1251,7 +1251,7 @@ EOD;
     /* wait for functional device */
     $max = 30;
     $i = 0;
-    while ($i < 30) {
+    while ($i < $max) {
         sleep(1);
         if (does_interface_exist($ppp['if'], 'up')) {
             break;


### PR DESCRIPTION
Adds `-u` flag to ifconfig check to ensure only interfaces that are UP are reported. Furthermore adds a check for the output of ifconfig to ensure that the interface in question in fact is listed.

Otherwise the check will "approve" an interface that is not yet UP, and subsequent calls to fetch the gateway of that interface might fail if issued to quickly thereafter.

Resolves #7691