### PR TITLE
tests: Add a unit test for ComparedToFieldConstraintTest

### DIFF
--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php
@@ -78,6 +78,55 @@ class ComparedToFieldConstraintTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(true, $ret);
     }
 
+    // Empty values
+    public function test_if_it_validates_node_empty_values_correctly_with_gt_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator('', 5, 'test', 'lt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_other_node_empty_values_correctly_with_gt_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(5, '', 'test', 'gt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+
+    // Null nodes
+    public function test_if_it_validates_constraint_if_node_is_null_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(null, 2, 'test', 'eq');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_constraint_if_other_is_null_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(2, null, 'test', 'eq');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_constraint_if_both_are_null_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(null, null, 'test', 'eq');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+
     /**
      * @param $node_value integer field content
      * @param $other_field_value integer field content


### PR DESCRIPTION
Add unit tests for a specific case as we had [concerns](https://github.com/opnsense/core/pull/7879#discussion_r1770370436) with this specific code when `$other_node_content` is `null` (x-link #7879)

![image](https://github.com/user-attachments/assets/2bf77abd-7323-4157-b0c6-16477b357315)

The tests `test_if_it_validates_constraint_if_other_is_null_and_no_error`/`test_if_it_validates_other_node_empty_values_correctly_with_gt_and_no_error` will specifically trigger that case.

/cc @fichtner :pray: 