### PR TITLE
Update php.ini to add dynamic session.name value

### DIFF
--- a/src/opnsense/service/templates/OPNsense/WebGui/php.ini
+++ b/src/opnsense/service/templates/OPNsense/WebGui/php.ini
@@ -35,3 +35,4 @@ error_log=/tmp/PHP_errors.log
 date.timezone="{{system.timezone|default('Etc/UTC')}}"
 session.save_path=/var/lib/php/sessions
 session.gc_maxlifetime={{system.webgui.session_timeout|default(240)|int * 60}}
+session.name={{system.hostname}}


### PR DESCRIPTION
This PR adds `session.name={{system.hostname}}` to the last line of `src/opnsense/service/templates/OPNsense/WebGui/php.ini` so that OPNSense sessions do not use the PHP default `PHPSESSID` cookie name.  This PR permits multiple OPNSense instances to operate on the same hostname (e.g. via localhost from SSH tunneled sessions) without interfering with each other.

Fixes #8365