### PR TITLE
dnsmasq: Add dhcpv6 captive-portal option

### DIFF
--- a/src/opnsense/scripts/dns/dnsmasq_dhcp_options.py
+++ b/src/opnsense/scripts/dns/dnsmasq_dhcp_options.py
@@ -38,8 +38,11 @@ result = {}
 
 # not yet registered by name, but pratical to have
 # https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml
+# https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml
 if args.mode == "dhcp":
     result['114'] = 'dhcp captive-portal [114]'
+elif args.mode == "dhcp6":
+    result['103'] = 'dhcp captive-portal [103]'
 
 sp = subprocess.run(['/usr/local/sbin/dnsmasq', '--help', args.mode], capture_output=True, text=True)
 for line in sp.stdout.split("\n"):


### PR DESCRIPTION
For: https://github.com/opnsense/docs/pull/722 since it states that DHCPv6 can be used for the captive portal option too. It was missing in dnsmasq.