### PR TITLE
src: fix 'Adress' -> 'Address' typo globally

### DIFF
--- a/plist
+++ b/plist
@@ -746,7 +746,7 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/ACL/ACL.xml
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/CharonLogLevelField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/ConnnectionField.php
-/usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IKEAdressField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IKEAddressField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/PoolsField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/SPDField.php

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/dialogCert.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/forms/dialogCert.xml
@@ -106,7 +106,7 @@
     </field>
     <field>
         <id>cert.altnames_ip</id>
-        <label>IP adresses</label>
+        <label>IP addresses</label>
         <type>textbox</type>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IKEAddressField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IKEAddressField.php
@@ -35,7 +35,7 @@ use OPNsense\Firewall\Util;
 /**
  * @package OPNsense\Base\FieldTypes
  */
-class IKEAdressField extends BaseField
+class IKEAddressField extends BaseField
 {
     /**
      * @var bool marks if this is a data node or a container

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -42,14 +42,14 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </mobike>
-                <local_addrs type=".\IKEAdressField"/>
+                <local_addrs type=".\IKEAddressField"/>
                 <local_port type="OptionField">
                     <OptionValues>
                         <port500 value="">500 (default)</port500>
                         <port4500 value="4500">4500 (NAT-T)</port4500>
                     </OptionValues>
                 </local_port>
-                <remote_addrs type=".\IKEAdressField"/>
+                <remote_addrs type=".\IKEAddressField"/>
                 <remote_port type="OptionField">
                     <OptionValues>
                         <port500 value="">500 (default)</port500>

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/HostnameFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/HostnameFieldTest.php
@@ -130,7 +130,7 @@ class HostnameFieldTest extends Field_Framework_TestCase
         }
     }
 
-    public function testIpAdress()
+    public function testIpAddress()
     {
         $field = new HostnameField();
         $field->setIpAllowed("N");


### PR DESCRIPTION
Spotted 'Adress' typo in a youtube tutorial; fixing it globally.