### PR TITLE
Suricata: Add support for all available EVE types

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -171,4 +171,16 @@
         <help>Custom TLS fields to include in eve-log for TLS. (Overrides extended if non-empty).</help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>ids.general.eveLog.types.enabled</id>
+        <label>Enabled EVE types</label>
+        <type>select_multiple</type>
+        <help>The type of events to include in the EVE log.</help>
+    </field>
+    <field>
+        <id>ids.general.eveLog.types.extended</id>
+        <label>Extended EVE types</label>
+        <type>select_multiple</type>
+        <help>The type of events which, if enabled in the EVE log, will contain extended information.</help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -293,6 +293,47 @@
                         <Multiple>Y</Multiple>
                     </custom>
                 </tls>
+                <types>
+                    <enabled type="OptionField">
+                        <OptionValues>
+                            <dns>DNS</dns>
+                            <files>Files</files>
+                            <smtp>SMTP</smtp>
+                            <dnp3>DNP3</dnp3>
+                            <ftp>FTP</ftp>
+                            <rdp>RDP</rdp>
+                            <nfs>NFS</nfs>
+                            <smb>SMB</smb>
+                            <tftp>TFTP</tftp>
+                            <ike>IKE</ike>
+                            <dcerpc>DCE-RPC</dcerpc>
+                            <krb5>Kerberos</krb5>
+                            <bittorrent-dht>BitTorrent DHT</bittorrent-dht>
+                            <snmp>SNMP</snmp>
+                            <rfb>RFB/VNC</rfb>
+                            <sip>SIP</sip>
+                            <quic>QUIC</quic>
+                            <dhcp>DHCP</dhcp>
+                            <mqtt>MQTT</mqtt>
+                            <http2>HTTP/2</http2>
+                            <pgsql>PostgreSQL</pgsql>
+                            <stats>Statistics</stats>
+                            <flow>Bi-directional Flows</flow>
+                            <netflow>Uni-directional Netflows</netflow>
+                        </OptionValues>
+                        <Multiple>Y</Multiple>
+                    </enabled>
+                    <extended type="OptionField">
+                        <OptionValues>
+                            <files>Files</files>
+                            <smtp>SMTP</smtp>
+                            <dhcp>DHCP</dhcp>
+                            <mqtt>MQTT</mqtt>
+                            <pgsql>PostgreSQL</pgsql>
+                        </OptionValues>
+                        <Multiple>Y</Multiple>
+                    </extended>
+                </types>
             </eveLog>
         </general>
     </items>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -220,34 +220,6 @@ outputs:
             dump-all-headers: {{OPNsense.IDS.general.eveLog.http.dumpAllHeaders}}
 {%          endif %}
 {%       endif %}
-#        - dns:
-            # This configuration uses the new DNS logging format,
-            # the old configuration is still available:
-            # https://docs.suricata.io/en/latest/output/eve/eve-json-output.html#dns-v1-format
-
-            # As of Suricata 5.0, version 2 of the eve dns output
-            # format is the default.
-            #version: 2
-
-            # Enable/disable this logger. Default: enabled.
-            #enabled: yes
-
-            # Control logging of requests and responses:
-            # - requests: enable logging of DNS queries
-            # - responses: enable logging of DNS answers
-            # By default both requests and responses are logged.
-            #requests: no
-            #responses: no
-
-            # Format of answer logging:
-            # - detailed: array item per answer
-            # - grouped: answers aggregated by type
-            # Default: all
-            #formats: [detailed, grouped]
-
-            # DNS record types to log, based on the query type.
-            # Default: all.
-            #types: [a, aaaa, cname, mx, ns, ptr, txt]
 {%      if not helpers.empty('OPNsense.IDS.general.eveLog.tls.enable') %}
         - tls:
             extended: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.tls.extended') else 'yes' }}
@@ -259,19 +231,25 @@ outputs:
             custom: [{{ OPNsense.IDS.general.eveLog.tls.custom }}]
 {%          endif %}
 {%      endif %}
-        #- files:
-            force-magic: no   # force logging magic on all logged files
-            # force logging of checksums, available hash functions are md5,
-            # sha1 and sha256
-            #force-hash: [md5]
 
         - drop:
             alerts: yes      # log alerts that caused drops
             flows: start     # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
 
