### PR TITLE
dnsmasq: Add full dhcp-host support for IPv4 and IPv6

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -181,9 +181,7 @@ function _dnsmasq_add_host_entries()
 
     foreach ($dnsmasqcfg['hosts'] as $host) {
         /* The host.ip field supports multiple IPv4 and IPv6 addresses */
-        $ipList = explode(',', $host['ip']);
-        foreach ($ipList as $ip) {
-            $ip = trim($ip);
+        foreach (explode(',', $host['ip']) as $ip) {
             if (!empty($host['host']) && empty($host['domain'])) {
                 $lhosts .= "{$ip}\t{$host['host']}\n";
             } elseif (!empty($host['host'])) {

--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -180,19 +180,24 @@ function _dnsmasq_add_host_entries()
     }
 
     foreach ($dnsmasqcfg['hosts'] as $host) {
-        if (!empty($host['host']) && empty($host['domain'])) {
-            $lhosts .= "{$host['ip']}\t{$host['host']}\n";
-        } elseif (!empty($host['host'])) {
-            /* XXX: The question is if we do want "host" as a global alias */
-            $lhosts .= "{$host['ip']}\t{$host['host']}.{$host['domain']} {$host['host']}\n";
-        }
-        if (!empty($host['aliases'])) {
-            foreach (explode(",", $host['aliases']) as $alias) {
-                /**
-                 * XXX: pre migration all hosts where added here as alias, when we combine host.domain we
-                 *      miss some information, which is likely not a very good idea anyway.
-                 */
-                $lhosts .= "{$host['ip']}\t{$alias}\n";
+        /* The host.ip field supports multiple IPv4 and IPv6 addresses */
+        $ipList = explode(',', $host['ip']);
+        foreach ($ipList as $ip) {
+            $ip = trim($ip);
+            if (!empty($host['host']) && empty($host['domain'])) {
+                $lhosts .= "{$ip}\t{$host['host']}\n";
+            } elseif (!empty($host['host'])) {
+                /* XXX: The question is if we do want "host" as a global alias */
+                $lhosts .= "{$ip}\t{$host['host']}.{$host['domain']} {$host['host']}\n";
+            }
+            if (!empty($host['aliases'])) {
+                foreach (explode(",", $host['aliases']) as $alias) {
+                    /**
+                    * XXX: pre migration all hosts where added here as alias, when we combine host.domain we
+                    *      miss some information, which is likely not a very good idea anyway.
+                    */
+                    $lhosts .= "{$ip}\t{$alias}\n";
+                }
             }
         }
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
@@ -17,15 +17,18 @@
     </field>
     <field>
         <id>host.ip</id>
-        <label>IP address</label>
-        <type>text</type>
-        <help>IP address of the host, e.g. 192.168.100.100 or fd00:abcd::1</help>
+        <label>IP addresses</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>IP addresses of the host, e.g. 192.168.100.100 or fd00:abcd::1. Can be multiple IPv4 and IPv6 addresses for dual stack configurations. Setting multiple addresses will automatically assign the best match based on the subnet of the interface receiving the DHCP Discover.</help>
     </field>
     <field>
         <id>host.aliases</id>
         <label>Aliases</label>
         <type>select_multiple</type>
         <style>tokenize</style>
+        <allownew>true</allownew>
         <help>list of aliases (fqdn)</help>
         <grid_view>
             <visible>false</visible>
@@ -36,16 +39,48 @@
         <label>DHCP</label>
     </field>
     <field>
+        <id>host.client_id</id>
+        <label>Client identifier</label>
+        <type>text</type>
+        <help>Match the identifier of the client, e.g., DUID for DHCPv6. Setting the special character "*" will ignore the client identifier for DHCPv4 leases if a client offers both as choice.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>host.hwaddr</id>
         <label>Hardware address</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Match the hardware address of the client. Can be multiple addresses, e.g., if the client has multiple network cards. Though keep in mind that DNSmasq cannot assume which address is the correct one when multiple send DHCP Discover at the same time.</help>
+    </field>
+    <field>
+        <id>host.lease_time</id>
+        <label>Lease time</label>
         <type>text</type>
-        <help>When offered and the client requests an address via dhcp, assign the address provided here</help>
+        <hint>86400</hint>
+        <help>Defines how long the addresses (leases) given out by the server are valid (in seconds)</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>host.set_tag</id>
         <label>Tag [set]</label>
         <type>dropdown</type>
-        <help>Optional tag to set for requests matching this range which can be used to selectively match dhcp options</help>
+        <help>Optional tag to set for requests matching this range which can be used to selectively match dhcp options. Can be left empty if options with an interface tag exist, since the client automatically receives this tag based on the interface receiving the DHCP Discover.</help>
+    </field>
+    <field>
+        <id>host.ignore</id>
+        <label>Ignore</label>
+        <type>checkbox</type>
+        <help>Ignore any DHCP packets of this host. Useful if it should get served by a different DHCP server.</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
     </field>
     <field>
         <type>header</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
@@ -49,7 +49,7 @@
     </field>
     <field>
         <id>host.hwaddr</id>
-        <label>Hardware address</label>
+        <label>Hardware addresses</label>
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -60,14 +60,6 @@ class Dnsmasq extends BaseModel
                 continue;
             }
             $key = $host->__reference;
-            if (!$host->hwaddr->isEmpty() && strpos($host->ip->getCurrentValue(), ':') !== false) {
-                $messages->appendMessage(
-                    new Message(
-                        gettext("Only IPv4 reservations are currently supported"),
-                        $key . ".ip"
-                    )
-                );
-            }
 
             if ($host->host->isEmpty() && $host->hwaddr->isEmpty()) {
                 $messages->appendMessage(

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -61,14 +61,22 @@ class Dnsmasq extends BaseModel
             }
             $key = $host->__reference;
 
-            if ($host->host->isEmpty() && $host->hwaddr->isEmpty()) {
+            if (
+                $host->host->isEmpty() &&
+                $host->hwaddr->isEmpty() &&
+                $host->client_id->isEmpty()
+            ) {
                 $messages->appendMessage(
                     new Message(
-                        gettext("Hostnames my only be omitted when a hardware address is offered."),
+                        gettext(
+                            "Hostnames may only be omitted when either a hardware address " .
+                            "or a client identifier is provided."
+                        ),
                         $key . ".host"
                     )
                 );
             }
+
         }
 
         foreach ($this->dhcp_ranges->iterateItems() as $range) {

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -95,7 +95,6 @@ class Dnsmasq extends BaseModel
                     )
                 );
             }
-
         }
 
         foreach ($this->dhcp_ranges->iterateItems() as $range) {

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -56,28 +56,32 @@ class Dnsmasq extends BaseModel
         $messages = parent::performValidation($validateFullModel);
 
         $usedDhcpIpAddresses = [];
+        foreach ($this->hosts->iterateItems() as $host) {
+            if (!$host->hwaddr->isEmpty() || !$host->client_id->isEmpty()) {
+                foreach (explode(',', (string)$host->ip) as $ip) {
+                    $usedDhcpIpAddresses[$ip] = isset($usedDhcpIpAddresses[$ip]) ? $usedDhcpIpAddresses[$ip] + 1 : 1;
+                }
+            }
+        }
 
         foreach ($this->hosts->iterateItems() as $host) {
+            if (!$validateFullModel && !$host->isFieldChanged()) {
+                continue;
+            }
             $key = $host->__reference;
 
             // all dhcp-host IP addresses must be unique, host overrides can have duplicate IP addresses
             if (!$host->hwaddr->isEmpty() || !$host->client_id->isEmpty()) {
                 foreach (explode(',', (string)$host->ip) as $ip) {
-                    if (isset($usedDhcpIpAddresses[$ip])) {
+                    if ($usedDhcpIpAddresses[$ip] > 1) {
                         $messages->appendMessage(
                             new Message(
                                 sprintf(gettext("'%s' is already used in another DHCP host entry."), $ip),
                                 $key . ".ip"
                             )
                         );
-                    } else {
-                        $usedDhcpIpAddresses[$ip] = true;
                     }
                 }
-            }
-
-            if (!$validateFullModel && !$host->isFieldChanged()) {
-                continue;
             }
 
             if (

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -85,7 +85,10 @@
                 <FieldSeparator>,</FieldSeparator>
                 <AsList>Y</AsList>
             </ip>
-            <client_id type="TextField"/>
+            <client_id type="TextField">
+                <Mask>/^(?:\*|(?:[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2})+))$/</Mask>
+                <ValidationMessage>Value must be a colon-separated hexadecimal sequence (e.g., 01:02:f3) or "*".</ValidationMessage>
+            </client_id>
             <hwaddr type="MacAddressField">
                 <FieldSeparator>,</FieldSeparator>
                 <AsList>Y</AsList>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -82,8 +82,18 @@
             <ip type="NetworkField">
                 <Required>Y</Required>
                 <NetMaskAllowed>N</NetMaskAllowed>
+                <FieldSeparator>,</FieldSeparator>
+                <AsList>Y</AsList>
             </ip>
-            <hwaddr type="MacAddressField"/>
+            <client_id type="TextField"/>
+            <hwaddr type="MacAddressField">
+                <FieldSeparator>,</FieldSeparator>
+                <AsList>Y</AsList>
+            </hwaddr>
+            <lease_time type="IntegerField">
+                <MinimumValue>1</MinimumValue>
+            </lease_time>
+            <ignore type="BooleanField"/>
             <set_tag type="ModelRelationField">
                 <Model>
                     <tag>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -200,13 +200,9 @@ id:{{ host.client_id }},
 {%-     if host.set_tag -%}
 set:{{ host.set_tag|replace('-', '') }},
 {%-     endif -%}
-{%-     if host.ip -%}
-{%-         set ip_list = host.ip.split(',') -%}
-{%-         for ip in ip_list -%}
-{%-             set ip = ip.strip() -%}
-{{ '[' if ':' in ip }}{{ ip }}{{ ']' if ':' in ip }}{%- if not loop.last %},{% endif %}
-{%-         endfor -%}
-{%-     endif -%}
+{%-     for ip in host.ip.split(',')|map('trim')  if host.ip -%}
+{{ '[' ~ ip ~ ']' if ':' in ip else ip  }}{%- if not loop.last %},{% endif %}
+{%-     endfor -%}
 {%-     if host.host -%}
 ,{{ host.host }}
 {%-     endif -%}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -186,9 +186,37 @@ ra-param={{ helpers.physical_interface(dhcp_range.interface) }}
 {% endfor %}
 
 {% for host in helpers.toList('dnsmasq.hosts') %}
-{%    if host.hwaddr and host.hwaddr.find(':') == -1%}
-dhcp-host={{host.hwaddr}}{% if host.set_tag%},set:{{host.set_tag|replace('-','')}}{% endif %},{{host.ip}}
-{%    endif %}
+{#     Skip if MAC is missing or invalid (no colon), unless client_id is present #}
+{%     if not host.client_id and (not host.hwaddr or host.hwaddr.find(':') == -1) %}
+{%         continue %}
+{%     endif %}
+dhcp-host=
+{%-     if host.client_id -%}
+id:{{ host.client_id }}
+{%-     endif -%}
+{%-     if host.hwaddr -%}
+{% if host.client_id %},{% endif %}{{ host.hwaddr }}
+{%-     endif -%}
+{%-     if host.set_tag -%}
+,set:{{ host.set_tag|replace('-', '') }}
+{%-     endif -%}
+{%-     if host.ip -%}
+,
+{%-         set ip_list = host.ip.split(',') -%}
+{%-         for ip in ip_list -%}
+{%-             set ip = ip.strip() -%}
+{{ '[' if ':' in ip }}{{ ip }}{{ ']' if ':' in ip }}{%- if not loop.last %},{% endif %}
+{%-         endfor -%}
+{%-     endif -%}
+{%-     if host.host -%}
+,{{ host.host }}
+{%-     endif -%}
+{%-     if host.lease_time -%}
+,{{ host.lease_time }}{% else %},86400
+{%-     endif -%}
+{%-     if host.ignore|default('0') == '1' -%}
+,ignore
+{%-     endif +%}
 {% endfor %}
 
 {% set has_default=[] %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -192,16 +192,15 @@ ra-param={{ helpers.physical_interface(dhcp_range.interface) }}
 {%     endif %}
 dhcp-host=
 {%-     if host.client_id -%}
-id:{{ host.client_id }}
+id:{{ host.client_id }},
 {%-     endif -%}
 {%-     if host.hwaddr -%}
-{% if host.client_id %},{% endif %}{{ host.hwaddr }}
+{{ host.hwaddr }},
 {%-     endif -%}
 {%-     if host.set_tag -%}
-,set:{{ host.set_tag|replace('-', '') }}
+set:{{ host.set_tag|replace('-', '') }},
 {%-     endif -%}
 {%-     if host.ip -%}
-,
 {%-         set ip_list = host.ip.split(',') -%}
 {%-         for ip in ip_list -%}
 {%-             set ip = ip.strip() -%}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8487

Directive:
https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
```
--dhcp-host=[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]
```

This should almost fully satisfy the requirements of the man page regarding this directive.

Test dataset:

```
    <hosts uuid="9e5eb2a8-0ab2-4ed9-af5b-0c2787ddbfab">
      <host>hostabc</host>
      <domain>example.com</domain>
      <ip>172.16.1.200,fd12:3456:789a:1::2</ip>
      <client_id>*</client_id>
      <hwaddr>aa:aa:aa:aa:aa:aa,bb:bb:bb:bb:bb:bb</hwaddr>
      <lease_time/>
      <ignore>1</ignore>
      <set_tag/>
      <descr/>
      <comments/>
      <aliases>abc1.example.com,abc2.example.com</aliases>
    </hosts>
    <hosts uuid="883bd818-2885-443d-a699-90fb55fe3466">
      <host>hostd</host>
      <domain>example.com</domain>
      <ip>172.16.1.199,fd12:3456:789a:1::1</ip>
      <client_id>12121-3243242-222</client_id>
      <hwaddr/>
      <lease_time>4040</lease_time>
      <ignore>0</ignore>
      <set_tag>09e84129-c07b-4133-8251-f17c4d00f675</set_tag>
      <descr/>
      <comments/>
      <aliases>abc1.example.com,abc2.example.com</aliases>
    </hosts>
    <hosts uuid="af0c1d49-cc38-4468-9af4-61c31933dc79">
      <host>hostggg</host>
      <domain>example.com</domain>
      <ip>192.168.4.5</ip>
      <client_id/>
      <hwaddr/>
      <lease_time/>
      <ignore>0</ignore>
      <set_tag/>
      <descr/>
      <comments/>
      <aliases/>
    </hosts>
    <hosts uuid="04b21c12-6a51-4e45-b219-54b8052c9a17">
      <host>hostfff</host>
      <domain>example.com</domain>
      <ip>192.168.4.6</ip>
      <client_id/>
      <hwaddr>fe:fe:fe:fe:fe:fe</hwaddr>
      <lease_time/>
      <ignore>0</ignore>
      <set_tag/>
      <descr/>
      <comments/>
      <aliases/>
    </hosts>
```

Result:

```/usr/local/etc/dnsmasq.conf```
```
dhcp-host=id:*,aa:aa:aa:aa:aa:aa,bb:bb:bb:bb:bb:bb,172.16.1.200,[fd12:3456:789a:1::2],hostabc,86400,ignore
dhcp-host=id:12121-3243242-222,set:09e84129c07b41338251f17c4d00f675,172.16.1.199,[fd12:3456:789a:1::1],hostd,4040
dhcp-host=fe:fe:fe:fe:fe:fe,192.168.4.6,hostfff,86400
```

```/var/etc/dnsmasq-hosts```
```
172.16.1.200	hostabc.example.com hostabc
172.16.1.200	abc1.example.com
172.16.1.200	abc2.example.com
fd12:3456:789a:1::2	hostabc.example.com hostabc
fd12:3456:789a:1::2	abc1.example.com
fd12:3456:789a:1::2	abc2.example.com
172.16.1.199	hostd.example.com hostd
172.16.1.199	abc1.example.com
172.16.1.199	abc2.example.com
fd12:3456:789a:1::1	hostd.example.com hostd
fd12:3456:789a:1::1	abc1.example.com
fd12:3456:789a:1::1	abc2.example.com
192.168.4.5	hostggg.example.com hostggg
192.168.4.6	hostfff.example.com hostfff
```