### PR TITLE
Services: Unbound DNS: Blocklist - CNAME and A record on query fix

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
@@ -59,15 +59,14 @@ local-data: "www.{{ domain }} CNAME forcesafesearch.google.com"
 {%   endfor%}
 
 # DuckDuckGo
-local-zone: "duckduckgo.com" redirect
+local-zone: "duckduckgo.com" transparent
 local-data: "duckduckgo.com CNAME safe.duckduckgo.com"
 local-zone: "duck.com" redirect
 local-data: "duck.com CNAME safe.duckduckgo.com"
-local-zone: "external-content.duckduckgo.com" always_transparent
 
 # Bing
-local-zone: "bing.com" redirect
-local-data: "bing.com CNAME strict.bing.com"
+local-zone: "www.bing.com" redirect
+local-data: "www.bing.com CNAME strict.bing.com"
 
 # YouTube
 local-zone: "www.youtube.com" redirect
@@ -82,10 +81,10 @@ local-zone: "www.youtube-nocookie.com" redirect
 local-data: "www.youtube-nocookie.com CNAME restrictmoderate.youtube.com"
 
 # Pixabay
-local-zone: "pixabay.com" redirect
+local-zone: "pixabay.com" transparent
 local-data: "pixabay.com CNAME safesearch.pixabay.com"
 
 # Qwant
-local-zone: "qwant.com" redirect
-local-data: "qwant.com CNAME safeapi.qwant.com"
+local-zone: "api.qwant.com" redirect
+local-data: "api.qwant.com CNAME safeapi.qwant.com"
 {% endif %}

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
@@ -61,8 +61,6 @@ local-data: "www.{{ domain }} CNAME forcesafesearch.google.com"
 # DuckDuckGo
 local-zone: "duckduckgo.com" transparent
 local-data: "duckduckgo.com CNAME safe.duckduckgo.com"
-local-zone: "duck.com" redirect
-local-data: "duck.com CNAME safe.duckduckgo.com"
 
 # Bing
 local-zone: "www.bing.com" redirect

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/safesearch.conf
@@ -81,8 +81,4 @@ local-data: "www.youtube-nocookie.com CNAME restrictmoderate.youtube.com"
 # Pixabay
 local-zone: "pixabay.com" transparent
 local-data: "pixabay.com CNAME safesearch.pixabay.com"
-
-# Qwant
-local-zone: "api.qwant.com" redirect
-local-data: "api.qwant.com CNAME safeapi.qwant.com"
 {% endif %}


### PR DESCRIPTION
With the current zone settings, Unbound returns both, the A and CNAME (to it self) record on different safe search subdomains.

Affected subdomains:
- `safe.duckduckgo.com`
- `strict.bing.com`
- `safesearch.pixabay.com`
- `safeapi.qwant.com`

This commit fixes this issue.
I also checked this on official documentations to be as accurate as possible, so nothing else breaks again.