### PR TITLE
dnsmasq: Use interface directly as tag in dhcp options

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
@@ -6,10 +6,16 @@
         <help>Option to offer to the client.</help>
     </field>
     <field>
+        <id>option.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>This adds a single interface as tag so this DHCP option can match the interface of a DHCP range.</help>
+    </field>
+    <field>
         <id>option.tag</id>
         <label>Tag</label>
         <type>select_multiple</type>
-        <help>If the optional tags are given then this option is only sent when all the tags are matched.</help>
+        <help>If the optional tags are given then this option is only sent when all the tags are matched. Can be optionally combined with an interface tag.</help>
     </field>
     <field>
         <id>option.value</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -167,6 +167,13 @@
                 <ConfigdPopulateAct>dnsmasq list dhcp_options</ConfigdPopulateAct>
                 <Required>Y</Required>
             </option>
+            <interface type="InterfaceField">
+                <BlankDesc>Any</BlankDesc>
+                <Filters>
+                    <if>/^(?!lo0$).*/</if>
+                </Filters>
+                <AllowDynamic>Y</AllowDynamic>
+            </interface>
             <tag type="ModelRelationField">
                 <Model>
                     <tag>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -115,7 +115,7 @@ conf-dir=/usr/local/etc/dnsmasq.conf.d,\*.conf
 {% if dhcp_range.start_addr and ':' not in dhcp_range.start_addr %}
 {# IPv4 range #}
 dhcp-range={%if dhcp_range.interface -%}
-tag:{{helpers.physical_interface(dhcp_range.interface)}},
+{% if dhcp_range.interface and dhcp_range.set_tag -%}tag:{%- endif -%}{{helpers.physical_interface(dhcp_range.interface)}},
 {%- endif -%}
 {%- if dhcp_range.set_tag -%}
 set:{{dhcp_range.set_tag|replace('-','')}},
@@ -131,7 +131,7 @@ set:{{dhcp_range.set_tag|replace('-','')}},
 {% else %}
 {# IPv6 range #}
 dhcp-range={%if dhcp_range.interface -%}
-{{helpers.physical_interface(dhcp_range.interface)}},
+{% if dhcp_range.interface and dhcp_range.set_tag -%}tag:{%- endif -%}{{helpers.physical_interface(dhcp_range.interface)}},
 {%- endif -%}
 {%- if dhcp_range.set_tag -%}
 set:{{dhcp_range.set_tag|replace('-','')}},
@@ -164,11 +164,21 @@ dhcp-host={{host.hwaddr}}{% if host.set_tag%},set:{{host.set_tag|replace('-','')
 
 {% set has_default=[] %}
 {% for option in helpers.toList('dnsmasq.dhcp_options') %}
-dhcp-option{% if option.force == '1' %}-force{% endif %}={% if option.tag %}tag:{{option.tag.replace('-','').split(',')|join(',tag:')}},{% endif %}{{ option.option }},{{ option.value }}
-{% if not option.tag and option.option == '6' %}
-{%- do has_default.append(1) -%}
-{%- endif -%}
+{%     set all_tags = [] %}
+{%     if option.tag %}
+{%         for tag in option.tag.replace('-','').split(',') %}
+{%             do all_tags.append('tag:' + tag) %}
+{%         endfor %}
+{%     endif %}
+{%     if option.interface %}
+{%         do all_tags.append('tag:' + helpers.physical_interface(option.interface)) %}
+{%     endif %}
+dhcp-option{% if option.force == '1' %}-force{% endif %}={% if all_tags %}{{ all_tags|join(',') }},{% endif %}{{ option.option }},{{ option.value }}
+{%     if not option.tag and not option.interface and option.option == '6' %}
+{%         do has_default.append(1) %}
+{%     endif %}
 {% endfor %}
+
 {% if not has_default %}
 # default dns mapped to this server (0.0.0.0)
 dhcp-option=6,0.0.0.0

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -115,7 +115,7 @@ conf-dir=/usr/local/etc/dnsmasq.conf.d,\*.conf
 {% if dhcp_range.start_addr and ':' not in dhcp_range.start_addr %}
 {# IPv4 range #}
 dhcp-range={%if dhcp_range.interface -%}
-{% if dhcp_range.interface and dhcp_range.set_tag -%}tag:{%- endif -%}{{helpers.physical_interface(dhcp_range.interface)}},
+tag:{{helpers.physical_interface(dhcp_range.interface)}},
 {%- endif -%}
 {%- if dhcp_range.set_tag -%}
 set:{{dhcp_range.set_tag|replace('-','')}},
@@ -131,7 +131,7 @@ set:{{dhcp_range.set_tag|replace('-','')}},
 {% else %}
 {# IPv6 range #}
 dhcp-range={%if dhcp_range.interface -%}
-{% if dhcp_range.interface and dhcp_range.set_tag -%}tag:{%- endif -%}{{helpers.physical_interface(dhcp_range.interface)}},
+tag:{{helpers.physical_interface(dhcp_range.interface)}},
 {%- endif -%}
 {%- if dhcp_range.set_tag -%}
 set:{{dhcp_range.set_tag|replace('-','')}},


### PR DESCRIPTION
This one makes simple setups simpler since we do not need to create any tags manually if we want to match custom DHCP options with a DHCP range.