### PR TITLE
System: Settings: Administration - add RekeyLimit with a limited set of choices

### DIFF
--- a/src/etc/inc/plugins.inc.d/openssh.inc
+++ b/src/etc/inc/plugins.inc.d/openssh.inc
@@ -183,6 +183,9 @@ function openssh_configure_do($verbose = false, $interface_map = null)
         $sshconf .= "ChallengeResponseAuthentication no\n";
         $sshconf .= "PasswordAuthentication no\n";
     }
+    if (!empty($sshcfg['rekeylimit'])) {
+        $sshconf .= sprintf("RekeyLimit %s\n", $sshcfg['rekeylimit']);
+    }
 
     foreach ($keys as $name) {
         $file = "/conf/sshd/{$name}";


### PR DESCRIPTION
In some regulated environments the openssh defaults are not acceptable, in which case we might need to offer some choices.

Since RekeyLimit specifies both data and time and we don't want to overcomplicate things, it might be best to just offer some (pre validated) options.