### PR TITLE
Openvpn authentication with otp as suffix

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/TOTP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/TOTP.php
@@ -54,7 +54,7 @@ trait TOTP
     /**
      * @var bool token after password
      */
-    private $passwordFirst = false;
+    public $passwordFirst = false;
 
     /**
      * use graceperiod and timeWindow to calculate which moments in time we should check


### PR DESCRIPTION
Authentication server as Local and LDAP with TOTP have an option which permits to enter the TOTP code after the password (default is as prefix)

In this case if you enable the TOTP question in Openvpn Client (static-challenge) the authentication fails as the PIN is presented as prefix and not as a suffix.

I currently have many configurations where static-challenge is not enabled and thus the users write the password and  the PIN in the password input on the client.
Migrating to support the static-challenge would require them to be changed all at the same time.

I propose the move of the check (and how the password is composed) based on the Authentication method settings.

