### PR TITLE
Dashboard: Change widgets menu buttons to a bootstrap group.

### DIFF
--- a/src/opnsense/www/js/opnsense_widget_manager.js
+++ b/src/opnsense/www/js/opnsense_widget_manager.js
@@ -258,10 +258,11 @@ class WidgetManager  {
 
     _renderHeader() {
         // Serialization options
-        let $btn_group = $('.btn-group-container');
+        let $btn_group_container = $('.btn-group-container');
+        let $btn_group = $('<div\>').addClass('btn-group');
 
         // Append Save button and directly next to it, a hidden spinner
-        $btn_group.append($(`
+        $btn_group_container.append($(`
             <button class="btn btn-primary" id="save-grid">
                 <span id="save-btn-text" class="show">${this.gettext.save}</span>
                 <span id="icon-container">
@@ -282,6 +283,9 @@ class WidgetManager  {
                 <i class="fa fa-unlock fa-fw"></i>
             </button>
         `));
+
+        // Append the button group to the container
+        $btn_group.appendTo($btn_group_container);
 
         // Initially hide the save button
         $('#save-grid').hide();


### PR DESCRIPTION
This PR fixes the grouping of the right buttons.

![image](https://github.com/user-attachments/assets/2aab7ae8-bace-444b-b0d4-2f56423bc1f0)
