### PR TITLE
mvc: fields should implement getCurrentValue() rather than __toString()

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
@@ -356,11 +356,11 @@ abstract class BaseField
 
     /**
      * return string interpretation of this field
-     * @return null|string string interpretation of this field
+     * @return string string interpretation of this field
      */
     public function __toString()
     {
-        return (string)$this->internalValue;
+        return $this->getCurrentValue() ?? '';
     }
 
     /**


### PR DESCRIPTION
To ease this effort avoid having derived classes implement both `__toString` and `getCurrentValue` for consistency across value return. Also only ever return strings (empty if not otherwise possible).