### PR TITLE
Firewall/Diagnostics/Sessions: Enable searching for query string via GET query parameter

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_pftop.volt
@@ -94,6 +94,15 @@
                 }
             }
         });
+
+        // search from query string - coming from Traffic view
+        const searchParams = new URLSearchParams(window.location.search);
+        const qsearch = searchParams.get('search');
+        if (qsearch) {
+            const searchElement = $('.search.form-group input.search-field');
+            searchElement.val(qsearch);
+            searchElement.trigger('keyup');
+        }
     });
 
 </script>


### PR DESCRIPTION
This adds support to open a search for IP sessions directly. Relates to #7979 where a button is added to each IP to find related sessions.