### PR TITLE
System/Logging - handle lines with no timestamp

### DIFF
--- a/src/opnsense/scripts/syslog/queryLog.py
+++ b/src/opnsense/scripts/syslog/queryLog.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
                 break
             # exit when data found is older than provided valid_from
             try:
-                if valid_from and isoparse(record['timestamp']).timestamp() < valid_from:
+                if valid_from and record.get('timestamp') and isoparse(record['timestamp']).timestamp() < valid_from:
                     break
             except ValueError:
                 pass


### PR DESCRIPTION
Recent feature addition to apply time constraint fails in cases where a log line does not contain a timestamp, as in the case of multi-line log entries. This change just moves on when a line contains no timestamp, as we will eventually find the line that contains the start of the log entry (and the timestamp).

fixes #7888