### PR TITLE
diagnostics/traffic: Improve Top talkers table in traffic

### DIFF
--- a/src/opnsense/www/themes/opnsense/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense/build/css/main.css
@@ -7407,3 +7407,23 @@ div[data-for*=help_for] {
 .modal-footer {
   padding: 15px;
 }
+
+#rxTopTable tr.unanswered>td {
+  opacity: 0.6;
+}
+
+#rxTopTable tr.tracked>td {
+  background-color: #f5e9e3;
+}
+
+#rxTopTable tr.active>.host {
+  font-weight: bold;
+}
+
+#rxTopTable tr>td.active {
+  font-weight: bold;
+}
+
+#toptalkers div {
+  overflow-y: auto;
+}


### PR DESCRIPTION
* Add bit/byte switch, current and max traffic is shown in selected units
* Allow to open directly with Top talkers tab active with URL #toptalkers
* Instead of last timestamp in ISO format show time in seconds an address was seen last
* Highlight values over 0.5 MB/s current traffic and values over 10 MB totals, if any of those is highlighted, the row is highlighted as well
* Mark rows where traffic only ever came in one direction as gray - unanswered
* Ability to click a row to mark it tracked, easier to follow someone in a table where the top get sorted often
* Add an action button to show sessions related to the IP
* Fix for mobile view - table does not overflow and can be scrolled