### PR TITLE
dnsmasq: Allow domain overrides to be optionally sorted by sequence number to support strict-order

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDomainOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDomainOverride.xml
@@ -1,5 +1,15 @@
 <form>
     <field>
+        <id>domainoverride.sequence</id>
+        <label>Sequence</label>
+        <type>text</type>
+        <help>Sort with a sequence number, e.g., for strict processing order when using the "strict-order" option.</help>
+        <grid_view>
+            <width>6em</width>
+            <order>asc</order>
+        </grid_view>
+    </field>
+    <field>
         <id>domainoverride.domain</id>
         <label>Domain</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -90,6 +90,11 @@
             </aliases>
         </hosts>
         <domainoverrides type="ArrayField">
+            <sequence type="AutoNumberField">
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>99999</MaximumValue>
+                <ValidationMessage>Please enter a value between 1 and 99999 or leave empty.</ValidationMessage>
+            </sequence>
             <domain type="HostnameField">
                 <IsDNSName>Y</IsDNSName>
                 <IpAllowed>N</IpAllowed>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>/dnsmasq</mount>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <enable type="BooleanField"/>
         <regdhcp type="BooleanField"/>
@@ -93,7 +93,9 @@
             <sequence type="AutoNumberField">
                 <MinimumValue>1</MinimumValue>
                 <MaximumValue>99999</MaximumValue>
-                <ValidationMessage>Please enter a value between 1 and 99999 or leave empty.</ValidationMessage>
+                <Default>1</Default>
+                <Required>Y</Required>
+                <ValidationMessage>Please enter a value between 1 and 99999.</ValidationMessage>
             </sequence>
             <domain type="HostnameField">
                 <IsDNSName>Y</IsDNSName>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -59,8 +59,14 @@ bind-interfaces
 bogus-priv
 {% endif %}
 
-{% for override in helpers.toList('dnsmasq.domainoverrides') %}
-server=/{{override.domain}}/{{override.ip}}{%if override.port %}#{{override.port}}{% endif %}{%if override.srcip %}@{{override.srcip}}{% endif %}
+{# Domain Overrides can be sorted by sequence to support strict order #}
+{% set unsorted_domainoverrides = helpers.toList('dnsmasq.domainoverrides') %}
+{% for item in unsorted_domainoverrides %}
+{%     set _ = item.update({'sequence': item.get('sequence', '0') | int}) %}
+{% endfor %}
+{% set sorted_domainoverrides = unsorted_domainoverrides | sort(attribute='sequence') %}
+{% for override in sorted_domainoverrides %}
+server=/{{override.domain}}/{{override.ip}}{%if override.port %}#{{override.port}}{% endif %}{%if override.srcip %}@{{override.srcip}}{% endif +%}
 {%    if helpers.exists('system.webgui.nodnsrebindcheck') %}
 rebind-domain-ok=/{{override.domain}}/
 {%    endif %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -60,8 +60,7 @@ bogus-priv
 {% endif %}
 
 {# Domain Overrides can be sorted by sequence to support strict order #}
-{% set sorted_domainoverrides = helpers.toList('dnsmasq.domainoverrides', sortBy='sequence', sortAs='int') %}
-{% for override in sorted_domainoverrides %}
+{% for override in helpers.toList('dnsmasq.domainoverrides', sortBy='sequence', sortAs='int') %}
 server=/{{override.domain}}/{{override.ip}}{%if override.port %}#{{override.port}}{% endif %}{%if override.srcip %}@{{override.srcip}}{% endif +%}
 {%    if helpers.exists('system.webgui.nodnsrebindcheck') %}
 rebind-domain-ok=/{{override.domain}}/

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -60,11 +60,7 @@ bogus-priv
 {% endif %}
 
 {# Domain Overrides can be sorted by sequence to support strict order #}
-{% set unsorted_domainoverrides = helpers.toList('dnsmasq.domainoverrides') %}
-{% for item in unsorted_domainoverrides %}
-{%     set _ = item.update({'sequence': item.get('sequence', '0') | int}) %}
-{% endfor %}
-{% set sorted_domainoverrides = unsorted_domainoverrides | sort(attribute='sequence') %}
+{% set sorted_domainoverrides = helpers.toList('dnsmasq.domainoverrides', sortBy='sequence', sortAs='int') %}
 {% for override in sorted_domainoverrides %}
 server=/{{override.domain}}/{{override.ip}}{%if override.port %}#{{override.port}}{% endif %}{%if override.srcip %}@{{override.srcip}}{% endif +%}
 {%    if helpers.exists('system.webgui.nodnsrebindcheck') %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8399