### PR TITLE
Make exceptions to unbound blocklists more intuitive

### DIFF
--- a/src/opnsense/scripts/unbound/blocklists/__init__.py
+++ b/src/opnsense/scripts/unbound/blocklists/__init__.py
@@ -67,6 +67,12 @@ class BaseBlocklistHandler:
         """
         pass
 
+    def get_excludelist(self):
+        """
+        Overridden by derived classes to produce a formatted exludelist. Returns a set of domains
+        """
+        return set()
+
     def _blocklist_reader(self, uri):
         """
         Used by a derived class to define a caching and/or download routine.
@@ -196,10 +202,13 @@ class BlocklistParser:
     def update_blocklist(self):
         blocklists = {}
         merged = {}
+        excludelist = set()
         for handler in self.handlers:
             blocklists[handler.priority] = handler.get_blocklist()
+            excludelist.update(handler.get_excludelist())
 
         merged['data'] = self._merge_results(blocklists)
+        merged['whitelist'] = list(excludelist)
         merged['config'] = self._get_config()
 
         # check if there are wildcards in the dataset

--- a/src/opnsense/scripts/unbound/blocklists/default_bl.py
+++ b/src/opnsense/scripts/unbound/blocklists/default_bl.py
@@ -37,7 +37,7 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
     def __init__(self):
         super().__init__('/usr/local/etc/unbound/unbound-blocklists.conf')
         self.priority = 100
-        self._whitelist_pattern = self._get_excludes()
+        self._whitelist_pattern, self._exclude_list = self._get_excludes()
 
     def get_config(self):
         cfg = {}
@@ -92,6 +92,12 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
 
         return result
 
+    def get_excludelist(self):
+        """
+        Overridden by derived classes to produce a formatted exludelist. Returns a set of domains
+        """
+        return self._exclude_list
+
     def _blocklists_in_config(self):
         """
         Generator for derived classes to iterate over configured blocklists.
@@ -143,8 +149,8 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
 
     def _get_excludes(self):
         whitelist_pattern = re.compile('$^') # match nothing
+        exclude_list = set()
         if self.cnf.has_section('exclude'):
-            exclude_list = set()
             for exclude_item in self.cnf['exclude']:
                 pattern = self.cnf['exclude'][exclude_item]
                 try:
@@ -163,4 +169,4 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
             whitelist_pattern = re.compile(wp, re.IGNORECASE)
             syslog.syslog(syslog.LOG_NOTICE, 'blocklist download : exclude domains matching %s' % wp)
 
-        return whitelist_pattern
+        return whitelist_pattern, exclude_list

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/dnsbl_module.py
@@ -327,6 +327,9 @@ class DNSBL:
         sub = domain
         match = None
         while match is None:
+            if "whitelist" in self.dnsbl:
+                if sub in self.dnsbl['whitelist']:
+                    break
             if sub in self.dnsbl['data']:
                 policy = self.dnsbl['data'][sub]
                 is_full_domain = sub == domain


### PR DESCRIPTION
This changes the way the exceptions for unbound DNS blocking work, in order to make it more intuitive. (see #8273)
Currently, this only writes all exceptions into a new list element in `dnsbl.json`. This only works for non-regex domains. It could be changed to use `re.findall`, but I suspect that will be slow.