### PR TITLE
dashboard: BaseWidget - Improve _formatBytes function

### DIFF
--- a/src/opnsense/www/js/widgets/BaseWidget.js
+++ b/src/opnsense/www/js/widgets/BaseWidget.js
@@ -239,17 +239,18 @@ export default class BaseWidget {
     }
 
     _formatBytes(value, decimals = 2) {
-        if (!isNaN(value) && value > 0) {
-            let fileSizeTypes = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
-            let ndx = Math.floor(Math.log(value) / Math.log(1000) );
-            if (ndx > 0) {
-                return  (value / Math.pow(1000, ndx)).toFixed(2) + ' ' + fileSizeTypes[ndx];
-            } else {
-                return value.toFixed(2);
-            }
-        } else {
+        if (isNaN(value) || value === null || value < 0) {
             return "";
         }
+
+        const fileSizeTypes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+        const ndx = Math.floor(Math.log(value) / Math.log(1000));
+
+        if (ndx === 0) {
+            return value.toFixed(decimals) + ' ' + fileSizeTypes[0];
+        }
+
+        return (value / Math.pow(1000, ndx)).toFixed(decimals) + ' ' + fileSizeTypes[ndx];
     }
 
     sanitizeSelector(selector) {


### PR DESCRIPTION
 - Remove nested if statements
 - always return size+unit (e.g. 0 B, 100 B, 10 KB...)
 - implement additional null check. (The OpenVPN api returns null sometimes, compare here: https://github.com/opnsense/core/issues/7701#issuecomment-2264662820 )

Fixes: https://github.com/opnsense/core/issues/7725 https://github.com/opnsense/core/issues/7701