### PR TITLE
Add System: Trust:  Settings page

### DIFF
--- a/src/etc/inc/plugins.inc.d/core.inc
+++ b/src/etc/inc/plugins.inc.d/core.inc
@@ -469,6 +469,7 @@ function core_configure()
         'syslog_reset' => ['system_syslog_reset'],
         'trust_reload' => ['system_trust_configure'],
         'user_changed' => ['core_user_changed_groups:2'],
+        'crl' => ['core_trust_crl'],
     ];
 }
 
@@ -514,5 +515,18 @@ function core_user_changed_groups($unused, $username)
                 }
             }
         }
+    }
+}
+
+/**
+ * When CRL's are deployed locally, we need to flush them to disk.
+ * If at some point in time it turns out this event is too slow, we should split system_trust_configure() and possibly
+ * certctl.py to only process CRL's on demand.
+ */
+function core_trust_crl()
+{
+    $trust = new \OPNsense\Trust\General();
+    if (!empty((string)$trust->install_crls)) {
+        system_trust_configure();
     }
 }

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -957,11 +957,22 @@ function system_trust_configure($verbose = false)
 
             if ($ca_count) {
                 $ca_file = sprintf($ca_files, $i . '.crt');
-                file_put_contents(sprintf($ca_file, $i), $ca);
-                chmod(sprintf($ca_file, $i), 0644);
+                \OPNsense\Core\File::file_put_contents(sprintf($ca_file, $i), $ca, 0644);
             }
         }
     }
+
+    if (!empty((string)$trust->install_crls)) {
+        # deploy all collected CRL's into the trust store, they will be hashed into /etc/ssl/certs/ by certctl eventually
+        foreach (config_read_array('crl') as $i => $entry) {
+            if (!empty($entry) && !empty($entry['text'])) {
+                $crl_file = sprintf($ca_files, $i . '.crl');
+                $payload = base64_decode($entry['text']) ?? '';
+                \OPNsense\Core\File::file_put_contents(sprintf($crl_file, $i), $payload, 0644);
+            }
+        }
+    }
+
 
     service_log("done.\n", $verbose);
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -883,6 +883,7 @@ function system_trust_configure($verbose = false)
     global $config;
 
     service_log('Writing trust files...', $verbose);
