### PR TITLE
Remote syslog localip

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
@@ -40,6 +40,11 @@
     <type>text</type>
   </field>
   <field>
+    <id>destination.localip</id>
+    <label>Local IP</label>
+    <type>text</type>
+  </field>
+  <field>
     <id>destination.certificate</id>
     <style>transport_type_tls4 transport_type_tls6 transport_type</style>
     <label>Certificate</label>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/dialogDestination.xml
@@ -43,6 +43,7 @@
     <id>destination.localip</id>
     <label>Local IP</label>
     <type>text</type>
+    <help>Optional bind to specific local ip.</help>
   </field>
   <field>
     <id>destination.certificate</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Syslog/Syslog.xml
@@ -96,6 +96,9 @@
                   <Default>0</Default>
                   <Required>Y</Required>
                 </rfc5424>
+                <localip type="HostnameField">
+                    <Required>N</Required>
+                </localip>
                 <description type="DescriptionField"/>
             </destination>
         </destinations>

--- a/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
+++ b/src/opnsense/service/templates/OPNsense/Syslog/syslog-ng-destinations.conf
@@ -27,6 +27,9 @@ destination d_{{dest_key}} {
         "{{destination.hostname}}"
         transport("{{destination.transport[:3]}}")
         port({{destination.port}})
+{%             if destination.localip|default("") != "" %}
+        localip("{{destination.localip}}")
+{%             endif %}
         ip-protocol({{destination.transport[3]}})
 {%             if destination.rfc5424|default('0') == '1' %}
         flags(syslog-protocol)


### PR DESCRIPTION
We ran into a problem where remote syslog from branch offices won't be sent through an IPSEC tunnel to the central log server. 
Solution to this issue is binding syslog-ng's source to a specific ip using syslog-ng's "localip" option.

