### PR TITLE
Suricata: Add support for PCAP logging

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -171,4 +171,32 @@
         <help>Custom TLS fields to include in eve-log for TLS. (Overrides extended if non-empty).</help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <label>PCAP Log</label>
+        <type>header</type>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <label>Enabled</label>
+        <id>ids.general.pcapLog.enabled</id>
+        <type>checkbox</type>
+        <help>Enable PCAP logging to record all monitored traffic.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <label>PCAP Size</label>
+        <id>ids.general.pcapLog.limit</id>
+        <type>text</type>
+        <help>Rotate PCAPs at the given size limit; Can be specified in kb, mb, gb. Just a number is parsed as bytes.</help>
+        <advanced>true</advanced>
+        <hint>1000mb</hint>
+    </field>
+    <field>
+        <label>PCAP Count</label>
+        <id>ids.general.pcapLog.files</id>
+        <type>text</type>
+        <help>Number of PCAPs to retain.</help>
+        <advanced>true</advanced>
+        <hint>5</hint>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -295,6 +295,24 @@
                     </custom>
                 </tls>
             </eveLog>
+            <pcapLog>
+                <enabled type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <limit type="TextField">
+                    <Required>Y</Required>
+                    <Default>1000mb</Default>
+                    <Mask>/^[1-9]\d*(kb|mb|gb)?$/</Mask>
+                    <ValidationMessage>Enter a valid log size limit to save which can be specified in kb, mb, gb; Just a number is parsed as bytes.</ValidationMessage>
+                </limit>
+                <files type="IntegerField">
+                    <Required>Y</Required>
+                    <Default>5</Default>
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Enter a valid number of logs to save</ValidationMessage>
+                </files>
+            </pcapLog>
         </general>
     </items>
 </model>

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -400,8 +400,8 @@ outputs:
       enabled: no
       #certs-log-dir: certs # directory to store the certificates files
 
-  # Packet log... log packets in pcap format. 2 modes of operation: "normal"
-  # and "multi".
+  # Packet log... log packets in pcap format. 3 modes of operation: "normal"
+  # "multi" and "sguil".
   #
   # In normal mode a pcap file "filename" is created in the default-log-dir,
   # or as specified by "dir".
@@ -421,24 +421,30 @@ outputs:
   # So the size limit when using 8 threads with 1000mb files and 2000 files
   # is: 8*1000*2000 ~ 16TiB.
   #
+  # In Sguil mode "dir" indicates the base directory. In this base dir the
+  # pcaps are created in the directory structure Sguil expects:
+  #
+  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>
+  #
   # By default all packets are logged except:
   # - TCP streams beyond stream.reassembly.depth
   # - encrypted streams after the key exchange
   #
   - pcap-log:
-      enabled: no
+      enabled: {{ 'yes' if not helpers.empty('OPNsense.IDS.general.pcapLog.enabled') else 'no' }}
       filename: log.pcap
 
       # File size limit.  Can be specified in kb, mb, gb.  Just a number
       # is parsed as bytes.
-      limit: 1000mb
+      limit: {{ OPNsense.IDS.general.pcapLog.limit|default('1000mb') }}
 
       # If set to a value, ring buffer mode is enabled. Will keep maximum of
       # "max-files" of size "limit"
-      max-files: 2000
+      max-files: {{ OPNsense.IDS.general.pcapLog.files|default('5') }}
 
       # Compression algorithm for pcap files. Possible values: none, lz4.
-      # Note also that on Windows, enabling compression will *increase* disk I/O.
+      # Enabling compression is incompatible with the sguil mode. Note also
+      # that on Windows, enabling compression will *increase* disk I/O.
       compression: none
 
       # Further options for lz4 compression. The compression level can be set
@@ -447,10 +453,10 @@ outputs:
       #lz4-checksum: no
       #lz4-level: 0
 
-      mode: normal # normal or multi
+      mode: normal # normal, multi or sguil.
 
       # Directory to place pcap files. If not provided the default log
-      # directory will be used.
+      # directory will be used. Required for "sguil" mode.
       #dir: /nsm_data/
 
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec


### PR DESCRIPTION
Another commonly used feature in network security monitoring is the capturing of all traffic (e.g., Malcolm, Security Onion, ...). This PR adds support for this feature through Suricata.

Notably:
- This PR changes the default number of retained PCAP files from `2000` to `5` in order to avoid accidental storage exhaustion.
- Some comments are furthermore updated to align with the [reference configuration](https://github.com/OISF/suricata/blob/suricata-7.0.8/suricata.yaml.in#L368-L432).
- The PR relies on the default `normal` PCAP logging mode to ease storage estimations , `multi` relying on the number of threads.