### PR TITLE
Thermal Sensors: Avoid reporting elevated and highly fluctuating "CPU" (core) temperatures

### DIFF
--- a/src/opnsense/scripts/system/temperature.sh
+++ b/src/opnsense/scripts/system/temperature.sh
@@ -46,6 +46,7 @@ else
 	# as long as we can find something that matches our search.
 	SYSCTLS=$(sysctl -aN | grep temperature)
 	if [ -n "${SYSCTLS}" ]; then
+		sleep 1	# Avoid returning elevated and highly fluctuating "CPU" (core) temperatures
 		sysctl -e ${SYSCTLS} | sort
 	fi
 fi


### PR DESCRIPTION
Thermal Sensors: Avoid reporting elevated and highly fluctuating "CPU" (core) temperatures

Running sysctl ${SYSCTLS} immediately after sysctl -aN | grep temperature results in elevated and highly fluctuating "CPU" (core) temperatures by about 10 to 20 degrees Celsius being returned.  Sleep for a second to avoid.

CPU: 11th Gen Intel(R) Core(TM) i3-1115G4

Dependent on
system: increase widget timeout to 5 seconds
0d38c780459117afb045d20c9e0ee8edbfc18c3b

Fixes Thermal sensors elevated highly fluctuating core temperatures #7727
https://github.com/opnsense/core/issues/7727#issue-2449698175