### PR TITLE
Update temperature.sh for smaller CPU footprint 

### DIFF
--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -1316,10 +1316,6 @@ if (!interface_ppps_capable($a_interfaces[$if], $a_ppps)) {
     /* do not offer these raw types as a transition back from PPP */
     $types4['staticv4'] = gettext('Static IPv4');
     $types4['dhcp'] = gettext('DHCP');
-
-    /* XXX only offer PPPoE for inline creation */
-    $types4['pppoe'] = gettext('PPPoE');
-    $types6['pppoev6'] = gettext('PPPoEv6');
 } else {
     switch ($a_ppps[$pppid]['type']) {
         case 'ppp':


### PR DESCRIPTION
Update temperature.sh for smaller CPU footprint
This patch eliminates many lines of output from sysctl and searches it much faster, because there is no regex matching.

This results in a smaller CPU footprint, thus reducing the impact of temperature monitoring itself on the reported temps, without changing the outcome.

See also: https://forum.opnsense.org/index.php?topic=36234.0