### PR TITLE
firewall/nat: Add type to add-unassociated so that the generated firewall rule can be edited

### DIFF
--- a/src/www/firewall_nat_edit.php
+++ b/src/www/firewall_nat_edit.php
@@ -274,6 +274,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $filterent = [];
             if (in_array($pconfig['associated-rule-id'], ['add-associated', 'add-unassociated'])) {
                 $filterent['associated-rule-id'] = $natent['associated-rule-id'];
+
+                if ($pconfig['associated-rule-id'] == 'add-unassociated') {
+                  $filterent['type'] = 'pass';
+                }
             } else {
                 $filterent['associated-rule-id'] = $natent['associated-rule-id'];
                 foreach ($config['filter']['rule'] as $key => &$item){


### PR DESCRIPTION
In Firewall: NAT: Port Forward, there is the option to add:

- Unassociated Filter rule
- Associated Filter rule

The associated filter rule links a firewall rule, and prevents it from being editable by not giving it a type. If the NAT rule is updated, the linked firewall rule is updated too.

The unassociated filter rule does not link a firewall rule, but also does not set a type. The firewall rule is not updated when the NAT rule is updated. That made it useless.

I think it's a bug, so I added a type to the unassociated filter rule. This makes it editable in the GUI after creation.