### PR TITLE
dnsmasq: Allow multiple tags per dhcp-boot, fix tag rendering by removing "-" like in other parts of template

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
@@ -8,7 +8,7 @@
     <field>
         <id>boot.tag</id>
         <label>Tag</label>
-        <type>dropdown</type>
+        <type>select_multiple</type>
         <help>Only offer this boot image to the clients matched by the given tag. Can be optionally combined with an interface tag.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -277,6 +277,7 @@
                         <display>tag</display>
                     </tag>
                 </Model>
+                <Multiple>Y</Multiple>
             </tag>
             <filename type="TextField"/>
             <servername type="TextField"/>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -251,7 +251,9 @@ dhcp-boot=
 tag:{{ boot.interface }},
 {%-    endif -%}
 {%-    if boot.tag -%}
-tag:{{ boot.tag }},
+{%-        for tag in boot.tag.replace('-','').split(',') -%}
+tag:{{ tag }},
+{%-        endfor -%}
 {%-    endif -%}
 {%-    if boot.filename -%}
 {{ boot.filename }},


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8690