### PR TITLE
Use CIDR notation for specifying masks to dnctl.

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Shaper/dnctl.conf
+++ b/src/opnsense/service/templates/OPNsense/Shaper/dnctl.conf
@@ -7,8 +7,8 @@ pipe {{ pipe.number }} config bw {{ pipe.bandwidth }}{{ pipe.bandwidthMetric }}/
  if pipe.queue %} queue {{ pipe.queue }}{%
  if pipe.queueMetric != 'slots' %}{{pipe.queueMetric}}{% endif %}{% endif
  %}{% if pipe.buckets %} buckets {{ pipe.buckets }}{% endif
- %}{% if pipe.mask in ['src-ip', 'dst-ip'] %} mask {{ pipe.mask }} 0xffffffff {% endif
- %}{% if pipe.mask in ['src-ip6', 'dst-ip6'] %} mask {{ pipe.mask }} 128 {% endif %}{%
+ %}{% if pipe.mask in ['src-ip', 'dst-ip'] %} mask {{ pipe.mask }} /32 {% endif
+ %}{% if pipe.mask in ['src-ip6', 'dst-ip6'] %} mask {{ pipe.mask }} /128 {% endif %}{%
  if pipe.delay|default('') != '' %} delay {{pipe.delay}} {% endif %} type {%
  if pipe.scheduler|default('') != '' %} {{pipe.scheduler}} {% else %} wf2q+ {% endif %}{%
  if pipe.codel_enable|default('0') == '1' and pipe.scheduler != 'fq_codel' %} codel {% endif %}{%
@@ -34,8 +34,8 @@ pipe {{ pipe.number }} config bw {{ pipe.bandwidth }}{{ pipe.bandwidthMetric }}/
 {%    if helpers.getUUIDtag(queue.pipe) in ['pipe'] %}
 queue {{ queue.number }} config pipe {{ helpers.getUUID(queue.pipe).number
 }}{% if queue.buckets %} buckets {{ queue.buckets }}{% endif
-%}{% if queue.mask in ['src-ip', 'dst-ip'] %} mask {{ queue.mask }} 0xffffffff {% endif
-%}{% if queue.mask in ['src-ip6', 'dst-ip6'] %} mask {{ queue.mask }} 128 {% endif
+%}{% if queue.mask in ['src-ip', 'dst-ip'] %} mask {{ queue.mask }} /32 {% endif
+%}{% if queue.mask in ['src-ip6', 'dst-ip6'] %} mask {{ queue.mask }} /128 {% endif
 %} weight {{ queue.weight }}{%
 if queue.codel_enable|default('0') == '1' %} codel {%
     if queue.codel_target|default('') != ''%} target {{queue.codel_target}} {% endif %}{%


### PR DESCRIPTION
Using the same format for both IPv4 and IPv6 mask specifications makes the template easier to understand at a glance.