### PR TITLE
mvc: fix NetworkValidator for IPv4-mapped addresses with netmask

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/Validators/NetworkValidator.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Validators/NetworkValidator.php
@@ -96,14 +96,14 @@ class NetworkValidator extends BaseValidator
                     } else {
                         $mask = $parts[1];
                         $value = $parts[0];
-                        if (strpos($parts[0], ".")) {
-                            // most likely ipv4 address, mask must be between 0..32
-                            if ($mask < 0 || $mask > 32) {
+                        if (strpos($parts[0], ":") !== false) {
+                            // probably ipv6, mask must be between 0..128
+                            if ($mask < 0 || $mask > 128) {
                                 $result = false;
                             }
                         } else {
-                            // probably ipv6, mask must be between 0..128
-                            if ($mask < 0 || $mask > 128) {
+                            // most likely ipv4 address, mask must be between 0..32
+                            if ($mask < 0 || $mask > 32) {
                                 $result = false;
                             }
                         }


### PR DESCRIPTION
The NetworkValidator fails on [IPv4-mapped addresses](https://www.rfc-editor.org/rfc/rfc4291#section-2.2), for example `::ffff:198.51.100.0/120`.  Inferring IPv4 from the presence of a period (.) fails as these IPv6 address forms contain periods. Inferring IPv6 from the presence of a colon (:) should be more robust.
