### PR TITLE
Firewall/Diagnostics/Sessions: Fix comparing IPv4 and IPv6 ranges

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/FirewallController.php
@@ -257,7 +257,7 @@ class FirewallController extends ApiControllerBase
                 }
                 foreach (['dst_addr', 'src_addr', 'gw_addr'] as $addr) {
                     foreach ($networks as $net) {
-                        if (Util::isIPInCIDR($row[$addr] ?? '', $net)) {
+                        if (str_contains($row[$addr], ':') === str_contains($net, ':') && Util::isIPInCIDR($row[$addr] ?? '', $net)) {
                             return true;
                         }
                     }


### PR DESCRIPTION
Searching an IPv6 address in Sessions yielded an error in certain situations. Only same protocol IP addresses should be compared when searching for matches.