### PR TITLE
IDS: Support configurating eve-log for HTTP and TLS

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -110,4 +110,53 @@
         <help>Send package payload to the log for further analyses.</help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>ids.general.eveLog.http.enable</id>
+        <label>Enable eve HTTP logging</label>
+        <type>checkbox</type>
+        <help>Send HTTP metadata to eve-log for further analyses.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.http.extended</id>
+        <label>Eve HTTP extended logging</label>
+        <type>checkbox</type>
+        <help>Add extended information to eve HTTP logging.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.http.dumpAllHeaders</id>
+        <label>Eve HTTP dump all headers</label>
+        <type>dropdown</type>
+        <help>Make eve HTTP logging dump all HTTP headers. You may choose to dump headers for requests or responses or both.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.tls.enable</id>
+        <label>Enable eve TLS logging</label>
+        <type>checkbox</type>
+        <help>Send TLS metadata to eve-log for further analyses.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.tls.extended</id>
+        <label>Eve TLS extended logging</label>
+        <type>checkbox</type>
+        <help>Add extended information to eve TLS logging. For example, SNI field.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.tls.sessionResumption</id>
+        <label>Eve TLS log session resumption</label>
+        <type>checkbox</type>
+        <help>Output TLS transaction where the session is resumed using a session id</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.tls.custom</id>
+        <label>Eve TLS custom logging</label>
+        <type>select_multiple</type>
+        <help>Custom TLS fields to include in eve-log for TLS. (Overrides extended if non-empty).</help>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -243,6 +243,57 @@
                     <vvvv>DEBUG (4)</vvvv>
                 </OptionValues>
             </verbosity>
+            <eveLog>
+                <http>
+                    <enable type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </enable>
+                    <extended type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </extended>
+                    <dumpAllHeaders type="OptionField">
+                        <OptionValues>
+                            <request>Request</request>
+                            <response>Response</response>
+                            <both>Both</both>
+                        </OptionValues>
+                    </dumpAllHeaders>
+                </http>
+                <tls>
+                    <enable type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </enable>
+                    <extended type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </extended>
+                    <sessionResumption type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </sessionResumption>
+                    <custom type="OptionField">
+                        <OptionValues>
+                            <subject>subject</subject>
+                            <issuer>issuer</issuer>
+                            <session_resumed>session_resumed</session_resumed>
+                            <serial>serial</serial>
+                            <fingerprint>fingerprint</fingerprint>
+                            <sni>sni</sni>
+                            <version>version</version>
+                            <not_before>not_before</not_before>
+                            <not_after>not_after</not_after>
+                            <certificate>certificate</certificate>
+                            <chain>chain</chain>
+                            <ja3>ja3</ja3>
+                            <ja3s>ja3s</ja3s>
+                        </OptionValues>
+                        <Multiple>Y</Multiple>
+                    </custom>
+                </tls>
+            </eveLog>
         </general>
     </items>
 </model>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -208,14 +208,18 @@ outputs:
             #packethdr: no
 
 
-#        - http:
-#            #extended: yes     # enable this for extended logging information
+{%      if not helpers.empty('OPNsense.IDS.general.eveLog.http.enable') %}
+        - http:
+            extended: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.http.extended') else 'yes' }}
             # custom allows additional HTTP fields to be included in eve-log.
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
             # set this value to one and only one from {both, request, response}
             # to dump all HTTP headers for every HTTP request and/or response
-            # dump-all-headers: none
+{%          if not helpers.empty('OPNsense.IDS.general.eveLog.http.dumpAllHeaders') %}
+            dump-all-headers: {{OPNsense.IDS.general.eveLog.http.dumpAllHeaders}}
+{%          endif %}
+{%       endif %}
 #        - dns:
             # This configuration uses the new DNS logging format,
             # the old configuration is still available:
@@ -244,13 +248,17 @@ outputs:
             # DNS record types to log, based on the query type.
             # Default: all.
             #types: [a, aaaa, cname, mx, ns, ptr, txt]
-        #- tls:
-            extended: yes     # enable this for extended logging information
+{%      if not helpers.empty('OPNsense.IDS.general.eveLog.tls.enable') %}
+        - tls:
+            extended: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.tls.extended') else 'yes' }}
             # output TLS transaction where the session is resumed using a
             # session id
-            #session-resumption: no
+            session-resumption: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.tls.sessionResumption') else 'yes' }}
             # custom controls which TLS fields that are included in eve-log
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s]
+{%          if not helpers.empty('OPNsense.IDS.general.eveLog.tls.custom') %}
+            custom: [{{ OPNsense.IDS.general.eveLog.tls.custom }}]
+{%          endif %}
+{%      endif %}
         #- files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,


### PR DESCRIPTION
Add the appropriate front end controls and backend template for setting up TLS and HTTP monitoring for Suricata's eve-log.