### PR TITLE
dhcp/dhcrelay, dns/unbound: Integrate layout_partials/base_apply_button

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/RelayController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/RelayController.php
@@ -35,10 +35,10 @@ class RelayController extends IndexController
     public function indexAction()
     {
         $this->view->formDialogRelay = $this->getForm('dialogRelay');
-        $this->view->formGridRelay = $this->getFormGrid("dialogRelay", null, "relayChangeMessage");
+        $this->view->formGridRelay = $this->getFormGrid('dialogRelay');
 
         $this->view->formDialogDest = $this->getForm('dialogDest');
-        $this->view->formGridDest = $this->getFormGrid("dialogDest", null, "relayChangeMessage");
+        $this->view->formGridDest = $this->getFormGrid('dialogDest');
 
         $this->view->pick('OPNsense/DHCRelay/relay');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/AclController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/AclController.php
@@ -37,7 +37,7 @@ class AclController extends IndexController
         $this->view->aclForm = $this->getForm('acl');
 
         $this->view->formDialogAcl = $this->getForm('dialogAcl');
-        $this->view->formGridAcl = $this->getFormGrid('dialogAcl', null, 'AclChangeMessage');
+        $this->view->formGridAcl = $this->getFormGrid('dialogAcl');
 
         $this->view->pick('OPNsense/Unbound/acl');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
@@ -38,7 +38,7 @@ class DotController extends IndexController
         $this->view->forwardingForm = $this->getForm('forwarding');
 
         $this->view->formDialogEdit = $this->getForm('dialogDot');
-        $this->view->formGridDot = $this->getFormGrid('dialogDot', null, 'DotChangeMessage');
+        $this->view->formGridDot = $this->getFormGrid('dialogDot');
 
         $this->view->pick('OPNsense/Unbound/dot');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
@@ -38,7 +38,7 @@ class ForwardController extends IndexController
         $this->view->forwardingForm = $this->getForm('forwarding');
 
         $this->view->formDialogEdit = $this->getForm('dialogDot');
-        $this->view->formGridDot = $this->getFormGrid('dialogDot', null, 'DotChangeMessage');
+        $this->view->formGridDot = $this->getFormGrid('dialogDot');
 
         $this->view->pick('OPNsense/Unbound/dot');
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/OverridesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/OverridesController.php
@@ -36,10 +36,10 @@ class OverridesController extends IndexController
     {
         $this->view->pick('OPNsense/Unbound/overrides');
 
-        $this->view->formDialogHostOverride = $this->getForm("dialogHostOverride");
-        $this->view->formGridHostOverride = $this->getFormGrid('dialogHostOverride', null, 'HostOverrideChangeMessage');
+        $this->view->formDialogHostOverride = $this->getForm('dialogHostOverride');
+        $this->view->formGridHostOverride = $this->getFormGrid('dialogHostOverride');
 
-        $this->view->formDialogHostAlias = $this->getForm("dialogHostAlias");
-        $this->view->formGridHostAlias = $this->getFormGrid('dialogHostAlias', null, 'HostOverrideChangeMessage');
+        $this->view->formDialogHostAlias = $this->getForm('dialogHostAlias');
+        $this->view->formGridHostAlias = $this->getFormGrid('dialogHostAlias');
     }
 }

--- a/src/opnsense/mvc/app/views/OPNsense/DHCRelay/relay.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/DHCRelay/relay.volt
@@ -51,33 +51,12 @@ $( document ).ready(function() {
     $("#reconfigureAct").SimpleActionButton();
 });
 </script>
-
 <div class="content-box __mb">
     {{ partial('layout_partials/base_bootgrid_table', formGridDest)}}
 </div>
-
 <div class="content-box __mb">
     {{ partial('layout_partials/base_bootgrid_table', formGridRelay)}}
 </div>
