### PR TITLE
tests: Add failing unit tests for ComparedToFieldConstraintTest

### DIFF
--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php
@@ -78,6 +78,44 @@ class ComparedToFieldConstraintTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(true, $ret);
     }
 
+    // zero values
+    public function test_if_it_validates_zero_number_ranges_correctly_with_lt_and_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(2, 0, 'test', 'lt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(1, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_zero_number_ranges_correctly_with_gt_and_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(0, 2, 'test', 'gt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(1, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_zero_number_ranges_correctly_with_lt_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(0, 2, 'test', 'lt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+    public function test_if_it_validates_zero_number_ranges_correctly_with_gt_and_no_error()
+    {
+        $validator = new \OPNsense\Base\Validation();
+        $validate = $this->make_validator(2, 0, 'test', 'gt');
+        $ret = $validate->validate($validator, '');
+        $messages = $validator->getMessages();
+        $this->assertEquals(0, count($messages));
+        $this->assertEquals(true, $ret);
+    }
+
     // Empty values
     public function test_if_it_validates_node_empty_values_correctly_with_gt_and_no_error()
     {


### PR DESCRIPTION
Relates #7883 #7878

@fichtner here are the failing tests (code fix in #7878)

```
root@OPNsense:/usr/local/opnsense/mvc/tests # phpunit --configuration PHPunit.xml
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.23
Configuration: PHPunit.xml

................................FF.............................  63 / 214 ( 29%)
............................................................... 126 / 214 ( 58%)
............................................................... 189 / 214 ( 88%)
.........................                                       214 / 214 (100%)

Time: 00:00.132, Memory: 50.88 MB

There were 2 failures:

1) OPNsense\Base\Constraints\ComparedToFieldConstraintTest::test_if_it_validates_zero_number_ranges_correctly_with_lt_and_error
Failed asserting that 0 matches expected 1.

/usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php:88

2) OPNsense\Base\Constraints\ComparedToFieldConstraintTest::test_if_it_validates_zero_number_ranges_correctly_with_gt_and_error
Failed asserting that 0 matches expected 1.

/usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/Constraints/ComparedToFieldConstraintTest.php:97

FAILURES!
Tests: 214, Assertions: 444, Failures: 2.
```