### PR TITLE
firewall/nat: Add missing columns in one-to-one nat bootgrid

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/OneToOneController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/OneToOneController.php
@@ -47,7 +47,13 @@ class OneToOneController extends \OPNsense\Base\IndexController
                 'id' => 'external', 'heading' => gettext('External')
             ],
             [
+                'id' => 'source_not', 'type' => 'boolean', 'formatter' => 'boolean', 'visible' => 'false', 'heading' => gettext('Source / Invert')
+            ],
+            [
                 'id' => 'source_net', 'heading' => gettext('Internal')
+            ],
+            [
+                'id' => 'destination_not', 'type' => 'boolean', 'formatter' => 'boolean', 'visible' => 'false', 'heading' => gettext('Destination / Invert')
             ],
             [
                 'id' => 'destination_net', 'heading' => gettext('Destination')

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter.volt
@@ -174,6 +174,7 @@
                         data-width="{{fieldlist['width']|default('')}}"
                         data-type="{{fieldlist['type']|default('string')}}"
                         data-formatter="{{fieldlist['formatter']|default('')}}"
+                        data-visible="{{fieldlist['visible']|default('')}}"
                     >{{fieldlist['heading']|default('')}}</th>
 {% endfor %}
                     <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8235