+    $trust = new \OPNsense\Trust\General();
 
     /*
      * Write separate files because certcl will blacklist the whole file
@@ -917,7 +918,7 @@ function system_trust_configure($verbose = false)
             }
             $ca = "# OPNsense trust authority: {$entry['descr']}\n";
             $ca_count = 0;
-            $include_intermediates = !empty($config['system']['store_intermediate_certs']);
+            $include_intermediates = !empty((string)$trust->store_intermediate_certs);
             foreach ($user_cas as $user_ca) {
                 if (!empty(trim($user_ca))) {
                     $certinfo = @openssl_x509_parse($user_ca);

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/SettingsController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Trust\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+/**
+ * Class SettingsController
+ * @package OPNsense\Trust\Api
+ */
+class SettingsController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'trust';
+    protected static $internalModelClass = 'OPNsense\Trust\General';
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/SettingsController.php
@@ -29,6 +29,7 @@
 namespace OPNsense\Trust\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
 
 /**
  * Class SettingsController
@@ -38,4 +39,14 @@ class SettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'trust';
     protected static $internalModelClass = 'OPNsense\Trust\General';
+
+    public function reconfigureAction()
+    {
+        if ($this->request->isPost()) {
+            (new Backend())->configdRun('system trust configure', true);
+            return ['status' => 'ok'];
+        }
+        return ['status' => 'failed'];
+
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/SettingsController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Trust;
+
+class SettingsController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->formSettings = $this->getForm("settings");
+        $this->view->pick('OPNsense/Trust/settings');
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/settings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/settings.xml
@@ -1,0 +1,10 @@
+<form>
+    <field>
+        <id>trust.store_intermediate_certs</id>
+        <label>Store intermediate</label>
+        <type>checkbox</type>
+        <help>Allow local defined intermediate certificate authorities to be used in the local trust store.
+            We advise to only store root certificates to prevent cross signed ones causing breakage when included but expired later in the chain.
+        </help>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/settings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/settings.xml
@@ -1,10 +1,74 @@
 <form>
     <field>
+        <type>header</type>
+        <label>General Settings</label>
+    </field>
+    <field>
         <id>trust.store_intermediate_certs</id>
         <label>Store intermediate</label>
         <type>checkbox</type>
         <help>Allow local defined intermediate certificate authorities to be used in the local trust store.
             We advise to only store root certificates to prevent cross signed ones causing breakage when included but expired later in the chain.
+        </help>
+    </field>
+    <field>
+        <id>trust.install_crls</id>
+        <label>Store CRL's</label>
+        <type>checkbox</type>
+        <help>Store all configured CRL's in the default trust store.</help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Configuration constraints</label>
+    </field>
+
+    <field>
+        <id>trust.enable_legacy_sect</id>
+        <label>Enable legacy</label>
+        <type>checkbox</type>
+        <help>Enable Legacy Providers.</help>
+    </field>
+    <field>
+        <id>trust.enable_config_constraints</id>
+        <label>Enable</label>
+        <type>checkbox</type>
+        <help>Enable custom constraints.</help>
+    </field>
+    <field>
+        <id>trust.CipherString</id>
+        <label>CipherString</label>
+        <type>select_multiple</type>
+        <style>config_constraints selectpicker</style>
+        <help>Sets the ciphersuite list for TLSv1.2 and below.</help>
+    </field>
+    <field>
+        <id>trust.Ciphersuites</id>
+        <label>Ciphersuites</label>
+        <type>select_multiple</type>
+        <style>config_constraints selectpicker</style>
+        <help>Sets the available ciphersuites for TLSv1.3.</help>
+    </field>
+    <field>
+        <id>trust.groups</id>
+        <label>DHGroups / Curves</label>
+        <type>select_multiple</type>
+        <style>config_constraints selectpicker</style>
+        <help>Limit the default set of built-in curves to be used when using the standard openssl configuration.</help>
+    </field>
+    <field>
+        <id>trust.MinProtocol</id>
+        <label>MinProtocol</label>
+        <type>dropdown</type>
+        <style>config_constraints selectpicker</style>
+        <help>Sets the minimum supported SSL or TLS version.</help>
+    </field>
+    <field>
+        <id>trust.MinProtocol_DTLS</id>
+        <label>MinProtocol (DTLS)</label>
+        <type>dropdown</type>
+        <style>config_constraints selectpicker</style>
+        <help>Sets the minimum supported DTLS version, when configuring MinProtocol and leaving this empty,
+        DTLS will be disabled.
         </help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
@@ -77,6 +77,7 @@
             <Authorities url="/ui/trust/ca"/>
             <Certificates url="/ui/trust/cert"/>
             <Revocation url="/ui/trust/crl"/>
+            <Settings order="100" url="/ui/trust/settings"/>
         </Trust>
         <Wizard url="/wizard.php?xml=system" cssClass="fa fa-magic fa-fw"/>
         <LogFiles order="150" VisibleName="Log Files" cssClass="fa fa-eye fa-fw">

--- a/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/Menu/Menu.xml
@@ -77,7 +77,7 @@
             <Authorities url="/ui/trust/ca"/>
             <Certificates url="/ui/trust/cert"/>
             <Revocation url="/ui/trust/crl"/>
-            <Settings order="100" url="/ui/trust/settings"/>
+            <Settings url="/ui/trust/settings"/>
         </Trust>
         <Wizard url="/wizard.php?xml=system" cssClass="fa fa-magic fa-fw"/>
         <LogFiles order="150" VisibleName="Log Files" cssClass="fa fa-eye fa-fw">

--- a/src/opnsense/mvc/app/models/OPNsense/Trust/General.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Trust/General.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Trust;
+
+use OPNsense\Base\BaseModel;
+
+class General extends BaseModel
+{
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
@@ -37,7 +37,6 @@
         </groups>
         <MinProtocol type="OptionField">
             <OptionValues>
-                <SSLv3>SSLv3</SSLv3>
                 <TLSv1>TLSv1</TLSv1>
                 <TLSv1.1>TLSv1.1</TLSv1.1>
                 <TLSv1.2>TLSv1.2</TLSv1.2>

--- a/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
@@ -1,0 +1,11 @@
+<model>
+    <mount>//OPNsense/trust/general</mount>
+    <description>Trust general settings</description>
+    <version>1.0.0</version>
+    <items>
+        <store_intermediate_certs type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </store_intermediate_certs>
+    </items>
+</model>

--- a/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Trust/General.xml
@@ -7,5 +7,48 @@
             <Default>0</Default>
             <Required>Y</Required>
         </store_intermediate_certs>
+        <install_crls type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </install_crls>
+        <enable_legacy_sect type="BooleanField">
+            <Default>1</Default>
+            <Required>Y</Required>
+        </enable_legacy_sect>
+        <enable_config_constraints type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </enable_config_constraints>
+        <!-- https://docs.openssl.org/3.0/man3/SSL_CONF_cmd/#supported-configuration-file-commands -->
+        <CipherString type="JsonKeyValueStoreField">
+            <Multiple>Y</Multiple>
+            <ConfigdPopulateAct>system ssl ciphers-keyval pre-TLSv1.3</ConfigdPopulateAct>
+            <SortByValue>Y</SortByValue>
+        </CipherString>
+        <Ciphersuites type="JsonKeyValueStoreField">
+            <Multiple>Y</Multiple>
+            <ConfigdPopulateAct>system ssl ciphers-keyval TLSv1.3</ConfigdPopulateAct>
+            <SortByValue>Y</SortByValue>
+        </Ciphersuites>
+        <groups type="JsonKeyValueStoreField">
+            <Multiple>Y</Multiple>
+            <ConfigdPopulateAct>system tls groups</ConfigdPopulateAct>
+            <SortByValue>Y</SortByValue>
+        </groups>
+        <MinProtocol type="OptionField">
+            <OptionValues>
+                <SSLv3>SSLv3</SSLv3>
+                <TLSv1>TLSv1</TLSv1>
+                <TLSv1.1>TLSv1.1</TLSv1.1>
+                <TLSv1.2>TLSv1.2</TLSv1.2>
+                <TLSv1.3>TLSv1.3</TLSv1.3>
+            </OptionValues>
+        </MinProtocol>
+        <MinProtocol_DTLS type="OptionField">
+            <OptionValues>
+                <DTLSv1>DTLSv1</DTLSv1>
+                <DTLSv1.1>DTLSv1.1</DTLSv1.1>
+            </OptionValues>
+        </MinProtocol_DTLS>
     </items>
 </model>

--- a/src/opnsense/mvc/app/models/OPNsense/Trust/Migrations/M1_0_0.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Trust/Migrations/M1_0_0.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Trust\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+use OPNsense\Trust\General;
+
+class M1_0_0 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        if (!$model instanceof General) {
+            return;
+        }
+        $cnf = Config::getInstance()->object();
+        if (!isset($cnf->system) || !isset($cnf->system->store_intermediate_certs)) {
+            return;
+        }
+        $model->store_intermediate_certs = !empty((string)$cnf->system->store_intermediate_certs) ? '1' : '0';
+        unset($cnf->system->store_intermediate_certs);
+    }
+}

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/settings.volt
@@ -1,0 +1,66 @@
+{#
+
+OPNsense® is Copyright © 2024 by Deciso B.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script>
+    $( document ).ready(function() {
+        mapDataToFormUI({'frm_settings':"/api/trust/settings/get"}).done(function(){
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+
+        $("#reconfigureAct").SimpleActionButton({
+            onPreAction: function() {
+                const dfObj = new $.Deferred();
+                saveFormToEndpoint("/api/trust/settings/set", 'frm_settings', function(){
+                    dfObj.resolve();
+                });
+                return dfObj;
+            }
+        });
+    });
+</script>
+
+<div class="tab-content content-box">
+    {{ partial("layout_partials/base_form",['fields':formSettings,'id':'frm_settings'])}}
+</div>
+
+<section class="page-content-main">
+    <div class="content-box">
+        <div class="col-md-12">
+            <br/>
+            <button class="btn btn-primary" id="reconfigureAct"
+                    data-endpoint='/api/wazuhagent/service/reconfigure'
+                    data-label="{{ lang._('Apply') }}"
+                    data-service-widget="wazuh_agent"
+                    data-error-title="{{ lang._('Error reconfiguring Wazuh Agent') }}"
+                    type="button"
+            ></button>
+            <br/><br/>
+        </div>
+    </div>
+</section>

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/settings.volt
@@ -42,6 +42,14 @@ POSSIBILITY OF SUCH DAMAGE.
                 return dfObj;
             }
         });
+
+        $("#trust\\.enable_config_constraints").change(function(){
+            if ($(this).is(':checked')) {
+                $(".config_constraints").closest('tr').show();
+            } else {
+                $(".config_constraints").closest('tr').hide();
+            }
+        });
     });
 </script>
 
@@ -54,10 +62,9 @@ POSSIBILITY OF SUCH DAMAGE.
         <div class="col-md-12">
             <br/>
             <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/wazuhagent/service/reconfigure'
+                    data-endpoint='/api/trust/settings/reconfigure'
                     data-label="{{ lang._('Apply') }}"
-                    data-service-widget="wazuh_agent"
-                    data-error-title="{{ lang._('Error reconfiguring Wazuh Agent') }}"
+                    data-error-title="{{ lang._('Error reconfiguring Trust') }}"
                     type="button"
             ></button>
             <br/><br/>

--- a/src/opnsense/scripts/system/tls_groups.py
+++ b/src/opnsense/scripts/system/tls_groups.py
@@ -1,0 +1,53 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2024 Ad Schellevis <ad@opnsense.org>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+    --------------------------------------------------------------------------------------
+    return all available dhgroups / curves
+"""
+import os
+import subprocess
+import ujson
+
+if __name__ == '__main__':
+    result = {}
+    # dhgroup params can't be queried from openssl.
+    for item in ['ffdhe2048', 'ffdhe3072', 'ffdhe4096', 'ffdhe6144', 'ffdhe8192', 'X25519', 'X448']:
+        result[item] = item
+    # use opnsense.cnf template to avoid generic config constraints limiting options
+    ossl_env = os.environ.copy()
+    ossl_env['OPENSSL_CONF'] = '/usr/local/etc/ssl/opnsense.cnf'
+    sp = subprocess.run(
+        ['/usr/local/bin/openssl', 'ecparam', '-list_curves'],
+        capture_output=True,
+        text=True,
+        env=ossl_env
+    )
+    for line in sp.stdout.split("\n"):
+        if line.startswith('  '):
+            tmp = line.strip().split(':')[0].strip()
+            result[tmp] = tmp
+    print (ujson.dumps(result))

--- a/src/opnsense/service/conf/actions.d/actions_system.conf
+++ b/src/opnsense/service/conf/actions.d/actions_system.conf
@@ -52,6 +52,19 @@ parameters:
 type:script_output
 message:List SSL ciphers
 
+[ssl.ciphers-keyval]
+command:/usr/local/opnsense/scripts/system/ssl_ciphers.py
+parameters: --filter %s --format key_value
+type:script_output
+message:List SSL ciphers
+
+
+[tls.groups]
+command:/usr/local/opnsense/scripts/system/tls_groups.py
+parameters:
+type:script_output
+message:List TLS curves
+
 [remote.backup]
 command:/usr/local/opnsense/scripts/system/remote_backup.php
 parameters: %s

--- a/src/opnsense/service/templates/OPNsense/Trust/openssl.cnf
+++ b/src/opnsense/service/templates/OPNsense/Trust/openssl.cnf
@@ -52,11 +52,35 @@ tsa_policy3 = 1.2.3.4.5.7
 
 [openssl_init]
 providers = provider_sect
+{% if not helpers.empty('OPNsense.trust.general.enable_config_constraints') %}
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+{%     if not helpers.empty('OPNsense.trust.general.CipherString') %}
+CipherString = {{OPNsense.trust.general.CipherString|replace(',',':')}}
+{%     endif %}
+{%     if not helpers.empty('OPNsense.trust.general.Ciphersuites') %}
+Ciphersuites = {{OPNsense.trust.general.Ciphersuites|replace(',',':')}}
+{%     endif %}
+{%     if not helpers.empty('OPNsense.trust.general.groups') %}
+Groups = {{OPNsense.trust.general.groups|replace(',',':')}}
+{%     endif %}
+{% endif %}
 
 # List of providers to load
 [provider_sect]
 default = default_sect
+{% if not helpers.empty('OPNsense.trust.general.enable_legacy_sect') %}
 legacy = legacy_sect
+
+[legacy_sect]
+activate = 1
+
+{% endif %}
+
 # The fips section name should match the section name inside the
 # included fipsmodule.cnf.
 # fips = fips_sect
@@ -72,8 +96,6 @@ legacy = legacy_sect
 [default_sect]
 activate = 1
 
-[legacy_sect]
-activate = 1
 
 
 ####################################################################

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -223,15 +223,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         /* time zone change first */
         system_timezone_configure();
