### PR TITLE
dnsmasq: Add internalModelUseSafeDelete to prevent deletion of currently used tags

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/SettingsController.php
@@ -35,6 +35,7 @@ class SettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'dnsmasq';
     protected static $internalModelClass = '\OPNsense\Dnsmasq\Dnsmasq';
+    protected static $internalModelUseSafeDelete = true;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
While testing I added and deleted tags, and then my configuration became inconsistent because tags are used in model relation fields.

This should prevent inconsistent configuration states as it disallows tags in use from being deleted.