### PR TITLE
opnsense: Add support for forward-first when configuring forwarders

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/dialogDot.xml
@@ -48,6 +48,19 @@
         </grid_view>
     </field>
     <field>
+        <id>dot.forward_first</id>
+        <label>Forward first</label>
+        <type>checkbox</type>
+        <help>
+            If a forwarded query is met with a SERVFAIL error, and this option is enabled, Unbound will fall back to normal recursive resolution for this query as if no query forwarding had been specified. The fallback will only occur after a delay, so consider refining any server timeouts as needed. Please note this setting applies to the domain, so when multiple forwarders are defined for the same domain, all are assumed to use this setting. 
+        </help>
+        <grid_view> 
+            <type>boolean</type> 
+            <formatter>boolean</formatter> 
+            <visible>false</visible> 
+        </grid_view>
+    </field>
+    <field>
         <id>dot.verify</id>
         <label>Verify CN</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -277,6 +277,10 @@
                     <Default>0</Default>
                     <Required>Y</Required>
                 </forward_tcp_upstream>
+                <forward_first type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </forward_first>
                 <description type="DescriptionField"/>
             </dot>
         </dots>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dot.conf
@@ -23,16 +23,20 @@ server:
 
 # Forward zones
 {%  for domain, forwards in all_forwards|groupby("domain", default=".") %}
-{% set domain_opts = namespace(forward_tcp_upstream=False) %}
+{% set domain_opts = namespace(forward_tcp_upstream=False, forward_first=False) %}
 forward-zone:
   name: "{{ domain }}"
 {%    for forward in forwards %}
   forward-addr: {{ forward.server }}{% if forward.port %}@{{ forward.port }}{% endif %}
 {%    set domain_opts.forward_tcp_upstream = domain_opts.forward_tcp_upstream or forward.forward_tcp_upstream == '1' %}
+{%    set domain_opts.forward_first = domain_opts.forward_first or forward.forward_first == '1' %}
 
 {%    endfor %}
 {%    if domain_opts.forward_tcp_upstream %}
   forward-tcp-upstream: yes
+{%    endif %}
+{%    if domain_opts.forward_first  %}
+  forward-first: yes
 {%    endif %}
 {%  endfor %}
 
@@ -41,14 +45,18 @@ forward-zone:
 server:
   tls-cert-bundle: /usr/local/etc/ssl/cert.pem
 {%     for domain, dots in all_dots|groupby("domain", default=".") %}
-
+{% set domain_opts = namespace(forward_first=False) %}
 forward-zone:
   name: "{{ domain }}"
   forward-tls-upstream: yes
 {%       for dot in dots %}
   forward-addr: {{ dot.server }}{% if dot.port %}@{{ dot.port }}{% endif %}{% if dot.verify %}#{{ dot.verify }}{% endif %}
+{%    set domain_opts.forward_first = domain_opts.forward_first or dot.forward_first == '1' %}
 
 {%       endfor %}
+{%    if domain_opts.forward_first  %}
+  forward-first: yes
+{%    endif %}
 {%     endfor %}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Description:

- Adds support for 'forward-first' configuration for unbound forwarders (regular & TLS)

Based on/tested on 24.10 (with an in-situ make mount to run master live)

Rationale:

When using TLS, or other, forwarding, if all servers become unavailable, unbound will return SERVFAIL.
By [setting 'forward-first' ](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html)unbound will instead fallback to recursive resolution.

In my case I typically use quad9 (9.9.9.9) but very very occasionally they have a glitch and resolution fails. For example this [happened last week](https://www.reddit.com/r/Quad9/comments/1ieb266/problems_in_uk/) in parts of the UK

Implementation:
- Added new checkbox to UI (controller) when setting up a forwarding server. I did try to set the advanced flag, however for DoT the advanced settings never appeared. I therefore removed the advanced option - but if reviewers think this a better choice please advise how to set this?
- Added new option in model
- Updated the generator for dot.conf so that if this value is set on any forwarder configured for a domain, it is set for the domain in the generated unbound configuration file.

Test:
Verified setting on/off flag for both regular forwarded and dot

Example config with the flag set:
```
# Forward zones
forward-zone:
  name: "google.com"
  forward-addr: 9.8.7.6
  forward-first: yes

# Forward zones over TLS
server:
  tls-cert-bundle: /usr/local/etc/ssl/cert.pem
forward-zone:
  name: "."
  forward-tls-upstream: yes
  forward-addr: 8.4.1.9
  forward-first: yes
```

These are invalid nameservers. With the option set, DNS resolution is slow - until the SERVFAIL timeout occurs, but then resolution does succeed. This can therefore add a level of resilience in the situation where a primary resolver network is misbehaving.

Note that I haven't not tested timeouts etc in detail, for example if multiple resolvers are setup. This is getting into the actual functionality supported by unbound. The intent here is just to expose this configuration in opnsense

Comments/feedback welcome. I hope this makes sense and could be a useful enhancement 