### PR TITLE
Update opnsense-version to restore old default output

### DIFF
--- a/src/sbin/opnsense-version
+++ b/src/sbin/opnsense-version
@@ -23,7 +23,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-DEFAULTS="\${product_name} \${product_version}"
+DEFAULTS="\${product_name} \${product_version} \(\${product_arch}\)"
 VERSIONDIR="/usr/local/opnsense/version"
 PLUGINCTL="/usr/local/sbin/pluginctl"
 PKG="/usr/local/sbin/pkg-static"


### PR DESCRIPTION
As discussed on the forum here: https://forum.opnsense.org/index.php?topic=43903

This PR restores pre-2019 default output format of the opnsense-version script, fixing some 3rd party integration which expects this field to be in a certain format.

Pre change:
```
root@x-y-z:~ # opnsense-version
OPNsense 24.10_7
```
Post change:
```
root@x-y-z:~ # opnsense-version
OPNsense 24.10_7 (amd64)
```

Problem was introduced here https://github.com/opnsense/core/commit/c1f839ef9d1f03be5ed0e7e720dae7802c3ac691 and discussed here https://github.com/opnsense/core/issues/4500