### PR TITLE
Add ability to specify pipe and queue masking using the *-ip6 specifiers.

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/TrafficShaper/TrafficShaper.xml
@@ -43,6 +43,8 @@
                         <none>(none)</none>
                         <src-ip>source</src-ip>
                         <dst-ip>destination</dst-ip>
+                        <src-ip6>source (ip6)</src-ip6>
+                        <dst-ip6>destination (ip6)</dst-ip6>
                     </OptionValues>
                 </mask>
                 <buckets type="IntegerField">
@@ -157,6 +159,8 @@
                         <none>(none)</none>
                         <src-ip>source</src-ip>
                         <dst-ip>destination</dst-ip>
+                        <src-ip6>source (ip6)</src-ip6>
+                        <dst-ip6>destination (ip6)</dst-ip6>
                     </OptionValues>
                 </mask>
                 <buckets type="IntegerField">

--- a/src/opnsense/service/templates/OPNsense/Shaper/dnctl.conf
+++ b/src/opnsense/service/templates/OPNsense/Shaper/dnctl.conf
@@ -7,7 +7,8 @@ pipe {{ pipe.number }} config bw {{ pipe.bandwidth }}{{ pipe.bandwidthMetric }}/
  if pipe.queue %} queue {{ pipe.queue }}{%
  if pipe.queueMetric != 'slots' %}{{pipe.queueMetric}}{% endif %}{% endif
  %}{% if pipe.buckets %} buckets {{ pipe.buckets }}{% endif
- %}{% if pipe.mask != 'none' %} mask {{ pipe.mask }} 0xffffffff {% endif %}{%
+ %}{% if pipe.mask in ['src-ip', 'dst-ip'] %} mask {{ pipe.mask }} 0xffffffff {% endif
+ %}{% if pipe.mask in ['src-ip6', 'dst-ip6'] %} mask {{ pipe.mask }} 128 {% endif %}{%
  if pipe.delay|default('') != '' %} delay {{pipe.delay}} {% endif %} type {%
  if pipe.scheduler|default('') != '' %} {{pipe.scheduler}} {% else %} wf2q+ {% endif %}{%
  if pipe.codel_enable|default('0') == '1' and pipe.scheduler != 'fq_codel' %} codel {% endif %}{%
@@ -32,7 +33,10 @@ pipe {{ pipe.number }} config bw {{ pipe.bandwidth }}{{ pipe.bandwidthMetric }}/
 {% for queue in helpers.toList('OPNsense.TrafficShaper.queues.queue') %}
 {%    if helpers.getUUIDtag(queue.pipe) in ['pipe'] %}
 queue {{ queue.number }} config pipe {{ helpers.getUUID(queue.pipe).number
-}}{% if queue.buckets %} buckets {{ queue.buckets }}{% endif %}{% if queue.mask != 'none' %} mask {{ queue.mask }} 0xffffffff {% endif %} weight {{ queue.weight }}{%
+}}{% if queue.buckets %} buckets {{ queue.buckets }}{% endif
+%}{% if queue.mask in ['src-ip', 'dst-ip'] %} mask {{ queue.mask }} 0xffffffff {% endif
+%}{% if queue.mask in ['src-ip6', 'dst-ip6'] %} mask {{ queue.mask }} 128 {% endif
+%} weight {{ queue.weight }}{%
 if queue.codel_enable|default('0') == '1' %} codel {%
     if queue.codel_target|default('') != ''%} target {{queue.codel_target}} {% endif %}{%
     if queue.codel_interval|default('') != ''%} interval {{queue.codel_interval}} {% endif %}{%


### PR DESCRIPTION
Currently, dynamic pipe and queues based on masking don't work (well) for IPv6. IPv6 flows appear to all end up bucketed into single `::/0` flow. This isn't particularly desirable when attempting to use the traffic shaper to implement the "share bandwidth equally among all users" use-case, because there's no way to distinguish between IPv6 flows.

From experimentation, it seems like configuring a mask using `*-ip` specifiers always buckets IPv6 flows into a single bucket, and vice versa for `*-ip6` specifiers.

This patch allows the user to decide which mask specifiers to use. As far as I can tell, this change should be backwards compatible with existing configuration.