### PR TITLE
OpenVPN: Instances: add Require Client Provisioning option

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -318,11 +318,8 @@ Set to 0 to disable, remember to change your client as well.
         <style>role role_server</style>
         <advanced>true</advanced>
         <help>
-        Require, as a condition of authentication, that a connecting client must be provisioned from an authentication backend.
-        If no authentication method or the local database has been selected, a client-specific override must be present
-        with at least the common name and a tunnel network specified (IPv4/IPv6). For other backends, the backend must
-        at least provide the client IP address. This is similar to OpenVPN's 'ccd-exclusive' option, but stricter
-        as the authentication backend must supply an IP address for the client.
+        Require, as a condition for authentication, that a tunnel address will be provisioned either from a local defined client-specific override or offered by an authenticator (such as RADIUS) .
+        This is similar to OpenVPN's 'ccd-exclusive' option, but stricter as we expect the client to receive a tunnel address for the protocol used.
         </help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -312,6 +312,20 @@ Set to 0 to disable, remember to change your client as well.
         </help>
     </field>
     <field>
+        <id>instance.provision_exclusive</id>
+        <label>Require Client Provisioning</label>
+        <type>checkbox</type>
+        <style>role role_server</style>
+        <advanced>true</advanced>
+        <help>
+        Require, as a condition of authentication, that a connecting client must be provisioned from an authentication backend.
+        If no authentication method or the local database has been selected, a client-specific override must be present
+        with at least the common name and a tunnel network specified (IPv4/IPv6). For other backends, the backend must
+        at least provide the client IP address. This is similar to OpenVPN's 'ccd-exclusive' option, but stricter
+        as the authentication backend must supply an IP address for the client.
+        </help>
+    </field>
+    <field>
         <type>header</type>
         <label>Routing</label>
     </field>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -170,9 +170,10 @@ class OpenVPN extends BaseModel
      * Retrieve overwrite content in legacy format
      * @param string $server_id vpnid
      * @param string $common_name certificate common name (or username when specified)
+     * @param array $overlay overwrite CSO properties
      * @return array legacy overwrite data
      */
-    public function getOverwrite($server_id, $common_name)
+    public function getOverwrite($server_id, $common_name, $overlay = [])
     {
         $result = [];
         foreach ($this->Overwrites->Overwrite->iterateItems() as $cso) {
@@ -230,6 +231,29 @@ class OpenVPN extends BaseModel
                     foreach (explode(',', (string)$cso->{$fieldname . 's'}) as $idx => $item) {
                         $result[$fieldname . (string)($idx + 1)] = $item;
                     }
+                }
+            }
+        }
+
+        if (empty($result)) {
+            $result['common_name'] = $common_name;
+        }
+
+        // overlay is fed by authentication backends and takes precedence
+        $result = array_merge($result, $overlay);
+
+        // check if provisioning by authentication backend is mandatory
+        foreach ($this->Instances->Instance->iterateItems() as $node_uuid => $node) {
+            if (
+                (!empty((string)$node->enabled)) &&
+                ($server_id == $node_uuid) &&
+                ((string)$node->role == 'server') &&
+                (!empty((string)$node->provision_exclusive))
+            ) {
+                if (!empty((string)$node->server) && empty($result['tunnel_network'])) {
+                    return [];
+                } elseif (!empty((string)$node->server_ipv6) && empty($result['tunnel_networkv6'])) {
+                    return [];
                 }
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -171,7 +171,7 @@ class OpenVPN extends BaseModel
      * @param string $server_id vpnid
      * @param string $common_name certificate common name (or username when specified)
      * @param array $overlay overwrite CSO properties
-     * @return array legacy overwrite data
+     * @return array legacy overwrite data, empty when failed
      */
     public function getOverwrite($server_id, $common_name, $overlay = [])
     {
@@ -245,10 +245,10 @@ class OpenVPN extends BaseModel
         // check if provisioning by authentication backend is mandatory
         foreach ($this->Instances->Instance->iterateItems() as $node_uuid => $node) {
             if (
-                (!empty((string)$node->enabled)) &&
-                ($server_id == $node_uuid) &&
-                ((string)$node->role == 'server') &&
-                (!empty((string)$node->provision_exclusive))
+                !empty((string)$node->enabled) &&
+                $server_id == $node_uuid &&
+                (string)$node->role == 'server' &&
+                !empty((string)$node->provision_exclusive)
             ) {
                 if (!empty((string)$node->server) && empty($result['tunnel_network'])) {
                     return [];

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/OpenVPN</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>OpenVPN</description>
     <items>
         <Overwrites>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -314,6 +314,10 @@
                 <auth-gen-token type="IntegerField">
                     <MinimumValue>0</MinimumValue>
                 </auth-gen-token>
+                <provision_exclusive type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </provision_exclusive>
                 <redirect_gateway type="OptionField">
                     <Multiple>Y</Multiple>
                     <OptionValues>

--- a/src/opnsense/scripts/openvpn/client_connect.php
+++ b/src/opnsense/scripts/openvpn/client_connect.php
@@ -40,7 +40,8 @@ $server = (new OPNsense\OpenVPN\OpenVPN())->getInstanceById($vpnid, 'server');
 if ($server) {
     $cso = (new OPNsense\OpenVPN\OpenVPN())->getOverwrite($vpnid, $common_name);
     if (empty($cso)) {
-        $cso = array("common_name" => $common_name);
+        syslog(LOG_NOTICE, "authentication failed for user '{$common_name}'. No tunnel network provisioned, but required.");
+        exit(1);
     }
     if (!empty($config_file)) {
         $cso_filename = openvpn_csc_conf_write($cso, $server, $config_file);

--- a/src/opnsense/scripts/openvpn/user_pass_verify.php
+++ b/src/opnsense/scripts/openvpn/user_pass_verify.php
@@ -125,12 +125,10 @@ function do_auth($common_name, $serverid, $method, $auth_file)
                     LOG_NOTICE,
                     "Locate overwrite for '{$common_name}' using server '{$serverid}' (vpnid: {$a_server['vpnid']})"
                 );
-                $cso = (new OPNsense\OpenVPN\OpenVPN())->getOverwrite($serverid, $common_name);
+                $cso = (new OPNsense\OpenVPN\OpenVPN())->getOverwrite($serverid, $common_name, parse_auth_properties($authenticator->getLastAuthProperties()));
                 if (empty($cso)) {
-                    $cso = array("common_name" => $common_name);
+                    return "authentication failed for user '{$username}'. No tunnel network provisioned, but required.";
                 }
-
-                $cso = array_merge($cso, parse_auth_properties($authenticator->getLastAuthProperties()));
                 $cso_filename = openvpn_csc_conf_write($cso, $a_server);
                 if (!empty($cso_filename)) {
                     $tmp = empty($a_server['cso_login_matching']) ? "CSO [CN]" : "CSO [USER]";


### PR DESCRIPTION
Fixes https://github.com/opnsense/core/issues/7953

`ccd-exclusive` doesn't work in our case, as explained in https://github.com/opnsense/core/issues/4293.

This is logical, as we use our own hook to dynamically generate the CSOs to allow for multiple authentication backends to dictate the contents of the CSO. Therefore, the `ccd-exclusive` option on it's own doesn't make much sense from the perspective of e.g. Radius, as there is no common name to match to and as such the original option would not add as much benefit in terms of security.

This PR matches both `common-name` and `tunnel_network`/`tunnel_networkv6`. In all cases an ipv4/ipv6 network must be provisioned with this option enabled.