### PR TITLE
Suricata: Add BPF filtering

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -28,6 +28,13 @@
         <help>Select interface(s) to use. When enabling IPS, make sure the (virtual) driver supports this feature.</help>
     </field>
     <field>
+        <id>ids.general.capture.bpf_filter</id>
+        <label>BPF Filter</label>
+        <type>text</type>
+        <help>BPF filter to apply on the interfaces (the pcap filter syntax applies here). A BPF filter should be used when logs are exported to avoid self-caused noise and amplifications.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <type>header</type>
         <label>Detection</label>
     </field>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -294,6 +294,9 @@
                     </custom>
                 </tls>
             </eveLog>
+            <capture>
+                <bpf_filter type="TextField" />
+            </capture>
         </general>
     </items>
 </model>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -723,6 +723,9 @@ af-packet:
     #threads: auto
     #use-mmap: no
     #tpacket-v3: yes
+{%  if not helpers.empty('OPNsense.IDS.general.capture.bpf_filter') %}
+    bpf-filter: {{ OPNsense.IDS.general.capture.bpf_filter }}
+{%  endif %}
 
 # Linux high speed af-xdp capture support
 af-xdp:
@@ -843,7 +846,9 @@ pcap:
     # as total memory used by the ring. So set this to something bigger
     # than 1% of your bandwidth.
     #buffer-size: 16777216
-    #bpf-filter: "tcp and port 25"
+{%  if not helpers.empty('OPNsense.IDS.general.capture.bpf_filter') %}
+    bpf-filter: {{ OPNsense.IDS.general.capture.bpf_filter }}
+{%  endif %}
     # Choose checksum verification mode for the interface. At the moment
     # of the capture, some packets may have an invalid checksum due to
     # the checksum computation being offloaded to the network card.
@@ -2006,7 +2011,9 @@ netmap:
    # Warning: 'checksum-validation' must be set to yes to have any validation
    checksum-checks: auto
    # BPF filter to apply to this interface. The pcap filter syntax apply here.
-   #bpf-filter: port 80 or udp
+{% if not helpers.empty('OPNsense.IDS.general.capture.bpf_filter') %}
+   bpf-filter: {{ OPNsense.IDS.general.capture.bpf_filter }}
+{% endif %}
 
   {% if helpers.exists('OPNsense.IDS.general.interfaces') %}
     {% for intfName in OPNsense.IDS.general.interfaces.split(',') %}


### PR DESCRIPTION
Add support for BPF filtering.

This feature can be employed to avoid amplification if Suricata logs are exported (for example, using https://github.com/opnsense/core/pull/8450).