### PR TITLE
fix undefined array key warnings

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3234,7 +3234,7 @@ function interface_dhcp_configure($interface = 'wan')
         return;
     }
 
-    if ($wancfg['dhcphostname']) {
+    if (!empty($wancfg['dhcphostname'])) {
         $dhclientconf_hostname = "send dhcp-client-identifier \"{$wancfg['dhcphostname']}\";\n";
         $dhclientconf_hostname .= "\tsend host-name \"{$wancfg['dhcphostname']}\";\n";
     } else {
@@ -3267,11 +3267,11 @@ EOD;
     $dhclientconf .= "}\n";
 
     // DHCP Config File Advanced
-    if ($wancfg['adv_dhcp_config_advanced']) {
+    if (!empty($wancfg['adv_dhcp_config_advanced'])) {
         $dhclientconf = DHCP_Config_File_Advanced($interface, $wancfg, $wanif);
     }
 
-    if (is_ipaddr($wancfg['alias-address'])) {
+    if (!empty($wancfg['alias-address']) && is_ipaddr($wancfg['alias-address'])) {
         $subnetmask = gen_subnet_mask($wancfg['alias-subnet']);
         $dhclientconf .= <<<EOD
 alias {


### PR DESCRIPTION
My 25.1 system has been giving me a crash report in the UI since I installed it, just because of some PHP warnings.  I think to some extent this is due to deployment type being development rather than production so I'm not sure if this is a concern, but this fixes the warnings and stops the alert.

They all do just appear to be config options that were not set in the config on initial install.  It looks like most other checks in the area use `empty()` so hopefully this is correct.  I did notice when making changes to the interface settings that they got populated with empty strings so the warnings might only happen on a fairly new install, where the initial config has been written and not all keys exist yet?

I since noticed a load of other warnings in `/usr/local/www/interfaces.php` while testing this, but haven't looked into those.