### PR TITLE
Change default DHCP domain to `internal`

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -6,7 +6,7 @@
   <system>
     <optimization>normal</optimization>
     <hostname>OPNsense</hostname>
-    <domain>localdomain</domain>
+    <domain>internal</domain>
     <dnsallowoverride>1</dnsallowoverride>
     <dnsallowoverride_exclude/>
     <group>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/forms/wizard_general_info.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/forms/wizard_general_info.xml
@@ -8,6 +8,7 @@
         <id>wizard.domain</id>
         <label>Domain</label>
         <type>text</type>
+        <help>Do not use 'local' as your internal domain name. It is reserved for and will interfere with mDNS (avahi, bonjour, etc.). Instead, use the special-use domain internal or home.arpa, also to avoid DNSSEC validation issues. E.g. internal, name.internal.</help>
     </field>
     <field>
         <id>wizard.language</id>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -341,9 +341,9 @@ $( document ).ready(function() {
               <td>
                 <input name="domain" type="text" value="<?=$pconfig['domain'];?>" />
                 <div class="hidden" data-for="help_for_domain">
-                  <?=gettext("Do not use 'local' as your internal domain name. It is reserved for and will interfere with mDNS (avahi, bonjour, etc.). Use the special-purpose home.arpa domain instead."); ?>
+                  <?=gettext("Do not use 'local' as your internal domain name. It is reserved for and will interfere with mDNS (avahi, bonjour, etc.). Instead, use the special-use domain internal or home.arpa, also to avoid DNSSEC validation issues."); ?>
                   <br />
-                  <?=sprintf(gettext("e.g. %sexample.net, branch.example.com, home.arpa, etc.%s"),'<em>','</em>') ?>
+                  <?=sprintf(gettext("e.g. %sinternal, name.internal%s"),'<em>','</em>') ?>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
as current domain is blocked by DNSSEC validating clients

This PR changes the domain, updates the help and also adds it to the new setup wizard. And don't just suggest the name as in #5898, update the default as previously suggested in #7193.

systemd-resolved has `internal` on its DNSSEC negative trust anchor list since 2016, where `home.arpa` was added later:
https://github.com/systemd/systemd/commit/30c778094b90a637c6691c462a66df81eeb865b5#diff-23206c93f79c419c8a911a58d533e3ca9a6103ff215a5fcc887aaecb59021276R155

**.internal history**

Internal was first mentioned in RFC 6762 (2013) within multicast DNS:
https://datatracker.ietf.org/doc/html/rfc6762#appendix-G

IANA assessment (2024-01):
https://itp.cdn.icann.org/en/files/root-system/identification-tld-private-use-24-01-2024-en.pdf

ICANN board resolution (2024-07):
https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-29-07-2024-en#section2.a

IETF RFC draft (2025-03):
https://datatracker.ietf.org/doc/html/draft-davies-internal-tld
According to the last IETF 122 meeting there is `Almost no work` to do:
https://datatracker.ietf.org/doc/minutes-122-dnsop/

**.home.arpa (former aproch/name)**
https://datatracker.ietf.org/doc/html/rfc8375