### PR TITLE
Interfaces / firewall: Improve private and bogon network filters

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -302,7 +302,7 @@ function filter_core_rules_system($fw, $defaults)
     // block bogons and private nets
     $bogontmpl = ['type' => 'block', 'log' => !isset($config['syslog']['nologbogons']), 'disablereplyto' => 1];
     $privtmpl = ['type' => 'block', 'log' => !isset($config['syslog']['nologprivatenets']),
-      'from' => '10.0.0.0/8,127.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16',
+      'from' => '10.0.0.0/8,127.0.0.0/8,100.64.0.0/10,172.16.0.0/12,169.254.0.0/16,192.168.0.0/16',
       'disablereplyto' => 1];
     foreach ($fw->getInterfaceMapping() as $intf => $intfinfo) {
         $fw->registerFilterRule(
@@ -333,7 +333,7 @@ function filter_core_rules_system($fw, $defaults)
             5,
             ['direction' => 'in', 'interface' => $intf, 'ipprotocol' => 'inet6',
             '#ref' => "interfaces.php?if=" . $intf . "#blockpriv",
-            'descr' => "Block private networks from " . $intfinfo['descr'], 'from' => 'fc00::/7',
+            'descr' => "Block private networks from " . $intfinfo['descr'], 'from' => 'fd00::/8,fe80::/64',
             'disabled' => $ipv6_disabled || empty($intfinfo['blockpriv'])],
             $privtmpl
         );

--- a/src/opnsense/scripts/firmware/bogons.sh
+++ b/src/opnsense/scripts/firmware/bogons.sh
@@ -58,7 +58,7 @@ LINES_V4=`wc -l ${WORKDIR}/fullbogons-ipv4.txt | awk '{ print $1 }'`
 if [ $ENTRIES_MAX -gt $((2*ENTRIES_TOT-${ENTRIES_V4:-0}+LINES_V4)) ]; then
     # private and pseudo-private networks will be excluded
     # as they are being operated by a separate GUI option
-    egrep -v "^100.64.0.0/10|^192.168.0.0/16|^172.16.0.0/12|^10.0.0.0/8" ${WORKDIR}/fullbogons-ipv4.txt > ${DESTDIR}/bogons
+    egrep -v "^169.254.0.0/16|^100.64.0.0/10|^192.168.0.0/16|^172.16.0.0/12|^10.0.0.0/8" ${WORKDIR}/fullbogons-ipv4.txt > ${DESTDIR}/bogons
     RESULT=`/sbin/pfctl -t bogons -T replace -f ${DESTDIR}/bogons 2>&1`
     echo "$RESULT" | awk '{ print "Bogons V4 file updated: " $0 }' | logger
 else
@@ -73,7 +73,11 @@ LINES_V6=`wc -l ${WORKDIR}/fullbogons-ipv6.txt | awk '{ print $1 }'`
 if [ $BOGONS_V6_TABLE_COUNT -gt 0 ]; then
     ENTRIES_V6=`pfctl -vvsTables | awk '/-\tbogonsv6$/ {getline; print $2}'`
     if [ $ENTRIES_MAX -gt $((2*ENTRIES_TOT-${ENTRIES_V6:-0}+LINES_V6)) ]; then
-        egrep -iv "^fc00::/7" ${WORKDIR}/fullbogons-ipv6.txt > ${DESTDIR}/bogonsv6
+        # private and pseudo-private networks will be excluded
+        # as they are being operated by a separate GUI option
+        cat ${WORKDIR}/fullbogons-ipv6.txt > ${DESTDIR}/bogonsv6
+        echo "!fd00::/8" >> ${DESTDIR}/bogonsv6
+        echo "!fe80::/64" >> ${DESTDIR}/bogonsv6
         RESULT=`/sbin/pfctl -t bogonsv6 -T replace -f ${DESTDIR}/bogonsv6 2>&1`
         echo "$RESULT" | awk '{ print "Bogons V6 file updated: " $0 }' | logger
     else
@@ -81,7 +85,11 @@ if [ $BOGONS_V6_TABLE_COUNT -gt 0 ]; then
     fi
 else
     if [ $ENTRIES_MAX -gt $((2*ENTRIES_TOT+LINES_V6)) ]; then
-        egrep -iv "^fc00::/7" ${WORKDIR}/fullbogons-ipv6.txt > ${DESTDIR}/bogonsv6
+        # private and pseudo-private networks will be excluded
+        # as they are being operated by a separate GUI option
+        cat ${WORKDIR}/fullbogons-ipv6.txt > ${DESTDIR}/bogonsv6
+        echo "!fd00::/8" >> ${DESTDIR}/bogonsv6
+        echo "!fe80::/64" >> ${DESTDIR}/bogonsv6
         echo "Not updating IPv6 bogons table because IPv6 Allow is off" | logger
     else
         echo "Not saving IPv6 bogons table (IPv6 Allow is off and table-entries limit is potentially too low)" | logger


### PR DESCRIPTION
Disabling 'Block private networks' now allows link-local addresses and ULAs without having to disable 'Block bogon networks'.

Draft, open for comments. If accepted, I'll update the help texts in `interfaces.php`.

Tests performed:
'Block private networks' enabled, 'Block bogon networks' enabled or disabled: Link-locals and ULAs are blocked.
'Block private networks' disabled, 'Block bogon networks' enabled or disabled: Link-locals and ULAs pass.

Inspired by #6776. Closes #8587.