### PR TITLE
dnsmasq: Add missing hint for lease time default value

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -46,6 +46,7 @@
         <id>range.lease_time</id>
         <label>Lease time</label>
         <type>text</type>
+        <hint>86400</hint>
         <help>Defines how long the addresses (leases) given out by the server are valid (in seconds)</help>
         <grid_view>
             <visible>false</visible>


### PR DESCRIPTION
https://github.com/opnsense/core/blob/877b219c64ac0919cec19482c9e7795b0fb3ef7d/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf#L132