### PR TITLE
radius: improved RFC alignment

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
@@ -102,8 +102,6 @@ class AccessController extends ApiControllerBase
 
     private function getClientMac($ip)
     {
-        $mac = null;
-
         if (empty(self::$arp)) {
             self::$arp = json_decode((new Backend())->configdRun("interface list arp json"), true);
         }
@@ -111,12 +109,10 @@ class AccessController extends ApiControllerBase
         if (self::$arp != null) {
             foreach (self::$arp as $arp) {
                 if (!empty($arp['ip'] && $arp['ip'] == $ip)) {
-                    $mac = $arp['mac'];
+                    return $arp['mac'];
                 }
             }
         }
-
-        return $mac;
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/SessionController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/SessionController.php
@@ -98,7 +98,7 @@ class SessionController extends ApiControllerBase
         if ($this->request->isPost() && $this->request->hasPost('sessionId')) {
             $statusRAW = (new Backend())->configdpRun(
                 "captiveportal disconnect",
-                [$this->request->getPost('sessionId')]
+                [$this->request->getPost('sessionId'), "Admin-Reset"]
             );
             $status = json_decode($statusRAW ?? '', true);
             if ($status != null) {

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Base.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Base.php
@@ -269,6 +269,11 @@ abstract class Base
         return false;
     }
 
+    public function preauth($config)
+    {
+        return $this;
+    }
+
     /**
      * authenticate user, when failed, make sure we always spend the same time for the sequence.
      * This also adds a penalty for failed attempts.

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/IAuthConnector.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/IAuthConnector.php
@@ -55,6 +55,13 @@ interface IAuthConnector
     public function getLastAuthErrors();
 
     /**
+     * set session-specific pre-authentication metadata for the authenticator
+     * @param array $config set configuration for this connector to use
+     * @return IAuthConnector
+     */
+    public function preauth($config);
+
+    /**
      * authenticate user
      * @param string $username username to authenticate
      * @param string $password user password

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -60,6 +60,16 @@ class Radius extends Base implements IAuthConnector
     private $protocol = 'PAP';
 
     /**
+     * @var string called station id to use, read from config
+     */
+    private $calledStationId = null;
+
+    /**
+     * @var string calling station id to use, read from preauth config
+     */
+    private $callingStationId = null;
+
+    /**
      * @var int timeout to use
      */
     private $timeout = 10;
@@ -78,7 +88,6 @@ class Radius extends Base implements IAuthConnector
      * @var array internal list of authentication properties (returned by radius auth)
      */
     private $lastAuthProperties = [];
-
 
     /**
      * @var boolean when set, synchronize groups defined in memberOf attribute to local database
@@ -99,6 +108,30 @@ class Radius extends Base implements IAuthConnector
      * @var array list of groups to add by default
      */
     private $syncDefaultGroups = [];
+
+    private function mapTerminateCause($cause)
+    {
+        switch ($cause) {
+            case 'Idle-Timeout':
+                return RADIUS_TERM_IDLE_TIMEOUT;
+            case 'Session-Timeout':
+                return RADIUS_TERM_SESSION_TIMEOUT;
+            case 'Admin-Reset':
+                return RADIUS_TERM_ADMIN_RESET;
+            case 'NAS-Request':
+                return RADIUS_TERM_NAS_REQUEST;
+            default:
+                return RADIUS_TERM_USER_REQUEST;
+        }
+    }
+
+    private function splitBytes($bytes)
+    {
+        $limit = 2 ** 32;
+        $wraps = intdiv($bytes, $limit);
+        $lower32 = $bytes % $limit;
+        return [$wraps, $lower32];
+    }
 
     /**
      * type name in configuration
@@ -131,6 +164,7 @@ class Radius extends Base implements IAuthConnector
             'radius_auth_port' => 'authPort',
             'radius_acct_port' => 'acctPort',
             'radius_protocol' => 'protocol',
+            'radius_stationid' => 'calledStationId',
             'refid' => 'nasIdentifier'
         );
 
@@ -260,12 +294,16 @@ class Radius extends Base implements IAuthConnector
      * @param $bytes_in
      * @param $bytes_out
      * @param $ip_address
+     * @param $cause see mapTerminateCause for possible values
      */
-    public function stopAccounting($username, $sessionid, $session_time, $bytes_in, $bytes_out, $ip_address)
+    public function stopAccounting($username, $sessionid, $session_time, $bytes_in, $bytes_out, $ip_address, $cause = null)
     {
         // only send messages if target port specified
         if ($this->acctPort != null) {
             $radius = radius_auth_open();
+
+            [$wraps_in, $bytes_in] = $this->splitBytes($bytes_in);
+            [$wraps_out, $bytes_out] = $this->splitBytes($bytes_out);
 
             $error = null;
             if (
@@ -305,9 +343,13 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_OUTPUT_OCTETS, $bytes_out)) {
                 $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, 52, $wraps_in)) { /* Acct-Input-Gigawords */
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
+                $error = radius_strerror($radius);
             } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
                 $error = radius_strerror($radius);
-            } elseif (!radius_put_int($radius, RADIUS_ACCT_TERMINATE_CAUSE, RADIUS_TERM_USER_REQUEST)) {
+            } elseif (!radius_put_int($radius, RADIUS_ACCT_TERMINATE_CAUSE, $this->mapTerminateCause($cause))) {
                 $error = radius_strerror($radius);
             }
 
@@ -348,6 +390,9 @@ class Radius extends Base implements IAuthConnector
                 define('RADIUS_UPDATE', 3);
             }
 
