### PR TITLE
Update ICANN Trust Anchor to include the new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ CORE_DEPENDS_aarch64?=	py${CORE_PYTHON}-duckdb \
 CORE_DEPENDS_amd64?=	beep \
 			${CORE_DEPENDS_aarch64}
 
-CORE_DEPENDS?=		choparp \
+CORE_DEPENDS?=		ca_root_nss \
+			choparp \
 			cpustats \
 			dhcp6c \
 			dhcrelay \


### PR DESCRIPTION
It will become active in 2026.

Signed-off-by: Jagveer Loky (jagveer@cyberstorm.mu)