-
-<section class="page-content-main">
-    <div class="content-box">
-        <div class="col-md-12">
-            <br/>
-            <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/dhcrelay/service/reconfigure'
-                    data-label="{{ lang._('Apply') }}"
-                    data-grid-reload="grid-relay"
-                    data-error-title="{{ lang._('Error reconfiguring dhcrelay') }}"
-                    type="button">
-            </button>
-            <br/><br/>
-        </div>
-    </div>
-    <div id="relayChangeMessage" class="alert alert-info" style="display: none" role="alert">
-        {{ lang._('After changing settings, please remember to apply them.') }}
-    </div>
-</section>
-
-{{ partial("layout_partials/base_dialog",['fields':formDialogRelay,'id':formGridRelay['edit_dialog_id'],'label':lang._('Edit DHCP relay')])}}
-{{ partial("layout_partials/base_dialog",['fields':formDialogDest,'id':formGridDest['edit_dialog_id'],'label':lang._('Edit DHCP destination')])}}
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/dhcrelay/service/reconfigure', 'data_grid_reload': formGridRelay['table_id']}) }}
+{{ partial('layout_partials/base_dialog',['fields':formDialogRelay,'id':formGridRelay['edit_dialog_id'],'label':lang._('Edit DHCP relay')])}}
+{{ partial('layout_partials/base_dialog',['fields':formDialogDest,'id':formGridDest['edit_dialog_id'],'label':lang._('Edit DHCP destination')])}}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/acl.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/acl.volt
@@ -71,24 +71,5 @@ $( document ).ready(function() {
 <div class="content-box __mb">
     {{ partial('layout_partials/base_bootgrid_table', formGridAcl)}}
 </div>
-<!-- reconfigure -->
-<section class="page-content-main">
-    <div class="content-box">
-        <div class="col-md-12">
-            <br/>
-            <div id="AclChangeMessage" class="alert alert-info" style="display: none" role="alert">
-                {{ lang._('After changing settings, please remember to apply them.') }}
-            </div>
-            <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/unbound/service/reconfigure'
-                    data-label="{{ lang._('Apply') }}"
-                    data-service-widget="unbound"
-                    data-error-title="{{ lang._('Error reconfiguring unbound') }}"
-                    type="button"
-            ></button>
-            <br/><br/>
-        </div>
-    </div>
-</section>
-
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/reconfigure', 'data_service_widget': 'unbound'}) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogAcl,'id':formGridAcl['edit_dialog_id'],'label':lang._('Edit ACL')])}}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/advanced.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/advanced.volt
@@ -55,15 +55,7 @@
     });
 </script>
 
-<div class="content-box" style="padding-bottom: 1.5em;">
-{{ partial("layout_partials/base_form",['fields':advancedForm,'id':'frm_AdvancedSettings'])}}
-    <div class="col-md-12 __mt">
-        <button class="btn btn-primary" id="reconfigureAct"
-                data-endpoint='/api/unbound/service/reconfigure'
-                data-label="{{ lang._('Apply') }}"
-                data-service-widget="unbound"
-                data-error-title="{{ lang._('Error reconfiguring unbound') }}"
-                type="button">
-        </button>
-    </div>
+<div class="content-box __mb">
+    {{ partial("layout_partials/base_form",['fields':advancedForm,'id':'frm_AdvancedSettings'])}}
 </div>
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/reconfigure', 'data_service_widget': 'unbound'}) }}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
@@ -35,7 +35,7 @@
            init_state = $('.safesearch').is(':checked');
        });
 
