### PR TITLE
VPN: OpenVPN: Instances - fix "auth-gen-token" and "reneg-sec" value validation

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -133,9 +133,15 @@ class OpenVPN extends BaseModel
                         $key . ".verify_client_cert"
                     ));
                 }
-                if ((string)$instance->{'auth-gen-token'} != '0' && (string)$instance->{'reneg-sec'} == '0') {
+                if (!empty((string)$instance->{'auth-gen-token'}) && (string)$instance->{'reneg-sec'} == '0') {
                     $messages->appendMessage(new Message(
                         gettext('A token lifetime requires a non zero Renegotiate time.'),
+                        $key . ".auth-gen-token"
+                    ));
+                }
+                if ((string)$instance->{'auth-gen-token'} == '0' && (string)$instance->{'reneg-sec'} == '0') {
+                    $messages->appendMessage(new Message(
+                        gettext('Zero Renegotiate time requires empty token lifetime value.'),
                         $key . ".auth-gen-token"
                     ));
                 }


### PR DESCRIPTION
Allow saving config when reneg-sec is set to zero and auth-gen-token has no value, but prevents saving config when both parameters are set to zero.
Setting both parameters to zero results invalid configuration with error message:
Options error: --auth-gen-token needs a non-infinite --renegotiate_seconds setting
