### PR TITLE
Firewall - adhere to best practices 

### DIFF
--- a/src/etc/inc/config.inc
+++ b/src/etc/inc/config.inc
@@ -244,7 +244,7 @@ function &config_read_array()
 
     foreach (func_get_args() as $key) {
         if (!isset($current[$key]) || !is_array($current[$key])) {
-            $current[$key] = array();
+            $current[$key] = [];
         }
         $current = &$current[$key];
     }
@@ -268,7 +268,7 @@ function make_config_revision_entry($desc = '')
         $desc = sprintf('%s made changes', $_SERVER['SCRIPT_NAME']);
     }
 
-    $revision = array();
+    $revision = [];
     $revision['username'] = $username;
     $revision['time'] = microtime(true);
     $revision['description'] = $desc;
@@ -281,11 +281,14 @@ function make_config_revision_entry($desc = '')
  * @param array $filters list of filters to apply
  * @return array interfaces
  */
-function legacy_config_get_interfaces($filters = array())
+function legacy_config_get_interfaces($filters = [], $exclude_ifs = [])
 {
-    $interfaces = array();
+    $interfaces = [];
 
     foreach (config_read_array('interfaces') as $ifname => $iface) {
+        if (in_array($ifname, $exclude_ifs)) {
+            continue;
+        }
         // undo stupid listags() turning our item into a new array, preventing certain names to be used as interface.
         // see src/etc/inc/xmlparse.inc
         if (isset($iface[0])) {

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -353,6 +353,7 @@ function filter_configure_sync($verbose = false, $load_aliases = true)
     $rules .= filter_setup_logging_interfaces($cnfint);
     $rules .= "\n";
     $rules .= "set skip on pfsync0\n";
+    $rules .= "set skip on lo0\n";
     $rules .= "\n";
     $rules .= filter_generate_scrubbing($cnfint);
     $rules .= "\n";

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -206,13 +206,6 @@ function filter_core_rules_system($fw, $defaults)
     $dhcrelay6_interfaces = plugins_run('dhcrelay_interfaces', ['inet6']);
     $dhcrelay6_interfaces = !empty($dhcrelay6_interfaces['dhcrelay']) ? $dhcrelay6_interfaces['dhcrelay'] : [];
 
-    // block All IPv6 except loopback traffic
-    $fw->registerFilterRule(
-        1,
-        array('interface' => 'lo0', 'ipprotocol' => 'inet6', 'disabled' => isset($config['system']['ipv6allow']),
-          'descr' => 'Pass all loopback IPv6', '#ref' => 'system_advanced_network.php#ipv6allow'),
-        $defaults['pass']
-    );
     $fw->registerFilterRule(
         1,
         ['ipprotocol' => 'inet6','descr' => 'Block all IPv6', 'disabled' => !$ipv6_disabled,
@@ -529,10 +522,6 @@ function filter_core_rules_system($fw, $defaults)
                 break;
         }
     }
-
-    // loopback. dont log internal communications
-    /* temporary work-around, syncookies require states to avoid dropping traffic */
-    $fw->registerFilterRule(5, array('interface' => 'lo0', 'log' => false, 'descr' => 'pass loopback'), $defaults['pass']);
 
     // out from this Firewall
     $fw->registerFilterRule(

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -233,7 +233,7 @@ class MenuSystem
                     $iftargets['wl'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                 }
                 // "Firewall: Rules" menu tab...
-                if (isset($node->enable)) {
+                if (isset($node->enable) && $node->if != 'lo0') {
                     $iftargets['fw'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                 }
                 // "Services: DHCPv[46]" menu tab:

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -32,6 +32,9 @@
                 </quick>
                 <interface type="InterfaceField">
                     <Multiple>Y</Multiple>
+                    <Filters>
+                        <if>/^(?!lo0$).*/</if>
+                    </Filters>
                     <AllowDynamic>Y</AllowDynamic>
                 </interface>
                 <direction type="OptionField">
@@ -126,6 +129,9 @@
                 <interface type="InterfaceField">
                     <Required>Y</Required>
                     <Default>lan</Default>
+                    <Filters>
+                        <if>/^(?!lo0$).*/</if>
+                    </Filters>
                     <AllowDynamic>Y</AllowDynamic>
                 </interface>
                 <ipprotocol type="OptionField">
@@ -214,6 +220,9 @@
                 <interface type="InterfaceField">
                     <Required>Y</Required>
                     <Default>lan</Default>
+                    <Filters>
+                        <if>/^(?!lo0$).*/</if>
+                    </Filters>
                     <AllowDynamic>Y</AllowDynamic>
                 </interface>
                 <source_net type="NetworkField">
@@ -263,6 +272,9 @@
                 <interface type="InterfaceField">
                     <Required>Y</Required>
                     <Default>wan</Default>
+                    <Filters>
+                        <if>/^(?!lo0$).*/</if>
+                    </Filters>
                     <AllowDynamic>Y</AllowDynamic>
                 </interface>
                 <type type="OptionField">

--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -561,7 +561,7 @@ $( document ).ready(function() {
                   <td>
                       <select name="interface[]" class="selectpicker" data-width="348px" data-live-search="true" multiple="multiple">
 <?php
-                        foreach (legacy_config_get_interfaces(array("enable" => true)) as $iface => $ifdetail): ?>
+                        foreach (legacy_config_get_interfaces(["enable" => true], ['lo0']) as $iface => $ifdetail): ?>
                         <option value="<?=$iface;?>" <?= in_array($iface, $pconfig['interface'] ?? []) ? "selected=\"selected\"" : ""; ?>>
                           <?=htmlspecialchars($ifdetail['descr']);?>
                         </option>

--- a/src/www/firewall_nat_out_edit.php
+++ b/src/www/firewall_nat_out_edit.php
@@ -448,7 +448,7 @@ include("head.inc");
                   <td><a id="help_for_interface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Interface"); ?></td>
                   <td>
                       <select name="interface" class="selectpicker" data-width="348px" data-live-search="true">
-<?php foreach (legacy_config_get_interfaces(array("enable" => true)) as $iface => $ifdetail): ?>
+<?php foreach (legacy_config_get_interfaces(["enable" => true], ['lo0']) as $iface => $ifdetail): ?>
                         <option value="<?=$iface;?>" <?= $iface == $pconfig['interface'] ? "selected=\"selected\"" : ""; ?>>
                           <?=htmlspecialchars($ifdetail['descr']);?>
                         </option>

--- a/src/www/firewall_rules_edit.php
+++ b/src/www/firewall_rules_edit.php
@@ -891,7 +891,7 @@ include("head.inc");
 <?php
                     endif;
 
-                    foreach (legacy_config_get_interfaces(array("enable" => true)) as $iface => $ifdetail): ?>
+                    foreach (legacy_config_get_interfaces(["enable" => true], ['lo0']) as $iface => $ifdetail): ?>
                         <option value="<?=$iface;?>"
                             <?= !empty($pconfig['interface']) && (
                                   $iface == $pconfig['interface'] ||


### PR DESCRIPTION
(https://www.openbsd.org/faq/pf/filter.html) and skip lo0 from processing. closes https://github.com/opnsense/core/issues/8009

Since I needed to skim the filter.* files anyway, also add the following minor improvements:

* change array() to []
* skip ipv6 only rules when ipv6 is disabled
* make carp rules conditional