### PR TITLE
fix: firmware/check.sh script now fails when updating packages fails

### DIFF
--- a/src/opnsense/scripts/firmware/check.sh
+++ b/src/opnsense/scripts/firmware/check.sh
@@ -37,6 +37,14 @@
 # downgrade_packages: array with { name: <package_name>, current_version: <current_version>, new_version: <new_version> }
 # upgrade_packages: array with { name: <package_name>, current_version: <current_version>, new_version: <new_version> }
 
+# Fail the script when any command fails
+# There are gotchas https://mywiki.wooledge.org/BashFAQ/105
+# But for the current script it does work as intended :
+# - When updating the package list fails it fails the script (first use case that prompted this addition)
+# - When other unintended thing happens to fail it fails the script
+# - When everything works as intended it works
+set -e
+
 # clear the file before we may wait for other init glue below
 JSONFILE="/tmp/pkg_upgrade.json"
 rm -f ${JSONFILE}


### PR DESCRIPTION
When running `/usr/local/opnsense/scripts/firmware/check.sh` and updating the packages fail, the commant still completes and returns a successful 0 exit code. That seems incorrect to me.

### Incorrect behavior, check.sh exits 0 when checking package list fails
```
root@OPNsense:/usr/local/opnsense/scripts/firmware # ./check.sh 
Fetching changelog information, please wait... fetch: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/sets/changelog.txz: Network is unreachable
Updating OPNsense repository catalogue...
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/meta.txz: Network is unreachable
repository OPNsense has no meta file, using default settings
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/packagesite.pkg: Network is unreachable
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/packagesite.txz: Network is unreachable
Unable to update repository OPNsense
Error updating repositories!
Checking integrity... done (0 conflicting)
Your packages are up to date.
root@OPNsense:/usr/local/opnsense/scripts/firmware # echo $?
0
```

With this patch, the behavior makes more sense with exit code 1

### Correct behavior
```
root@OPNsense:/usr/local/opnsense/scripts/firmware # vi check.sh     # <== add `set -e`
root@OPNsense:/usr/local/opnsense/scripts/firmware # ./check.sh 
Fetching changelog information, please wait... fetch: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/sets/changelog.txz: Network is unreachable
Updating OPNsense repository catalogue...
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/meta.txz: Network is unreachable
repository OPNsense has no meta file, using default settings
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/packagesite.pkg: Network is unreachable
pkg: https://pkg.opnsense.org/FreeBSD:14:amd64/24.7/latest/packagesite.txz: Network is unreachable
Unable to update repository OPNsense
Error updating repositories!
root@OPNsense:/usr/local/opnsense/scripts/firmware # echo $?
1
```

I guess changing this behavior can have significant impact in deployments without WAN access but I am still taking the time to suggest it, as it makes more sense to me.

I currently have to first check if I can reach `pkg.opnsense.org` before making the package update because the output of this script cannot be trusted.

But then if something else fails in the script such as a missing file or something like that, my patch of checking if pkg.opnsense.org is reachable won't be enough and my automation will be broken again.