### PR TITLE
dnsmasq: Add add-mac, add-subnet and strip-subnet options

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -107,6 +107,27 @@
         <help>If this option is set, we will not forward reverse DNS lookups (PTR) for private addresses (RFC 1918) to upstream name servers. Any entries in the Domain Overrides section forwarding private "n.n.n.in-addr.arpa" names to a specific server are still forwarded. If the IP to name is not known from /etc/hosts, DHCP or a specific domain override then a "not found" answer is immediately returned.</help>
     </field>
     <field>
+        <id>dnsmasq.add_mac</id>
+        <label>Add MAC</label>
+        <type>dropdown</type>
+        <help>Add the MAC address of the requestor to DNS queries which are forwarded upstream. The MAC address will only be added if the upstream DNS Server is in the same subnet as the requestor. Since this is not standardized, it should be considered experiemental. This is useful for selective DNS filtering on the upstream DNS server.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>dnsmasq.add_subnet</id>
+        <label>Add subnet</label>
+        <type>checkbox</type>
+        <help>Add the real client IPv4 and IPv6 addresses (add-subnet=32,128) to DNS queries which are forwarded upstream. Be careful setting this option as it can undermine privacy. This is useful for selective DNS filtering on the upstream DNS server.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>dnsmasq.strip_subnet</id>
+        <label>Strip subnet</label>
+        <type>checkbox</type>
+        <help>Strip the subnet received by a downstream DNS server. If add_subnet is used and the downstream DNS server already added a subnet, DNSMasq will not replace it without setting strip_subnet.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <type>header</type>
         <label>DHCP</label>
     </field>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -33,6 +33,15 @@
         <local_ttl type="IntegerField">
             <MinimumValue>0</MinimumValue>
         </local_ttl>
+        <add_mac type="OptionField">
+            <OptionValues>
+                <default>default</default>
+                <base64>base64</base64>
+                <text>text</text>
+            </OptionValues>
+        </add_mac>
+        <add_subnet type="BooleanField"/>
+        <strip_subnet type="BooleanField"/>
         <dhcp>
             <no_interface type="InterfaceField">
                 <Multiple>Y</Multiple>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -54,6 +54,17 @@ dhcp-reply-delay={{dnsmasq.dhcp.reply_delay}}
 bind-interfaces
 {% endif %}
 
+{% if dnsmasq.add_mac %}
+add-mac{% if dnsmasq.add_mac != 'default' %}={{dnsmasq.add_mac}}{% endif %}
+{% endif %}
+
+{% if dnsmasq.add_subnet %}
+add-subnet=32,128
+{% endif %}
+
+{% if dnsmasq.strip_subnet %}
+strip-subnet
+{% endif %}
 
 {% if dnsmasq.no_private_reverse == '1' %}
 # Never forward addresses in the non-routed address spaces.


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8440

The "add-subnet" option would be pretty hard to validate without a custom field type, or splitting the field up into like 2 integer and 2 Network fields (4 fields). Thus only the most probable use-case of adding the IPv4 and IPv6 client addresses was added. Even that would be hard to split up, as the documentation is a little fuzzy about only setting IPv6 for example.

This here is the simplest fix without spending too much time.