### PR TITLE
routing/gateways: Fix ipv4 and ipv6 validation not being displayed in the gateway form

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
@@ -62,9 +62,9 @@ class Gateways extends BaseModel
                 if (empty((string)$gateway->$key) || (string)$gateway->$key == 'dynamic') {
                     continue;
                 } elseif ((string)$gateway->ipprotocol === 'inet' && !Util::isIpv4Address((string)$gateway->$key)) {
-                    $messages->appendMessage(new Message(gettext('Invalid IPv4 address'), $ref . '.' . $tag));
+                    $messages->appendMessage(new Message(gettext('Invalid IPv4 address'), $ref . '.' . $key));
                 } elseif ((string)$gateway->ipprotocol === 'inet6' && !Util::isIpv6Address((string)$gateway->$key)) {
-                    $messages->appendMessage(new Message(gettext('Invalid IPv6 address'), $ref . '.' . $tag));
+                    $messages->appendMessage(new Message(gettext('Invalid IPv6 address'), $ref . '.' . $key));
                 }
             }
             if (intval((string)$gateway->current_latencylow) > intval((string)$gateway->current_latencyhigh)) {


### PR DESCRIPTION
Before patch:

```
{
    "result": "failed",
    "validations": {
        "gateway_item.": "Invalid IPv4 address"
    }
}
```

After this patch:

```
{
    "result": "failed",
    "validations": {
        "gateway_item.gateway": "Invalid IPv4 address"
    }
}
```