### PR TITLE
monit: wrap exec in double quotes to allow arguments

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Monit/monitrc
+++ b/src/opnsense/service/templates/OPNsense/Monit/monitrc
@@ -147,7 +147,7 @@ check {{ service.type }} {{ service.name }} {{ path }}
 {%       if test.condition is defined and test.action is defined %}
 {%        set epath = '' %}
 {%        if test.action == 'exec' and test.path|default('') != '' %}
-{%         set epath = test.path %}
+{%         set epath = "\"" ~ test.path ~ "\"" %}
 {%        endif %}
    if {{ test.condition }} then {{ test.action }} {{ epath }}
 {%       endif %}


### PR DESCRIPTION
Currently, if you want to execute command with arguments, you have to create a script somewhere on filesystem, then specify path to it in the Execute parameter.
With this patch, it's possible to pass command line arguments as part of Execute string, e.g. `/sbin/ifconfig wg0 down`.

From [monit documentation](https://mmonit.com/monit/documentation/monit.html#ACTION):

> EXEC can be used to execute an arbitrary program and send an alert. If you choose this action you must state the program to be executed and if the program requires arguments you must enclose the program and its arguments in a quoted string