### PR TITLE
Feature Request #8204 -- Show "Active" beside the active gateway in the Gateways Widget on the Dashboard

### DIFF
--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -100,8 +100,6 @@ export default class Gateways extends BaseTableWidget {
                 return;
             }
 
-            let active = defaultgw ? "(active)" : "";
-
             let color = "text-success";
 
             if (status.toLowerCase().includes("offline")) {
@@ -119,8 +117,7 @@ export default class Gateways extends BaseTableWidget {
                     ${name}
                 </a>
                 &nbsp;
-                ${active}
-                &nbsp;
+                ${defaultgw ? `(${this.translations.active})` : ''}
                 <br/>
                 <div style="margin-top: 5px; margin-bottom: 5px; font-size: 15px;">${address}</div>
             </div>`;

--- a/src/opnsense/www/js/widgets/Gateways.js
+++ b/src/opnsense/www/js/widgets/Gateways.js
@@ -95,10 +95,12 @@ export default class Gateways extends BaseTableWidget {
         const config = await this.getWidgetConfig();
 
         let data = [];
-        gateways.forEach(({ uuid, name, gateway: address, status, loss, delay, stddev }) => {
+        gateways.forEach(({ uuid, name, gateway: address, status, loss, delay, stddev, defaultgw }) => {
             if (!config.gateways.includes(uuid)) {
                 return;
             }
+
+            let active = defaultgw ? "(active)" : "";
 
             let color = "text-success";
 
@@ -116,6 +118,8 @@ export default class Gateways extends BaseTableWidget {
                 <a href="/ui/routing/configuration#edit=${encodeURIComponent(uuid)}" target="_blank" rel="noopener noreferrer">
                     ${name}
                 </a>
+                &nbsp;
+                ${active}
                 &nbsp;
                 <br/>
                 <div style="margin-top: 5px; margin-bottom: 5px; font-size: 15px;">${address}</div>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -186,6 +186,7 @@
             <rtt>RTT</rtt>
             <rttd>RTTd</rttd>
             <loss>Loss</loss>
+            <active>active</active>
         </translations>
     </gateways>
     <thermalsensors>


### PR DESCRIPTION
The PR addresses an [issue/feature request 8204](https://github.com/opnsense/core/issues/8204) I have previous opened.

Adds "(active)" beside the gateway name when defaultgw is true in the json returned by `/api/routing/settings/searchGateway`