### PR TITLE
DHCP6: use `lease_type` to key lease map in addition to `iaid_duid`

### DIFF
--- a/src/opnsense/scripts/dhcp/get_leases6.py
+++ b/src/opnsense/scripts/dhcp/get_leases6.py
@@ -148,7 +148,7 @@ if __name__ == '__main__':
                 elif len(line) > 1 and line[0] == '}' and len(cur_lease) > 0:
                     cur_lease.append(line)
                     parsed_lease = parse_lease(cur_lease)
-                    last_leases[parsed_lease['iaid_duid']] = parsed_lease
+                    last_leases[parsed_lease['lease_type'], parsed_lease['iaid_duid']] = parsed_lease
                     cur_lease = []
                 elif len(cur_lease) > 0:
                     cur_lease.append(line)


### PR DESCRIPTION
## Description

Currently, `get_leases6` misreports clients that request an address *and* a prefix delegation. Adding the lease type to the map key prevents this.

## Testing

Request an address and a PD from the same client (same DUID) and verify that the address appeared in the output of `/api/dhcpv6/leases/searchLease/` and that the delegated prefix appeared in `/api/dhcpv6/leases/searchPrefix/`.

Fixes: #8472