### PR TITLE
ISO dates in health graphs

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
@@ -81,7 +81,7 @@
 
         chart.x2Axis
                 .tickFormat(function (d) {
-                    return d3.time.format('%x')(new Date(d))
+                    return d3.time.format('%Y-%m-%d')(new Date(d))
                 });
 
         chart.yAxis
@@ -210,7 +210,7 @@
             if (status == "success") {
                 let stepsize = data["set"]["step_size"];
                 let scale = "{{ lang._('seconds') }}";
-                let dtformat = '%m/%d %H:%M';
+                let dtformat = '%m-%d %H:%M';
 
                 // set defaults based on stepsize
                 if (stepsize >= 86400) {


### PR DESCRIPTION
American date format is not the standard for most of the world. Slashes indicate ambiguity for dates like 4/7, hindering readability.