### PR TITLE
configctl service reload all hangs

### DIFF
--- a/src/etc/rc.d/netflow
+++ b/src/etc/rc.d/netflow
@@ -164,7 +164,7 @@ netflow_start()
     # forward netflow packets, make sure $netflow_int_destination forwards to localhost (127.0.0.1)
     if [ "$netflow_destinations" != "" ]; then
         netflow_port=$(echo $netflow_int_destination | /usr/bin/sed 's/:/ /g' | /usr/bin/awk '{print $2}')
-        /usr/sbin/daemon -p /var/run/netflow_samplicate.pid -u nobody /usr/local/bin/samplicate  -s 127.0.0.1 -p $netflow_port $netflow_destinations
+        /usr/sbin/daemon -f -p /var/run/netflow_samplicate.pid -u nobody /usr/local/bin/samplicate  -s 127.0.0.1 -p $netflow_port $netflow_destinations
     fi
 
 }


### PR DESCRIPTION
While testing some changes I ran `configctl service reload all` and got a timeout error.  After doing some digging I found that this relates to netflow data collection and doesn't happen if netflow collection is disabled.

After a bit of poking around it is due to the daemon/samplicate processes keeping a pipe open shared with the reload_all script, which then never termintes.  Adding the `daemon -f` parameter fixes.
