### PR TITLE
dashboard: Improved widget links with automatic edit and/or search

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
@@ -69,7 +69,7 @@ class ClientController extends ApiMutableModelControllerBase
 
         return $this->searchBase(
             'clients.client',
-            ["uuid", "enabled", "name", "pubkey", "tunneladdress", "serveraddress", "serverport", "servers"],
+            ["enabled", "name", "pubkey", "tunneladdress", "serveraddress", "serverport", "servers"],
             null,
             $filter_funct
         );

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
@@ -69,7 +69,7 @@ class ClientController extends ApiMutableModelControllerBase
 
         return $this->searchBase(
             'clients.client',
-            ["enabled", "name", "pubkey", "tunneladdress", "serveraddress", "serverport", "servers"],
+            ["uuid", "enabled", "name", "pubkey", "tunneladdress", "serveraddress", "serverport", "servers"],
             null,
             $filter_funct
         );

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
@@ -116,6 +116,15 @@
         });
 
         updateServiceControlUI('ipsec');
+
+        /* for ipsec tunnels widget */
+        $('#grid-phase1').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-phase1');
+        });
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-phase1');
+        });
+
     });
 
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
@@ -121,9 +121,6 @@
         $('#grid-phase1').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-phase1');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-phase1');
-        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/sessions.volt
@@ -117,11 +117,8 @@
 
         updateServiceControlUI('ipsec');
 
-        /* for ipsec tunnels widget */
-        $('#grid-phase1').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-phase1');
-        });
-
+        /* for ipsec widget */
+        handleSearchAndEdit('#grid-phase1');
     });
 
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
@@ -72,6 +72,15 @@
         });
 
         $("#reconfigureAct").SimpleActionButton();
+
+        /* for carp widget */
+        $('#grid-vips').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-vips');
+        });
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-vips');
+        });
+
     });
 </script>
 <div class="tab-content content-box">

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
@@ -77,9 +77,6 @@
         $('#grid-vips').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-vips');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-vips');
-        });
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/vip.volt
@@ -74,9 +74,7 @@
         $("#reconfigureAct").SimpleActionButton();
 
         /* for carp widget */
-        $('#grid-vips').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-vips');
-        });
+        handleSearchAndEdit('#grid-vips');
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
@@ -101,6 +101,15 @@
         });
 
         $("#type_filter_container").detach().prependTo('#grid-sessions-header > .row > .actionBar > .actions');
+
+        /* for openvpn widgets */
+        $('#grid-sessions').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-sessions');
+        });
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-sessions');
+        });
+
     });
 
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
@@ -106,9 +106,6 @@
         $('#grid-sessions').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-sessions');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-sessions');
-        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/OpenVPN/status.volt
@@ -103,9 +103,7 @@
         $("#type_filter_container").detach().prependTo('#grid-sessions-header > .row > .actionBar > .actions');
 
         /* for openvpn widgets */
-        $('#grid-sessions').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-sessions');
-        });
+        handleSearchAndEdit('#grid-sessions');
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
@@ -95,9 +95,6 @@
         $('#grid-gateways').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-gateways');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-gateways');
-        });
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
@@ -92,9 +92,7 @@
         $("#reconfigureAct").SimpleActionButton();
 
         /* for gateway widget */
-        $('#grid-gateways').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-gateways');
-        });
+        handleSearchAndEdit('#grid-gateways');
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Routing/configuration.volt
@@ -90,6 +90,15 @@
         });
 
         $("#reconfigureAct").SimpleActionButton();
+
+        /* for gateway widget */
+        $('#grid-gateways').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-gateways');
+        });
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-gateways');
+        });
+
     });
 </script>
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -161,32 +161,14 @@
             }
         });
 
-        /* For certificate dashboard widget */
-        function handleSearchAndEdit() {
-            const hash = window.location.hash;
+        /* for certificate widget */
+        $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-cert');
+        });
 
-            if (hash.includes('#SearchPhrase=')) {
-                const searchPhrase = decodeURIComponent(hash.split('=')[1]);
-                const searchField = $('.search-field');
-
-                if (searchField.val() !== searchPhrase) {
-                    searchField.val(searchPhrase).trigger('keyup');
-
-                    // Wait for grid to reload after search and simulate edit button click
-                    $('#grid-cert').one("loaded.rs.jquery.bootgrid", function () {
-                        const editButton = $(`#grid-cert .command-edit[data-row-id="${searchPhrase}"]`);
-                        if (editButton.length) {
-                            editButton.trigger('click');
-                        }
-                    });
-
-                    history.replaceState(null, null, window.location.pathname + window.location.search);
-                }
-            }
-        }
-
-        $('#grid-cert').on("loaded.rs.jquery.bootgrid", handleSearchAndEdit);
-        $(window).on('hashchange', handleSearchAndEdit);
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-cert');
+        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -165,9 +165,6 @@
         $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-cert');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-cert');
