### PR TITLE
auth/user: Fix url hash in link so redirection shows the correct menu path

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
@@ -43,7 +43,7 @@
                         let refid = $(this).data("row-id") !== undefined ? $(this).data("row-id") : '';
                         ajaxGet('/api/auth/user/get/' + refid, {}, function(data){
                             if (data.user) {
-                                window.location ='/ui/trust/cert/#user=' + data.user.name ;
+                                window.location ='/ui/trust/cert#user=' + data.user.name ;
                             }
                         });
                     },


### PR DESCRIPTION
Right now, clicking `Search certificates by username` will redirect to:

`/ui/trust/cert/#user=test-user`

which will get history replaced to:

`/ui/trust/cert/#`

Due to the additional /# this does not exist in the menu.