### PR TITLE
opnsense-beep: serialize access to /dev/speaker

### DIFF
--- a/src/sbin/opnsense-beep
+++ b/src/sbin/opnsense-beep
@@ -26,7 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 BEEPDIR="/usr/local/etc/opnsense-beep.d"
-LOCK="${BEEPDIR}/low"
+LOCK="${BEEPDIR}/start"
 COMMAND=${1}
 
 if [ -z "${COMMAND}" ]; then

--- a/src/sbin/opnsense-beep
+++ b/src/sbin/opnsense-beep
@@ -69,4 +69,4 @@ fi
 			/usr/local/bin/beep -p "${NOTE}" "${DURATION}"
 		done
 	fi
-) 9 < ${BEEPDIR}/start
+) 9< ${BEEPDIR}/start

--- a/src/sbin/opnsense-beep
+++ b/src/sbin/opnsense-beep
@@ -26,7 +26,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 BEEPDIR="/usr/local/etc/opnsense-beep.d"
-LOCK="${BEEPDIR}/start"
 COMMAND=${1}
 
 if [ -z "${COMMAND}" ]; then

--- a/src/sbin/opnsense-beep
+++ b/src/sbin/opnsense-beep
@@ -63,9 +63,10 @@ if [ ! -f "${BEEPFILE}" ]; then
 	exit 1
 fi
 
-exec 9<"$LOCK" || exit 1
-/usr/local/bin/flock --exclusive 9 || exit 1
-
-cat "${BEEPFILE}" | while read NOTE DURATION; do
-	/usr/local/bin/beep -p "${NOTE}" "${DURATION}"
-done
+(
+	if /usr/local/bin/flock 9; then
+		cat "${BEEPFILE}" | while read NOTE DURATION; do
+			/usr/local/bin/beep -p "${NOTE}" "${DURATION}"
+		done
+	fi
+) 9 < ${BEEPDIR}/start

--- a/src/sbin/opnsense-beep
+++ b/src/sbin/opnsense-beep
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 BEEPDIR="/usr/local/etc/opnsense-beep.d"
+LOCK="${BEEPDIR}/low"
 COMMAND=${1}
 
 if [ -z "${COMMAND}" ]; then
@@ -62,6 +63,9 @@ fi
 if [ ! -f "${BEEPFILE}" ]; then
 	exit 1
 fi
+
+exec 9<"$LOCK" || exit 1
+/usr/local/bin/flock --exclusive 9 || exit 1
 
 cat "${BEEPFILE}" | while read NOTE DURATION; do
 	/usr/local/bin/beep -p "${NOTE}" "${DURATION}"


### PR DESCRIPTION
Otherwise one of concurrent calls to `beep' might fail with error message "beep: open of /dev/speaker for writing: Device busy".

Locking is done in `opnsense-beep` and not in `beep` to preserve tune (avoid cacophony).  ${BEEPDIR}/low is used as a lock-file as `low' beep is already a special file: it's default beep.

This might sound like a trivial change, but it might affect system behavior, e.g. when `opnsense-beep' is used in some shell script with errexit enabled.