### PR TITLE
Handle dev.pchtherm temperatures in the thermal dashboard widget

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -240,13 +240,16 @@ class SystemController extends ApiControllerBase
             $tempItem['temperature'] = trim(str_replace('C', '', $value));
             $tempItem['type_translated'] = gettext('CPU');
             $tempItem['type'] = 'cpu';
-            if (strpos($tempItem['device'], 'hw.acpi') !== false) {
+            if (str_starts_with($tempItem['device'], 'hw.acpi') !== false) {
                 $tempItem['type_translated'] = gettext('Zone');
                 $tempItem['type'] = 'zone';
             /* XXX may or may not be a good idea */
-            } elseif (strpos($tempItem['device'], 'dev.amdtemp') !== false) {
+            } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp') !== false) {
                 $tempItem['type_translated'] = gettext('AMD');
                 $tempItem['type'] = 'amd';
+            } else if (str_starts_with($tempItem['device'], 'dev.pchtherm') !== false) {
+                $tempItem['type'] = 'pch';
+                $tempItem['type_translated'] = gettext('Platform');
             }
             $result[] = $tempItem;
         }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -246,7 +246,7 @@ class SystemController extends ApiControllerBase
             } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp.')) {
                 $tempItem['type_translated'] = gettext('AMD');
                 $tempItem['type'] = 'amd';
-            } else if (str_starts_with($tempItem['device'], 'dev.pchtherm') !== false) {
+            } else if (str_starts_with($tempItem['device'], 'dev.pchtherm.')) {
                 $tempItem['type'] = 'pch';
                 $tempItem['type_translated'] = gettext('Platform');
             }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -247,7 +247,7 @@ class SystemController extends ApiControllerBase
                 $tempItem['type_translated'] = gettext('AMD');
                 $tempItem['type'] = 'amd';
             } else if (str_starts_with($tempItem['device'], 'dev.pchtherm.')) {
-                $tempItem['type'] = 'pch';
+                $tempItem['type'] = 'platform';
                 $tempItem['type_translated'] = gettext('Platform');
             }
             $result[] = $tempItem;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -243,7 +243,6 @@ class SystemController extends ApiControllerBase
             if (str_starts_with($tempItem['device'], 'hw.acpi.')) {
                 $tempItem['type_translated'] = gettext('Zone');
                 $tempItem['type'] = 'zone';
-            /* XXX may or may not be a good idea */
             } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp') !== false) {
                 $tempItem['type_translated'] = gettext('AMD');
                 $tempItem['type'] = 'amd';

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -240,7 +240,7 @@ class SystemController extends ApiControllerBase
             $tempItem['temperature'] = trim(str_replace('C', '', $value));
             $tempItem['type_translated'] = gettext('CPU');
             $tempItem['type'] = 'cpu';
-            if (str_starts_with($tempItem['device'], 'hw.acpi') !== false) {
+            if (str_starts_with($tempItem['device'], 'hw.acpi.')) {
                 $tempItem['type_translated'] = gettext('Zone');
                 $tempItem['type'] = 'zone';
             /* XXX may or may not be a good idea */

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -243,7 +243,7 @@ class SystemController extends ApiControllerBase
             if (str_starts_with($tempItem['device'], 'hw.acpi.')) {
                 $tempItem['type_translated'] = gettext('Zone');
                 $tempItem['type'] = 'zone';
-            } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp') !== false) {
+            } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp.')) {
                 $tempItem['type_translated'] = gettext('AMD');
                 $tempItem['type'] = 'amd';
             } else if (str_starts_with($tempItem['device'], 'dev.pchtherm') !== false) {


### PR DESCRIPTION
on my system, supermicro X11SCL-iF, PCH temperature is reported and get identified as a CPU.

```
# /usr/local/opnsense/scripts/system/temperature.sh
dev.cpu.0.temperature=48.0C
dev.cpu.1.temperature=46.0C
dev.cpu.2.temperature=45.0C
dev.cpu.3.temperature=46.0C
dev.pchtherm.0.temperature=45.0C
hw.acpi.thermal.tz0.temperature=27.9C
```

this PR adds additional parsing to identify this temperature sysctl.