-        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -162,9 +162,7 @@
         });
 
         /* for certificate widget */
-        $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-cert');
-        });
+        handleSearchAndEdit('#grid-cert');
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/ca.volt
@@ -165,7 +165,6 @@
         $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-cert');
         });
-
         $(window).on('hashchange', function () {
             handleSearchAndEdit('#grid-cert');
         });

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -285,9 +285,6 @@
         $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-cert');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-cert');
-        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -281,32 +281,14 @@
             }
         });
 
-        /* For certificate dashboard widget */
-        function handleSearchAndEdit() {
-            const hash = window.location.hash;
+        /* for certificate widget */
+        $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-cert');
+        });
 
-            if (hash.includes('#SearchPhrase=')) {
-                const searchPhrase = decodeURIComponent(hash.split('=')[1]);
-                const searchField = $('.search-field');
-
-                if (searchField.val() !== searchPhrase) {
-                    searchField.val(searchPhrase).trigger('keyup');
-
-                    // Wait for grid to reload after search and simulate edit button click
-                    $('#grid-cert').one("loaded.rs.jquery.bootgrid", function () {
-                        const editButton = $(`#grid-cert .command-edit[data-row-id="${searchPhrase}"]`);
-                        if (editButton.length) {
-                            editButton.trigger('click');
-                        }
-                    });
-
-                    history.replaceState(null, null, window.location.pathname + window.location.search);
-                }
-            }
-        }
-
-        $('#grid-cert').on("loaded.rs.jquery.bootgrid", handleSearchAndEdit);
-        $(window).on('hashchange', handleSearchAndEdit);
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-cert');
+        });
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -282,9 +282,7 @@
         });
 
         /* for certificate widget */
-        $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-cert');
-        });
+        handleSearchAndEdit('#grid-cert');
 
     });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -285,7 +285,6 @@
         $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-cert');
         });
-
         $(window).on('hashchange', function () {
             handleSearchAndEdit('#grid-cert');
         });

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -265,9 +265,7 @@
         });
 
         /* for wireguard widget */
-        $('#grid-peers').on("loaded.rs.jquery.bootgrid", function () {
-            handleSearchAndEdit('#grid-peers');
-        });
+        handleSearchAndEdit('#grid-peers');
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -268,9 +268,6 @@
         $('#grid-peers').on("loaded.rs.jquery.bootgrid", function () {
             handleSearchAndEdit('#grid-peers');
         });
-        $(window).on('hashchange', function () {
-            handleSearchAndEdit('#grid-peers');
-        });
 
     });
 </script>

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -263,6 +263,15 @@
         $(window).on('hashchange', function(e) {
             $('a[href="' + window.location.hash + '"]').click()
         });
+
+        /* for wireguard widget */
+        $('#grid-peers').on("loaded.rs.jquery.bootgrid", function () {
+            handleSearchAndEdit('#grid-peers');
+        });
+        $(window).on('hashchange', function () {
+            handleSearchAndEdit('#grid-peers');
+        });
+
     });
 </script>
 

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -609,6 +609,9 @@ $.fn.UIBootgrid = function (params) {
                 });
             });
 
+            // expose grid instance for external events
+            $(this).data('_instance', grid);
+
             return grid;
         }
     }));

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -730,14 +730,18 @@ $.fn.SimpleFileUploadDlg = function (params) {
  *      }
  * @param {*} params data structure to use for the select picker
  */
