### PR TITLE
VPN: IPsec: Mobile Clients - explicit split-include - charon attribute 

### DIFF
--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -964,7 +964,11 @@ function ipsec_write_strongswan_conf()
         if (!empty($net_list)) {
             $net_list_str = implode(",", $net_list);
             $strongswanTree['charon']['plugins']['attr']['subnet'] = $net_list_str;
-            $strongswanTree['charon']['plugins']['attr']['split-include'] = $net_list_str;
+            if(!empty($a_client['net_list_explicit'])) {
+                $strongswanTree['charon']['plugins']['attr']['split-include'] = $a_client['net_list_explicit'];
+            } else {
+                $strongswanTree['charon']['plugins']['attr']['split-include'] = $net_list_str;
+            }
         }
         $cfgservers = [];
         foreach (array('dns_server1', 'dns_server2', 'dns_server3', 'dns_server4') as $dns_server) {


### PR DESCRIPTION
Enabling more than one split network to be used with both vpnc and macos cisco vpn. Phase2 networks are set to 0.0.0.0/0 but the split-include is explicit.

Manual SPDs couldn't be added with mobile clients.
Using the IPsec Phase2 for more than one network didn't work as the SPD for the first network was the only one setup.
Rendering the subsequent networks in the split-include to be dropped on the way back to the vpn client IP address.
