### PR TITLE
dnsmasq: Add option6 to support DHCPv6 options

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
@@ -6,6 +6,12 @@
         <help>Option to offer to the client.</help>
     </field>
     <field>
+        <id>option.protocol</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help>The protocol to use for this option. Options used for DHCPv6 require IPv6 to match.</help>
+    </field>
+    <field>
         <id>option.interface</id>
         <label>Interface</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -178,6 +178,12 @@
                 <ConfigdPopulateAct>dnsmasq list dhcp_options</ConfigdPopulateAct>
                 <Required>Y</Required>
             </option>
+            <protocol type="OptionField">
+                <BlankDesc>IPv4</BlankDesc>
+                <OptionValues>
+                    <option6>IPv6</option6>
+                </OptionValues>
+            </protocol>
             <interface type="InterfaceField">
                 <BlankDesc>Any</BlankDesc>
                 <Filters>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -54,7 +54,6 @@ dhcp-reply-delay={{dnsmasq.dhcp.reply_delay}}
 bind-interfaces
 {% endif %}
 
-
 {% if dnsmasq.no_private_reverse == '1' %}
 # Never forward addresses in the non-routed address spaces.
 bogus-priv
@@ -175,7 +174,7 @@ dhcp-host={{host.hwaddr}}{% if host.set_tag%},set:{{host.set_tag|replace('-','')
 {%     if option.interface %}
 {%         do all_tags.append('tag:' + helpers.physical_interface(option.interface)) %}
 {%     endif %}
-dhcp-option{% if option.force == '1' %}-force{% endif %}={% if all_tags %}{{ all_tags|join(',') }},{% endif %}{{ option.option }},{{ option.value }}
+dhcp-option{% if option.force == '1' %}-force{% endif %}={% if all_tags %}{{ all_tags|join(',') }},{% endif %}{% if option.protocol %}{{option.protocol}}:{% endif%}{{ option.option }},{{ option.value }}
 {%     if not option.tag and not option.interface and option.option == '6' %}
 {%         do has_default.append(1) %}
 {%     endif %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -174,7 +174,7 @@ dhcp-host={{host.hwaddr}}{% if host.set_tag%},set:{{host.set_tag|replace('-','')
 {%     if option.interface %}
 {%         do all_tags.append('tag:' + helpers.physical_interface(option.interface)) %}
 {%     endif %}
-dhcp-option{% if option.force == '1' %}-force{% endif %}={% if all_tags %}{{ all_tags|join(',') }},{% endif %}{% if option.protocol %}{{option.protocol}}:{% endif%}{{ option.option }},{{ option.value }}
+dhcp-option{% if option.force == '1' %}-force{% endif %}={% if all_tags %}{{ all_tags|join(',') }},{% endif %}{% if option.protocol %}{{ option.protocol }}:{% endif %}{{ option.option }},{{ option.value }}
 {%     if not option.tag and not option.interface and option.option == '6' %}
 {%         do has_default.append(1) %}
 {%     endif %}


### PR DESCRIPTION
From man page:

`IPv6 options are specified using the option6: keyword, followed by the option number or option name. The IPv6 option name space is disjoint from the IPv4 option name space. IPv6 addresses in options must be bracketed with square brackets, eg. --dhcp-option=option6:ntp-server,[1234::56] For IPv6, [::] means "the global address of the machine running dnsmasq", whilst [fd00::] is replaced with the ULA, if it exists, and [fe80::] with the link-local address.`