### PR TITLE
dnsmasq: Adjust filter on interface field so group interfaces are filtered

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -143,6 +143,7 @@
                 <BlankDesc>Any</BlankDesc>
                 <Filters>
                     <if>/^(?!lo0$).*/</if>
+                    <type>/(?s)^((?!group).)*$/</type>
                 </Filters>
                 <AllowDynamic>Y</AllowDynamic>
             </interface>
@@ -215,6 +216,7 @@
                 <BlankDesc>Any</BlankDesc>
                 <Filters>
                     <if>/^(?!lo0$).*/</if>
+                    <type>/(?s)^((?!group).)*$/</type>
                 </Filters>
                 <AllowDynamic>Y</AllowDynamic>
             </interface>


### PR DESCRIPTION
Right now it reveals group interfaces since they do not have an additional filter set.

Compare to this:

https://github.com/opnsense/core/blob/01f364e1bdbde2ae77dd1f6419c49a3823799466/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml#L143-L152