### PR TITLE
dnsmasq: When dhcp-fqdn is set, there must be a domain without an address set as default

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
@@ -42,7 +42,7 @@ class SettingsController extends ApiMutableModelControllerBase
     public function getAction()
     {
         $data = parent::getAction();
-        $data[self::$internalModelName]['dhcp']['domain'] = (string)Config::getInstance()->object()->system->domain;
+        $data[self::$internalModelName]['dhcp']['this_domain'] = (string)Config::getInstance()->object()->system->domain;
 
         return $data;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
@@ -29,11 +29,23 @@
 namespace OPNsense\Dnsmasq\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Config;
 
 class SettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'dnsmasq';
     protected static $internalModelClass = '\OPNsense\Dnsmasq\Dnsmasq';
+
+    /**
+     * @inheritdoc
+     */
+    public function getAction()
+    {
+        $data = parent::getAction();
+        $data[self::$internalModelName]['dhcp']['domain'] = (string)Config::getInstance()->object()->system->domain;
+
+        return $data;
+    }
 
     /* hosts */
     public function searchHostAction()

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -129,7 +129,7 @@
         <id>dnsmasq.dhcp.domain</id>
         <label>DHCP default domain</label>
         <type>text</type>
-        <help>To ensure that all names have a domain part, there must be a default domain specified when dhcp-fqdn is set.</help>
+        <help>To ensure that all names have a domain part, there must be a default domain specified when dhcp-fqdn is set. Leave empty to use the system domain.</help>
     </field>
     <field>
         <id>dnsmasq.dhcp.lease_max</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -126,6 +126,12 @@
         <help>In the default mode, we insert the unqualified names of DHCP clients into the DNS, in which case they have to be unique. Using this option the unqualified name is no longer put in the DNS, only the qualified name.</help>
     </field>
     <field>
+        <id>dnsmasq.dhcp.domain</id>
+        <label>DHCP default domain</label>
+        <type>text</type>
+        <help>To ensure that all names have a domain part, there must be a default domain specified when dhcp-fqdn is set.</help>
+    </field>
+    <field>
         <id>dnsmasq.dhcp.lease_max</id>
         <label>DHCP max leases</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -129,6 +129,7 @@
         <id>dnsmasq.dhcp.domain</id>
         <label>DHCP default domain</label>
         <type>text</type>
+        <hint>internal</hint>
         <help>To ensure that all names have a domain part, there must be a default domain specified when dhcp-fqdn is set.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -129,7 +129,6 @@
         <id>dnsmasq.dhcp.domain</id>
         <label>DHCP default domain</label>
         <type>text</type>
-        <hint>internal</hint>
         <help>To ensure that all names have a domain part, there must be a default domain specified when dhcp-fqdn is set.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -38,6 +38,10 @@
                 <Multiple>Y</Multiple>
             </no_interface>
             <fqdn type="BooleanField"/>
+            <domain type="HostnameField">
+                <IsDNSName>Y</IsDNSName>
+                <IpAllowed>N</IpAllowed>
+            </domain>
             <lease_max type="IntegerField">
                 <MinimumValue>0</MinimumValue>
             </lease_max>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -31,7 +31,7 @@
             try {
                 $("#dnsmasq\\.dhcp\\.domain").attr(
                     "placeholder",
-                    data.frm_settings.dhcp.domain
+                    data.frm_settings.dnsmasq.dhcp.this_domain
                 );
             } catch (e) {
                 null;

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -28,6 +28,14 @@
     $( document ).ready(function() {
         let data_get_map = {'frm_settings':"/api/dnsmasq/settings/get"};
         mapDataToFormUI(data_get_map).done(function(data){
+            try {
+                $("#dnsmasq\\.dhcp\\.domain").attr(
+                    "placeholder",
+                    data.frm_settings.dhcp.domain
+                );
+            } catch (e) {
+                null;
+            }
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
             updateServiceControlUI('dnsmasq');

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -31,7 +31,7 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
-domain={{dnsmasq.dhcp.domain}}
+domain={{dnsmasq.dhcp.domain|default(system.domain)}}
 {% endif %}
 
 {% if dnsmasq.dhcp.authoritative == '1' %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -31,7 +31,7 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
-domain={{dnsmasq.dhcp.domain|default('internal')}}
+domain={{dnsmasq.dhcp.domain}}
 {% endif %}
 
 {% if dnsmasq.dhcp.authoritative == '1' %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -31,10 +31,7 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
-{% endif %}
-
-{% if dnsmasq.dhcp.domain %}
-domain={{dnsmasq.dhcp.domain}}
+domain={{dnsmasq.dhcp.domain|default('internal')}}
 {% endif %}
 
 {% if dnsmasq.dhcp.authoritative == '1' %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -33,6 +33,10 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 dhcp-fqdn
 {% endif %}
 
+{% if dnsmasq.dhcp.domain %}
+domain={{dnsmasq.dhcp.domain}}
+{% endif %}
+
 {% if dnsmasq.dhcp.authoritative == '1' %}
 dhcp-authoritative
 {% endif %}


### PR DESCRIPTION
https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html

`--dhcp-fqdn`

``To ensure that all names have a domain part, there must be at least --domain without an address specified when --dhcp-fqdn is set.``

Fixes the following error:

```
2025-03-05T15:44:42 | Critical | dnsmasq | FAILED to start up
2025-03-05T15:44:42 | Critical | dnsmasq | there must be a default domain when --dhcp-fqdn is set
```

