### PR TITLE
ipsec: settings: Add make_before_break option

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/settings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/settings.xml
@@ -79,6 +79,12 @@
             <help>Limit new connections based on the current number of half open IKE_SAs.</help>
         </field>
         <field>
+            <id>ipsec.charon.make_before_break</id>
+            <label>Make Before Break</label>
+            <type>checkbox</type>
+            <help>Initiate IKEv2 reauthentication with a make-before-break instead of a break-before-make scheme. Make-before-break uses overlapping IKE and CHILD SA during reauthentication by first recreating all new SAs before deleting the old ones. This behavior can be beneficial to avoid connectivity gaps during reauthentication, but requires support for overlapping SAs by the peer.</help>
+        </field>
+        <field>
             <type>header</type>
             <label>Retransmission</label>
         </field>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
@@ -55,6 +55,7 @@
                 <Default>1</Default>
                 <Required>Y</Required>
             </ignore_acquire_ts>
+            <make_before_break type="BooleanField"/>
             <retransmit_tries type="IntegerField"/>
             <retransmit_timeout type="NumericField"/>
             <retransmit_base type="NumericField"/>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/7776

Since the default for "make_before_break" is "no" without the option set, it is not required and does not provide a default in the model.