### PR TITLE
Add SFP module details to interface details

### DIFF
--- a/src/etc/inc/interfaces.lib.inc
+++ b/src/etc/inc/interfaces.lib.inc
@@ -397,6 +397,13 @@ function legacy_interfaces_details($intf = null)
             $result[$current_interface]['media_raw'] = substr(trim($line), 7);
         } elseif (preg_match("/media (.*)/", $line, $matches)) {
             $result[$current_interface]["supported_media"][] = str_replace(" mediaopt ", " ", trim($matches[1]));
+        } elseif (preg_match("/plugged: (.*)/", $line, $matches)) {
+            $result[$current_interface]['sfp_transceiver_plugged'] = $matches[1];
+        } elseif (preg_match("/vendor:\s+(.*)\s+PN:(.*)\s+SN:\s+(.*)\s+DATE:\s+(.*)/", $line, $matches)) {
+            $result[$current_interface]['sfp_transceiver_vendor'] = $matches[1];
+            $result[$current_interface]['sfp_transceiver_part_number'] = $matches[2];
+            $result[$current_interface]['sfp_transceiver_serial_number'] = $matches[3];
+            $result[$current_interface]['sfp_transceiver_manufacturing_date'] = $matches[4];
         } elseif (preg_match("/status: (.*)$/", $line, $matches)) {
             $result[$current_interface]['status'] = $matches[1];
         } elseif (preg_match("/channel (\S*)/", $line, $matches)) {


### PR DESCRIPTION
I noticed that the interface details link (clicking on the magnifying glass on an interface in the Interfaces > Overview page) wasn't showing some of the information about the SFP transceivers I have plugged in to those ports.  It turns out that OPNsense is already grabbing that data (it's retrieved via `ifconfig -v`), but it just isn't parsing it when it's available.

So, this adds a few entries to the interface info in order to display those things.  In my case, these look like this:

field_name | field_value
-- | --
sfp_transceiver_plugged | SFP/SFP+/SFP28 Unknown (RJ45)
sfp_transceiver_vendor | FS
sfp_transceiver_part_number | SFP-10GM-T
sfp_transceiver_serial_number | SOMESERIALNUMBER
sfp_transceiver_manufacturing_date | 2000-01-31

In theory, there are also other things that could show up like module temperature or TX/RX strength (https://forums.freebsd.org/threads/network-card-sfp-module-status.68666/ has an example of this), but my modules don't report those, so I left them out since I wouldn't have a way of testing them.