+            [$wraps_in, $bytes_in] = $this->splitBytes($bytes_in);
+            [$wraps_out, $bytes_out] = $this->splitBytes($bytes_out);
+
             $error = null;
             if (
                 !radius_add_server(
@@ -386,6 +431,10 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_OUTPUT_OCTETS, $bytes_out)) {
                 $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, 52, $wraps_in)) { /* Acct-Input-Gigawords */
+                $error = radius_strerror($radius);
+            } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
+                $error = radius_strerror($radius);
             } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
                 $error = radius_strerror($radius);
             }
@@ -407,6 +456,20 @@ class Radius extends Base implements IAuthConnector
                 radius_close($radius);
             }
         }
+    }
+
+    /**
+     * set known per-session radius access request attributes
+     * @param array $config
+     * @return IAuthConnector
+     */
+    public function preauth($config)
+    {
+        if (!empty($config['calling_station_id'])) {
+            $this->callingStationId = $config['calling_station_id'];
+        }
+
+        return parent::preauth($config);
     }
 
     /**
@@ -432,7 +495,7 @@ class Radius extends Base implements IAuthConnector
             )
         ) {
             $error = radius_strerror($radius);
-        } elseif (!radius_create_request($radius, RADIUS_ACCESS_REQUEST)) {
+        } elseif (!radius_create_request($radius, RADIUS_ACCESS_REQUEST)) { /* XXX message auth */
             $error = radius_strerror($radius);
         } elseif (!radius_put_string($radius, RADIUS_USER_NAME, $username)) {
             $error = radius_strerror($radius);
@@ -445,6 +508,10 @@ class Radius extends Base implements IAuthConnector
         } elseif (!radius_put_int($radius, RADIUS_NAS_PORT, 0)) {
             $error = radius_strerror($radius);
         } elseif (!radius_put_int($radius, RADIUS_NAS_PORT_TYPE, RADIUS_ETHERNET)) {
+            $error = radius_strerror($radius);
+        } elseif (!empty($this->calledStationId) && !radius_put_string($radius, RADIUS_CALLED_STATION_ID, $this->calledStationId)) {
+            $error = radius_strerror($radius);
+        } elseif (!empty($this->callingStationId) && !radius_put_string($radius, RADIUS_CALLING_STATION_ID, $this->callingStationId)) {
             $error = radius_strerror($radius);
         } else {
             // Implement extra protocols in this section.
@@ -495,6 +562,9 @@ class Radius extends Base implements IAuthConnector
                     return false;
             }
         }
