### PR TITLE
dnsmasq: Extract MAC from DUID in most cases to allow vendor information

### DIFF
--- a/src/opnsense/scripts/dhcp/get_dnsmasq_leases.py
+++ b/src/opnsense/scripts/dhcp/get_dnsmasq_leases.py
@@ -64,6 +64,14 @@ if __name__ == '__main__':
                     else:
                         lease['hwaddr'] = parts[1]
 
+                    # DUID-LL and DUID-LLT (IPv6) contain the hwaddr, extract it
+                    if lease['hwaddr'] == '' and lease['client_id'] != '*':
+                        parts_client_id = lease['client_id'].lower().split(":")
+                        if len(parts_client_id) >= 10:
+                            duid_type = parts_client_id[0:2]
+                            if duid_type in [['00', '01'], ['00', '03']]:
+                                lease['hwaddr'] = ":".join(parts_client_id[-6:])
+
                     for net in ranges:
                         if net.overlaps(ipaddress.ip_network(lease['address'])):
                             lease['if'] = ranges[net]

--- a/src/opnsense/scripts/dhcp/get_dnsmasq_leases.py
+++ b/src/opnsense/scripts/dhcp/get_dnsmasq_leases.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
                         lease['hwaddr'] = parts[1]
 
                     # DUID-LL and DUID-LLT (IPv6) contain the hwaddr, extract it
-                    if lease['hwaddr'] == '' and lease['client_id'] != '*':
+                    if lease['hwaddr'] == '' and ':' in lease['client_id']:
                         parts_client_id = lease['client_id'].lower().split(":")
                         if len(parts_client_id) >= 10:
                             duid_type = parts_client_id[0:2]


### PR DESCRIPTION
For: https://github.com/opnsense/core/issues/8643

In most cases the DUID can be used to extract the MAC address to show vendor information for IPv6 leases just like IPv4 leases.