### PR TITLE
Feature: add cert description to filename on download

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
@@ -237,9 +237,11 @@ class CaController extends ApiMutableModelControllerBase
                 $result['error'] = gettext('Misssing certificate');
             } elseif ($type == 'crt') {
                 $result['status'] = 'ok';
+                $result['descr'] = (string)$node->descr;
                 $result['payload'] = (string)$node->crt_payload;
             } elseif ($type == 'prv') {
                 $result['status'] = 'ok';
+                $result['descr'] = (string)$node->descr;
                 $result['payload'] = (string)$node->prv_payload;
             }
         }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
@@ -279,9 +279,11 @@ class CertController extends ApiMutableModelControllerBase
                 $result['error'] = gettext('Misssing certificate');
             } elseif ($type == 'crt') {
                 $result['status'] = 'ok';
+                $result['descr'] = (string)$node->descr;
                 $result['payload'] = (string)$node->crt_payload;
             } elseif ($type == 'prv') {
                 $result['status'] = 'ok';
+                $result['descr'] = (string)$node->descr;
                 $result['payload'] = (string)$node->prv_payload;
             } elseif ($type == 'pkcs12') {
                 $passphrase = $this->request->getPost('password', null, '');
@@ -294,6 +296,7 @@ class CertController extends ApiMutableModelControllerBase
                 if (!empty($tmp['payload'])) {
                     // binary data, we need to encode it to deliver it to the client
                     $result['payload_b64'] = base64_encode($tmp['payload']);
+                    $result['descr'] = (string)$node->descr;
                     $result['status'] = 'ok';
                 } else {
                     $result['error'] = $tmp['error'] ?? '';

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -82,7 +82,7 @@
                                         '/api/trust/ca/generate_file/'+uuid+'/'+$type.val(),
                                         params,
                                         function(data, status) {
-                                            download_content(data.payload, $type.val() + '.pem', 'application/octet-stream');
+                                            download_content(data.payload, data.descr + '_' + $type.val() + '.pem', 'application/octet-stream');
                                         }
                                     )
                                     dialogItself.close();

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -109,10 +109,10 @@
                                             if (data.payload_b64) {
                                                 mediatype += ';base64';
                                                 payload = data.payload_b64;
-                                                filename = 'cert.p12';
+                                                filename = data.descr + '.p12';
                                             } else if (data.payload) {
                                                 payload = data.payload;
-                                                filename = $type.val() + '.pem';
+                                                filename = data.descr + '_' + $type.val() + '.pem';
                                             }
                                             if (payload !== null) {
                                                 download_content(payload, filename, mediatype);


### PR DESCRIPTION
This PR aims to add enhance the cert download experience by adding the cert description to the filename. This is especially useful if you download multiple certs because then you can distinguish between them by their filename.