### PR TITLE
Expose radvd option nat64prefix (PREF64) in GUI 

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcpd.inc
+++ b/src/etc/inc/plugins.inc.d/dhcpd.inc
@@ -387,6 +387,11 @@ function dhcpd_radvd_configure($verbose = false, $blacklist = [])
             $radvdconf .= "\t};\n";
         }
 
+        if (!empty($dhcpv6ifconf['nat64prefix'])) {
+            $radvdconf .= "\tnat64prefix {$dhcpv6ifconf['nat64prefix']} {\n";
+            $radvdconf .= "\t};\n";
+        }
+
         $radvdconf .= "};\n";
     }
 

--- a/src/www/services_router_advertisements.php
+++ b/src/www/services_router_advertisements.php
@@ -47,6 +47,7 @@ $advanced_options = [
     'AdvLinkMTU',
     'AdvDeprecatePrefix',
     'AdvRemoveRoute',
+    'nat64prefix',
 ];
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {


### PR DESCRIPTION
Expose the `nat64prefix` option in Router Advertisements in the GUI. This is an alternative to the existing DNS64 support in Unbound, which breaks DNSSEC. Support for this option appeared in radvd 2.20, which was added in OPNSense 25.1.

The option is added in the Router Advertisements advanced options section. I kept the lowercase naming to match the option in the config, but it does look a bit out of place in the GUI this way.

I did not add the `AdvValidLifeTime` option within as it conflicts with an existing advanced option with the same name. I also did not add any input validation, but can add some if this is requested.

Fixes #7487 