### PR TITLE
captive portal: align accounting session timeout with captive portal API

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
@@ -326,9 +326,27 @@ class AccessController extends ApiControllerBase
 
             $zone = (new \OPNsense\CaptivePortal\CaptivePortal())->getByZoneId($zoneId);
 
-            if ($zone != null && !empty((string)$zone->hardtimeout) && !empty($clientSession['startTime'])) {
-                if ((time() - (int)$clientSession['startTime']) < (string)$zone->hardtimeout * 60) {
-                    $result['seconds-remaining'] = (string)$zone->hardtimeout * 60 - ((time() - (int)$clientSession['startTime']));
+            if ($zone != null && !empty($clientSession['startTime'])) {
+                $startTime = (int)$clientSession['startTime'];
+                $secondsPassed = time() - $startTime;
+                $remainingTimes = [];
+
+                if (!empty((string)$zone->hardtimeout)) {
+                    $timeout = (int)$zone->hardtimeout * 60;
+                    if ($secondsPassed < $timeout) {
+                        $remainingTimes[] = $timeout - $secondsPassed;
+                    }
+                }
+
+                if (!empty($clientSession['acc_session_timeout'])) {
+                    $timeout = (int)$clientSession['acc_session_timeout'];
+                    if ($secondsPassed < $timeout) {
+                        $remainingTimes[] = $timeout - $secondsPassed;
+                    }
+                }
+
+                if (!empty($remainingTimes)) {
+                    $result['seconds-remaining'] = min($remainingTimes);
                 }
             }
 

--- a/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
+++ b/src/opnsense/scripts/OPNsense/CaptivePortal/cp-background-process.py
@@ -150,6 +150,8 @@ class CPBackgroundProcess(object):
                 # there are different reasons why a session should be removed, check for all reasons and
                 # use the same method for the actual removal
                 drop_session_reason = None
+                # XXX delete_reason is currently mapped to RADIUS keywords, as is this
+                # is the only authenticator handling accounting
                 delete_reason = None
 
                 # session cleanups, only for users not for static hosts/ranges.


### PR DESCRIPTION
The voucher system (specifically, voucher validity) currently wasn't reflected in the timeout calculation, include it here.

While here, added a small note about the intent of `drop_reason`.