### PR TITLE
Ntp: Add pool checkbox to timeserver configuration

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -323,6 +323,7 @@
     <enable/>
   </rrd>
   <ntpd>
+    <pool_server>0.opnsense.pool.ntp.org 1.opnsense.pool.ntp.org 2.opnsense.pool.ntp.org 3.opnsense.pool.ntp.org</pool_server>
     <prefer>0.opnsense.pool.ntp.org</prefer>
   </ntpd>
   <widgets>

--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -329,17 +329,18 @@ function ntpd_configure_do($verbose = false)
 
     $noselect = isset($config['ntpd']['noselect']) ? explode(' ', $config['ntpd']['noselect']) : [];
     $prefer = isset($config['ntpd']['prefer']) ? explode(' ', $config['ntpd']['prefer']) : [];
+    $pool_server = isset($config['ntpd']['pool_server']) ? explode(' ', $config['ntpd']['pool_server']) : [];
     $iburst = isset($config['ntpd']['iburst']) ? explode(' ', $config['ntpd']['iburst']) : [];
 
     $ntpcfg .= "\n\n# Upstream Servers\n";
     /* foreach through ntp servers and write out to ntpd.conf */
     foreach (explode(' ', $config['system']['timeservers']) as $ts) {
-        /* Determine if Network Time Server is from the NTP Pool or not */
-        if (preg_match("/\.pool\.ntp\.org$/", $ts)) {
-            $ntpcfg .= "pool {$ts}";
+        if (in_array($ts, $pool_server)) {
+            $ntpcfg .= "pool";
         } else {
-            $ntpcfg .= "server {$ts}";
+            $ntpcfg .= "server";
         }
+        $ntpcfg .= " {$ts}";
         if (in_array($ts, $iburst)) {
             $ntpcfg .= ' iburst';
         }

--- a/src/www/services_ntpd.php
+++ b/src/www/services_ntpd.php
@@ -75,10 +75,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // parse timeservers
     $pconfig['timeservers_host'] = array();
+    $pconfig['timeservers_pool'] = array();
     $pconfig['timeservers_noselect'] = array();
     $pconfig['timeservers_prefer'] = array();
     $pconfig['timeservers_iburst'] = array();
     if (!empty($config['system']['timeservers'])) {
+        $pconfig['timeservers_pool'] = !empty($a_ntpd['pool_server']) ? explode(' ', $a_ntpd['pool_server']) : array();
         $pconfig['timeservers_noselect'] = !empty($a_ntpd['noselect']) ? explode(' ', $a_ntpd['noselect']) : array();
         $pconfig['timeservers_prefer'] = !empty($a_ntpd['prefer']) ? explode(' ', $a_ntpd['prefer']) : array();
         $pconfig['timeservers_iburst'] = !empty($a_ntpd['iburst']) ? explode(' ', $a_ntpd['iburst']) : array();
@@ -115,13 +117,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         // list types
         $config['system']['timeservers'] = trim(implode(' ', $pconfig['timeservers_host']));
+        $a_ntpd['pool_server'] = !empty($pconfig['timeservers_pool']) ? trim(implode(' ', $pconfig['timeservers_pool'])) : null;
         $a_ntpd['noselect'] = !empty($pconfig['timeservers_noselect']) ? trim(implode(' ', $pconfig['timeservers_noselect'])) : null;
         $a_ntpd['prefer'] = !empty($pconfig['timeservers_prefer']) ? trim(implode(' ', $pconfig['timeservers_prefer'])) : null;
         $a_ntpd['iburst'] = !empty($pconfig['timeservers_iburst']) ? trim(implode(' ', $pconfig['timeservers_iburst'])) : null;
         $a_ntpd['interface'] = !empty($pconfig['interface']) ? implode(',', $pconfig['interface']) : null;
 
         // unset empty
-        foreach (array('noselect', 'prefer', 'iburst', 'interface') as $fieldname) {
+        foreach (array('pool_server', 'noselect', 'prefer', 'iburst', 'interface') as $fieldname) {
             if (empty($a_ntpd[$fieldname])) {
                 unset($a_ntpd[$fieldname]);
             }
@@ -256,6 +259,7 @@ include("head.inc");
                           <tr>
                             <th></th>
                             <th><?=gettext("Network"); ?></th>
+                            <th><?=gettext("Pool"); ?></th>
                             <th><?=gettext("Prefer"); ?></th>
                             <th><?=gettext("Iburst"); ?></th>
                             <th><?=gettext("Do not use"); ?></th>
@@ -273,6 +277,9 @@ include("head.inc");
                             </td>
                             <td>
                               <input name="timeservers_host[]" type="text" value="<?=$timeserver;?>" />
+                            </td>
+                            <td>
+                              <input name="timeservers_pool[]" class="ts_checkbox" type="checkbox" value="<?=$timeserver;?>" <?= !empty($pconfig['timeservers_pool']) && in_array($timeserver, $pconfig['timeservers_pool']) ? 'checked="checked"' : '' ?>/>
                             </td>
                             <td>
                               <input name="timeservers_prefer[]" class="ts_checkbox" type="checkbox" value="<?=$timeserver;?>" <?= !empty($pconfig['timeservers_prefer']) && in_array($timeserver, $pconfig['timeservers_prefer']) ? 'checked="checked"' : '' ?>/>
@@ -298,6 +305,8 @@ include("head.inc");
                       <div class="hidden" data-for="help_for_timeservers">
                         <?=gettext('For best results three to five servers should be configured here.'); ?>
                         <?=gettext('When no servers are specified NTP will be completely disabled.'); ?>
+                        <br />
+                        <?= gettext('The "pool" option indicates that the specified hostname represents a server pool instead of a single server.') ?>
                         <br />
                         <?= gettext('The "prefer" option indicates that NTP should favor the use of this server more than all others.') ?>
                         <br />


### PR DESCRIPTION
This PR solves #6923 while preserving the current default behavior.

## Technical description
I more or less just copied one of the other checkboxes and replaced everything with "pool_server". I also tested it by copying the impacted files into a running OPNSense, and then successfully using the new configuration option and verifying the result by inspecting the generated ntp.conf file.

## Reasoning
This change makes it more transparent how the entries in the ntp config are configured, and gives more options to administrators to either set a NTP Pool server as "server" type or use the "pool" keyword for pooled servers besides the NTP Pool.

## Impact
I extended the default configuration file to set the pool config for the default timeservers, so new installations will not change their behavior.

For existing installations, since the option is "opt in", the missing pool option will set all confgurations for NTP Pool servers back to a "server" type association. If there is a possibility to migrate existing configurations and keep the existing configuration during installation of this fix (`pool` for all NTP Pool servers, `server` for anything else), that would be preferrable but I don't know how to do that. One alternative idea was to make the feature "opt out", setting the pool type unless a timeserver gets explicitely marked as "not pool", but that also would impact existing installations by setting the pool type for manually configured not-NTP Pool servers.