### PR TITLE
dashboard: monit widget: Invert the logic of success and failed

### DIFF
--- a/src/opnsense/www/js/widgets/Monit.js
+++ b/src/opnsense/www/js/widgets/Monit.js
@@ -54,7 +54,7 @@ export default class Monit extends BaseTableWidget {
         };
 
         this.statusColors = {
-            "1": "text-danger",
+            "0": "text-success",
             "2": "text-warning",
             "3": "text-warning"
         };
@@ -91,13 +91,14 @@ export default class Monit extends BaseTableWidget {
 
         let rows = [];
         $.each(data['status']['service'], (index, service) => {
-            let color = this.statusColors[service['status']] || "text-success";
+            let color = this.statusColors[service['status']] || "text-danger";
+            let statusTooltip = this.statusMap[service['status']] || this.translations.failed;
             let icon = this.serviceIcons[service['@attributes']['type']] || "fa-circle";
 
             let $header = $(`
                 <div>
                     <i class="fa fa-circle text-muted ${color} monit-status-icon" style="font-size: 11px; cursor: pointer;"
-                        data-toggle="tooltip" title="${this.statusMap[service['status']]}">
+                        data-toggle="tooltip" title="${statusTooltip}">
                     </i>
                     &nbsp;
                     <i class="fa ${icon} monit-type-icon" style="font-size: 11px;"


### PR DESCRIPTION
When a status code is not mapped, it will always fall back to failed in the tooltip, and text-danger as color. Fixes issue with ping check, the status is 16384 when failed. Since it can be assumed that all statuses other than 0 are bad, this change in logic seems pragmatic.

Fixes: https://github.com/opnsense/core/issues/7669