### PR TITLE
aliases: add optional authorization for URL type aliases

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -79,20 +79,20 @@ class Alias extends BaseModel
             $ref = $alias->__reference;
 
             $username = (string)$alias->username;
-            $token = (string)$alias->token;
+            $password = (string)$alias->password;
 
             switch ((string)$alias->authtype) {
                 case 'Basic':
-                    if (empty($username) || empty($token)) {
+                    if (empty($username) || empty($password)) {
                         $messages->appendMessage(new Message(gettext('Please provide a username and password when Basic auth is selected'), $ref . '.authtype'));
                     }
                     break;
                 case 'Bearer':
-                    if (empty($token)) {
+                    if (empty($password)) {
                         $messages->appendMessage(new Message(gettext('Please provide an API token when Bearer auth is selected'), $ref . '.authtype'));
-                    } elseif (strlen($token) > 512) {
+                    } elseif (strlen($password) > 512) {
                         $messages->appendMessage(new Message(gettext('Invalid token length'), $ref . '.authtype'));
-                    } elseif (!preg_match('/^[A-Za-z0-9-_.]+$/', $token)) {
+                    } elseif (!preg_match('/^[A-Za-z0-9-_.]+$/', $password)) {
                         $messages->appendMessage(new Message(gettext('Illegal characters in token'), $ref . '.authtype'));
                     }
                     break;

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -78,11 +78,10 @@ class Alias extends BaseModel
 
             $ref = $alias->__reference;
 
-            $authtype = (string)$alias->authtype;
             $username = (string)$alias->username;
             $token = (string)$alias->token;
 
-            switch ($authtype) {
+            switch ((string)$alias->authtype) {
                 case 'Basic':
                     if (empty($username) || empty($token)) {
                         $messages->appendMessage(new Message(gettext('Please provide a username and password when Basic auth is selected'), $ref . '.authtype'));

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -80,23 +80,23 @@ class Alias extends BaseModel
 
             $authtype = (string)$alias->authtype;
             $username = (string)$alias->username;
-            $password = (string)$alias->password;
             $token = (string)$alias->token;
 
-            if ($authtype == 'Basic') {
-                if (empty($username) || empty($password)) {
-                    $messages->appendMessage(new Message(gettext('Please provide a username and password when Basic auth is selected'), $ref . '.authtype'));
-                }
-            } elseif ($authtype == 'Bearer') {
-                if (empty($token)) {
-                    $messages->appendMessage(new Message(gettext('Please provide an API token when Bearer auth is selected'), $ref . '.authtype'));
-                } elseif (strlen($token) > 512) {
-                    $messages->appendMessage(new Message(gettext('Invalid token length'), $ref . '.authtype'));
-                } elseif (!preg_match('/^[A-Za-z0-9-_.]+$/', $token)) {
-                    $messages->appendMessage(new Message(gettext('Illegal characters in token'), $ref . '.authtype'));
-                }
-            } else if (!empty($authtype)) {
-                $messages->appendMessage(new Message(gettext('Unsupported auth type'), $ref . '.authtype'));
+            switch ($authtype) {
+                case 'Basic':
+                    if (empty($username) || empty($token)) {
+                        $messages->appendMessage(new Message(gettext('Please provide a username and password when Basic auth is selected'), $ref . '.authtype'));
+                    }
+                    break;
+                case 'Bearer':
+                    if (empty($token)) {
+                        $messages->appendMessage(new Message(gettext('Please provide an API token when Bearer auth is selected'), $ref . '.authtype'));
+                    } elseif (strlen($token) > 512) {
+                        $messages->appendMessage(new Message(gettext('Invalid token length'), $ref . '.authtype'));
+                    } elseif (!preg_match('/^[A-Za-z0-9-_.]+$/', $token)) {
+                        $messages->appendMessage(new Message(gettext('Illegal characters in token'), $ref . '.authtype'));
+                    }
+                    break;
             }
         }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
@@ -67,7 +67,7 @@
                     <ValidationMessage>Days and hours should be numeric values or left empty.</ValidationMessage>
                 </updatefreq>
                 <content type=".\AliasContentField"/>
-                <token type="TextField"/>
+                <password type="TextField"/>
                 <username type="TextField"/>
                 <authtype type="OptionField">
                     <OptionValues>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
@@ -69,7 +69,6 @@
                 <content type=".\AliasContentField"/>
                 <token type="TextField"/>
                 <username type="TextField"/>
-                <password type="TextField"/>
                 <authtype type="OptionField">
                     <OptionValues>
                         <Basic>Basic</Basic>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.xml
@@ -67,6 +67,15 @@
                     <ValidationMessage>Days and hours should be numeric values or left empty.</ValidationMessage>
                 </updatefreq>
                 <content type=".\AliasContentField"/>
+                <token type="TextField"/>
+                <username type="TextField"/>
+                <password type="TextField"/>
+                <authtype type="OptionField">
+                    <OptionValues>
+                        <Basic>Basic</Basic>
+                        <Bearer>Bearer</Bearer>
+                    </OptionValues>
+                </authtype>
                 <categories type="ModelRelationField">
                     <Model>
                         <rulesets>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -327,6 +327,7 @@
         $("#alias\\.type").change(function(){
             $(".alias_type").hide();
             $("#row_alias\\.updatefreq").hide();
+            $("#row_alias\\.authtype").hide();
             $("#row_alias\\.interface").hide();
             $("#copy-paste").hide();
             switch ($(this).val()) {
@@ -358,6 +359,28 @@
                     break;
                 case 'urltable':
                     $("#row_alias\\.updatefreq").show();
+                    /* FALLTHROUGH */
+                case 'url':
+                    $("#row_alias\\.authtype").show();
+
+                    $("#alias\\.authtype").change(function() {
+                        switch ($(this).val()) {
+                            case 'Basic':
+                                $("#alias\\.token").hide();
+                                $("#alias\\.username").show();
+                                $("#alias\\.password").show();
+                                break;
+                            case 'Bearer':
+                                $("#alias\\.username").hide();
+                                $("#alias\\.password").hide();
+                                $("#alias\\.token").show();
+                                break;
+                            default:
+                                $("#alias\\.token").hide();
+                                $("#alias\\.username").hide();
+                                $("#alias\\.password").hide();
+                        }
+                    });
                     /* FALLTHROUGH */
                 default:
                     $("#alias_type_default").show();
@@ -877,6 +900,28 @@
                                     </td>
                                     <td>
                                         <span class="help-block" id="help_block_alias.content"></span>
+                                    </td>
+                                </tr>
+                                <tr id="row_alias.authtype">
+                                    <td>
+                                        <div class="control-label" id="control_label_alias.authtype">
+                                            <a id="help_for_alias.authtype" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>
+                                            <b>{{lang._('Authorization')}}</b>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <select id="alias.authtype" title="{{lang._('Authorization type')}}" data-container="body" style="margin-bottom: 3px;"></select>
+                                        <input type="password" placeholder="{{lang._('API Token')}}" class="form-control" size="50" id="alias.token">
+                                        <input type="text" placeholder="{{lang._('Username')}}" class="form-control" size="50" id="alias.username">
+                                        <input type="password" placeholder="{{lang._('Password')}}" class="form-control" size="50" id="alias.password">
+                                        <div class="hidden" data-for="help_for_alias.authorization">
+                                            <small>
+                                                {{lang._('If the remote server enforces authorization, you can specify the authorization type and token here. Basic authorization expects username:password.')}}
+                                            </small>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <span class="help-block" id="help_block_alias.authtype"></span>
                                     </td>
                                 </tr>
                                 <tr id="row_alias.interface">

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -366,19 +366,16 @@
                     $("#alias\\.authtype").change(function() {
                         switch ($(this).val()) {
                             case 'Basic':
-                                $("#alias\\.token").hide();
                                 $("#alias\\.username").show();
-                                $("#alias\\.password").show();
+                                $("#alias\\.token").show().attr('placeholder', '{{lang._('Password')}}');
                                 break;
                             case 'Bearer':
                                 $("#alias\\.username").hide();
-                                $("#alias\\.password").hide();
-                                $("#alias\\.token").show();
+                                $("#alias\\.token").show().attr('placeholder', '{{lang._('API token')}}');
                                 break;
                             default:
                                 $("#alias\\.token").hide();
                                 $("#alias\\.username").hide();
-                                $("#alias\\.password").hide();
                                 break;
                         }
                     });
@@ -912,9 +909,8 @@
                                     </td>
                                     <td>
                                         <select id="alias.authtype" title="{{lang._('Authorization type')}}" data-container="body" style="margin-bottom: 3px;"></select>
-                                        <input type="password" placeholder="{{lang._('API Token')}}" class="form-control" size="50" id="alias.token">
-                                        <input type="text" placeholder="{{lang._('Username')}}" class="form-control" size="50" id="alias.username">
-                                        <input type="password" placeholder="{{lang._('Password')}}" class="form-control" size="50" id="alias.password">
+                                        <input type="text" placeholder="{{lang._('Username')}}" class="form-control" size="50" id="alias.username"/>
+                                        <input type="password" class="form-control" size="50" id="alias.token"/>
                                         <div class="hidden" data-for="help_for_alias.authtype">
                                             <small>
                                                 {{lang._('If the remote server enforces authorization, you can specify the authorization type here.')}}

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -379,6 +379,7 @@
                                 $("#alias\\.token").hide();
                                 $("#alias\\.username").hide();
                                 $("#alias\\.password").hide();
+                                break;
                         }
                     });
                     /* FALLTHROUGH */

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -915,9 +915,9 @@
                                         <input type="password" placeholder="{{lang._('API Token')}}" class="form-control" size="50" id="alias.token">
                                         <input type="text" placeholder="{{lang._('Username')}}" class="form-control" size="50" id="alias.username">
                                         <input type="password" placeholder="{{lang._('Password')}}" class="form-control" size="50" id="alias.password">
-                                        <div class="hidden" data-for="help_for_alias.authorization">
+                                        <div class="hidden" data-for="help_for_alias.authtype">
                                             <small>
-                                                {{lang._('If the remote server enforces authorization, you can specify the authorization type and token here. Basic authorization expects username:password.')}}
+                                                {{lang._('If the remote server enforces authorization, you can specify the authorization type here.')}}
                                             </small>
                                         </div>
                                     </td>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias.volt
@@ -364,18 +364,15 @@
                     $("#row_alias\\.authtype").show();
 
                     $("#alias\\.authtype").change(function() {
+                        $("#alias\\.username").hide();
+                        $("#alias\\.password").hide();
                         switch ($(this).val()) {
                             case 'Basic':
                                 $("#alias\\.username").show();
-                                $("#alias\\.token").show().attr('placeholder', '{{lang._('Password')}}');
+                                $("#alias\\.password").show().attr('placeholder', '{{lang._('Password')}}');
                                 break;
                             case 'Bearer':
-                                $("#alias\\.username").hide();
-                                $("#alias\\.token").show().attr('placeholder', '{{lang._('API token')}}');
-                                break;
-                            default:
-                                $("#alias\\.token").hide();
-                                $("#alias\\.username").hide();
+                                $("#alias\\.password").show().attr('placeholder', '{{lang._('API token')}}');
                                 break;
                         }
                     });
@@ -908,9 +905,9 @@
                                         </div>
                                     </td>
                                     <td>
-                                        <select id="alias.authtype" title="{{lang._('Authorization type')}}" data-container="body" style="margin-bottom: 3px;"></select>
+                                        <select id="alias.authtype"  data-container="body" class="selectpicker" style="margin-bottom: 3px;"></select>
                                         <input type="text" placeholder="{{lang._('Username')}}" class="form-control" size="50" id="alias.username"/>
-                                        <input type="password" class="form-control" size="50" id="alias.token"/>
+                                        <input type="password" class="form-control" size="50" id="alias.password"/>
                                         <div class="hidden" data-for="help_for_alias.authtype">
                                             <small>
                                                 {{lang._('If the remote server enforces authorization, you can specify the authorization type here.')}}

--- a/src/opnsense/scripts/filter/lib/alias/__init__.py
+++ b/src/opnsense/scripts/filter/lib/alias/__init__.py
@@ -60,7 +60,9 @@ class Alias(object):
             'ssl_no_verify': ssl_no_verify,
             'timeout': timeout,
             'interface': None,
-            'proto': 'IPv4,IPv6'
+            'proto': 'IPv4,IPv6',
+            'token': None,
+            'authtype': None,
         }
         self._ttl = ttl
         self._name = None
@@ -90,6 +92,15 @@ class Alias(object):
                 self._items = set(sorted(subelem.text.split()))
             elif subelem.tag == 'url':
                 self._items = set(sorted(subelem.text.split()))
+            elif subelem.tag == 'authtype':
+                self._properties['authtype'] = subelem.text
+            elif subelem.tag == 'token':
+                self._properties['token'] = subelem.text
+            elif subelem.tag == 'username':
+                self._properties['username'] = subelem.text
+            elif subelem.tag == 'password':
+                self._properties['password'] = subelem.text
+
         # we'll save the calculated hash for the unparsed alias content
         self._filename_alias_hash = '/var/db/aliastables/%s.md5.txt' % self._name
         # the generated alias contents, without dependencies

--- a/src/opnsense/scripts/filter/lib/alias/__init__.py
+++ b/src/opnsense/scripts/filter/lib/alias/__init__.py
@@ -61,7 +61,7 @@ class Alias(object):
             'timeout': timeout,
             'interface': None,
             'proto': 'IPv4,IPv6',
-            'token': None,
+            'password': None,
             'authtype': None,
         }
         self._ttl = ttl
@@ -94,8 +94,8 @@ class Alias(object):
                 self._items = set(sorted(subelem.text.split()))
             elif subelem.tag == 'authtype':
                 self._properties['authtype'] = subelem.text
-            elif subelem.tag == 'token':
-                self._properties['token'] = subelem.text
+            elif subelem.tag == 'password':
+                self._properties['password'] = subelem.text
             elif subelem.tag == 'username':
                 self._properties['username'] = subelem.text
 

--- a/src/opnsense/scripts/filter/lib/alias/__init__.py
+++ b/src/opnsense/scripts/filter/lib/alias/__init__.py
@@ -98,8 +98,6 @@ class Alias(object):
                 self._properties['token'] = subelem.text
             elif subelem.tag == 'username':
                 self._properties['username'] = subelem.text
-            elif subelem.tag == 'password':
-                self._properties['password'] = subelem.text
 
         # we'll save the calculated hash for the unparsed alias content
         self._filename_alias_hash = '/var/db/aliastables/%s.md5.txt' % self._name

--- a/src/opnsense/scripts/filter/lib/alias/uri.py
+++ b/src/opnsense/scripts/filter/lib/alias/uri.py
@@ -34,13 +34,13 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class UriParser(BaseContentParser):
 
-    def __init__(self, timeout=120, ssl_no_verify=False, authtype=None, token=None, username=None, **kwargs):
+    def __init__(self, timeout=120, ssl_no_verify=False, authtype=None, username=None, password=None, **kwargs):
         super().__init__(**kwargs)
         self._timeout = timeout
         self._ssl_no_verify = ssl_no_verify
         self._authtype = authtype
-        self._token = token
         self._username = username
+        self._password = password
 
     def iter_addresses(self, url):
         """ return unparsed (raw) alias entries without dependencies
@@ -55,11 +55,11 @@ class UriParser(BaseContentParser):
         if self._ssl_no_verify:
             req_opts['verify'] = False
 
-        if self._authtype is not None and self._token is not None:
+        if self._authtype is not None and self._password is not None:
             if self._authtype == 'Basic' and self._username is not None:
-                req_opts['auth'] = requests.auth.HTTPBasicAuth(self._username, self._token)
+                req_opts['auth'] = requests.auth.HTTPBasicAuth(self._username, self._password)
             elif self._authtype == 'Bearer':
-                req_opts['headers'] = {'Authorization': f'Bearer {self._token}'}
+                req_opts['headers'] = {'Authorization': f'Bearer {self._password}'}
 
         # fetch data
         try:

--- a/src/opnsense/scripts/filter/lib/alias/uri.py
+++ b/src/opnsense/scripts/filter/lib/alias/uri.py
@@ -34,10 +34,14 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class UriParser(BaseContentParser):
 
-    def __init__(self, timeout=120, ssl_no_verify=False, **kwargs):
+    def __init__(self, timeout=120, ssl_no_verify=False, authtype=None, token=None, username=None, password=None, **kwargs):
         super().__init__(**kwargs)
         self._timeout = timeout
         self._ssl_no_verify = ssl_no_verify
+        self._authtype = authtype
+        self._token = token
+        self._username = username
+        self._password = password
 
     def iter_addresses(self, url):
         """ return unparsed (raw) alias entries without dependencies
@@ -51,6 +55,12 @@ class UriParser(BaseContentParser):
         req_opts['timeout'] = self._timeout
         if self._ssl_no_verify:
             req_opts['verify'] = False
+
+        if self._authtype is not None:
+            if self._authtype == 'Basic' and self._username is not None and self._password is not None:
+                req_opts['auth'] = requests.auth.HTTPBasicAuth(self._username, self._password)
+            elif self._authtype == 'Bearer' and self._token is not None:
+                req_opts['headers'] = {'Authorization': f'Bearer {self._token}'}
 
         # fetch data
         try:

--- a/src/opnsense/scripts/filter/lib/alias/uri.py
+++ b/src/opnsense/scripts/filter/lib/alias/uri.py
@@ -34,14 +34,13 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class UriParser(BaseContentParser):
 
-    def __init__(self, timeout=120, ssl_no_verify=False, authtype=None, token=None, username=None, password=None, **kwargs):
+    def __init__(self, timeout=120, ssl_no_verify=False, authtype=None, token=None, username=None, **kwargs):
         super().__init__(**kwargs)
         self._timeout = timeout
         self._ssl_no_verify = ssl_no_verify
         self._authtype = authtype
         self._token = token
         self._username = username
-        self._password = password
 
     def iter_addresses(self, url):
         """ return unparsed (raw) alias entries without dependencies
@@ -56,10 +55,10 @@ class UriParser(BaseContentParser):
         if self._ssl_no_verify:
             req_opts['verify'] = False
 
-        if self._authtype is not None:
-            if self._authtype == 'Basic' and self._username is not None and self._password is not None:
-                req_opts['auth'] = requests.auth.HTTPBasicAuth(self._username, self._password)
-            elif self._authtype == 'Bearer' and self._token is not None:
+        if self._authtype is not None and self._token is not None:
+            if self._authtype == 'Basic' and self._username is not None:
+                req_opts['auth'] = requests.auth.HTTPBasicAuth(self._username, self._token)
+            elif self._authtype == 'Bearer':
                 req_opts['headers'] = {'Authorization': f'Bearer {self._token}'}
 
         # fetch data

--- a/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
+++ b/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
@@ -41,8 +41,8 @@
 {%      if alias.username %}
       <username>{{ alias.username|e }}</username>
 {%      endif %}
-{%      if alias.token %}
-      <token>{{ alias.token|e }}</token>
+{%      if alias.password %}
+      <password>{{ alias.password|e }}</password>
 {%      endif %}
 {%      endif %}
     </table>

--- a/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
+++ b/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
@@ -36,6 +36,18 @@
 {% elif alias.type in ['dynipv6host', 'authgroup'] %}
       <ttl>1</ttl>
 {%      endif %}
+{%      if alias.authtype %}
+      <authtype>{{ alias.authtype|e }}</authtype>
+{%      if alias.token %}
+      <token>{{ alias.token|e }}</token>
+{%      endif %}
+{%      if alias.username %}
+      <username>{{ alias.username|e }}</username>
+{%      endif %}
+{%      if alias.password %}
+      <password>{{ alias.password|e }}</password>
+{%      endif %}
+{%      endif %}
     </table>
 {%     endif %}
 {%   endfor %}

--- a/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
+++ b/src/opnsense/service/templates/OPNsense/Filter/filter_tables.conf
@@ -38,14 +38,11 @@
 {%      endif %}
 {%      if alias.authtype %}
       <authtype>{{ alias.authtype|e }}</authtype>
-{%      if alias.token %}
-      <token>{{ alias.token|e }}</token>
-{%      endif %}
 {%      if alias.username %}
       <username>{{ alias.username|e }}</username>
 {%      endif %}
-{%      if alias.password %}
-      <password>{{ alias.password|e }}</password>
+{%      if alias.token %}
+      <token>{{ alias.token|e }}</token>
 {%      endif %}
 {%      endif %}
     </table>


### PR DESCRIPTION
Selectpicker class is omitted from the PR due to single-select dropdown issues.

Note: backend code could be shortened if the the model were to have an additional read-only property that could contain either the bearer token or the base64-encoded version of the username+password, but I doubt the config should be abused as such, so kept it simple here.