### PR TITLE
dnsmasq: Set aliases of dhcp-host as cname directive

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -208,7 +208,7 @@ set:{{ host.set_tag|replace('-', '') }},
 {%-     endif +%}
 {#      Output CNAME records for aliases #}
 {%-     if host.aliases and host.host -%}
-cname={{ host.aliases }},{{ host.host }}{% if host.domain %}.{{ host.domain }}{% endif %}
+cname={{ host.aliases }},{{ host.host }}
 {%     endif +%}
 {% endfor %}
 

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -206,6 +206,10 @@ set:{{ host.set_tag|replace('-', '') }},
 {%-     if host.ignore|default('0') == '1' -%}
 ,ignore
 {%-     endif +%}
+{#      Output CNAME records for aliases #}
+{%-     if host.aliases and host.host -%}
+cname={{ host.aliases }},{{ host.host }}{% if host.domain %}.{{ host.domain }}{% endif %}
+{%     endif +%}
 {% endfor %}
 
 {% set has_default=[] %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8694

A minimal suggestion for a fix. Will need validation for the cnames and maybe some UX.