### PR TITLE
dashboard: Add certificate widget that displays CAs and Certs sorted by expiration date

### DIFF
--- a/plist
+++ b/plist
@@ -2070,6 +2070,7 @@
 /usr/local/opnsense/www/js/widgets/BaseTableWidget.js
 /usr/local/opnsense/www/js/widgets/BaseWidget.js
 /usr/local/opnsense/www/js/widgets/Carp.js
+/usr/local/opnsense/www/js/widgets/Certificates.js
 /usr/local/opnsense/www/js/widgets/Cpu.js
 /usr/local/opnsense/www/js/widgets/Disk.js
 /usr/local/opnsense/www/js/widgets/Firewall.js

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
@@ -142,7 +142,7 @@ class CaController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             'ca',
-            ['refid', 'descr', 'caref', 'name', 'refcount', 'valid_from', 'valid_to'],
+            ['uuid', 'refid', 'descr', 'caref', 'name', 'refcount', 'valid_from', 'valid_to'],
         );
     }
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
@@ -186,7 +186,7 @@ class CertController extends ApiMutableModelControllerBase
         return $this->searchBase(
             'cert',
             [
-                'refid', 'descr', 'caref', 'rfc3280_purpose', 'name',
+                'uuid', 'refid', 'descr', 'caref', 'rfc3280_purpose', 'name',
                 'valid_from', 'valid_to' , 'in_use', 'is_user', 'commonname'
             ],
             null,

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -160,6 +160,29 @@
                 }
             }
         });
+
+        /* For certificate dashboard widget */
+        function handleSearchPhrase(hashKey, searchFieldSelector) {
+            const hash = window.location.hash;
+            const searchField = $(searchFieldSelector);
+
+            if (hash.includes(hashKey)) {
+                const searchPhrase = decodeURIComponent(hash.split('=')[1]);
+                if (searchField.val() !== searchPhrase) {
+                    searchField.val(searchPhrase).trigger('keyup');
+                    history.replaceState(null, null, window.location.pathname + window.location.search);
+                }
+            }
+        }
+
+        grid_cert.on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchPhrase('#SearchPhrase=', '.search-field');
+        });
+
+        $(window).on('hashchange', function () {
+            handleSearchPhrase('#SearchPhrase=', '.search-field');
+        });
+
     });
 
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -162,26 +162,31 @@
         });
 
         /* For certificate dashboard widget */
-        function handleSearchPhrase(hashKey, searchFieldSelector) {
+        function handleSearchAndEdit() {
             const hash = window.location.hash;
-            const searchField = $(searchFieldSelector);
 
-            if (hash.includes(hashKey)) {
+            if (hash.includes('#SearchPhrase=')) {
                 const searchPhrase = decodeURIComponent(hash.split('=')[1]);
+                const searchField = $('.search-field');
+
                 if (searchField.val() !== searchPhrase) {
                     searchField.val(searchPhrase).trigger('keyup');
+
+                    // Wait for grid to reload after search and simulate edit button click
+                    $('#grid-cert').one("loaded.rs.jquery.bootgrid", function () {
+                        const editButton = $(`#grid-cert .command-edit[data-row-id="${searchPhrase}"]`);
+                        if (editButton.length) {
+                            editButton.trigger('click');
+                        }
+                    });
+
                     history.replaceState(null, null, window.location.pathname + window.location.search);
                 }
             }
         }
 
-        grid_cert.on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchPhrase('#SearchPhrase=', '.search-field');
-        });
-
-        $(window).on('hashchange', function () {
-            handleSearchPhrase('#SearchPhrase=', '.search-field');
-        });
+        $('#grid-cert').on("loaded.rs.jquery.bootgrid", handleSearchAndEdit);
+        $(window).on('hashchange', handleSearchAndEdit);
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -282,26 +282,31 @@
         });
 
         /* For certificate dashboard widget */
