### PR TITLE
Use FontAwesome for menu entries

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
@@ -122,7 +122,7 @@
             <Traceroute VisibleName="Trace Route" url="/ui/diagnostics/traceroute"/>
         </Diagnostics>
     </Interfaces>
-    <Firewall order="40" cssClass="glyphicon glyphicon-fire">
+    <Firewall order="40" cssClass="fa fa-fire">
         <Aliases url="/ui/firewall/alias" cssClass="fa fa-list-alt fa-fw">
             <Edit url="/ui/firewall/alias/*" visibility="hidden"/>
         </Aliases>


### PR DESCRIPTION
Glyphicon is not compatible with Apple's [Lockdown Mode](https://support.apple.com/en-us/105120) resulting in broken icons on iOS. This PR switches the Firewall menu entry's icon over to Font Awesome, as is the case for the other menu entries.

![image](https://github.com/user-attachments/assets/cb48cd0d-2830-421f-9d4e-d7a60d1180fa)

