### PR TITLE
Skip tentative IPv6 addresses for binding of webgui. Fixes: #7649

### DIFF
--- a/src/etc/inc/plugins.inc.d/webgui.inc
+++ b/src/etc/inc/plugins.inc.d/webgui.inc
@@ -83,7 +83,7 @@ function webgui_configure_do($verbose = false, $interface = '')
     $listeners = count($interfaces) ? [] : ['0.0.0.0', '::'];
 
     foreach (interfaces_addresses($interfaces) as $tmpaddr => $info) {
-        if (!$info['bind']) {
+        if (!$info['bind'] || ($info['family'] == 'inet6' && $info['tentative'])) {
             continue;
         }
 


### PR DESCRIPTION
IPv6 addresses might be tentative. lighttpd will fail when trying to bind to a tentative address. This commit skips tentative IPv6 addresses for binding.