### PR TITLE
mvc/view: Create layout_partials/base_apply_button to centralize design of the standard Apply button

### DIFF
--- a/plist
+++ b/plist
@@ -974,6 +974,7 @@
 /usr/local/opnsense/mvc/app/views/OPNsense/Unbound/stats.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Wireguard/diagnostics.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+/usr/local/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_dialog.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_dialog_processing.volt

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -290,7 +290,7 @@ class ControllerBase extends ControllerRoot
         return [
             'table_id' => $basename,
             'edit_dialog_id' => 'dialog_' . $basename,
-            'edit_alert_id' => $edit_alert_id == null ? 'change_message_' . $basename : $edit_alert_id,
+            'edit_alert_id' => $edit_alert_id == null ? 'change_message_base_form' : $edit_alert_id,
             'fields' => array_values($all_data)
         ];
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/DhcpController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/DhcpController.php
@@ -52,13 +52,13 @@ class DhcpController extends \OPNsense\Base\IndexController
         $this->view->formGeneralSettings = $this->getForm("generalSettings4");
 
         $this->view->formDialogSubnet = $this->getForm("dialogSubnet4");
-        $this->view->formGridSubnet = $this->getFormGrid("dialogSubnet4", null, "keaChangeMessage");
+        $this->view->formGridSubnet = $this->getFormGrid("dialogSubnet4");
 
         $this->view->formDialogReservation = $this->getForm("dialogReservation4");
-        $this->view->formGridReservation = $this->getFormGrid("dialogReservation4", null, "keaChangeMessage");
+        $this->view->formGridReservation = $this->getFormGrid("dialogReservation4");
 
         $this->view->formDialogPeer = $this->getForm("dialogPeer4");
-        $this->view->formGridPeer = $this->getFormGrid("dialogPeer4", null, "keaChangeMessage");
+        $this->view->formGridPeer = $this->getFormGrid("dialogPeer4");
     }
 
     public function leases4Action()

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -158,23 +158,10 @@
     </div>
 </div>
 
-<section class="page-content-main">
-    <div class="content-box">
-        <div class="col-md-12">
-            <br/>
-            <div id="keaChangeMessage" class="alert alert-info" style="display: none" role="alert">
-                {{ lang._('After changing settings, please remember to apply them.') }}
-            </div>
-            <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/kea/service/reconfigure'
-                    data-label="{{ lang._('Apply') }}"
-                    data-error-title="{{ lang._('Error reconfiguring DHCPv4') }}"
-                    type="button"
-            ></button>
-            <br/><br/>
-        </div>
-    </div>
-</section>
+{{ partial('layout_partials/base_apply_button', {
+    'data_endpoint': '/api/kea/service/reconfigure',
+    'edit_alert_ids': [formGridSubnet['edit_alert_id'], formGridReservation['edit_alert_id'], formGridPeer['edit_alert_id']]
+}) }}
 
 {{ partial("layout_partials/base_dialog",['fields':formDialogSubnet,'id':formGridSubnet['edit_dialog_id'],'label':lang._('Edit Subnet')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogReservation,'id':formGridReservation['edit_dialog_id'],'label':lang._('Edit Reservation')])}}

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -158,10 +158,7 @@
     </div>
 </div>
 
-{{ partial('layout_partials/base_apply_button', {
-    'data_endpoint': '/api/kea/service/reconfigure',
-    'edit_alert_ids': [formGridSubnet['edit_alert_id'], formGridReservation['edit_alert_id'], formGridPeer['edit_alert_id']]
-}) }}
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/kea/service/reconfigure'}) }}
 
 {{ partial("layout_partials/base_dialog",['fields':formDialogSubnet,'id':formGridSubnet['edit_dialog_id'],'label':lang._('Edit Subnet')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogReservation,'id':formGridReservation['edit_dialog_id'],'label':lang._('Edit Reservation')])}}

--- a/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
@@ -2,22 +2,19 @@
     <div class="content-box">
         <div class="col-md-12">
             <br/>
-{% if edit_alert_ids %}
-{%     for id in edit_alert_ids %}
-            <div id="{{ id }}" class="alert alert-info" style="display: none" role="alert">
+            <div id="{{ message_id|default('change_message_base_form') }}" class="alert alert-info" style="display: none" role="alert">
                 {{ lang._('After changing settings, please remember to apply them.') }}
             </div>
-{%     endfor %}
-{% endif %}
-            <button class="btn btn-primary" id="reconfigureAct"
-{% if data_endpoint %}
+            <button class="btn btn-primary" id="{{ button_id|default('reconfigureAct') }}"
                     data-endpoint="{{ data_endpoint }}"
-{% endif %}
                     data-label="{{ lang._(data_label|default('Apply')) }}"
+                    data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
 {% if data_service_widget %}
                     data-service-widget="{{ data_service_widget }}"
 {% endif %}
-                    data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
+{% if data_grid_reload %}
+                    data-grid-reload="{{ data_grid_reload }}"
+{% endif %}
                     type="button">
             </button>
             <br/><br/>

--- a/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
@@ -1,0 +1,26 @@
+<section class="page-content-main">
+    <div class="content-box">
+        <div class="col-md-12">
+            <br/>
+{% if edit_alert_ids %}
+{%     for id in edit_alert_ids %}
+            <div id="{{ id }}" class="alert alert-info" style="display: none" role="alert">
+                {{ lang._('After changing settings, please remember to apply them.') }}
+            </div>
+{%     endfor %}
+{% endif %}
+            <button class="btn btn-primary" id="reconfigureAct"
+{% if data_endpoint %}
+                    data-endpoint="{{ data_endpoint }}"
+{% endif %}
+                    data-label="{{ lang._(data_label|default('Apply')) }}"
+{% if data_service_widget %}
+                    data-service-widget="{{ data_service_widget }}"
+{% endif %}
+                    data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
+                    type="button">
+            </button>
+            <br/><br/>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8284

Example of generated HTML with the KEA example implementation:

```
<section class="page-content-main">
    <div class="content-box">
        <div class="col-md-12">
            <br>
            <div id="change_message_base_form" class="alert alert-info" style="display: none;" role="alert">
                After changing settings, please remember to apply them.            </div>
            <button class="btn btn-primary" id="reconfigureAct" data-endpoint="/api/kea/service/reconfigure" data-label="Apply" data-error-title="Error reconfiguring service." type="button"><b>Apply</b> <i class="reload_progress"></i></button>
            <br><br>
        </div>
    </div>
</section>
```