### PR TITLE
Traffic ipv6 translation support

### DIFF
--- a/src/opnsense/scripts/routes/ipv6_gateways.php
+++ b/src/opnsense/scripts/routes/ipv6_gateways.php
@@ -1,0 +1,21 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Returns static IPv6 routes with gateway names in TSV format.
+ * It is used for approximate IPv6 translation of dynamic addresses in traffic view (traffic_top.py).
+ */
+require_once 'config.inc';
+require_once 'util.inc';
+
+$allRoutes = get_staticroutes();
+$allSubnets = [];
+foreach ($allRoutes as $route) {
+    if (str_contains($route['network'], ':') && is_subnet($route['network'])) {
+        $allSubnets[$route['network']] = $route['gateway'];
+    }
+}
+
+foreach ($allSubnets as $network => $gateway) {
+    echo $network . "\t" . $gateway . "\n";
+}


### PR DESCRIPTION
This adds a support for resolving IPv6 reverse addresses.
Second commit is a bit more controversial, but handy as well. Imagine you have static IPv6 prefixes delegated in your network. For that you need static IPv6 routes to properly configured home routers. This feature allows to translate a dynamically created IP via SLAAC into last part of IPv6 address@GatewayName. eg. **fc00:106:4:0:fc82:c2ff:ffff:a0cb** would be translated to **a0cb@ClientsName**.