-       $("#saveAct").SimpleActionButton({
+       $("#reconfigureAct").SimpleActionButton({
           onPreAction: function() {
               const dfObj = new $.Deferred();
               let safesearch_changed = !($('.safesearch').is(':checked') == init_state);
@@ -58,14 +58,7 @@
    });
 </script>
 
-<div class="content-box" style="padding-bottom: 1.5em;">
+<div class="content-box __mb">
     {{ partial("layout_partials/base_form",['fields':dnsblForm,'id':'frm_dnsbl_settings'])}}
-    <div class="col-md-12 __mt">
-        <button class="btn btn-primary" id="saveAct"
-                data-endpoint='/api/unbound/service/dnsbl'
-                data-label="{{ lang._('Apply') }}"
-                data-error-title="{{ lang._('Error updating blocklists') }}"
-                type="button">
-        </button>
-    </div>
 </div>
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/dnsbl'}) }}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dot.volt
@@ -126,23 +126,5 @@
         in System->Settings->General or those obtained via DHCP or PPP on WAN if the "Allow DNS server list to be overridden by DHCP/PPP on WAN" is checked.') }}
     </div>
 </div>
-<section class="page-content-main">
-    <div class="content-box">
-        <div class="col-md-12">
-            <br/>
-            <div id="DotChangeMessage" class="alert alert-info" style="display: none" role="alert">
-                {{ lang._('After changing settings, please remember to apply them.') }}
-            </div>
-            <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/unbound/service/reconfigure'
-                    data-label="{{ lang._('Apply') }}"
-                    data-service-widget="unbound"
-                    data-error-title="{{ lang._('Error reconfiguring unbound') }}"
-                    type="button"
-            ></button>
-            <br/><br/>
-        </div>
-    </div>
-</section>
-
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/reconfigure', 'data_service_widget': 'unbound'}) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEdit,'id':formGridDot['edit_dialog_id'],'label':lang._('Edit server')])}}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/general.volt
@@ -44,15 +44,7 @@
     });
 </script>
 
-<div class="content-box" style="padding-bottom: 1.5em;">
+<div class="content-box __mb">
 {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_GeneralSettings'])}}
-    <div class="col-md-12 __mt">
-        <button class="btn btn-primary" id="reconfigureAct"
-                data-endpoint='/api/unbound/service/reconfigureGeneral'
-                data-service-widget="unbound"
-                data-label="{{ lang._('Apply') }}"
-                data-error-title="{{ lang._('Error reconfiguring unbound') }}"
-                type="button">
-        </button>
-    </div>
 </div>
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/reconfigureGeneral', 'data_service_widget': 'unbound'}) }}

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
@@ -133,7 +133,6 @@ $( document ).ready(function() {
     }
 </style>
 
-<!-- host overrides -->
 <div class="content-box __mb">
     {{ partial('layout_partials/base_bootgrid_table', formGridHostOverride)}}
     <div id="infosection" class="tab-content col-xs-12 __mb">
@@ -142,29 +141,9 @@ $( document ).ready(function() {
         {{ lang._('Keep in mind that all resource record types (i.e. A, AAAA, MX, etc. records) of a specified host below are being overwritten.') }}
     </div>
 </div>
-<!-- aliases for host overrides -->
 <div class="content-box __mb">
     {{ partial('layout_partials/base_bootgrid_table', formGridHostAlias)}}
 </div>
-<!-- reconfigure -->
-<section class="page-content-main">
-    <div class="content-box">
-        <div class="col-md-12">
-            <br/>
-            <div id="HostOverrideChangeMessage" class="alert alert-info" style="display: none" role="alert">
-                {{ lang._('After changing settings, please remember to apply them.') }}
-            </div>
-            <button class="btn btn-primary" id="reconfigureAct"
-                    data-endpoint='/api/unbound/service/reconfigure'
-                    data-label="{{ lang._('Apply') }}"
-                    data-service-widget="unbound"
-                    data-error-title="{{ lang._('Error reconfiguring unbound') }}"
-                    type="button"
-            ></button>
-            <br/><br/>
-        </div>
-    </div>
-</section>
-
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/reconfigure', 'data_service_widget': 'unbound'}) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogHostOverride,'id':formGridHostOverride['edit_dialog_id'],'label':lang._('Edit Host Override')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogHostAlias,'id':formGridHostAlias['edit_dialog_id'],'label':lang._('Edit Host Override Alias')])}}


### PR DESCRIPTION
Requires: https://github.com/opnsense/core/issues/8284

A further cleanup of dhcrelay and unbound after these two commits integrating the new apply button template:
https://github.com/opnsense/core/commit/a3bdccd5e4f19a27c5ee37039e5abb02a5b90050
https://github.com/opnsense/core/commit/a556e10d06b16576b2c98bbba6014242d5854441

