### PR TITLE
Add boot file selection for Kea

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -93,9 +93,21 @@
         <help>TFTP server address or fqdn</help>
     </field>
     <field>
-        <id>subnet4.option_data.boot_file_name</id>
-        <label>TFTP bootfile name</label>
+        <id>subnet4.client_classes.x86_uefi_file</id>
+        <label>x86 UEFI (32-bit) bootfile name</label>
         <type>text</type>
-        <help>Boot filename to request</help>
+        <help>Boot filename to request for 32-bit x86 UEFI systems.</help>
+    </field>
+    <field>
+        <id>subnet4.client_classes.x64_uefi_file</id>
+        <label>x64 UEFI/EBC (64-bit) bootfile name</label>
+        <type>text</type>
+        <help>Boot filename to request for 64-bit x64 UEFI/EBC systems.</help>
+    </field>
+    <field>
+        <id>subnet4.client_classes.boot_file</id>
+        <label>Default bootfile name</label>
+        <type>text</type>
+        <help>Boot filename to request if no other boot file matches (e.g. legacy BIOS boot).</help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -90,10 +90,18 @@
                     <tftp_server_name type="TextField">
                         <Mask>/^([^\n"])*$/u</Mask>
                     </tftp_server_name>
-                    <boot_file_name type="TextField">
-                        <Mask>/^([^\n"])*$/u</Mask>
-                    </boot_file_name>
                 </option_data>
+                <client_classes>
+                    <x86_uefi_file type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </x86_uefi_file>
+                    <x64_uefi_file type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </x64_uefi_file>
+                    <boot_file type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </boot_file>
+                </client_classes>
                 <pools type=".\KeaPoolsField">
                 </pools>
                 <description type="DescriptionField"/>


### PR DESCRIPTION
I would like to use Kea, but it would be good to be able to select which boot file is served.  So, I implemented this.  However, it has some downsides and I imagine will need some revisions before it's ready to be committed.

The biggest downside is that it moves the location of the default boot file, so it is a breaking change.  I did this because it seems that the Kea config doesn't allow client classifications (which seem to be the only way to use conditional statements) directly in the `subnet4` block.

I've also only tested this with one subnet, but I have designed it so that I expect it should work with multiple subnets, and select boot files appropriately.  But, I will probably need some help with that testing.

I could also use assistance in testing the x86 UEFI boot process, as I don't actually have any UEFI-based x86 machines that support network booting.  The code I used to identify 32-bit UEFI machines does [match the RFC](https://www.rfc-editor.org/rfc/rfc4578.html#section-2.1), though, so I don't see any reason why it wouldn't work.  I just haven't been able to personally verify it.  I have, however, been able to verify booting x64 UEFI and BIOS systems through payloads configured with this code.