-        #- smtp:
-            #extended: yes # enable this for extended logging information
+        - ssh
+
+{%      set eveLog_types_enabled = (OPNsense.IDS.general.eveLog.types.enabled|default('')).split(',') %}
+{%      set eveLog_types_extended = (OPNsense.IDS.general.eveLog.types.extended|default('')).split(',') %}
+{%      for opt in eveLog_types_enabled %}
+        - {{opt}}:
+{%          if opt == 'files' and opt in eveLog_types_extended %}
+            force-magic: yes   # force logging magic on all logged files
+            # force logging of checksums, available hash functions are md5,
+            # sha1 and sha256
+            #force-hash: [md5]
+{%          elif opt == 'smtp' and opt in eveLog_types_extended %}
+            extended: yes # enable this for extended logging information
             # this includes: bcc, message-id, subject, x_mailer, user-agent
             # custom fields logging from the list:
             #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
@@ -282,43 +260,18 @@ outputs:
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
             #md5: [body, subject]
-
-        #- dnp3
-        #- ftp
-        #- rdp
-        #- nfs
-        #- smb
-        #- tftp
-        #- ike
-        #- dcerpc
-        #- krb5
-        #- bittorrent-dht
-        #- snmp
-        #- rfb
-        #- sip
-        #- quic
-        #- dhcp:
-            #enabled: yes
+{%          elif opt == 'dhcp' and opt in eveLog_types_extended %}
             # When extended mode is on, all DHCP messages are logged
             # with full detail. When extended mode is off (the
             # default), just enough information to map a MAC address
             # to an IP address is logged.
-            #extended: no
-        - ssh
-        #- mqtt:
-            # passwords: yes           # enable output of passwords
-        #- http2
-        #- pgsql:
-            #enabled: no
-            # passwords: yes           # enable output of passwords. Disabled by default
-        #- stats:
-            #totals: yes       # stats for all threads merged together
-            #threads: no       # per thread stats
-            #deltas: no        # include delta values
-        # bi-directional flows
-        #- flow
-        # uni-directional flows
-        #- netflow
+            extended: yes
+{%          elif opt == 'mqtt' and opt in eveLog_types_extended %}
+            passwords: yes           # enable output of passwords
+{%          elif opt == 'pgsql' and opt in eveLog_types_extended %}
+            passwords: yes           # enable output of passwords. Disabled by default
+{%          endif %}
+{%      endfor %}
 
         # Metadata event type. Triggered whenever a pktvar is saved
         # and will include the pktvars, flowvars, flowbits and
@@ -942,7 +895,7 @@ app-layer:
       #encryption-handling: default
 
     pgsql:
-      enabled: no
+      enabled: {{ 'yes' if 'pgsql' in eveLog_types_enabled else 'no' }}
       # Stream reassembly size for PostgreSQL. By default, track it completely.
       stream-depth: 0
       # Maximum number of live PostgreSQL transactions per flow
@@ -998,14 +951,14 @@ app-layer:
         #log-url-scheme: yes
         # Set to yes to compute the md5 of the mail body. You will then
         # be able to journalize it.
-        body-md5: no
+        body-md5: {{ 'yes' if 'smtp' in eveLog_types_extended else 'no' }}
       # Configure inspected-tracker for file_data keyword
       inspected-tracker:
         content-limit: 100000
         content-inspect-min-size: 32768
         content-inspect-window: 4096
     imap:
-      enabled: detection-only
+      enabled: {{ 'yes' if 'imap' in eveLog_types_enabled else 'detection-only' }}
     smb:
       enabled: yes
       detection-ports:
@@ -1171,7 +1124,7 @@ app-layer:
 
     # DNP3
     dnp3:
-      enabled: no
+      enabled: {{ 'yes' if 'dnp3' in eveLog_types_enabled else 'no' }}
       detection-ports:
         dp: 20000
 
@@ -1192,7 +1145,7 @@ app-layer:
       enabled: yes
 
     sip:
-      #enabled: yes
+      enabled: {{ 'yes' if 'sip' in eveLog_types_enabled else 'no' }}
 
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256


### PR DESCRIPTION
Add support for all available Suricata EVE types.

This PR avoids migrations for existing types (e.g., `http`, `tls`, `alert`, `ssh`, ...) and hence does not offer the best UX. A migration will be proposed at a later stage.