### PR TITLE
Add field boottime to api/system/systemTime

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -145,6 +145,7 @@ class SystemController extends ApiControllerBase
         $response = [
             'uptime' => $this->formatUptime(time() - $matches[1]),
             'datetime' => date("D M j G:i:s T Y"),
+            'boottime' => date("D M j G:i:s T Y", $matches[1]),
             'config' => $last_change,
             'loadavg' => $loadavg,
         ];


### PR DESCRIPTION
This PR implements the feature request in #8556
Additionally to the calculated and formatted uptime, it exposes the systems boot time as Date-Time-String alongside the Current System time. This makes it easier for API consumers to work with the value, instead of having to try to calculate the boot time from the uptime.