-        function handleSearchPhrase(hashKey, searchFieldSelector) {
+        function handleSearchAndEdit() {
             const hash = window.location.hash;
-            const searchField = $(searchFieldSelector);
 
-            if (hash.includes(hashKey)) {
+            if (hash.includes('#SearchPhrase=')) {
                 const searchPhrase = decodeURIComponent(hash.split('=')[1]);
+                const searchField = $('.search-field');
+
                 if (searchField.val() !== searchPhrase) {
                     searchField.val(searchPhrase).trigger('keyup');
+
+                    // Wait for grid to reload after search and simulate edit button click
+                    $('#grid-cert').one("loaded.rs.jquery.bootgrid", function () {
+                        const editButton = $(`#grid-cert .command-edit[data-row-id="${searchPhrase}"]`);
+                        if (editButton.length) {
+                            editButton.trigger('click');
+                        }
+                    });
+
                     history.replaceState(null, null, window.location.pathname + window.location.search);
                 }
             }
         }
 
-        grid_cert.on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchPhrase('#SearchPhrase=', '.search-field');
-        });
-
-        $(window).on('hashchange', function () {
-            handleSearchPhrase('#SearchPhrase=', '.search-field');
-        });
+        $('#grid-cert').on("loaded.rs.jquery.bootgrid", handleSearchAndEdit);
+        $(window).on('hashchange', handleSearchAndEdit);
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -281,6 +281,28 @@
             }
         });
 
