### PR TITLE
dnsmasq: Allow static on IPv6 ranges

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -101,7 +101,7 @@
         <id>range.mode</id>
         <label>Mode</label>
         <type>select_multiple</type>
-        <style>selectpicker style_dhcpv4</style>
+        <style>selectpicker</style>
         <help>Mode flags to set for this range, 'static' means no addresses will be automatically assigned. </help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -184,14 +184,6 @@ class Dnsmasq extends BaseModel
                     )
                 );
             }
-            if ($is_static && $start_inet == 'inet6') {
-                $messages->appendMessage(
-                    new Message(
-                        gettext("Static is only available IPv4."),
-                        $key . ".mode"
-                    )
-                );
-            }
 
             if ($range->interface->isEmpty() && !$range->ra_mode->isEmpty()) {
                 $messages->appendMessage(


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8641

I had already prepared it in the template and the configuration seems valid for dhcpv6 and ra.