### PR TITLE
mvc/view: Ensure fields stay aligned relatively to another when headers are used in forms

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2015 Deciso B.V.
+ # Copyright (c) 2014-2025 Deciso B.V.
  # All rights reserved.
  #
  # Redistribution and use in source and binary forms, with or without modification,
@@ -66,11 +66,11 @@
             <div class="modal-body">
                 <form id="frm_{{base_dialog_id}}">
                   <div class="table-responsive">
-                    <table class="table table-striped table-condensed">
+                    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
                         <colgroup>
-                            <col class="col-md-3"/>
-                            <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
-                            <col class="col-md-{{ msgzone_width|default(5) }}"/>
+                            <col style="width: 25%;" />
+                            <col style="width: 40%;" />
+                            <col style="width: 35%;" />
                         </colgroup>
                         <tbody>
                         {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
@@ -99,11 +99,11 @@
     </table>
   </div>
   <div class="table-responsive {{field['style']|default('')}}">
-    <table class="table table-striped table-condensed">
+    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
         <colgroup>
-            <col class="col-md-3"/>
-            <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
-            <col class="col-md-{{ msgzone_width|default(5) }}"/>
+            <col style="width: 25%;" />
+            <col style="width: 40%;" />
+            <col style="width: 35%;" />
         </colgroup>
         <thead style="cursor: pointer;">
           <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>
@@ -143,3 +143,11 @@
         </div>
     </div>
 </div>
+
+{# Ensure all fields stay the same width relative to each other inside the modal #}
+<style>
+  .bootstrap-select:not(.bs-container),
+  .tokenize ul.tokens-container {
+      width: 100% !important;
+  }
+</style>

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -68,9 +68,15 @@
                   <div class="table-responsive">
                     <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
                         <colgroup>
+                        {% if msgzone_width is defined %}
+                            <col class="col-md-3"/>
+                            <col class="col-md-{{ 12 - 3 - msgzone_width }}"/>
+                            <col class="col-md-{{ msgzone_width }}"/>
+                        {% else %}
                             <col style="width: 25%;" />
                             <col style="width: 40%;" />
                             <col style="width: 35%;" />
+                        {% endif %}
                         </colgroup>
                         <tbody>
                         {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
@@ -101,9 +107,15 @@
   <div class="table-responsive {{field['style']|default('')}}">
     <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
         <colgroup>
+        {% if msgzone_width is defined %}
+            <col class="col-md-3"/>
+            <col class="col-md-{{ 12 - 3 - msgzone_width }}"/>
+            <col class="col-md-{{ msgzone_width }}"/>
+        {% else %}
             <col style="width: 25%;" />
             <col style="width: 40%;" />
             <col style="width: 35%;" />
+        {% endif %}
         </colgroup>
         <thead style="cursor: pointer;">
           <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -146,8 +146,8 @@
 
 {# Ensure all fields stay the same width relative to each other inside the modal #}
 <style>
-  .bootstrap-select:not(.bs-container),
-  .tokenize ul.tokens-container {
-      width: 100% !important;
-  }
+    .modal-dialog .bootstrap-select:not(.bs-container),
+    .modal-dialog .tokenize ul.tokens-container {
+        width: 100% !important;
+    }
 </style>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -115,3 +115,14 @@
     </table>
   </div>
 </form>
+
+{# Ensure all fields stay the same width relative to each other inside the modal #}
+<style>
+@media (max-width: 760px) {
+    .bootstrap-select:not(.bs-container),
+    .tokenize ul.tokens-container {
+         width: 100% !important;
+         min-width: 0 !important;
+    }
+}
+</style>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -118,11 +118,11 @@
 
 {# Ensure all fields stay the same width relative to each other inside the modal #}
 <style>
-@media (max-width: 760px) {
-    .bootstrap-select:not(.bs-container),
-    .tokenize ul.tokens-container {
-         width: 100% !important;
-         min-width: 0 !important;
+  @media (max-width: 760px) {
+    .form-inline .bootstrap-select:not(.bs-container),
+    .form-inline .tokenize ul.tokens-container {
+      width: 100% !important;
+      min-width: 0 !important;
     }
-}
+  }
 </style>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2015 Deciso B.V.
+ # Copyright (c) 2014-2025 Deciso B.V.
  # All rights reserved.
  #
  # Redistribution and use in source and binary forms, with or without modification,
@@ -52,11 +52,11 @@
 {% endfor %}
 <form id="{{base_form_id}}" class="form-inline" data-title="{{data_title|default('')}}">
   <div class="table-responsive">
-    <table class="table table-striped table-condensed">
+    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
         <colgroup>
-            <col class="col-md-3"/>
-            <col class="col-md-4"/>
-            <col class="col-md-5"/>
+            <col style="width: 25%;" />
+            <col style="width: 40%;" />
+            <col style="width: 35%;" />
         </colgroup>
         <tbody>
 {% if advanced|default(false) or help|default(false) %}
@@ -77,11 +77,11 @@
     </table>
   </div>
   <div class="table-responsive {{field['style']|default('')}}">
-    <table class="table table-striped table-condensed table-responsive">
+    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
         <colgroup>
-            <col class="col-md-3"/>
-            <col class="col-md-4"/>
-            <col class="col-md-5"/>
+            <col style="width: 25%;" />
+            <col style="width: 40%;" />
+            <col style="width: 35%;" />
         </colgroup>
         <thead style="cursor: pointer;" class="{{field['style']|default('')}}">
           <tr {% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>


### PR DESCRIPTION
This fixes an issue where introducing headers in forms will botch the alignment of fields because they all spawn their own table. Using relative sizes in the table and colgroup fixes this issue.

This also improves responsiveness of the modal.

Bonus: This also improved how form modals render on mobile devices.