### PR TITLE
dnsmasq: Improve interface/tag selectpicker

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -257,7 +257,7 @@
 </div>
 
 <div id="tag_select_container" class="btn-group" style="display: none;">
-    <button type="button" id="tag_select_clear" class="btn btn-default" title="Clear Selection">
+    <button type="button" id="tag_select_clear" class="btn btn-default" title="{{ lang._('Clear Selection') }}">
         <i id="tag_select_icon" class="fa fa-fw fa-filter"></i>
     </button>
     <select id="tag_select" class="selectpicker" multiple data-title="{{ lang._('Tags & Interfaces') }}" data-show-subtext="true" data-live-search="true" data-size="15" data-width="200px" data-container="body">

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -187,6 +187,18 @@
                     all_grids[grid_id].bootgrid('reload');
                 }
             });
+
+            $('#tag_select_icon')
+                .toggleClass('text-success fa-filter-circle-xmark', ($(this).val() || []).length > 0)
+                .toggleClass('fa-filter', !($(this).val() || []).length);
+
+        });
+
+        // Clear tag selectpicker
+        $('#tag_select_clear').on('click', function () {
+            $('#tag_select').selectpicker('val', []);
+            $('#tag_select').selectpicker('refresh');
+            $('#tag_select').trigger('change');
         });
 
     });
@@ -196,8 +208,15 @@
     tbody.collapsible > tr > td:first-child {
         padding-left: 30px;
     }
+    #tag_select_clear {
+        border-right: none;
+    }
     #tag_select_container {
         margin-right: 20px;
+    }
+    #tag_select_container .bootstrap-select > .dropdown-toggle {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
     }
 </style>
 
@@ -215,6 +234,9 @@
 </div>
 
 <div id="tag_select_container" class="btn-group" style="display: none;">
+    <button type="button" id="tag_select_clear" class="btn btn-default" title="Clear Selection">
+        <i id="tag_select_icon" class="fa fa-fw fa-filter"></i>
+    </button>
     <select id="tag_select" class="selectpicker" multiple data-title="{{ lang._('Tags & Interfaces') }}" data-show-subtext="true" data-live-search="true" data-size="15" data-width="200px" data-container="body">
     </select>
 </div>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -201,6 +201,29 @@
             $('#tag_select').trigger('change');
         });
 
+        // Autofill interface/tag when add dialog is opened
+        $(
+            '#{{ formGridHostOverride["edit_dialog_id"] }}, ' +
+            '#{{ formGridDHCPrange["edit_dialog_id"] }}, ' +
+            '#{{ formGridDHCPoption["edit_dialog_id"] }}, ' +
+            '#{{ formGridDHCPboot["edit_dialog_id"] }}'
+        ).on('opnsense_bootgrid_mapped', function(e, actionType) {
+            if (actionType === 'add') {
+                const selectedTags = $('#tag_select').val();
+
+                if (selectedTags && selectedTags.length > 0) {
+                    $(
+                        '#host\\.set_tag, ' +
+                        '#range\\.interface, #range\\.set_tag, ' +
+                        '#option\\.interface, #option\\.tag, ' +
+                        '#boot\\.tag'
+                    )
+                    .selectpicker('val', selectedTags)
+                    .selectpicker('refresh');
+                }
+            }
+        });
+
     });
 </script>
 


### PR DESCRIPTION
- Add button to clear the filter instantly, and show that the current view is filtered by changing the fa-icon and color
- When interfaces and tags are selected, add them on best effort basis in the opened add dialog