### PR TITLE
Expose Kea option v6-only-preferred in the GUI

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -145,7 +145,7 @@
             <visible>false</visible>
         </grid_view>
     </field>
-        <field>
+    <field>
         <id>subnet4.option_data.v6_only_preferred</id>
         <label>IPv6-only Preferred</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -147,11 +147,12 @@
     </field>
     <field>
         <id>subnet4.option_data.v6_only_preferred</id>
-        <label>IPv6-only Preferred</label>
+        <label>IPv6-only Preferred (Option 108)</label>
         <type>text</type>
-        <help>The number of seconds for which the client should disable DHCPv4</help>
+        <help>The number of seconds for which the client should disable DHCPv4. The minimum value is 300 seconds.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
+        <advanced>true</advanced>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -145,4 +145,13 @@
             <visible>false</visible>
         </grid_view>
     </field>
+        <field>
+        <id>subnet4.option_data.v6_only_preferred</id>
+        <label>IPv6-only Preferred</label>
+        <type>text</type>
+        <help>The number of seconds for which the client should disable DHCPv4</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -101,6 +101,9 @@
                     <boot_file_name type="TextField">
                         <Mask>/^([^\n"])*$/u</Mask>
                     </boot_file_name>
+                    <v6_only_preferred type="IntegerField">
+                        <MinimumValue>300</MinimumValue>
+                    </v6_only_preferred>
                 </option_data>
                 <match-client-id type="BooleanField">
                     <Default>1</Default>


### PR DESCRIPTION
Pull requests to expose the Kea option `v6-only-preferred` in the GUI.

I have set the MinimumValue to MIN_V6ONLY_WAIT (300 sec) as defined in https://www.rfc-editor.org/rfc/rfc8925.html#name-constants-and-configuration. I have not set the default value as this would always include the `v6-only-preferred` option in the configuration.

I have tested the config generation using OPNSense 25.1 and can confirm that a working config is generated both with and without value defined.