### PR TITLE
dnsmasq: Add no-resolv option to prevent use of system defined dns servers

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -104,7 +104,7 @@
         <id>dnsmasq.no_resolv</id>
         <label>Do not forward to system defined DNS servers</label>
         <type>checkbox</type>
-        <help>If this option is set, DNS forwarding to system nameservers (defined in System: General Setup: DNS Servers) will be disabled. Upstream servers defined in Services: Dnsmasq DNS & DHCP: Domains will still be used. This option is recommended when Unbound forwards local domain queries to Dnsmasq, so that all queries terminate without further lookups if they are unknown.</help>
+        <help><![CDATA[If this option is set, DNS forwarding to system nameservers (defined in System: General Setup: DNS Servers) will be disabled. Upstream servers defined in Services: Dnsmasq DNS & DHCP: Domains will still be used. This option is recommended when Unbound forwards local domain queries to Dnsmasq, so that all queries terminate without further lookups if they are unknown.]]></help>
     </field>
     <field>
         <id>dnsmasq.no_private_reverse</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -104,7 +104,7 @@
         <id>dnsmasq.no_resolv</id>
         <label>Do not forward to system defined DNS servers</label>
         <type>checkbox</type>
-        <help>If this option is set, do not use (System: General Setup: DNS Servers). Only use upstream servers defined in (Services: Dnsmasq DNS & DHCP: Domains). This option is recommended when Unbound forwards local domain queries to Dnsmasq, so that all queries terminate without further lookups if they are unknown.</help>
+        <help>If this option is set, DNS forwarding to system nameservers (defined in System: General Setup: DNS Servers) will be disabled. Upstream servers defined in Services: Dnsmasq DNS & DHCP: Domains will still be used. This option is recommended when Unbound forwards local domain queries to Dnsmasq, so that all queries terminate without further lookups if they are unknown.</help>
     </field>
     <field>
         <id>dnsmasq.no_private_reverse</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -101,6 +101,12 @@
         <help>If this option is set, we will not forward A or AAAA queries for plain names, without dots or domain parts, to upstream name servers. If the name is not known from /etc/hosts or DHCP then a "not found" answer is returned.</help>
     </field>
     <field>
+        <id>dnsmasq.no_resolv</id>
+        <label>Do not forward to system defined DNS servers</label>
+        <type>checkbox</type>
+        <help>If this option is set, do not use System: General Setup: DNS Servers. Get upstream servers only from the dnsmasq configuration. This is needed when forwarding queries from Unbound to Dnsmasq to prevent long lookup times.</help>
+    </field>
+    <field>
         <id>dnsmasq.no_private_reverse</id>
         <label>Do not forward private reverse lookups</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -104,7 +104,7 @@
         <id>dnsmasq.no_resolv</id>
         <label>Do not forward to system defined DNS servers</label>
         <type>checkbox</type>
-        <help>If this option is set, do not use System: General Setup: DNS Servers. Get upstream servers only from the dnsmasq configuration. This is needed when forwarding queries from Unbound to Dnsmasq to prevent long lookup times.</help>
+        <help>If this option is set, do not use (System: General Setup: DNS Servers). Only use upstream servers defined in (Services: Dnsmasq DNS & DHCP: Domains). This option is recommended when Unbound forwards local domain queries to Dnsmasq, so that all queries terminate without further lookups if they are unknown.</help>
     </field>
     <field>
         <id>dnsmasq.no_private_reverse</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -9,6 +9,7 @@
         <strict_order type="BooleanField"/>
         <domain_needed type="BooleanField"/>
         <no_private_reverse type="BooleanField"/>
+        <no_resolv type="BooleanField"/>
         <log_queries type="BooleanField"/>
         <no_hosts type="BooleanField"/>
         <strictbind type="BooleanField"/>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -92,6 +92,11 @@ rebind-domain-ok=/{{override.domain}}/
 strict-order
 {% endif %}
 
+{% if dnsmasq.no_resolv == '1' %}
+# Never forward to servers in /etc/resolv.conf
+no-resolv
+{% endif %}
+
 {% if dnsmasq.domain_needed  == '1' %}
 # Never forward plain names (without a dot or domain part)
 domain-needed


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8708