### PR TITLE
Add OpenVPN option for case insensitive Strict UserCN check

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -271,8 +271,8 @@
     <field>
         <id>instance.strictusercn</id>
         <label>Strict User/CN Matching</label>
-        <type>checkbox</type>
-        <style>role role_server</style>
+        <type>dropdown</type>
+        <style>selectpicker role role_server</style>
         <help>When authenticating users, enforce a match between the Common Name of the client certificate and the username given at login.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -293,9 +293,14 @@
                     <Default>0</Default>
                     <Required>Y</Required>
                 </username_as_common_name>
-                <strictusercn type="BooleanField">
-                    <Default>0</Default>
+                <strictusercn type="OptionField">
                     <Required>Y</Required>
+                    <Default></Default>
+                    <OptionValues>
+                        <o0 value="">No</o0>
+                        <o1 value="1">Yes</o1>
+                        <o2 value="2">Yes (case insensitive)</o2>
+                    </OptionValues>
                 </strictusercn>
                 <username type="TextField"/>
                 <password type="TextField"/>

--- a/src/opnsense/scripts/openvpn/user_pass_verify.php
+++ b/src/opnsense/scripts/openvpn/user_pass_verify.php
@@ -95,7 +95,8 @@ function do_auth($common_name, $serverid, $method, $auth_file)
     $a_server = $serverid !== null ? (new OPNsense\OpenVPN\OpenVPN())->getInstanceById($serverid, 'server') : null;
     if ($a_server == null) {
         return "OpenVPN '$serverid' was not found. Denying authentication for user {$username}";
-    } elseif (!empty($a_server['strictusercn']) && $username != $common_name) {
+    } elseif (!empty($a_server['strictusercn']) && ((($a_server['strictusercn']==2) && (strtolower($username) != strtolower($common_name))) ||
+                                                    (($a_server['strictusercn']!=2) && ($username != $common_name)))) {
         return sprintf(
             "Username does not match certificate common name (%s != %s), access denied.",
             $username,

--- a/src/www/vpn_openvpn_server.php
+++ b/src/www/vpn_openvpn_server.php
@@ -1073,7 +1073,25 @@ $( document ).ready(function() {
                     <tr class="opt_mode opt_mode_server_tls_user">
                       <td style="width:22%"><a id="help_for_strictusercn" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Strict User/CN Matching"); ?></td>
                       <td>
-                        <input name="strictusercn" type="checkbox" value="yes" <?=!empty($pconfig['strictusercn']) ? "checked=\"checked\"" : "" ;?> />
+                        <select name="strictusercn" class="selectpicker">
+                          <option value=""><?=gettext('No') ?></option>
+<?php
+                          $openvpn_strictusercn = array(
+                            1 => gettext('Yes'),
+                            2 => gettext('Yes (case insensitive)'),
+                          );
+			  $value = $pconfig['strictusercn']=="yes"?1:$pconfig['strictusercn'];
+                          foreach ($openvpn_strictusercn as $strictusercn => $strictusercndesc) :
+                              $selected = "";
+                              if ($strictusercn == $value) {
+                                  $selected = " selected=\"selected\"";
+                              }
+                          ?>
+                            <option value="<?= $strictusercn ?>" <?= $selected ?>><?= $strictusercndesc ?></option>
+<?php
+                        endforeach; ?>
+                        </select>
+
                         <div class="hidden" data-for="help_for_strictusercn">
                           <span>
                               <?=gettext("When authenticating users, enforce a match between the Common Name of the client certificate and the username given at login."); ?>


### PR DESCRIPTION
Using an LDAP authentication like MS Active Directory permits the username to match independently from char case.
When generating certificates for openvpn on users, the certificate CN is generated matching the user original case set in AD (for example Mario.Rossi)
Right now if the "Strict User/CN Matching" is set and the user uses "mario.rossi" as the authentication user name, this check results in a failed authentication even though the password is correct.
Currently the only solution is either forcing the user to write the username matching the original case, or disabling this option.

This change adds an option on OpenVPN "Strict User/CN Matching" to be done also ignoring the char case of the certificate CN.