### PR TITLE
dnsmasq: When dhcp-fqdn is active, set all dhcp domains as local

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>/dnsmasq</mount>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <items>
         <enable type="BooleanField"/>
         <regdhcp type="BooleanField"/>
@@ -47,7 +47,10 @@
             <no_interface type="InterfaceField">
                 <Multiple>Y</Multiple>
             </no_interface>
-            <fqdn type="BooleanField"/>
+            <fqdn type="BooleanField">
+                <Required>Y</Required>
+                <Default>1</Default>
+            </fqdn>
             <domain type="HostnameField">
                 <IsDNSName>Y</IsDNSName>
                 <IpAllowed>N</IpAllowed>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -32,6 +32,17 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
 domain={{dnsmasq.dhcp.domain|default(system.domain)}}
+# This tells dnsmasq that a domain is local and it may answer queries from /etc/hosts
+# or DHCP but should never forward queries on that domain to any upstream servers.
+{%     set dhcp_domains = [dnsmasq.dhcp.domain|default(system.domain)] %}
+{%     for dhcp_range in helpers.toList('dnsmasq.dhcp_ranges') %}
+{%         if dhcp_range.domain %}
+{%             do dhcp_domains.append(dhcp_range.domain) %}
+{%         endif %}
+{%     endfor %}
+{%     for dhcp_domain in dhcp_domains|unique %}
+local=/{{ dhcp_domain }}/
+{%     endfor %}
 {% endif %}
 
 {% if dnsmasq.dhcp.authoritative == '1' %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -29,7 +29,7 @@ no-dhcp-interface={{helpers.physical_interfaces(dnsmasq.dhcp.no_interface.split(
 dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 {% endif %}
 
-{% if dnsmasq.dhcp.fqdn == '1' %}
+{% if helpers.exists('dnsmasq.dhcp_ranges') and dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
 domain={{dnsmasq.dhcp.domain|default(system.domain)}}
 # This tells dnsmasq that a domain is local and it may answer queries from /etc/hosts


### PR DESCRIPTION
to prevent queries to upstream servers, this makes dnsmasq solely responsible for them. Otherwise it could accidentally ask its upstream servers if it acts as a resolver at the same time.

```
-S, --local, --server=[/[<domain>]/[domain/]][<server>[#<port>]][@<interface>][@<source-ip>[#<port>]]
Also permitted is a -S flag which gives a domain but no IP address; this tells dnsmasq that a domain is local and it may answer queries from /etc/hosts or DHCP but should never forward queries on that domain to any upstream servers. --local is a synonym for --server to make configuration files clearer in this case.
```

Log file example:

```
2025-05-22T07:05:26Informationaldnsmasqusing only locally-known addresses for ad.pischem.com
2025-05-22T07:05:26Informationaldnsmasqusing only locally-known addresses for test.pischem.com
2025-05-22T07:05:26Informationaldnsmasqusing only locally-known addresses for 3.test.pischem.com
2025-05-22T07:05:26Informationaldnsmasqusing only locally-known addresses for 4.test.pischem.com
```

Fixes: https://github.com/opnsense/core/issues/8708