+        /* For certificate dashboard widget */
+        function handleSearchPhrase(hashKey, searchFieldSelector) {
+            const hash = window.location.hash;
+            const searchField = $(searchFieldSelector);
+
+            if (hash.includes(hashKey)) {
+                const searchPhrase = decodeURIComponent(hash.split('=')[1]);
+                if (searchField.val() !== searchPhrase) {
+                    searchField.val(searchPhrase).trigger('keyup');
+                    history.replaceState(null, null, window.location.pathname + window.location.search);
+                }
+            }
+        }
+
+        grid_cert.on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchPhrase('#SearchPhrase=', '.search-field');
+        });
+
+        $(window).on('hashchange', function () {
+            handleSearchPhrase('#SearchPhrase=', '.search-field');
+        });
+
     });
 
 </script>

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -109,6 +109,10 @@ export default class Certificates extends BaseTableWidget {
                 const statusText = remainingDays === 0 ? this.translations.expired : this.translations.valid;
                 const iconClass = remainingDays === 0 ? 'fa fa-unlock' : 'fa fa-lock';
 
+                const expirationText = remainingDays === 0
+                    ? `${this.translations.expiredon} ${validTo.toLocaleString()}`
+                    : `${this.translations.expiresin} ${remainingDays} ${this.translations.days}, ${validTo.toLocaleString()}`;
+
                 const row = `
                     <div>
                         <i class="${iconClass} ${colorClass} certificate-tooltip" style="cursor: pointer;"
@@ -118,8 +122,7 @@ export default class Certificates extends BaseTableWidget {
                         <span><b>${item.descr}</b></span>
                         <br/>
                         <div style="margin-top: 5px; margin-bottom: 5px;">
-                            <i>${this.translations.expires}</i> ${remainingDays} ${this.translations.days},
-                            ${validTo.toLocaleString()}
+                            ${expirationText}
                         </div>
                     </div>`;
                 rows.push({ html: row, expirationDate: validTo });

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -92,7 +92,7 @@ export default class Certificates extends BaseTableWidget {
                     : `${this.translations.expiresin} ${remainingDays} ${this.translations.days}, ${validTo.toLocaleString()}`;
 
                 const descrContent = (type === 'cert' || type === 'ca')
-                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#SearchPhrase=${encodeURIComponent(item.descr)}" class="${type}-link">${item.descr}</a>`
+                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#SearchPhrase=${encodeURIComponent(item.uuid)}" class="${type}-link">${item.descr}</a>`
                     : `<b>${item.descr}</b>`;
 
                 const row = `

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -141,7 +141,6 @@ export default class Certificates extends BaseTableWidget {
         $('.certificate-tooltip').tooltip('hide');
 
         const hiddenItems = config.hiddenItems || [];
-        console.log("Hidden Items:", hiddenItems);
         const rows = [];
 
         if (cas.length > 0) {

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -28,7 +28,7 @@ export default class Certificates extends BaseTableWidget {
 
     constructor(config) {
         super(config);
-        this.tickTimeout = 30;
+        this.tickTimeout = 180;
         this.configurable = true;
         this.configChanged = false;
     }
@@ -141,6 +141,7 @@ export default class Certificates extends BaseTableWidget {
         $('.certificate-tooltip').tooltip('hide');
 
         const hiddenItems = config.hiddenItems || [];
+        console.log("Hidden Items:", hiddenItems);
         const rows = [];
 
         if (cas.length > 0) {
@@ -177,7 +178,6 @@ export default class Certificates extends BaseTableWidget {
 
         let apacheRows = [];
 
-        // Use endpointExists to check for Apache endpoint availability
         if (await this.endpointExists('/api/apache/gateway/certs')) {
             const apacheResponse = await this.ajaxCall('/api/apache/gateway/certs');
             apacheRows = apacheResponse.rows || [];
@@ -187,19 +187,19 @@ export default class Certificates extends BaseTableWidget {
 
         if (caResponse.rows) {
             caResponse.rows.forEach(ca => {
-                hiddenItemOptions.push({ value: `ca-${ca.descr}`, label: ca.descr });
+                hiddenItemOptions.push({ value: `${ca.descr}`, label: ca.descr });
             });
         }
 
         if (certResponse.rows) {
             certResponse.rows.forEach(cert => {
-                hiddenItemOptions.push({ value: `cert-${cert.descr}`, label: cert.descr });
+                hiddenItemOptions.push({ value: `${cert.descr}`, label: cert.descr });
             });
         }
 
         if (apacheRows.length > 0) {
             apacheRows.forEach(cert => {
-                hiddenItemOptions.push({ value: `apache-${cert.descr}`, label: cert.descr });
+                hiddenItemOptions.push({ value: `${cert.descr}`, label: cert.descr });
             });
         }
 
@@ -216,6 +216,7 @@ export default class Certificates extends BaseTableWidget {
 
     async onWidgetOptionsChanged() {
         this.configChanged = true;
+        await this.onWidgetTick();
     }
 }
 

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -91,13 +91,17 @@ export default class Certificates extends BaseTableWidget {
                     ? `${this.translations.expiredon} ${validTo.toLocaleString()}`
                     : `${this.translations.expiresin} ${remainingDays} ${this.translations.days}, ${validTo.toLocaleString()}`;
 
+                const descrContent = (type === 'cert' || type === 'ca')
+                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#SearchPhrase=${encodeURIComponent(item.descr)}" class="${type}-link">${item.descr}</a>`
+                    : `<b>${item.descr}</b>`;
+
                 const row = `
                     <div>
                         <i class="${iconClass} ${colorClass} certificate-tooltip" style="cursor: pointer;"
                             data-tooltip="${type}-${item.descr}" title="${statusText}">
                         </i>
                         &nbsp;
-                        <span><b>${item.descr}</b></span>
+                        <span>${descrContent}</span>
                         <br/>
                         <div style="margin-top: 5px; margin-bottom: 5px;">
                             ${expirationText}
@@ -182,4 +186,3 @@ export default class Certificates extends BaseTableWidget {
         await this.onWidgetTick();
     }
 }
-

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2024 Cedrik Pischem
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export default class Certificates extends BaseTableWidget {
+
+    constructor(config) {
+        super(config);
+        this.configurable = true;
+        this.configChanged = false;
+    }
+
+    getGridOptions() {
+        return {
+            sizeToContent: 650
+        };
+    }
+
+    getMarkup() {
+        const $container = $('<div></div>');
+        const $certificateTable = this.createTable('certificateTable', {
+            headerPosition: 'none'
+        });
+
+        $container.append($certificateTable);
+        return $container;
+    }
+
+    async onWidgetTick() {
+        const cas = (await this.ajaxCall('/api/trust/ca/search')).rows || [];
+        const certs = (await this.ajaxCall('/api/trust/cert/search')).rows || [];
+
+        if (cas.length === 0 && certs.length === 0) {
+            this.displayError(`${this.translations.noitems}`);
+            return;
+        }
+
+        this.clearError();
+        await this.processCertificates(cas, certs);
+    }
+
+    displayError(message) {
+        const $error = $(`<div class="error-message">${message}</div>`);
+        $('#certificateTable').empty().append($error);
+    }
+
+    clearError() {
+        $('#certificateTable .error-message').remove();
+    }
+
+    processItems(items, type, hiddenItems, rows) {
+        items.forEach(item => {
+            if (!hiddenItems.includes(item.descr)) {
+                const validTo = new Date(parseInt(item.valid_to) * 1000);
+                const now = new Date();
+                const remainingDays = Math.max(0, Math.floor((validTo - now) / (1000 * 60 * 60 * 24)));
+
+                const colorClass = remainingDays === 0
+                    ? 'text-danger'
+                    : remainingDays < 14
+                        ? 'text-warning'
+                        : 'text-success';
+
+                const statusText = remainingDays === 0 ? this.translations.expired : this.translations.valid;
+
+                const row = `
+                    <div>
+                        <i class="fa fa-lock ${colorClass} certificate-tooltip" style="cursor: pointer;"
+                            data-tooltip="${type}-${item.descr}" title="${statusText}">
+                        </i>
+                        &nbsp;
+                        <span><b>${item.descr}${type === 'ca' ? ' (CA)' : ''}</b></span>
+                        <br/>
+                        <div style="margin-top: 5px; margin-bottom: 5px;">
+                            <i>${this.translations.expires}</i> ${remainingDays} ${this.translations.days},
+                            ${validTo.toLocaleString()}
+                        </div>
+                    </div>`;
+                rows.push({ html: row, expirationDate: validTo });
+            }
+        });
+    }
+
+    async processCertificates(cas, certs) {
+        const config = await this.getWidgetConfig() || {};
+
+        if (!this.dataChanged('certificates', { cas, certs }) && !this.configChanged) {
+            return;
+        }
+
+        if (this.configChanged) {
+            this.configChanged = false;
+        }
+
+        $('.certificate-tooltip').tooltip('hide');
+
+        const hiddenItems = config.hiddenItems || [];
+        const rows = [];
+
+        if (cas.length > 0) {
+            this.processItems(cas, 'ca', hiddenItems, rows);
+        }
+        if (certs.length > 0) {
+            this.processItems(certs, 'cert', hiddenItems, rows);
+        }
+
+        if (rows.length === 0) {
+            this.displayError(`${this.translations.noitems}`);
+            return;
+        }
+
+        // Sort rows by expiration date from earliest to latest
+        rows.sort((a, b) => a.expirationDate - b.expirationDate);
+
+        const sortedRows = rows.map(row => [row.html]);
+        super.updateTable('certificateTable', sortedRows);
+
+        $('.certificate-tooltip').tooltip({ container: 'body' });
+    }
+
+    async getWidgetOptions() {
+        const [caResponse, certResponse] = await Promise.all([
+            this.ajaxCall('/api/trust/ca/search'),
+            this.ajaxCall('/api/trust/cert/search')
+        ]);
+
+        const hiddenItemOptions = [];
+
+        if (caResponse.rows) {
+            caResponse.rows.forEach(ca => {
+                hiddenItemOptions.push({ value: ca.descr, label: `${ca.descr} (CA)` });
+            });
+        }
+
+        if (certResponse.rows) {
+            certResponse.rows.forEach(cert => {
+                hiddenItemOptions.push({ value: cert.descr, label: cert.descr });
+            });
+        }
+
+        return {
+            hiddenItems: {
+                title: this.translations.hiddenitems,
+                type: 'select_multiple',
+                options: hiddenItemOptions,
+                default: [],
+                required: false
+            }
+        };
+    }
+
+    async onWidgetOptionsChanged() {
+        this.configChanged = true;
+    }
+}

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -360,7 +360,8 @@
             <noitems>No certificates to display.</noitems>
             <expired>Expired</expired>
             <valid>Valid</valid>
-            <expires>Expires in</expires>
+            <expiresin>Expires in</expiresin>
+            <expiredon>Expired on</expiredon>
             <days>days</days>
             <hiddenitems>Hidden Certificates</hiddenitems>
         </translations>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -348,4 +348,21 @@
             <nopicture>No picture was supplied for this system.</nopicture>
         </translations>
     </picture>
+    <certificates>
+        <filename>Certificates.js</filename>
+        <link>/ui/trust/cert</link>
+        <endpoints>
+            <endpoint>/api/trust/ca/search</endpoint>
+            <endpoint>/api/trust/cert/search</endpoint>
+        </endpoints>
+        <translations>
+            <title>Certificates</title>
+            <noitems>No certificates to display.</noitems>
+            <expired>Expired</expired>
+            <valid>Valid</valid>
+            <expires>Expires in</expires>
+            <days>days</days>
+            <hiddenitems>Hidden Certificates</hiddenitems>
+        </translations>
+    </certificates>
 </metadata>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/7898

Adds a widget that pulls all CA and Certificates from the trust store API and displays them sorted by expiration date.

- Certificates with more than 14 days show a green lock
- with less than 14 days show yellow lock
- with no days left show red log and expired

An additional self populating dropdown allows to configure the plugin, hiding certificates.
The default is displaying all existing certificates.