### PR TITLE
vxlan: fix interface being busy when vxlanlocal or vxlanremote is changed

### DIFF
--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -142,8 +142,7 @@ function vxlan_configure_do($verbose = false, $device = null)
         // The device will be busy, first bring it down, apply changes, then bring it back up
         if ($isChanged) {
             mwexecf('/sbin/ifconfig %s down', [$device_name]);
-            mwexecf($ifcnfcmd, $ifcnfcmdp);
-            mwexecf('/sbin/ifconfig %s up', [$device_name]);
+            mwexecf($ifcnfcmd . ' up', $ifcnfcmdp);
             $changed_devices[] = $device_name;
         }
     }

--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -138,8 +138,12 @@ function vxlan_configure_do($verbose = false, $device = null)
                 $isChanged = true;
             }
         }
+
+        // The device will be busy, first bring it down, apply changes, then bring it back up
         if ($isChanged) {
+            mwexecf('/sbin/ifconfig %s down', [$device_name]);
             mwexecf($ifcnfcmd, $ifcnfcmdp);
+            mwexecf('/sbin/ifconfig %s up', [$device_name]);
             $changed_devices[] = $device_name;
         }
     }


### PR DESCRIPTION
Changing either vxlanlocal or vxlanremote in the GUI in an existing vxlan entry and applying will lead to no changes because the device silently fails during ifconfig:

```
root@opn-be-01:~ # ifconfig vxlan1 vxlanid 1 vxlanlocal 172.16.88.2 vxlanremote 172.16.88.3 vxlanlocalport 4789 vxlanremoteport 4789
ifconfig: VXLAN_CMD_SET_VNI: Device busy
```

Bringing the device down, applying the change and then bringing it back up will apply these changes.

```
vxlan1: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> metric 0 mtu 1500
	description: lan_vxlan1 (opt3)
	options=80020<JUMBO_MTU,LINKSTATE>
	ether 58:9c:fc:00:3a:05
	inet6 fe80::5a9c:fcff:fe00:3a05%vxlan1 prefixlen 64 scopeid 0xd
	groups: vxlan
	vxlan vni 1 local 172.16.99.2:4789 remote 172.16.99.3:4789
	media: Ethernet autoselect (autoselect <full-duplex>)
	status: active
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
root@opn-be-01:~ # ifconfig vxlan1 vxlanid 1 vxlanlocal 172.16.88.2 vxlanremote 172.16.88.3 vxlanlocalport 4789 vxlanremoteport 4789
ifconfig: VXLAN_CMD_SET_VNI: Device busy
root@opn-be-01:~ # ifconfig vxlan1 down
root@opn-be-01:~ # ifconfig vxlan1 vxlanid 1 vxlanlocal 172.16.88.2 vxlanremote 172.16.88.3 vxlanlocalport 4789 vxlanremoteport 4789
root@opn-be-01:~ # ifconfig vxlan1 up
root@opn-be-01:~ # ifconfig vxlan1
vxlan1: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> metric 0 mtu 1500
	description: lan_vxlan1 (opt3)
	options=80020<JUMBO_MTU,LINKSTATE>
	ether 58:9c:fc:00:3a:05
	inet6 fe80::5a9c:fcff:fe00:3a05%vxlan1 prefixlen 64 scopeid 0xd
	groups: vxlan
	vxlan vni 1 local 172.16.88.2:4789 remote 172.16.88.3:4789
	media: Ethernet autoselect (autoselect <full-duplex>)
	status: active
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
```
Otherwise, these changes would only be applied when the device is being recreated (e.g. during a reboot).