### PR TITLE
Sunset mirror dns-root.de

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
@@ -17,10 +17,6 @@
             <description>Deciso (HTTPS, NL, Commercial)</description>
         </mirror>
         <mirror>
-            <url>https://mirror.dns-root.de/opnsense</url>
-            <description>dns-root.de (HTTPS, Cloudflare CDN)</description>
-        </mirror>
-        <mirror>
             <url>https://opnsense.c0urier.net</url>
             <description>c0urier.net (HTTPS, Horsens, DK)</description>
         </mirror>


### PR DESCRIPTION
After much deliberation, I have decided to shut down my dns-root.de mirror for the opnsense package files.

### Why?
There are two main reasons for this decision:

1. Less involvement in the development & deployment process, which makes it hard for me to track new releases etc.
2. Still technical issues with the combination of Cloudflare and the mechanism behind pkg.

Unfortunately, I'm not very active in the opnsense community anymore and therefore don't catch problems with the mirror etc. fast enough.
In combination with work & personal projects I don't see my own demand for availability fulfilled.

### Outlook
With this pull request the mirror will be removed from the source, but will be online & supported at least until opnsense 26.1.
Based on the traffic I will decide in early 2026 how to proceed and most likely block access to the mirror in about a year.

### Important
This only affects the package files, not the release files like ISOs etc.
If the core team has no objection, I will continue to support the release files; only the package files will be deprecated in early 2026.

---
I would like to thank the core team of opnsense for their support over the years, and especially @fichtner for all the help he has given to get things up and running.

I'd also like to mention that I'm not moving away from opnsense with this decision.
I'm still using it at home and at work, and I'm currently planning to move more work environments to it.
So I'm still here, just with a slightly different focus.