### PR TITLE
bootgrid: improve UX and extend bootgrid behavior

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -57,13 +57,6 @@
         // Test if the UUID is valid, used to determine if automation model or internal rule
         const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-        // XXX: Clear any stored column visibility settings for the firewall filter page
-        // Synergizes with the Inspect Button since it unhides certain columns that should be hidden on page load
-        // Prevents messed up views, we always control the intentional default of the page
-        Object.keys(localStorage)
-            .filter(key => key.startsWith("visibleColumns[/ui/firewall/filter/"))
-            .forEach(key => localStorage.removeItem(key));
-
         // Initialize grid
         const grid = $("#{{formGridFilterRule['table_id']}}").UIBootgrid({
             search:'/api/firewall/filter/search_rule/',

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -92,6 +92,30 @@
                     }
                     return request;
                 },
+                headerFormatters: {
+                    enabled: function (column) { return "" },
+                    icons: function (column) { return "" },
+                    source_port: function (column) { return "{{ lang._('Port') }}" },
+                    destination_port: function (column) { return "{{ lang._('Port') }}" },
+                    interface: function (column) {
+                        return '<i class="fa-solid fa-fw fa-network-wired" data-toggle="tooltip" data-placement="right" title="{{ lang._('Network Interface') }}"></i>';
+                    },
+                    evaluations: function (column) {
+                        return '<i class="fa-solid fa-fw fa-bullseye" data-toggle="tooltip" data-placement="left" title="{{ lang._('Number of rule evaluations') }}"></i>';
+                    },
+                    states: function (column) {
+                        return '<i class="fa-solid fa-fw fa-chart-line" data-toggle="tooltip" data-placement="left" title="{{ lang._('Current active states for this rule') }}"></i>';
+                    },
+                    packets: function (column) {
+                        return '<i class="fa-solid fa-fw fa-box" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total packets matched by this rule') }}"></i>';
+                    },
+                    bytes: function (column) {
+                        return '<i class="fa-solid fa-fw fa-database" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total bytes matched by this rule') }}"></i>';
+                    },
+                    categories: function (column) {
+                        return '<i class="fa-solid fa-fw fa-tag" data-toggle="tooltip" data-placement="left" title="{{ lang._('Categories') }}"></i>';
+                    }
+                },
                 formatters:{
                     // Only show command buttons for rules that have a uuid, internal rules will not have one
                     commands: function (column, row) {
@@ -452,35 +476,8 @@
 
         });
 
