### PR TITLE
Captive portal logoff issue fixed

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
@@ -244,7 +244,7 @@ class AccessController extends ApiControllerBase
             ) {
                 // you can only disconnect a connected client
                 $backend = new Backend();
-                $statusRAW = $backend->configdpRun("captiveportal disconnect", [$zoneid, $clientSession['sessionId']]);
+                $statusRAW = $backend->configdpRun("captiveportal disconnect", [$clientSession['sessionId']]);
                 $status = json_decode($statusRAW, true);
                 if ($status != null) {
                     $this->getLogger("captiveportal")->info(


### PR DESCRIPTION
Captive portal > user unable to logoff via the user form 

I found the issue that actions.d > captive portal > disconnect command is mismatched parameters that is why it is not getting logoff.

either we can modify the actions.d command for captive portal with parameter or as I raised this PR, remove zoneid from the accesscontroller.

 