### PR TITLE
dnsmasq: Add missing dhcp_boot to template

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
@@ -21,7 +21,7 @@
         <type>text</type>
     </field>
     <field>
-        <id>option.description</id>
+        <id>boot.description</id>
         <label>Description</label>
         <type>text</type>
         <help>You may enter a description here for your reference (not parsed).</help>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -251,6 +251,22 @@ option6:{{ option.option6 }}{% if option.value %},{{ option.value }}{% endif %}
 dhcp-option=6,0.0.0.0
 {% endif %}
 
+{% for boot in helpers.toList('dnsmasq.dhcp_boot') %}
+dhcp-boot=
+{%-    if boot.tag -%}
+tag:{{ boot.tag }},
+{%-    endif -%}
+{%-    if boot.filename -%}
+{{ boot.filename }},
+{%-    endif -%}
+{%-    if boot.servername -%}
+{{ boot.servername }},
+{%-    endif -%}
+{%-    if boot.address -%}
+{{ boot.address }}
+{%-    endif +%}
+{% endfor %}
+
 {% if dnsmasq.no_ident  == '1' %}
 no-ident
 {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8624

Since any dhcp_boot parameter is optional, there is no additional validation needed.

I tested it in most combinations, even all empty container, and it did not cause dnsmasq to fail.