### PR TITLE
Check if any gateways exist before iterating

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
@@ -205,12 +205,14 @@ class SettingsController extends ApiMutableModelControllerBase
                 }
 
                 $groups = [];
-                foreach ($cfg->gateways->children() as $tag => $gw_group) {
-                    if ($tag == 'gateway_group' && !empty($gw_group)) {
-                        foreach ($gw_group->item as $item) {
-                            $name = explode("|", (string)$item);
-                            if ($name[0] == $gateway->name) {
-                                $groups[] = (string)$gw_group->name;
+                if ($cfg->gateways->count() > 0) {
+                    foreach ($cfg->gateways->children() as $tag => $gw_group) {
+                        if ($tag == 'gateway_group' && !empty($gw_group)) {
+                            foreach ($gw_group->item as $item) {
+                                $name = explode("|", (string)$item);
+                                if ($name[0] == $gateway->name) {
+                                    $groups[] = (string)$gw_group->name;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
**Important notices**

Before you add a new report, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I am convinced that my issue is new after having checked both open and closed issues at https://github.com/opnsense/core/issues?q=is%3Aissue

**Describe the bug**

On a fresh OPNsense configuration the key `/opnsense/gateways` does not exist in the config.xml. If a Gateway is created and then deleted an error is raise.

```
foreach() argument must be of type array|object, null given
```

To delete the gateway a gateway group needs to be createt (and can be deleted again). This leafs the following in the `config.xml`.

```
  <gateways>
    <gateway_group/>
  </gateways>
```

**To Reproduce**

Steps to reproduce the behavior:
1. Delete the `gateways` node from `config.xml`
2. Create a Gateway
3. Delete the Gateway
4. See error

**Expected behavior**

The gateway should be deleted.

**Describe alternatives you considered**


**Screenshots**


**Relevant log files**

```
[10-Oct-2024 15:04:52 Etc/UTC] ErrorException: foreach() argument must be of type array|object, null given in /usr/local/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php:208
Stack trace:
#0 /usr/local/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php(208): {closure}(2, 'foreach() argum...', '/usr/local/opns...', 208)
#1 /usr/local/opnsense/mvc/app/library/OPNsense/Mvc/Dispatcher.php(165): OPNsense\Routing\Api\SettingsController->delGatewayAction('bcad02aa-a52d-4...')
#2 /usr/local/opnsense/mvc/app/library/OPNsense/Mvc/Router.php(156): OPNsense\Mvc\Dispatcher->dispatch(Object(OPNsense\Mvc\Request), Object(OPNsense\Mvc\Response), Object(OPNsense\Mvc\Session))
#3 /usr/local/opnsense/mvc/app/library/OPNsense/Mvc/Router.php(139): OPNsense\Mvc\Router->performRequest(Object(OPNsense\Mvc\Dispatcher))
#4 /usr/local/opnsense/www/api.php(36): OPNsense\Mvc\Router->routeRequest('/api/routing/se...', Array)
#5 {main}
```

**Additional context**


**Environment**

Software version used and hardware type if relevant, e.g.:

OPNsense 24.7.6-amd64