### PR TITLE
OpenVPN: Add support for various options

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -433,6 +433,28 @@ Set to 0 to disable, remember to change your client as well.
         </grid_view>
     </field>
     <field>
+        <id>instance.auth-gen-token-renewal</id>
+        <label>Auth Token Renewal</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <style>role role_server</style>
+        <help>How often the auth token will be renewed, token expire after 2 * renewal time.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.auth-gen-token-secret</id>
+        <label>Auth Token secret</label>
+        <type>textbox</type>
+        <advanced>true</advanced>
+        <style>role role_server</style>
+        <help>Optional secret for use with auth-gen-token. This is useful to allow failover between multiple servers without user interaction.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>instance.provision_exclusive</id>
         <label>Require Client Provisioning</label>
         <type>checkbox</type>
@@ -493,6 +515,17 @@ Set to 0 to disable, remember to change your client as well.
         <style>selectpicker role role_server</style>
         <type>select_multiple</type>
         <help>Various less frequently used yes/no options which can be pushed to the client for this instance.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.push_inactive</id>
+        <label>Push inactivity timeout</label>
+        <style>role role_server</style>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Push an inactivity timeout to client connecting. Number of seconds with inactivity before the client should exit.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
@@ -605,6 +638,30 @@ Set to 0 to disable, remember to change your client as well.
         <type>checkbox</type>
         <advanced>true</advanced>
         <help>Announce to TCP sessions running over the tunnel that they should limit their send packet sizes such that after OpenVPN has encapsulated them, the resulting UDP packet size that OpenVPN sends to its peer will not exceed the recommended size.</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.compress_migrate</id>
+        <label>Compression migrate</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Conditionally use stub compression for clients configured with compression. This functionality is deprecated in OpenVPN.</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.ifconfig-pool-persist</id>
+        <label>Persist address pool</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Save ip address pool to disk</help>
         <grid_view>
             <visible>false</visible>
             <type>boolean</type>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -144,6 +144,20 @@ class OpenVPN extends BaseModel
                         $key . ".auth-gen-token"
                     ));
                 }
+
+                if (!empty((string)$instance->{'auth-gen-token-renewal'}) && (string)$instance->{'auth-gen-token'} === '') {
+                    $messages->appendMessage(new Message(
+                        gettext('A token renewal requires a token lifetime.'),
+                        $key . ".auth-gen-token-renewal"
+                    ));
+                }
+
+                if (!empty((string)$instance->{'auth-gen-token-secret'}) && (string)$instance->{'auth-gen-token'} === '') {
+                    $messages->appendMessage(new Message(
+                        gettext('A token secret requires a token lifetime.'),
+                        $key . ".auth-gen-token-secret"
+                    ));
+                }
             }
             if (!empty((string)$instance->cert)) {
                 $tmp = Store::getCertificate((string)$instance->cert);
@@ -643,10 +657,28 @@ class OpenVPN extends BaseModel
                             $options['push'][] = "\"dhcp-option NTP {$opt}\"";
                         }
                     }
-                    foreach (['auth-gen-token'] as $opt) {
-                        if ((string)$node->$opt != '') {
-                            $options[$opt] = str_replace(',', ':', (string)$node->$opt);
+                    if (!empty((string)$node->push_inactive)) {
+                        $options['push'][] = "\"inactive {$node->push_inactive}\"";
+                    }
+
+                    if ((string)$node->{'auth-gen-token'} !== '') {
+                        $options['auth-gen-token'] = $node->{'auth-gen-token'};
+
+                        if ((string)$node->{'auth-gen-token-renewal'} !== '') {
+                            $options['auth-gen-token'] .= ' ' . $node->{'auth-gen-token-renewal'};
                         }
+                    }
+
+                    if (!empty((string)$node->{'auth-gen-token-secret'})) {
+                        $options['<auth-gen-token-secret>'] = $node->{'auth-gen-token-secret'};
+                    }
+
+                    if (!empty((string)$node->compress_migrate)) {
+                        $options['compress'] = 'migrate';
+                    }
+
+                    if (!empty((string)$node->{'ifconfig-pool-persist'})) {
+                        $options['ifconfig-pool-persist'] = "/var/etc/openvpn/instance-{$node_uuid}.pool";
                     }
                 }
                 $options['persist-tun'] = null;

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -280,6 +280,7 @@
                         <remote-random>remote-random</remote-random>
                         <route-noexec>route-noexec</route-noexec>
                         <route-nopull>route-nopull</route-nopull>
+                        <explicit-exit-notify>explicit-exit-notify</explicit-exit-notify>
                     </OptionValues>
                 </various_flags>
                 <various_push_flags type="OptionField">
@@ -287,8 +288,10 @@
                     <OptionValues>
                         <block-outside-dns>push block-outside-dns</block-outside-dns>
                         <register-dns>push register-dns</register-dns>
+                        <explicit-exit-notify>explicit-exit-notify</explicit-exit-notify>
                     </OptionValues>
                 </various_push_flags>
+                <push_inactive type="IntegerField"/>
                 <username_as_common_name type="BooleanField">
                     <Default>0</Default>
                     <Required>Y</Required>
@@ -319,6 +322,10 @@
                 <auth-gen-token type="IntegerField">
                     <MinimumValue>0</MinimumValue>
                 </auth-gen-token>
+                <auth-gen-token-renewal type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                </auth-gen-token-renewal>
+                <auth-gen-token-secret type="TextField"/>
                 <provision_exclusive type="BooleanField">
                     <Default>0</Default>
                     <Required>Y</Required>
@@ -373,6 +380,8 @@
                     <key>mvc</key>
                 </carp_depend_on>
                 <description type="DescriptionField"/>
+                <compress_migrate type="BooleanField"/>
+                <ifconfig-pool-persist type="BooleanField"/>
             </Instance>
         </Instances>
         <StaticKeys>


### PR DESCRIPTION
Add support for auth-gen-token renawal time.

Add support for auth-gen-token-secrets to allow failover between servers.

Add support for pushing inactive to clients to have them disconnect after being idle for a set time.

Add support for explicit-exit-notify and for pushing it. This will allow UDP connection to notify peers that they are going away.

Add support for ifconfig-pool-persist, which will allow smoother roaming combined with auth-gen-token since client will keep their ip address.

Add support from compress migrate. This option will conditionally use stub compression for clients announcing they have compression enabled while leaving it of for all other clients.