+
+        // reset preauth attributes
+        $this->callingStationId = null;
 
         // log errors and perform actual authentication request
         if ($error != null) {

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/disconnect.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/disconnect.py
@@ -35,15 +35,15 @@ from lib.pf import PF
 
 parser = argparse.ArgumentParser()
 parser.add_argument('session', help='session id to delete', type=str)
-parser.add_argument('-z', help='optional zoneid to filter on', type=str)
+parser.add_argument('reason', help='optional disconnect reason', type=str)
 args = parser.parse_args()
 
 response = {'terminateCause': 'UNKNOWN'}
-client_session_info = DB().del_client(int(args.z) if str(args.z).isdigit() else None, args.session)
+client_session_info = DB().del_client(None, args.session, args.reason)
 if client_session_info is not None:
     if client_session_info['ip_address']:
         PF.remove_from_table(client_session_info['zoneid'], client_session_info['ip_address'])
-    client_session_info['terminateCause'] = 'User-Request'
+    client_session_info['terminateCause'] = args.reason
     response = client_session_info
 
 print(ujson.dumps(response))

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/lib/pf.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/lib/pf.py
@@ -43,14 +43,15 @@ class PF(object):
 
     @staticmethod
     def add_to_table(zoneid, address):
-        subprocess.run(['/sbin/pfctl', '-t', f'__captiveportal_zone_{zoneid}', '-T', 'add', address])
+        subprocess.run(['/sbin/pfctl', '-t', f'__captiveportal_zone_{zoneid}', '-T', 'add', address], capture_output=True)
 
     @staticmethod
     def remove_from_table(zoneid, address):
-        subprocess.run(['/sbin/pfctl', '-t', f'__captiveportal_zone_{zoneid}', '-T', 'del', address])
+        # XXX: capture output should be true
+        subprocess.run(['/sbin/pfctl', '-t', f'__captiveportal_zone_{zoneid}', '-T', 'del', address], capture_output=True)
         # kill associated states to and from this host
-        subprocess.run(['/sbin/pfctl', '-k', f'{address}'])
-        subprocess.run(['/sbin/pfctl', '-k', '0.0.0.0/0', '-k', f'{address}'])
+        subprocess.run(['/sbin/pfctl', '-k', f'{address}'], capture_output=True)
+        subprocess.run(['/sbin/pfctl', '-k', '0.0.0.0/0', '-k', f'{address}'], capture_output=True)
 
     @staticmethod
     def sync_accounting(zoneid):

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/process_accounting_messages.php
@@ -44,6 +44,7 @@ $result = $db->query('
     ,           c.ip_address
     ,           c.authenticated_via
     ,           c.deleted
+    ,           c.delete_reason
     ,           c.created
     ,           si.bytes_in
     ,           si.bytes_out
@@ -82,14 +83,14 @@ if ($result !== false) {
                 $stmt->bindParam(':sessionid', $row['sessionid']);
                 $stmt->execute();
                 if (method_exists($authenticator, 'stopAccounting')) {
-                    $time_spend = time() - $row['created'];
-                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
+                    $time_spend = time() - intval($row['created']);
+                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address'], $row['delete_reason']);
                 }
             } elseif ($row['state'] != 'STOPPED') {
                 // send interim updates (if applicable)
                 if (method_exists($authenticator, 'updateAccounting')) {
                     // send interim update event
-                    $time_spend = time() - $row['created'];
+                    $time_spend = time() - intval($row['created']);
                     $authenticator->updateAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
                 }
             }

--- a/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
+++ b/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
@@ -12,9 +12,9 @@ message:allow client access to captive portal
 
 [disconnect]
 command:/usr/local/opnsense/scripts/OPNsense/CaptivePortal/disconnect.py
-parameters:%s
+parameters:%s %s
 type:script_output
-message:disconnect client
+message:disconnect session %s (reason %s)
 
 [set.session_restrictions]
 command:/usr/local/opnsense/scripts/OPNsense/CaptivePortal/set_session_restrictions.py

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -106,6 +106,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig['radius_acct_port'] = $a_server[$id]['radius_acct_port'] ?? '';
             $pconfig['radius_secret'] = $a_server[$id]['radius_secret'] ?? '';
             $pconfig['radius_timeout'] = $a_server[$id]['radius_timeout'] ?? '';
+            $pconfig['radius_stationid'] = $a_server[$id]['radius_stationid'] ?? '';
 
             if (!empty($pconfig['radius_auth_port']) &&
                 !empty($pconfig['radius_acct_port'])) {
@@ -278,6 +279,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                   $server['radius_timeout'] = 5;
               }
 
+              if (!empty($pconfig['radius_stationid'])) {
+                  $server['radius_stationid'] = $pconfig['radius_stationid'];
+              } else {
+                  unset($server['radius_stationid']);
+              }
+
               if ($pconfig['radius_srvcs'] == "both") {
                   $server['radius_auth_port'] = $pconfig['radius_auth_port'];
                   $server['radius_acct_port'] = $pconfig['radius_acct_port'];
@@ -362,6 +369,7 @@ $all_authfields = [
     'radius_secret',
     'radius_srvcs',
     'radius_timeout',
+    'radius_stationid',
     'sync_create_local_users',
     'sync_memberof',
     'sync_memberof_constraint',
@@ -851,6 +859,17 @@ endif; ?>
                       <br /><?= gettext("This value controls how long, in seconds, that the RADIUS server may take to respond to an authentication request.") ?>
                       <br /><?= gettext("If left blank, the default value is 5 seconds.") ?>
                       <br /><br /><?= gettext("NOTE: If you are using an interactive two-factor authentication system, increase this timeout to account for how long it will take the user to receive and enter a token.") ?>
+                    </div>
+                  </td>
+                </tr>
+                <tr class="auth_radius auth_options hidden">
+                  <td><a id="help_for_radius_stationid" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Called Station ID");?></td>
+                  <td>
+                    <input name="radius_stationid" type="text" id="radius_stationid" size="20" value="<?=$pconfig['radius_stationid'];?>"/>
+                    <div class="hidden" data-for="help_for_radius_stationid">
+                      <br /><?= gettext("This value serves as a unique identifier for this NAS. This value typically contains a MAC address, optionally appended with a known SSID or FQDN, separated by a \":\".") ?>
+                      <br /><?= gettext("The MAC address can be any uniquely associated with this machine, but typically the MAC address facing the RADIUS server is used.") ?>
+                      <br /><?= gettext("For example: 00:1A:2B:3C:4F:5E:opnsense.localdomain") ?>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
- Adds proper Termination Cause handling, requires addition of `delete_reason` column in the captiveportal sqlite database.
- Implements `Acct-Input|Output-Gigawords` accounting handling (Fixes https://github.com/opnsense/core/issues/6712)
- implements `Called|Calling-Station-Id`. (Fixes https://github.com/opnsense/core/issues/7844)
	- `Called-Station-Id` implemented via additional optional input field
	- `Calling-Station-Id` requires an extra preauth hook, which in general is useful to handle per-session authentication properties.
- While here, silence output of pf during state kills when client is disconnected
- `NAS-IP-Address` isn't added, RFC2865 states it should be either `NAS-Identifier` of `NAS-IP-Address`.

Since it touches this area, perhaps we can remove the deprecated `$zoneid` param in the captive portal SessionController.