### PR TITLE
root.hints permissions

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -271,6 +271,19 @@ EOD;
 
     file_put_contents("/var/unbound/resolv.conf.root", $resolv_conf_root, LOCK_EX);
 
+    /* Unbound load tripping over this file is very strange so make it a very safe rewrite */
+    $root_hints_source = '/usr/local/opnsense/data/unbound/root.min.hints';
+    $root_hints_tmp = tempnam('/var/unbound', 'root.hints.');
+    $root_hints = '/var/unbound/root.hints';
+    $root_hints_mod = 0644;
+
+    if (file_exists($root_hints_source) && copy($root_hints_source, $root_hints_tmp)) {
+        chmod($root_hints_tmp, $root_hints_mod);
+        if (rename($root_hints_tmp, $root_hints)) {
+            chmod($root_hints, $root_hints_mod);
+        }
+    }
+
     $so_reuseport = empty(system_sysctl_get()['net.inet.rss.enabled']) ? 'yes' : 'no';
 
     $unboundconf = <<<EOD
@@ -343,11 +356,6 @@ remote-control:
 EOD;
 
     file_put_contents('/var/unbound/unbound.conf', $unboundconf);
-
-    /* Unbound load tripping over this file is very strange so make it a very safe rewrite */
-    $root_hints_tmp = tempnam('/var/unbound', 'root.hints.');
-    copy('/usr/local/opnsense/data/unbound/root.min.hints', $root_hints_tmp);
-    rename($root_hints_tmp, '/var/unbound/root.hints');
 
     configd_run('template reload OPNsense/Unbound/*');
 }

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -271,19 +271,6 @@ EOD;
 
     file_put_contents("/var/unbound/resolv.conf.root", $resolv_conf_root, LOCK_EX);
 
-    /* Unbound load tripping over this file is very strange so make it a very safe rewrite */
-    $root_hints_source = '/usr/local/opnsense/data/unbound/root.min.hints';
-    $root_hints_tmp = tempnam('/var/unbound', 'root.hints.');
-    $root_hints = '/var/unbound/root.hints';
-    $root_hints_mod = 0644;
-
-    if (file_exists($root_hints_source) && copy($root_hints_source, $root_hints_tmp)) {
-        chmod($root_hints_tmp, $root_hints_mod);
-        if (rename($root_hints_tmp, $root_hints)) {
-            chmod($root_hints, $root_hints_mod);
-        }
-    }
-
     $so_reuseport = empty(system_sysctl_get()['net.inet.rss.enabled']) ? 'yes' : 'no';
 
     $unboundconf = <<<EOD
@@ -356,6 +343,14 @@ remote-control:
 EOD;
 
     file_put_contents('/var/unbound/unbound.conf', $unboundconf);
+
+    /* Unbound load tripping over this file is very strange so make it a very safe rewrite */
+    $root_hints_tmp = tempnam('/var/unbound', 'root.hints.');
+    copy('/usr/local/opnsense/data/unbound/root.min.hints', $root_hints_tmp);
+    chmod($root_hints_tmp, 0644);
+    chown($root_hints_tmp, 'unbound');
+    chgrp($root_hints_tmp, 'unbound');
+    rename($root_hints_tmp, '/var/unbound/root.hints');
 
     configd_run('template reload OPNsense/Unbound/*');
 }


### PR DESCRIPTION
sometimes, during interface reset, unbound config is regenerated/reloaded and I'm getting errors in unbound log like this:

```
 error: could not read root hints /root.hints: Permission denied
```

it looks like there could be 2 reasons for that:
1. race condition: `/var/unbound/unbound.conf` file is [regenerated](https://github.com/opnsense/core/blob/master/src/etc/inc/plugins.inc.d/unbound.inc#L345) , which triggers unbound process to reread it and thus reload root.hints, but at the same time new root.hints is [created](https://github.com/opnsense/core/blob/master/src/etc/inc/plugins.inc.d/unbound.inc#L350)
2. actually wrong permissions, default ones are 0600, so if there is some mismatch between file owner and unbound user - unbound cannot read it

so, by moving root.hints generation before unbound.conf generation and setting permissions to 0644 we can eliminate both reasons

usually rename preserves source file permissions, this is why permissions are set before rename, but to be 101% sure - chmod is used again after rename