-
-        if ($sync_trust) {
-            /*
-             * FreeBSD trust store integration is slow so we need
-             * to avoid processing when setting is unchanged.
-             */
-            system_trust_configure();
-        }
-
         system_hostname_configure();
         system_resolver_configure();
         plugins_configure('dns');

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -54,7 +54,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['hostname'] = $config['system']['hostname'];
     $pconfig['language'] = $config['system']['language'];
     $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
-    $pconfig['store_intermediate_certs'] = isset($config['system']['store_intermediate_certs']);
     $pconfig['theme'] = $config['theme'] ?? '';
     $pconfig['timezone'] = empty($config['system']['timezone']) ? 'Etc/UTC' : $config['system']['timezone'];
 
@@ -157,9 +156,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         } elseif (isset($config['system']['prefer_ipv4'])) {
             unset($config['system']['prefer_ipv4']);
         }
-
-        $sync_trust = !empty($pconfig['store_intermediate_certs']) !== isset($config['system']['store_intermediate_certs']);
-        $config['system']['store_intermediate_certs'] = !empty($pconfig['store_intermediate_certs']);
 
         if (!empty($pconfig['dnsallowoverride'])) {
             $config['system']['dnsallowoverride'] = true;
@@ -369,28 +365,6 @@ $( document ).ready(function() {
             </tr>
           </table>
         </div>
-
-        <div class="content-box tab-content __mb">
-          <table class="table table-striped opnsense_standard_table_form">
-            <tr>
-              <td style="width:22%"><strong><?= gettext('Trust') ?></strong></td>
-              <td style="width:78%"></td>
-            </tr>
-            <tr>
-              <td><a id="help_for_trust_store_intermediate_certs" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Store intermediate"); ?></td>
-              <td>
-                <input name="store_intermediate_certs" type="checkbox" id="store_intermediate_certs" <?= !empty($pconfig['store_intermediate_certs']) ? "checked=\"checked\"" : "";?> />
-                <div class="hidden" data-for="help_for_trust_store_intermediate_certs">
-                  <?=gettext(
-                    "Allow local defined intermediate certificate authorities to be used in the local trust store. ".
-                    "We advise to only store root certificates to prevent cross signed ones causing breakage when included but expired later in the chain."
-                  ); ?>
-                </div>
-              </td>
-            </tr>
-          </table>
-        </div>
-
 
         <div class="content-box tab-content __mb">
           <table class="table table-striped opnsense_standard_table_form">


### PR DESCRIPTION
This PR offers our Trust settings it's own configuration area, moves `store_intermediate_certs` into it and adds the following functionality:

* Optionally deploy CRL's into their designated place, so the default OpenSSL can make use of them
* Make `legacy_sect` an optional feature, enabled by default to not change current behavior
* Allow configuration constraints for the following parameters when the OpenSSL consumer doesn't offer its own: CipherString, Ciphersuites, groups(Curves), MinProtocol[DTLS]

todo:

* implement 'crl' event for local CRL's
* maybe, optional autofetch CRL's for known CA's 


