### PR TITLE
dnsmasq: Do not create entries in dnsmasq-hosts file for dhcp-host entries

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -180,6 +180,10 @@ function _dnsmasq_add_host_entries()
     }
 
     foreach ($dnsmasqcfg['hosts'] as $host) {
+        // Do not create entries in dnsmasq-hosts file for dhcp-host entries
+        if (!empty($host['client_id']) || !empty($host['hwaddr'])) {
+            continue;
+        }
         /* The host.ip field supports multiple IPv4 and IPv6 addresses */
         foreach (explode(',', $host['ip']) as $ip) {
             if (!empty($host['host']) && empty($host['domain'])) {


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8642

As the form allows both Host Overrides and dhcp-host entries to be created, there can be wrong entries in the /var/etc/dnsmasq-host file.

Dnsmasq registers the names of leases dynamically. We do not need to additionally add them statically.
If there is already something in this host file, registering the name will fail, as also shown here in the forum:

https://forum.opnsense.org/index.php?topic=47135.msg237342#msg237342

It also prevents partial IPv6 addresses to be resolved with their full prefix and registered, returning just partial entries.