-        grid.on("loaded.rs.jquery.bootgrid", function () {
-            // XXX: Replace these labels to save some space in the grid
-            // This is a workaround, to change labels in the grid, but NOT in the grid selection dropdown
-            $(this).find('th[data-column-id="enabled"] .text').text("");
-            $(this).find('th[data-column-id="icons"] .text').text("");
-            $(this).find('th[data-column-id="source_port"] .text').text("{{ lang._('Port') }}");
-            $(this).find('th[data-column-id="destination_port"] .text').text("{{ lang._('Port') }}");
-            $(this).find('th[data-column-id="interface"] .text').html(`
-                <i class="fa-solid fa-fw fa-network-wired" data-toggle="tooltip" data-placement="right" title="{{ lang._('Network Interface') }}"></i>
-            `);
-            $(this).find('th[data-column-id="evaluations"] .text').html(`
-                <i class="fa-solid fa-fw fa-bullseye" data-toggle="tooltip" data-placement="left" title="{{ lang._('Number of rule evaluations') }}"></i>
-            `);
-            $(this).find('th[data-column-id="states"] .text').html(`
-                <i class="fa-solid fa-fw fa-chart-line" data-toggle="tooltip" data-placement="left" title="{{ lang._('Current active states for this rule') }}"></i>
-            `);
-            $(this).find('th[data-column-id="packets"] .text').html(`
-                <i class="fa-solid fa-fw fa-box" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total packets matched by this rule') }}"></i>
-            `);
-            $(this).find('th[data-column-id="bytes"] .text').html(`
-                <i class="fa-solid fa-fw fa-database" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total bytes matched by this rule') }}"></i>
-            `);
-            $(this).find('th[data-column-id="categories"] .text').html(`
-                <i class="fa-solid fa-fw fa-tag" data-toggle="tooltip" data-placement="left" title="{{ lang._('Categories') }}"></i>
-            `);
-
-            // Initialize tooltips
+        grid.on("loaded.rs.jquery.bootgrid", function() {
             $('[data-toggle="tooltip"]').tooltip();
-
         });
 
         /* for performance reasons, only load catagories on page load */
@@ -556,22 +553,10 @@
 
         $("#internal_rule_selector").detach().insertAfter("#type_filter_container");
         $('#all_rules_checkbox').change(function(){
-            grid.bootgrid('reload');
+            const isChecked = $('#all_rules_checkbox').is(':checked');
+            grid.bootgrid(isChecked ? "setColumns" : "unsetColumns", ['evaluations', 'states', 'packets', 'bytes'])
+            grid.bootgrid("reload");
         });
-
-        /* XXX: needs fix if we want to show the inspect columns on button press */
-        // Once the grid has reloaded, update the specified checkboxes
-        // grid.on("loaded.rs.jquery.bootgrid", function () {
-        //     const isChecked = $('#all_rules_checkbox').is(':checked');
-        //     const checkboxes = ['evaluations', 'states', 'packets', 'bytes'];
-        //     checkboxes.forEach(name => {
-        //         const $checkbox = $('input[name="' + name + '"].dropdown-item-checkbox');
-        //         if ($checkbox.length && $checkbox.prop('checked') !== isChecked) {
-        //             $checkbox.click();
-        //         }
-        //     });
-        // });
-
 
         $('#all_rules_button').click(function(){
             let $checkbox = $('#all_rules_checkbox');

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -547,7 +547,7 @@
         $("#internal_rule_selector").detach().insertAfter("#type_filter_container");
         $('#all_rules_checkbox').change(function(){
             const isChecked = $('#all_rules_checkbox').is(':checked');
-            grid.bootgrid(isChecked ? "setColumns" : "unsetColumns", ['evaluations', 'states', 'packets', 'bytes'])
+            grid.bootgrid(isChecked ? "setColumns" : "unsetColumns", ['evaluations', 'states', 'packets', 'bytes']);
             grid.bootgrid("reload");
         });
 

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -310,7 +310,6 @@
     $.extend(jQuery.fn.bootgrid.prototype.constructor.Constructor.defaults.labels, {
         all: "{{ lang._('All') }}",
         infos: "{{ lang._('Showing %s to %s of %s entries') | format('{{ctx.start}}','{{ctx.end}}','{{ctx.total}}') }}",
-        loading: "{{ lang._('Loading...') }}",
         noResults: "{{ lang._('No results found!') }}",
         refresh: "{{ lang._('Refresh') }}",
         search: "{{ lang._('Search') }}"

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -312,6 +312,7 @@
         infos: "{{ lang._('Showing %s to %s of %s entries') | format('{{ctx.start}}','{{ctx.end}}','{{ctx.total}}') }}",
         noResults: "{{ lang._('No results found!') }}",
         refresh: "{{ lang._('Refresh') }}",
+        reset: "{{ lang._('Reset to defaults') }}",
         search: "{{ lang._('Search') }}"
     });
     $.extend(jQuery.fn.selectpicker.Constructor.DEFAULTS, {

--- a/src/opnsense/www/css/jquery.bootgrid.css
+++ b/src/opnsense/www/css/jquery.bootgrid.css
@@ -115,10 +115,28 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.bootgrid-table td.loading,
 .bootgrid-table td.no-results {
   background: #fff;
   text-align: center;
+}
+.bootgrid-table tbody {
+    position: relative;
+}
+.bootgrid-table tbody > .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+}
+.overlay > i {
+    font-size: 20px;
+    color: black;
 }
 .bootgrid-table th.select-cell,
 .bootgrid-table td.select-cell {

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -400,6 +400,25 @@ function renderActions()
             // Column selection
             renderColumnSelection.call(this, actions);
 
+            // Reset button
+            if (this.options.resetButton) {
+                var resetIcon = tpl.icon.resolve(getParams.call(this, { iconCss: css.iconReset }))
+                var reset = $(tpl.actionButton.resolve(getParams.call(this, {
+                    content: resetIcon, text: this.options.labels.reset
+                }))).on("click" + namespace, function (e) {
+                    e.stopPropagation();
+                    Object.keys(localStorage)
+                        .filter(key =>
+                            key.startsWith(`visibleColumns[${that.uid}`) ||
+                            key.startsWith(`rowCount[${that.uid}`) ||
+                            key.startsWith(`sortColumns[${that.uid}`)
+                        )
+                        .forEach(key => localStorage.removeItem(key));
+                        location.reload();
+                })
+                actions.append(reset);
+            }
+
             replacePlaceHolder.call(this, actionItems, actions);
         }
     }
@@ -1039,7 +1058,7 @@ var Grid = function(element, options)
     this.sortDictionary = {};
     this.total = 0;
     this.totalPages = 0;
-    this.columnSelectForceReload  = this.options.columnSelectForceReload || false;
+    this.columnSelectForceReload  = this.options.columnSelectForceReload;
     this.cachedResponse = {
         rows: [],
         total: 0
@@ -1074,6 +1093,7 @@ Grid.defaults = {
     navigation: 3, // it's a flag: 0 = none, 1 = top, 2 = bottom, 3 = both (top and bottom)
     padding: 2, // page padding (pagination)
     columnSelection: true,
+    columnSelectForceReload: false, // force data fetch on column select
     rowCount: [10, 25, 50, -1], // rows per page int or array of int (-1 represents "All")
 
     /**
@@ -1124,6 +1144,7 @@ Grid.defaults = {
     highlightRows: false, // highlights new rows (find the page of the first new row)
     sorting: true,
     multiSort: false,
+    resetButton: true,
 
     /**
      * General search settings to configure the search field behaviour.
@@ -1345,6 +1366,7 @@ Grid.defaults = {
         iconColumns: "fa-list",
         iconDown: "fa-chevron-down",
         iconRefresh: "fa-arrows-rotate",
+        iconReset: "fa-share-square",
         iconSearch: "fa-magnifying-glass",
         iconUp: "fa-chevron-up",
         infos: "infos", // must be a unique class name or constellation of class names within the header and footer,
@@ -1416,6 +1438,7 @@ Grid.defaults = {
         loading: '<i class="fa fa-spinner fa-spin"></i>',
         noResults: "No results found!",
         refresh: "Refresh",
+        reset: "Reset",
         search: "Search"
     },
 
@@ -1973,7 +1996,7 @@ Grid.prototype.getTotalPageCount = function()
 Grid.prototype.getTotalRowCount = function()
 {
     return this.total;
-    };
+};
 
 // GRID COMMON TYPE EXTENSIONS
 // ============

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -125,7 +125,8 @@ function loadColumns()
                 cssClass: data.cssClass || "",
                 headerCssClass: data.headerCssClass || "",
                 headerFormatter: that.options.headerFormatters[data.headerformatter] || /* explicitly defined through data-headerFormatter */
-                                 that.options.headerFormatters[data.columnId] || /* implicitly defined through data-columnId */
+                                 !(Object.getOwnPropertyNames(Object.prototype).includes(data.columnId)) ? /* reserved keywords */
+                                 that.options.headerFormatters[data.columnId] : /* implicitly defined through data-columnId */
                                  null, /* no header formatter present */
                 formatter: that.options.formatters[data.formatter] || null,
                 order: !sorted ?

--- a/src/opnsense/www/js/jquery.bootgrid.js
+++ b/src/opnsense/www/js/jquery.bootgrid.js
@@ -186,14 +186,17 @@ function update(rows, total)
     }
 
     var shouldRenderHeader = false;
-    that.columns.forEach(col => {
-        if (col.setStaged) {
-            col.visible = shouldRenderHeader = true;
-            col.setStaged = false;
+    $.each(that.columns, function (i, column) {
+        var checkbox = $('#' + that.element.attr('id') + '_' + column.id);
+        if (column.setStaged) {
+            column.visible = shouldRenderHeader = true;
+            checkbox.prop('checked', true);
+            column.setStaged = false;
         }
 
-        if (col.unsetStaged) {
-            col.visible = col.unsetStaged = false;
+        if (column.unsetStaged) {
+            column.visible = column.unsetStaged = false;
+            checkbox.prop('checked', false);
             shouldRenderHeader = true;
         }
     });
@@ -442,7 +445,7 @@ function renderColumnSelection(actions)
             if (column.visibleInSelection)
             {
                 var item = $(tpl.actionDropDownCheckboxItem.resolve(getParams.call(that,
-                    { name: column.id, label: column.text, checked: column.visible })))
+                    { name: column.id, label: column.text, checked: column.visible, id: that.element.attr('id') + '_' + column.id })))
                         .on("click" + namespace, selector, function (e)
                         {
                             e.stopPropagation();
@@ -1499,7 +1502,7 @@ Grid.defaults = {
         actionButton: "<button class=\"btn btn-default\" type=\"button\" title=\"{{ctx.text}}\">{{ctx.content}}</button>",
         actionDropDown: "<div class=\"{{css.dropDownMenu}}\"><button class=\"btn btn-default dropdown-toggle\" type=\"button\" data-toggle=\"dropdown\"><span class=\"{{css.dropDownMenuText}}\">{{ctx.content}}</span> <span class=\"caret\"></span></button><ul class=\"{{css.dropDownMenuItems}}\" role=\"menu\"></ul></div>",
         actionDropDownItem: "<li><a data-action=\"{{ctx.action}}\" class=\"{{css.dropDownItem}} {{css.dropDownItemButton}}\">{{ctx.text}}</a></li>",
-        actionDropDownCheckboxItem: "<li><label class=\"{{css.dropDownItem}}\"><input name=\"{{ctx.name}}\" type=\"checkbox\" value=\"1\" class=\"{{css.dropDownItemCheckbox}}\" {{ctx.checked}} /> {{ctx.label}}</label></li>",
+        actionDropDownCheckboxItem: "<li><label class=\"{{css.dropDownItem}}\"><input id=\"{{ctx.id}}\" name=\"{{ctx.name}}\" type=\"checkbox\" value=\"1\" class=\"{{css.dropDownItemCheckbox}}\" {{ctx.checked}} /> {{ctx.label}}</label></li>",
         actions: "<div class=\"{{css.actions}}\"></div>",
         body: "<tbody></tbody>",
         cell: "<td class=\"{{ctx.css}}\" style=\"{{ctx.style}}\">{{ctx.content}}</td>",

--- a/src/opnsense/www/themes/opnsense-dark/build/css/jquery.bootgrid.css
+++ b/src/opnsense/www/themes/opnsense-dark/build/css/jquery.bootgrid.css
@@ -114,9 +114,27 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.bootgrid-table td.loading,
 .bootgrid-table td.no-results {
   text-align: center;
+}
+.bootgrid-table tbody {
+    position: relative;
+}
+.bootgrid-table tbody > .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+}
+.overlay > i {
+    font-size: 20px;
+    color: white;
 }
 .bootgrid-table th.select-cell,
 .bootgrid-table td.select-cell {


### PR DESCRIPTION
Added options:

- `columnSelectForceReload` (default false). Changes current behavior for all bootgrids (currently adding a new column re-fetches the data, which is unnecessary in most cases). Caches response internally, thereby assuming the data for a newly added column is already present.
- `headerFormatters` object. Can be explicitly set via `data-headerFormatter-<identifier>` or implicitly linked via the row id.
- `setColumns` function (`grid.bootgrid("setColumns", ['colA', 'colB' ...])`). Marks passed columns for addition. Requires either a `reload` or `softreload` to apply.
- `unsetColumns` function (`grid.bootgrid("unsetColumns", ['colA', 'colB' ...])`). Marks passed columns for removal. Requires either a `reload` or `softreload` to apply.
- `softreload` function (`grid.bootgrid("softreload")`).

UX changes:

- `headerFormatters` now makes sure that if column headers require styling, the styling doesn't flash and is applied from the beginning / during reloads.
- The "Loading..." status has been replaced with a transparent overlay containing a spinner. This prevents unnecessary style flashing when data is reloaded, i.e. when scrolling through pages, setting columns, forced refreshes etc.
- Added "reset to defaults" button, resetting the sort, visiblity and rowcount options to the controller defaults (removes them from localstorage).

Fixes https://github.com/opnsense/core/issues/8457 