### PR TITLE
interfaces/bridge: Fix migration when there are no bridge members set

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/Bridge.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/Bridge.php
@@ -45,6 +45,11 @@ class Bridge extends BaseModel
                 continue;
             }
             $key = $bridge->__reference;
+
+            if (!isset($bridge->members)) {
+                continue;
+            }
+
             $members = explode(',', $bridge->members->getCurrentValue());
             if (!$bridge->span->isEmpty() && in_array($bridge->span->getCurrentValue(), $members)) {
                 $messages->appendMessage(


### PR DESCRIPTION
Fixes this:

```
root@opn-dev-01:/usr/local/opnsense/mvc/script # ./run_migrations.php

Fatal error: Uncaught Error: Call to a member function getCurrentValue() on null in /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/Bridge.php:49
Stack trace:
#0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(683): OPNsense\Interfaces\Bridge->performValidation(false)
#1 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(824): OPNsense\Base\BaseModel->serializeToConfig()
#2 /usr/local/opnsense/mvc/script/run_migrations.php(54): OPNsense\Base\BaseModel->runMigrations()
#3 {main}
  thrown in /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/Bridge.php on line 49
```

I have no bridge configuration in my config.

After this patch the migration succeeds:

`Migrated OPNsense\Interfaces\Bridge from <unversioned> to 1.0.0`