### PR TITLE
dnsmasq: Require interface when ra_mode is selected due to ra-param interface requirement.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -28,7 +28,7 @@
         <label>Constructor</label>
         <type>dropdown</type>
         <style>selectpicker</style>
-        <help>Interface to use to calculate a DHCPv6 and/or RA range. Start address can then be specified as a suffix (e.g. ::, ::1 or ::400).</help>
+        <help>Interface to use to calculate a DHCPv6 or RA range. Start address can then be specified as a suffix (e.g. ::, ::1 or ::400).</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -27,8 +27,8 @@
         <id>range.constructor</id>
         <label>Constructor</label>
         <type>dropdown</type>
-        <style>selectpicker style_dhcpv6</style>
-        <help>Interface to use to calculate the proper range, when selected, a range may be specified as a suffix (e.g. ::1, ::400)</help>
+        <style>selectpicker</style>
+        <help>Interface to use to calculate a DHCPv6 and/or RA range. Start address can then be specified as a suffix (e.g. ::, ::1 or ::400).</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
@@ -60,7 +60,7 @@
         <label>RA Priority</label>
         <type>dropdown</type>
         <help>Priority of the RA announcements.</help>
-        <style>selectpicker style_dhcpv6</style>
+        <style>selectpicker style_ra</style>
         <grid_view>
             <visible>false</visible>
         </grid_view>
@@ -69,7 +69,7 @@
         <id>range.ra_mtu</id>
         <label>RA MTU</label>
         <type>text</type>
-        <style>style_dhcpv6</style>
+        <style>style_ra</style>
         <help>Optional MTU to send to clients via Router Advertisements. If unsure leave empty.</help>
         <grid_view>
             <visible>false</visible>
@@ -80,7 +80,7 @@
         <label>RA Interval</label>
         <type>text</type>
         <hint>60</hint>
-        <style>style_dhcpv6</style>
+        <style>style_ra</style>
         <help>Time (seconds) between Router Advertisements.</help>
         <grid_view>
             <visible>false</visible>
@@ -91,7 +91,7 @@
         <label>RA Router Lifetime</label>
         <type>text</type>
         <hint>1200</hint>
-        <style>style_dhcpv6</style>
+        <style>style_ra</style>
         <help>The lifetime of the route may be changed or set to zero, which allows a router to advertise prefixes but not a route via itself. When using HA, setting a short timespan here is adviced for faster IPv6 failover. A good combination could be 10 seconds RA interval and 30 seconds RA router lifetime. Going lower than that can pose issues in busy networks.</help>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -203,7 +203,6 @@ class Dnsmasq extends BaseModel
                     );
                 }
             }
-
         }
 
         foreach ($this->dhcp_options->iterateItems() as $option) {

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -161,6 +161,15 @@ class Dnsmasq extends BaseModel
                 );
             }
 
+            if ($range->interface->isEmpty() && !$range->ra_mode->isEmpty()) {
+                $messages->appendMessage(
+                    new Message(
+                        gettext("Selecting an RA Mode requires an interface."),
+                        $key . ".interface"
+                    )
+                );
+            }
+
             // Validate RA mode combinations
             $valid_ra_mode_combinations = [
                 ['ra-names', 'slaac'],
@@ -194,6 +203,7 @@ class Dnsmasq extends BaseModel
                     );
                 }
             }
+
         }
 
         foreach ($this->dhcp_options->iterateItems() as $option) {

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -90,7 +90,6 @@
                         }
                     } else {
                         all_grids[grid_id].bootgrid('reload');
-
                     }
                 });
             }

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -90,6 +90,7 @@
                         }
                     } else {
                         all_grids[grid_id].bootgrid('reload');
+
                     }
                 });
             }
@@ -125,15 +126,29 @@
         let selected_tab = window.location.hash != "" ? window.location.hash : "#general";
         $('a[href="' +selected_tab + '"]').click();
 
-        $("#range\\.start_addr").on("keyup change", function() {
-            let value = $(this).val() || "";
-            if (value.includes(":")) {
-                $(".style_dhcpv6").closest('tr').show();
-                $(".style_dhcpv4").closest('tr').hide();
-            } else {
-                $(".style_dhcpv6").closest('tr').hide();
-                $(".style_dhcpv4").closest('tr').show();
-            }
+        $("#range\\.start_addr, #range\\.ra_mode").on("keyup change", function () {
+            const addr = $("#range\\.start_addr").val() || "";
+            const ra_mode = String($("#range\\.ra_mode").val() || "").trim();
+
+            const styleVisibility = [
+                {
+                    class: "style_dhcpv4",
+                    visible: !addr.includes(":")
+                },
+                {
+                    class: "style_dhcpv6",
+                    visible: addr.includes(":")
+                },
+                {
+                    class: "style_ra",
+                    visible: ra_mode !== ""
+                }
+            ];
+
+            styleVisibility.forEach(style => {
+                const elements = $("." + style.class).closest("tr");
+                style.visible ? elements.show() : elements.hide();
+            });
         });
 
     });

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -174,8 +174,9 @@ constructor:{{helpers.physical_interface(dhcp_range.constructor)}},
 domain={{ dhcp_range.domain }},{{dhcp_range.start_addr}},{{dhcp_range.end_addr}}
 {% endif %}
 
-{% if dhcp_range.ra_mode %}
-ra-param={{ helpers.physical_interface(dhcp_range.constructor) }}
+{#- Only gets added if a custom ra_mode is chosen, otherwise the global defaults of enable-ra are used. -#}
+{% if dhcp_range.ra_mode and dhcp_range.interface %}
+ra-param={{ helpers.physical_interface(dhcp_range.interface) }}
 {%- if dhcp_range.ra_mtu %},mtu:{{ dhcp_range.ra_mtu }}{% endif -%}
 {%- if dhcp_range.ra_priority %},{{ dhcp_range.ra_priority }}{% endif -%},
 {%- if dhcp_range.ra_interval %}{{ dhcp_range.ra_interval }}{% else %}60{% endif -%},


### PR DESCRIPTION
There were a few choices how to solve this, but this seemed to be the best in my opinion:

- Constructor is not a requirement for using RA now, as you can also use SLAAC with static IPv6 e.g. ``2003:aaaa:bbbb:cc00::`` without using a constructor, if you do not want to set a GUA on the interface.
- ``Default`` ra_mode with enable_ra does not use custom ra_params, but use implicit global defaults from enable_ra
- When a custom ra_mode is selected, the interface becomes a requirement, but thats how SLAAC works anyway, it must use an interface.

This prevents any new checkboxes or type selectpickers from being introduced.

Validation prevents misconfiguration and style visibility hides options automatically that are not executed in the template for the current choice.

Fixes: https://github.com/opnsense/core/issues/8479