### PR TITLE
Default checksum offloading for the vtnet(4) driver to disabled

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -135,11 +135,6 @@
       <value>default</value>
     </item>
     <item>
-      <descr><![CDATA[Disable receive and send checksum offload for vtnet(4). Recommended for most KVM based cloud providers.]]></descr>
-      <tunable>hw.vtnet.csum_disable</tunable>
-      <value>default</value>
-    </item>
-    <item>
       <descr><![CDATA[Enable TCP extended debugging]]></descr>
       <tunable>net.inet.tcp.log_debug</tunable>
       <value>default</value>

--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -135,6 +135,11 @@
       <value>default</value>
     </item>
     <item>
+      <descr><![CDATA[Disable receive and send checksum offload for vtnet(4). Recommended for most KVM based cloud providers.]]></descr>
+      <tunable>hw.vtnet.csum_disable</tunable>
+      <value>default</value>
+    </item>
+    <item>
       <descr><![CDATA[Enable TCP extended debugging]]></descr>
       <tunable>net.inet.tcp.log_debug</tunable>
       <value>default</value>

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -73,7 +73,9 @@ function system_sysctl_defaults()
         'debug.kassert.warn_only' => [ 'default' => '1', 'required' => true, 'description' => 'KASSERT triggers a panic (0) or just a warning (1)', 'type' => 'w' ],
         'hw.ibrs_disable' => [ 'default' => '0' ],
         'hw.ixl.enable_head_writeback' => [ 'default' => '0', 'required' => true ],
+        'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true ],
         'hw.syscons.kbd_reboot' => [ 'default' => '0' ],
+        'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true, 'description' => 'Disable receive and send checksum offload for vtnet(4). Recommended for most KVM based cloud providers.' ],
         'hw.uart.console' => [ 'default' => 'io:0x3f8,br:' . system_console_speed(), 'type' => 't' ], /* XXX support comconsole_port if needed */
         'kern.coredump' => [ 'default' => '0', 'required' => true ],
         'kern.ipc.maxsockbuf' => [ 'default' => '4262144' ],

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -75,7 +75,7 @@ function system_sysctl_defaults()
         'hw.ixl.enable_head_writeback' => [ 'default' => '0', 'required' => true ],
         'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true ],
         'hw.syscons.kbd_reboot' => [ 'default' => '0' ],
-        'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true, 'description' => 'Disable receive and send checksum offload for vtnet(4). Recommended for most KVM based cloud providers.' ],
+        'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true ],
         'hw.uart.console' => [ 'default' => 'io:0x3f8,br:' . system_console_speed(), 'type' => 't' ], /* XXX support comconsole_port if needed */
         'kern.coredump' => [ 'default' => '0', 'required' => true ],
         'kern.ipc.maxsockbuf' => [ 'default' => '4262144' ],

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -73,7 +73,6 @@ function system_sysctl_defaults()
         'debug.kassert.warn_only' => [ 'default' => '1', 'required' => true, 'description' => 'KASSERT triggers a panic (0) or just a warning (1)', 'type' => 'w' ],
         'hw.ibrs_disable' => [ 'default' => '0' ],
         'hw.ixl.enable_head_writeback' => [ 'default' => '0', 'required' => true ],
-        'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true ],
         'hw.syscons.kbd_reboot' => [ 'default' => '0' ],
         'hw.vtnet.csum_disable' => [ 'default' => '1', 'required' => true ],
         'hw.uart.console' => [ 'default' => 'io:0x3f8,br:' . system_console_speed(), 'type' => 't' ], /* XXX support comconsole_port if needed */


### PR DESCRIPTION
Most cloud providers based on KVM have either a bug or a common misconfiguration in their VirtIO network interface implementation which leads to FreeBSD falsely probing the interface as checksum offload capable while the emulated hardware in fact does not perform the offload.

The root cause of the problem is currently investigated by various developers in the FreeBSD community with support from at least Vultr and possibly Digitalocean last that I heard of the current state.

The simple and effective workaround is to disable checksum offloading globally for vtnet(4) interfaces.

I therefore argue this sysctl value should be the default for OPNsense installations.

See this forum post for more background and links:
https://forum.opnsense.org/index.php?topic=43583.msg216918#msg216918

I can of course refer you to people involved - or you simply join the bhyve production users call taking place every Thursday evening (european time).

I am not quite sure the proposed changes are everything that is necessary but I *am* fully convinced changing the tunable by default is the reasonable thing to do. The POLA violation when people get only a couple of 100 k/s of throughput far outweighs the minimal performance penalty with the tunable set to 1.

Kind regards,
Patrick