### PR TITLE
dnsmasq: Add filter function for interfaces and tags with multiselect

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
@@ -408,15 +408,15 @@ class SettingsController extends ApiMutableModelControllerBase
 
         // Assemble result
         return [
-            'interfaces' => [
-                'label' => gettext('Interfaces'),
-                'icon'  => 'fa fa-ethernet text-info',
-                'items' => $interfaces
-            ],
             'tags' => [
                 'label' => gettext('Tags'),
                 'icon'  => 'fa fa-tag text-primary',
                 'items' => $tags
+            ],
+            'interfaces' => [
+                'label' => gettext('Interfaces'),
+                'icon'  => 'fa fa-ethernet text-info',
+                'items' => $interfaces
             ]
         ];
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
@@ -37,8 +37,8 @@ class SettingsController extends ApiMutableModelControllerBase
     protected static $internalModelClass = '\OPNsense\Dnsmasq\Dnsmasq';
 
     /**
-     * Tags and interface filter function. Interfaces are tags too
-     * in the sense of dnsmasq.
+     * Tags and interface filter function.
+     * Interfaces are tags too, in the sense of dnsmasq.
      *
      * @param array $filterValues List of values to filter against (e.g. UUIDs, interface names).
      * @param array $fieldNames   List of field names to extract values from in each record.

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -41,17 +41,6 @@
             updateServiceControlUI('dnsmasq');
         });
 
-        function insertTagSelect(grid_id) {
-            if (!['domain', 'boot'].includes(grid_id)) {
-                let header = $("#" + grid_id + "-header");
-                let $actionBar = header.find('.actionBar');
-                if ($actionBar.length) {
-                    $("#tag_select_container").detach().insertBefore($actionBar.find('.search'));
-                    $("#tag_select_container").show();
-                }
-            }
-        }
-
         let all_grids = {};
         $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
             let grid_ids = null;
@@ -110,10 +99,18 @@
                         } else if (grid_id == 'host') {
                             all_grids[grid_id].find("tfoot td:last").append($("#hosts_tfoot_append > button").detach());
                         }
-                        insertTagSelect(grid_id);
                     } else {
                         all_grids[grid_id].bootgrid('reload');
-                        insertTagSelect(grid_id);
+
+                    }
+                    // insert tag selectpicker in all grids that use tags or interfaces, boot excluded cause two grids in same tab
+                    if (!['domain', 'boot'].includes(grid_id)) {
+                        let header = $("#" + grid_id + "-header");
+                        let $actionBar = header.find('.actionBar');
+                        if ($actionBar.length) {
+                            $("#tag_select_container").detach().insertBefore($actionBar.find('.search'));
+                            $("#tag_select_container").show();
+                        }
                     }
                 });
             }
@@ -192,6 +189,7 @@
 
         $('#tag_select').on('changed.bs.select', function () {
             Object.keys(all_grids).forEach(function (grid_id) {
+                // boot is not excluded here, as it reloads in same tab as options
                 if (!['domain'].includes(grid_id)) {
                     all_grids[grid_id].bootgrid('reload');
                 }
@@ -224,7 +222,7 @@
 </div>
 
 <div id="tag_select_container" class="btn-group" style="display: none;">
-    <select id="tag_select" class="selectpicker" multiple data-title="Interfaces / Tags" data-live-search="true" data-size="10" data-width="200px" data-container="body">
+    <select id="tag_select" class="selectpicker" multiple data-title="{{ lang._('Tags / Interfaces') }}" data-live-search="true" data-size="10" data-width="200px" data-container="body">
     </select>
 </div>
 

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -108,8 +108,8 @@
                         let header = $("#" + grid_id + "-header");
                         let $actionBar = header.find('.actionBar');
                         if ($actionBar.length) {
-                            $("#tag_select_container").detach().insertBefore($actionBar.find('.search'));
-                            $("#tag_select_container").show();
+                            $('#tag_select_container').detach().insertBefore($actionBar.find('.search'));
+                            $('#tag_select_container').show();
                         }
                     }
                 });
@@ -175,7 +175,9 @@
                         $optgroup.append(
                             $('<option>', {
                                 value: item.value,
-                                text: item.label
+                                text: item.label,
+                                'data-icon': group.icon,
+                                'data-subtext': group.label
                             })
                         );
                     }
@@ -222,7 +224,7 @@
 </div>
 
 <div id="tag_select_container" class="btn-group" style="display: none;">
-    <select id="tag_select" class="selectpicker" multiple data-title="{{ lang._('Tags / Interfaces') }}" data-live-search="true" data-size="10" data-width="200px" data-container="body">
+    <select id="tag_select" class="selectpicker" multiple data-title="{{ lang._('Tags & Interfaces') }}" data-show-subtext="true" data-live-search="true" data-size="15" data-width="200px" data-container="body">
     </select>
 </div>
 

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -158,38 +158,9 @@
         });
 
         // Populate tag selectpicker
-        ajaxCall('/api/dnsmasq/settings/getTagList', {}, function (data) {
-            const $select = $('#tag_select');
-            $select.empty();
+        $('#tag_select').fetch_options('/api/dnsmasq/settings/get_tag_list');
 
-            for (const groupKey in data) {
-                const group = data[groupKey];
-
-                if (group.items.length > 0) {
-                    const $optgroup = $('<optgroup>', {
-                        label: group.label,
-                        'data-icon': group.icon
-                    });
-
-                    for (const item of group.items) {
-                        $optgroup.append(
-                            $('<option>', {
-                                value: item.value,
-                                text: item.label,
-                                'data-icon': group.icon,
-                                'data-subtext': group.label
-                            })
-                        );
-                    }
-
-                    $select.append($optgroup);
-                }
-            }
-
-            $select.selectpicker('refresh');
-        });
-
-        $('#tag_select').on('changed.bs.select', function () {
+        $('#tag_select').change(function () {
             Object.keys(all_grids).forEach(function (grid_id) {
                 // boot is not excluded here, as it reloads in same tab as options
                 if (!['domain'].includes(grid_id)) {

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -622,6 +622,74 @@ $.fn.SimpleActionButton = function (params) {
     });
 }
 
+/**
+ * fetch option list for remote url, when a list is returned, expects either a list of items formatted like
+ * [
+ *    {'label': 'my_label', value: 'my_value'}
+ * ]
+ * or an option group like:
+ * {
+ *      group_value: {
+ *          label: 'my_group_label',
+ *          icon: 'fa fa-tag text-primary',
+ *          items: [{'label': 'my_label', value: 'my_value'}]
+ *      }
+ * }
+ *
+ * When data is formatted differently, the data_callback can be used to re-format.
+ *
+ * @param url
+ * @param params
+ * @param data_callback callout to cleanse data before usage
+ * @param store_data store data in data attribute (in its original form)
+ */
+$.fn.fetch_options = function(url, params, data_callback, store_data) {
+    var deferred = $.Deferred();
+    var $obj = $(this);
+    $obj.empty();
+
+    ajaxGet(url, params ?? {}, function(data){
+        if (store_data === true) {
+            $obj.data("store", data);
+        }
+        if (typeof data_callback === "function") {
+            data = data_callback(data);
+        }
+        if (Array.isArray(data)) {
+            data.map(function (item) {
+                $obj.append($("<option/>").attr({"value": item.value}).text(item.label));
+            });
+        } else {
+            for (const groupKey in data) {
+                const group = data[groupKey];
+                if (group.items.length > 0) {
+                    const $optgroup = $('<optgroup>', {
+                        label: group.label,
+                        'data-icon': group.icon
+                    });
+                    for (const item of group.items) {
+                        $optgroup.append(
+                            $('<option>', {
+                                value: item.value,
+                                text: item.label,
+                                'data-subtext': group.label
+                            })
+                        );
+                    }
+                    $obj.append($optgroup);
+                }
+            }
+        }
+        if ($obj.hasClass('selectpicker')) {
+            $obj.selectpicker('refresh');
+        }
+        $obj.change();
+        deferred.resolve();
+    });
+
+    return deferred.promise();
+};
+
 
 /**
  *  File upload dialog, constructs a modal, asks for a file to upload and sets {'payload': ..,, 'filename': ...}


### PR DESCRIPTION
I really want something like this.

It's a combined selectpicker for interfaces and tags, and you can quickly filter seamlessly through multiple tabs to get a quick overview of the current configuration.

It improves UX quite a bit if the configuration is larger, especially if multiple tags and interfaces are used.

@AdSchellevis It might need some cleanup but the concept works.