### PR TITLE
Logical health graph ranges

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
@@ -372,6 +372,7 @@
                             return d3.time.format(dtformat)(new Date(d))
                         });
                 chart.yAxis.axisLabel(data["y-axis_label"]);
+                chart.forceY([0]);
                 chart.useInteractiveGuideline(true);
                 chart.interactive(true);
 


### PR DESCRIPTION
I couldn't spend enough time on making the "pretty" extents function work with the dynamic graphs, as per #7392. Here's a simpler patch that should at least stop the graphs showing wild volatility when the values have a narrow range.