-$.fn.replaceInputWithSelector = function (data) {
+$.fn.replaceInputWithSelector = function (data, multiple=false) {
     let that = this;
     this.new_item = function() {
         let $div = $("<div/>");
         let $table = $('<table style="max-width: 348px"/>');
+        let $select = $('<select data-live-search="true" data-size="5" data-width="348px"/>');
+        if (multiple) {
+            $select.attr('multiple', 'multiple');
+        }
         $table.append(
             $("<tr/>").append(
-                $("<td/>").append($('<select data-live-search="true" data-size="5" data-width="348px"/>'))
+                $("<td/>").append($select)
             )
         );
         $table.append(
@@ -773,6 +777,9 @@ $.fn.replaceInputWithSelector = function (data) {
         $this_select.attr('for', $(this).attr('id')).selectpicker();
         $this_select.change(function(){
             let $value = $(this).val();
+            if (Array.isArray($value)) {
+                $value = $value.filter(value => value !== '').join(',');
+            }
             if ($value !== '') {
                 $this_input.val($value);
                 $this_input.hide();
@@ -782,8 +789,12 @@ $.fn.replaceInputWithSelector = function (data) {
         });
         $this_input.attr('id', $(this).attr('id'));
         $this_input.change(function(){
-            $this_select.val($(this).val());
-            if ($this_select.val() === null || $this_select.val() == '') {
+            if (multiple) {
+                $this_select.val($(this).val().split(','));
+            } else {
+                $this_select.val($(this).val());
+            }
+            if ($(this).val() === '' || $this_select.val() === null || $this_select.val() == '') {
                 $this_select.val('');
                 $this_input.show();
             } else {
@@ -797,7 +808,6 @@ $.fn.replaceInputWithSelector = function (data) {
     return this.each(function () {
         return $.proxy(that.construct, $(this))();
     });
-
 }
 
 /**

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -815,47 +815,53 @@ $.fn.replaceInputWithSelector = function (data, multiple=false) {
  * - Supports hashes with direct actions like "#edit=UUID" or "#search=UUID" without a tab.
  * - If the hash includes a tab name, & must be used (e.g., "#peers&edit=UUID").
  *
- * Example Usage:
- *     $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
- *         handleSearchAndEdit('#grid-cert');
- *     });
- *
  * @param {string} gridSelector - The selector for the grid to target (e.g., '#grid-cert').
  */
 function handleSearchAndEdit(gridSelector) {
-    const hash = window.location.hash.slice(1);
-    if (!hash) return;
+    let gridLoaded = false;
 
-    const splitIndex = hash.indexOf('&');
-    const tabName = splitIndex !== -1 ? hash.substring(0, splitIndex) : null;
-    const action = splitIndex !== -1 ? hash.substring(splitIndex + 1) : hash;
+    const processHash = () => {
+        if (!gridLoaded) return;
 
-    if (tabName) {
-        const tabElement = $(`a[href="#${tabName}"]`);
-        if (tabElement.length) {
-            tabElement.tab('show');
+        const hash = window.location.hash.slice(1);
+        if (!hash) return;
+
+        const splitIndex = hash.indexOf('&');
+        const tabName = splitIndex !== -1 ? hash.substring(0, splitIndex) : null;
+        const action = splitIndex !== -1 ? hash.substring(splitIndex + 1) : hash;
+
+        if (tabName) {
+            const tabElement = $(`a[href="#${tabName}"]`);
+            if (tabElement.length) {
+                tabElement.tab('show');
+            }
         }
-    }
 
-    if (action) {
-        const [prefix, rawPhrase] = action.includes('=') ? action.split('=') : [null, null];
-        const decodedPhrase = rawPhrase ? decodeURIComponent(rawPhrase.trim()) : null;
-        if (!decodedPhrase) return;
+        if (action) {
+            const [prefix, rawPhrase] = action.includes('=') ? action.split('=') : [null, null];
+            const decodedPhrase = rawPhrase ? decodeURIComponent(rawPhrase.trim()) : null;
+            if (!decodedPhrase) return;
 
-        if (prefix === 'edit') {
-            $(gridSelector).one("loaded.rs.jquery.bootgrid", function () {
+            if (prefix === 'edit') {
                 const editButton = $(`${gridSelector} .command-edit[data-row-id="${decodedPhrase}"]`);
                 if (editButton.length) {
                     editButton.trigger('click');
                 }
-            });
+            }
+
+            const searchField = $('.search-field');
+            if (searchField.val() !== decodedPhrase) {
+                searchField.val(decodedPhrase).trigger('keyup');
+            }
         }
 
-        const searchField = $('.search-field');
-        if (searchField.val() !== decodedPhrase) {
-            searchField.val(decodedPhrase).trigger('keyup');
-        }
-    }
+        history.replaceState(null, null, window.location.pathname + window.location.search);
+    };
 
-    history.replaceState(null, null, window.location.pathname + window.location.search);
+    $(gridSelector).one("loaded.rs.jquery.bootgrid", function () {
+        gridLoaded = true;
+        processHash();
+
+        $(window).on('hashchange', processHash);
+    });
 }

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -832,7 +832,6 @@ function handleSearchAndEdit(gridSelector) {
                 });
             }
 
-            history.replaceState(null, null, window.location.pathname + window.location.search);
         }
     }
 }

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -813,7 +813,7 @@ $.fn.replaceInputWithSelector = function (data, multiple=false) {
 /**
  * Processes URL hash to activate a tab and/or perform search or edit actions in a grid.
  * - Supports hashes with direct actions like "#edit=UUID" or "#search=UUID" without a tab.
- * - If the hash includes a tab name, $ must be used (e.g., "#peers$edit=UUID").
+ * - If the hash includes a tab name, & must be used (e.g., "#peers&edit=UUID").
  *
  * Example Usage:
  *     $('#grid-cert').on("loaded.rs.jquery.bootgrid", function () {
@@ -826,7 +826,7 @@ function handleSearchAndEdit(gridSelector) {
     const hash = window.location.hash.slice(1);
     if (!hash) return;
 
-    const splitIndex = hash.indexOf('$');
+    const splitIndex = hash.indexOf('&');
     const tabName = splitIndex !== -1 ? hash.substring(0, splitIndex) : null;
     const action = splitIndex !== -1 ? hash.substring(splitIndex + 1) : hash;
 

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -842,11 +842,6 @@ function handleSearchAndEdit(gridSelector) {
         const decodedPhrase = rawPhrase ? decodeURIComponent(rawPhrase.trim()) : null;
         if (!decodedPhrase) return;
 
-        const searchField = $('.search-field');
-        if (searchField.val() !== decodedPhrase) {
-            searchField.val(decodedPhrase).trigger('keyup');
-        }
-
         if (prefix === 'edit') {
             $(gridSelector).one("loaded.rs.jquery.bootgrid", function () {
                 const editButton = $(`${gridSelector} .command-edit[data-row-id="${decodedPhrase}"]`);
@@ -854,6 +849,11 @@ function handleSearchAndEdit(gridSelector) {
                     editButton.trigger('click');
                 }
             });
+        }
+
+        const searchField = $('.search-field');
+        if (searchField.val() !== decodedPhrase) {
+            searchField.val(decodedPhrase).trigger('keyup');
         }
     }
 

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -856,4 +856,6 @@ function handleSearchAndEdit(gridSelector) {
             });
         }
     }
+
+    history.replaceState(null, null, window.location.pathname + window.location.search);
 }

--- a/src/opnsense/www/js/widgets/Carp.js
+++ b/src/opnsense/www/js/widgets/Carp.js
@@ -71,7 +71,7 @@ export default class Carp extends BaseTableWidget {
                 return;
             }
 
-            let $intf = `<div><a href="/ui/interfaces/vip">${primary.interface} @ VHID ${primary.vhid}</a></div>`;
+            let $intf = `<div><a href="/ui/interfaces/vip#search=${primary.interface}">${primary.interface} @ VHID ${primary.vhid}</a></div>`;
             let vips = [
                 `<div>
                     <span class="badge badge-pill carp-status-icon"

--- a/src/opnsense/www/js/widgets/Carp.js
+++ b/src/opnsense/www/js/widgets/Carp.js
@@ -71,7 +71,11 @@ export default class Carp extends BaseTableWidget {
                 return;
             }
 
-            let $intf = `<div><a href="/ui/interfaces/vip#search=${primary.interface}">${primary.interface} @ VHID ${primary.vhid}</a></div>`;
+            let $intf = `<div>
+                <a href="/ui/interfaces/vip#search=${encodeURIComponent(primary.interface)}" target="_blank" rel="noopener noreferrer">
+                    ${primary.interface} @ VHID ${primary.vhid}
+                </a>
+            </div>`;
             let vips = [
                 `<div>
                     <span class="badge badge-pill carp-status-icon"

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -92,7 +92,7 @@ export default class Certificates extends BaseTableWidget {
                     : `${this.translations.expiresin} ${remainingDays} ${this.translations.days}, ${validTo.toLocaleString()}`;
 
                 const descrContent = (type === 'cert' || type === 'ca')
-                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#Edit=${encodeURIComponent(item.uuid)}" class="${type}-link">${item.descr}</a>`
+                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#edit=${encodeURIComponent(item.uuid)}" class="${type}-link">${item.descr}</a>`
                     : `<b>${item.descr}</b>`;
 
                 const row = `

--- a/src/opnsense/www/js/widgets/Certificates.js
+++ b/src/opnsense/www/js/widgets/Certificates.js
@@ -92,7 +92,7 @@ export default class Certificates extends BaseTableWidget {
                     : `${this.translations.expiresin} ${remainingDays} ${this.translations.days}, ${validTo.toLocaleString()}`;
 
                 const descrContent = (type === 'cert' || type === 'ca')
-                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#SearchPhrase=${encodeURIComponent(item.uuid)}" class="${type}-link">${item.descr}</a>`
+                    ? `<a href="/ui/trust/${type === 'cert' ? 'cert' : 'ca'}#Edit=${encodeURIComponent(item.uuid)}" class="${type}-link">${item.descr}</a>`
                     : `<b>${item.descr}</b>`;
 
                 const row = `

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -93,27 +93,22 @@ export default class Gateways extends BaseTableWidget {
         const config = await this.getWidgetConfig();
 
         let data = [];
-        gateways.forEach(({ uuid, name, gateway: address, status, loss, delay, stddev, status_translated }) => {
-            if (!config.gateways.includes(name)) {
+        gateways.forEach(({ uuid, name, gateway: address, status, loss, delay, stddev }) => {
+            if (!config.gateways.includes(uuid)) {
                 return;
             }
 
             let color = "text-success";
-            switch (status.toLowerCase()) {
-                case "force_down":
-                case "down":
-                    color = "text-danger";
-                    break;
-                case "loss":
-                case "delay":
-                case "delay+loss":
-                    color = "text-warning";
-                    break;
+
+            if (status.toLowerCase().includes("offline")) {
+                color = "text-danger";
+            } else if (status.toLowerCase() !== "online") {
+                color = "text-warning";
             }
 
             let gw = `<div>
                 <i class="fa fa-circle text-muted ${color} gateways-status-icon" style="font-size: 11px; cursor: pointer;"
-                    data-toggle="tooltip" title="${status_translated}">
+                    data-toggle="tooltip" title="${status}">
                 </i>
                 &nbsp;
                 <a href="/ui/routing/configuration#edit=${uuid}">${name}</a>

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -116,7 +116,7 @@ export default class Gateways extends BaseTableWidget {
                     data-toggle="tooltip" title="${status_translated}">
                 </i>
                 &nbsp;
-                <a href="/ui/routing/configuration#edit=${name}">${name}</a>
+                <a href="/ui/routing/configuration#search=${name}">${name}</a>
                 &nbsp;
                 <br/>
                 <div style="margin-top: 5px; margin-bottom: 5px; font-size: 15px;">${address}</div>

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -61,17 +61,19 @@ export default class Gateways extends BaseTableWidget {
     }
 
     async getWidgetOptions() {
+        const gateways = await this._fetchGateways();
+
         return {
             gateways: {
                 title: this.translations.title,
                 type: 'select_multiple',
-                options: this.cachedGateways.map(({ name, uuid }) => {
+                options: gateways.map(({ name, uuid }) => {
                     return {
                         value: uuid,
                         label: name,
                     };
                 }),
-                default: this.cachedGateways.map(({ uuid }) => uuid),
+                default: gateways.map(({ uuid }) => uuid),
             },
         };
     }

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -116,7 +116,7 @@ export default class Gateways extends BaseTableWidget {
                     data-toggle="tooltip" title="${status_translated}">
                 </i>
                 &nbsp;
-                <a href="/ui/routing/configuration">${name}</a>
+                <a href="/ui/routing/configuration#edit=${name}">${name}</a>
                 &nbsp;
                 <br/>
                 <div style="margin-top: 5px; margin-bottom: 5px; font-size: 15px;">${address}</div>

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -111,7 +111,9 @@ export default class Gateways extends BaseTableWidget {
                     data-toggle="tooltip" title="${status}">
                 </i>
                 &nbsp;
-                <a href="/ui/routing/configuration#edit=${uuid}">${name}</a>
+                <a href="/ui/routing/configuration#edit=${encodeURIComponent(uuid)}" target="_blank" rel="noopener noreferrer">
+                    ${name}
+                </a>
                 &nbsp;
                 <br/>
                 <div style="margin-top: 5px; margin-bottom: 5px; font-size: 15px;">${address}</div>

--- a/src/opnsense/www/js/widgets/IpsecTunnels.js
+++ b/src/opnsense/www/js/widgets/IpsecTunnels.js
@@ -157,7 +157,11 @@ export default class IpsecTunnels extends BaseTableWidget {
 
             let row = `
                 <div style="display: flex; justify-content: center; align-items: center;">
-                    <span><a href="/ui/ipsec/sessions#search=${tunnel.name}">${tunnel.localAddrs} | ${tunnel.remoteAddrs}</a></span>
+                <span>
+                    <a href="/ui/ipsec/sessions#search=${encodeURIComponent(tunnel.name)}" target="_blank" rel="noopener noreferrer">
+                        ${tunnel.localAddrs} | ${tunnel.remoteAddrs}
+                    </a>
+                </span>
                     ${connectDisconnectButton}
                 </div>
                 <div>

--- a/src/opnsense/www/js/widgets/IpsecTunnels.js
+++ b/src/opnsense/www/js/widgets/IpsecTunnels.js
@@ -102,6 +102,7 @@ export default class IpsecTunnels extends BaseTableWidget {
             bytesOut: tunnel['bytes-out'] != null && tunnel['bytes-out'] !== 0 ? this._formatBytes(tunnel['bytes-out']) : this.translations.notavailable,
             connected: tunnel.connected,
             ikeid: tunnel.ikeid,
+            name: tunnel.name,
             statusIcon: tunnel.connected ? 'fa-exchange text-success' : 'fa-exchange text-danger'
         }));
 
@@ -156,7 +157,7 @@ export default class IpsecTunnels extends BaseTableWidget {
 
             let row = `
                 <div style="display: flex; justify-content: center; align-items: center;">
-                    <span><a href="/ui/ipsec/sessions">${tunnel.localAddrs} | ${tunnel.remoteAddrs}</a></span>
+                    <span><a href="/ui/ipsec/sessions#search=${tunnel.name}">${tunnel.localAddrs} | ${tunnel.remoteAddrs}</a></span>
                     ${connectDisconnectButton}
                 </div>
                 <div>

--- a/src/opnsense/www/js/widgets/OpenVPNClients.js
+++ b/src/opnsense/www/js/widgets/OpenVPNClients.js
@@ -116,7 +116,7 @@ export default class OpenVPNClients extends BaseTableWidget {
                                    title="${client.status}">
                                 </i>
                                 &nbsp;
-                                <a href="/ui/openvpn/status">${client.common_name}</a>
+                                <a href="/ui/openvpn/status#search=${client.common_name}">${client.common_name}</a>
 
                                 <span class="ovpn-client-command ovpn-command-kill"
                                   data-row-id="${client.id}"

--- a/src/opnsense/www/js/widgets/OpenVPNClients.js
+++ b/src/opnsense/www/js/widgets/OpenVPNClients.js
@@ -146,7 +146,9 @@ export default class OpenVPNClients extends BaseTableWidget {
                     `));
                 });
             } else {
-                $clients = $(`<a href="/ui/openvpn/status">${this.translations.noclients}</a>`);
+                $clients = $(`<a href="/ui/openvpn/status#search=${encodeURIComponent(server.description)}" target="_blank" rel="noopener noreferrer">
+                    ${this.translations.noclients}
+                </a>`);
             }
 
             let clientInfo = server.clients ? `

--- a/src/opnsense/www/js/widgets/OpenVPNClients.js
+++ b/src/opnsense/www/js/widgets/OpenVPNClients.js
@@ -116,7 +116,9 @@ export default class OpenVPNClients extends BaseTableWidget {
                                    title="${client.status}">
                                 </i>
                                 &nbsp;
-                                <a href="/ui/openvpn/status#search=${client.common_name}">${client.common_name}</a>
+                                <a href="/ui/openvpn/status#search=${encodeURIComponent(client.common_name)}" target="_blank" rel="noopener noreferrer">
+                                    ${client.common_name}
+                                </a>
 
                                 <span class="ovpn-client-command ovpn-command-kill"
                                   data-row-id="${client.id}"

--- a/src/opnsense/www/js/widgets/OpenVPNServers.js
+++ b/src/opnsense/www/js/widgets/OpenVPNServers.js
@@ -86,7 +86,9 @@ export default class OpenVPNServers extends BaseTableWidget {
                         title="${server.status || this.translations.stopped}">
                     </i>
                     &nbsp;
-                    <a href="/ui/openvpn/status#search=${server.description}">${server.description || this.translations.client}</a>
+                    <a href="/ui/openvpn/status#search=${encodeURIComponent(server.description)}" target="_blank" rel="noopener noreferrer">
+                        ${server.description || this.translations.client}
+                    </a>
                     <i class="fa fa-arrows-h" style="font-size: 13px;"></i>
                     ${server.real_address || ''}
                 </div>

--- a/src/opnsense/www/js/widgets/OpenVPNServers.js
+++ b/src/opnsense/www/js/widgets/OpenVPNServers.js
@@ -86,7 +86,7 @@ export default class OpenVPNServers extends BaseTableWidget {
                         title="${server.status || this.translations.stopped}">
                     </i>
                     &nbsp;
-                    <a href="/ui/openvpn/status">${server.description || this.translations.client}</a>
+                    <a href="/ui/openvpn/status#search=${server.description}">${server.description || this.translations.client}</a>
                     <i class="fa fa-arrows-h" style="font-size: 13px;"></i>
                     ${server.real_address || ''}
                 </div>

--- a/src/opnsense/www/js/widgets/Wireguard.js
+++ b/src/opnsense/www/js/widgets/Wireguard.js
@@ -118,7 +118,11 @@ export default class Wireguard extends BaseTableWidget {
                 </div>`;
             let row = `
                 <div>
-                    <span><a href="/ui/wireguard/general#peers&search=${tunnel.name}">${tunnel.name}</a> | ${tunnel.allowed_ips}</span>
+                    <span>
+                        <a href="/ui/wireguard/general#peers&search=${encodeURIComponent(tunnel.name)}" target="_blank" rel="noopener noreferrer">
+                            ${tunnel.name}
+                        </a> | ${tunnel.allowed_ips}
+                    </span>
                 </div>
                 <div>
                     ${tunnel.latest_handshake_fmt

--- a/src/opnsense/www/js/widgets/Wireguard.js
+++ b/src/opnsense/www/js/widgets/Wireguard.js
@@ -61,14 +61,11 @@ export default class Wireguard extends BaseTableWidget {
             return;
         }
 
-        const clientData = await this.ajaxCall('/api/wireguard/client/get');
-        const uuidMapping = this.buildUuidMapping(clientData);
-
         if (!this.dataChanged('wg-tunnels', response.rows)) {
             return; // No changes detected, do not update the UI
         }
 
-        this.processTunnels(response.rows, uuidMapping);
+        this.processTunnels(response.rows);
     }
 
     displayError(message) {
@@ -77,43 +74,23 @@ export default class Wireguard extends BaseTableWidget {
         );
     }
 
-    buildUuidMapping(clientData) {
-        let mapping = {};
-        if (clientData && clientData.client && clientData.client.clients && clientData.client.clients.client) {
-            const clients = clientData.client.clients.client;
-            for (const [uuid, details] of Object.entries(clients)) {
-                if (details && details.pubkey) {
-                    // Map public key from client details to UUID
-                    mapping[details.pubkey] = uuid;
-                }
-            }
-        }
-        return mapping;
-    }
-
-    processTunnels(newTunnels, uuidMapping) {
+    processTunnels(newTunnels) {
         $('.wireguard-interface').tooltip('hide');
 
         let now = moment().unix(); // Current time in seconds
-        let tunnels = newTunnels
-            .filter(row => row.type == 'peer')
-            .map(row => {
-                const publicKey = row['public-key'];
-                const uuid = uuidMapping[publicKey] || '';
-                return {
-                    uuid: uuid,
-                    ifname: row.ifname ? row.if + ' (' + row.ifname + ') ' : row.if,
-                    name: row.name,
-                    allowed_ips: row['allowed-ips'] || this.translations.notavailable,
-                    rx: row['transfer-rx'] ? this._formatBytes(row['transfer-rx']) : this.translations.notavailable,
-                    tx: row['transfer-tx'] ? this._formatBytes(row['transfer-tx']) : this.translations.notavailable,
-                    latest_handshake: row['latest-handshake'], // No fallback since we handle if 0
-                    latest_handshake_fmt: row['latest-handshake'] ? moment.unix(row['latest-handshake']).local().format('YYYY-MM-DD HH:mm:ss') : null,
-                    connected: row['latest-handshake'] && (now - row['latest-handshake']) <= 180, // Considered online if last handshake was within 3 minutes
-                    statusIcon: row['latest-handshake'] && (now - row['latest-handshake']) <= 180 ? 'fa-exchange text-success' : 'fa-exchange text-danger',
-                    publicKey: publicKey,
-                };
-            });
+        let tunnels = newTunnels.filter(row => row.type == 'peer').map(row => ({
+            ifname: row.ifname ? row.if + ' (' + row.ifname + ') ' : row.if,
+            name: row.name,
+            allowed_ips: row['allowed-ips'] || this.translations.notavailable,
+            rx: row['transfer-rx'] ? this._formatBytes(row['transfer-rx']) : this.translations.notavailable,
+            tx: row['transfer-tx'] ? this._formatBytes(row['transfer-tx']) : this.translations.notavailable,
+            latest_handshake: row['latest-handshake'], // No fallback since we handle if 0
+            latest_handshake_fmt: row['latest-handshake'] ? moment.unix(row['latest-handshake']).local().format('YYYY-MM-DD HH:mm:ss') : null,
+            connected: row['latest-handshake'] && (now - row['latest-handshake']) <= 180, // Considered online if last handshake was within 3 minutes
+            statusIcon: row['latest-handshake'] && (now - row['latest-handshake']) <= 180 ? 'fa-exchange text-success' : 'fa-exchange text-danger',
+            publicKey: row['public-key'],
+            uniqueId: row.if + row['public-key']
+        }));
 
         tunnels.sort((a, b) => a.connected === b.connected ? 0 : a.connected ? -1 : 1);
 
@@ -141,7 +118,7 @@ export default class Wireguard extends BaseTableWidget {
                 </div>`;
             let row = `
                 <div>
-                    <span><a href="/ui/wireguard/general#peers&edit=${tunnel.uuid}">${tunnel.name}</a> | ${tunnel.allowed_ips}</span>
+                    <span><a href="/ui/wireguard/general#peers&search=${tunnel.name}">${tunnel.name}</a> | ${tunnel.allowed_ips}</span>
                 </div>
                 <div>
                     ${tunnel.latest_handshake_fmt
@@ -157,7 +134,7 @@ export default class Wireguard extends BaseTableWidget {
                 </div>`;
 
             // Update the HTML table with the sorted rows
-            super.updateTable('wgTunnelTable', [[header, row]], tunnel.uuid);
+            super.updateTable('wgTunnelTable', [[header, row]], tunnel.uniqueId);
         });
 
         // Activate tooltips for new dynamic elements

--- a/src/opnsense/www/js/widgets/Wireguard.js
+++ b/src/opnsense/www/js/widgets/Wireguard.js
@@ -112,7 +112,6 @@ export default class Wireguard extends BaseTableWidget {
                     connected: row['latest-handshake'] && (now - row['latest-handshake']) <= 180, // Considered online if last handshake was within 3 minutes
                     statusIcon: row['latest-handshake'] && (now - row['latest-handshake']) <= 180 ? 'fa-exchange text-success' : 'fa-exchange text-danger',
                     publicKey: publicKey,
-                    uniqueId: row.if + publicKey
                 };
             });
 
@@ -158,7 +157,7 @@ export default class Wireguard extends BaseTableWidget {
                 </div>`;
 
             // Update the HTML table with the sorted rows
-            super.updateTable('wgTunnelTable', [[header, row]], tunnel.uniqueId);
+            super.updateTable('wgTunnelTable', [[header, row]], tunnel.uuid);
         });
 
         // Activate tooltips for new dynamic elements

--- a/src/opnsense/www/js/widgets/Wireguard.js
+++ b/src/opnsense/www/js/widgets/Wireguard.js
@@ -142,7 +142,7 @@ export default class Wireguard extends BaseTableWidget {
                 </div>`;
             let row = `
                 <div>
-                    <span><a href="/ui/wireguard/general#peers$edit=${tunnel.uuid}">${tunnel.name}</a> | ${tunnel.allowed_ips}</span>
+                    <span><a href="/ui/wireguard/general#peers&edit=${tunnel.uuid}">${tunnel.name}</a> | ${tunnel.allowed_ips}</span>
                 </div>
                 <div>
                     ${tunnel.latest_handshake_fmt


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/7895

- Introduces a generalized function to handle "search" and "edit" in url hashes. 
- Can handle changing a tab before firing a search and/or edit.

Implementations:
- [x] Certificate widget (edit uuid)
- [x] Gateway widget (edit either name or uuid)
- [x] Wireguard widget (change tab to peers and search uuid)
- [x] IPsec Tunnels (search a session)
- [x] CARP (search an interface)
- [x] OpenVPN Client Connections (search a session)
- [x] OpenVPN Server Connections (search a session)