### PR TITLE
Improve dummynet_stats.py parsing of mask descriptor lines.

### DIFF
--- a/src/opnsense/scripts/shaper/lib/__init__.py
+++ b/src/opnsense/scripts/shaper/lib/__init__.py
@@ -34,9 +34,7 @@ import datetime
 
 def parse_flow(flow_line):
     tmp = flow_line.split()
-    if tmp[0] == 'mask:':
-        return None
-    if flow_line.find(':') > 0 and len(tmp) > 8:
+    if flow_line.find(':') > 0 and len(tmp) > 8 and tmp[0].isdigit():
         # IPv6 layout
         return {
             'BKT':tmp[0],
@@ -49,7 +47,7 @@ def parse_flow(flow_line):
             'drop_pkt':int(tmp[7]) if tmp[7].isdigit() else 0,
             'drop_bytes':int(tmp[8]) if tmp[8].isdigit() else 0,
         }
-    elif len(tmp) > 7:
+    elif len(tmp) > 7 and tmp[0].isdigit():
         return {
             'BKT':tmp[0],
             'Prot':tmp[1],

--- a/src/opnsense/scripts/shaper/lib/__init__.py
+++ b/src/opnsense/scripts/shaper/lib/__init__.py
@@ -34,6 +34,8 @@ import datetime
 
 def parse_flow(flow_line):
     tmp = flow_line.split()
+    if tmp[0] == 'mask:':
+        return None
     if flow_line.find(':') > 0 and len(tmp) > 8:
         # IPv6 layout
         return {


### PR DESCRIPTION
When using the *-ip6 mask specifiers introduced in #8581, dnctl produces output that dummynet_stats.py fails to correctly parse.

The line in particular is:

```
        mask: proto: 0x00, flow_id: 0x00000000,  ::/0x0000 -> ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0x0000
```

The line above is currently incorrectly parsed as an IPv6 flow, rather than being ignored. This PR improves the flow parsing by explicitly rejecting lines that describes a mask.