### PR TITLE
Fix help message for Kea static routes

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -59,7 +59,7 @@
         <id>subnet4.option_data.static_routes</id>
         <label>Static routes</label>
         <type>text</type>
-        <help>Static routes that the client should install in its routing cache, defined as dest-ip1,router-ip1;dest-ip2,router-ip2</help>
+        <help>Static routes that the client should install in its routing cache, defined as dest-ip1,router-ip1,dest-ip2,router-ip2</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>


### PR DESCRIPTION
Using semicolons to separate destination–router pairs is a syntax error. Kea expects the `static-routes` option to be a list of IP addresses: https://github.com/isc-projects/kea/blob/60222843a6b2c4e7a6c7d4e63f88d0dcfa0d5b97/doc/examples/kea4/all-options.json#L415-L430