### PR TITLE
Adjust a few instances of dnsmasq labeling/description primarily for the services widget display

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -60,7 +60,7 @@ function dnsmasq_services()
     if (!empty((string)$mdl->dns_port)) {
         $pconfig['dns_ports'] = [ (string)$mdl->dns_port ];
     }
-    $pconfig['description'] = gettext('Dnsmasq DNS');
+    $pconfig['description'] = gettext('Dnsmasq DNS/DHCP');
     $pconfig['php']['restart'] = ['dnsmasq_configure_do'];
     $pconfig['php']['start'] = ['dnsmasq_configure_do'];
     $pconfig['configd']['stop'] = ['dnsmasq stop'];
@@ -84,7 +84,7 @@ function dnsmasq_xmlrpc_sync()
     $result = [];
 
     $result[] = [
-        'description' => gettext('Dnsmasq DNS'),
+        'description' => gettext('Dnsmasq DNS/DHCP'),
         'section' => 'dnsmasq',
         'id' => 'dnsforwarder',
         'services' => ['dnsmasq'],
@@ -146,7 +146,7 @@ function dnsmasq_configure_do($verbose = false)
         return;
     }
 
-    service_log('Starting Dnsmasq DNS...', $verbose);
+    service_log('Starting Dnsmasq DNS/DHCP...', $verbose);
 
     _dnsmasq_add_host_entries();
 


### PR DESCRIPTION
Not sure what the roadmap/plans for this are but I noticed this after migrating from KEA to dnsmasq for my DHCP usage today (especially since I use 0 for the DNS port to disable it, which makes the service name/label of `Dnsmasq DNS` even more confusing for me). I figured it would be easier to open a PR instead of an issue for such a small thing...

![image](https://github.com/user-attachments/assets/86e1e031-b00e-4a80-a7ed-ead9b3216774)
