### PR TITLE
feat(dhcp): add dhcp-socket-type option to Kea DHCP server

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
@@ -28,6 +28,12 @@
         <help>Automatically add a basic set of firewall rules to allow dhcp traffic, more fine grained controls can be offered manually when disabling this option.</help>
     </field>
     <field>
+        <id>dhcpv4.general.dhcp_socket_type</id>
+        <label>Socket Type</label>
+        <type>dropdown</type>
+        <help>Socket type used for DHCP communication</help>
+    </field>
+    <field>
         <type>header</type>
         <label>High Availability</label>
     </field>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -189,7 +189,8 @@ class KeaDhcpv4 extends BaseModel
             'Dhcp4' => [
                 'valid-lifetime' => (int)$this->general->valid_lifetime->__toString(),
                 'interfaces-config' => [
-                    'interfaces' => $this->getConfigPhysicalInterfaces()
+                    'interfaces' => $this->getConfigPhysicalInterfaces(),
+                    'dhcp-socket-type' => (string)$this->general->dhcp_socket_type
                 ],
                 'lease-database' => [
                     'type' => 'memfile',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -20,7 +20,7 @@
                 <Default>1</Default>
             </fwrules>
             <dhcp_socket_type type="OptionField">
-                <Default>udp</Default>
+                <Default>raw</Default>
                 <Required>Y</Required>
                 <OptionValues>
                     <udp>udp</udp>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -19,6 +19,14 @@
                 <Required>Y</Required>
                 <Default>1</Default>
             </fwrules>
+            <dhcp_socket_type type="OptionField">
+                <Default>udp</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <udp>udp</udp>
+                    <raw>raw</raw>
+                </OptionValues>
+            </dhcp_socket_type>
         </general>
         <ha>
             <enabled type="BooleanField">

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>


### PR DESCRIPTION
This adds the ability to configure the DHCP socket type (UDP/Raw) in the Kea DHCP server settings through the web UI.

- Added socket type field to model definition
- Added dropdown in general settings form
- Updated config generation to include socket type setting