### PR TITLE
dnsmasq: Hide static mode in dhcp-range in advanced mode

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -102,7 +102,11 @@
         <label>Mode</label>
         <type>select_multiple</type>
         <style>selectpicker</style>
-        <help>Mode flags to set for this range, 'static' means no addresses will be automatically assigned. </help>
+        <advanced>true</advanced>
+        <help>Mode flags to set for this range, 'static' means no addresses will be automatically assigned.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>range.lease_time</id>


### PR DESCRIPTION
It is not needed in most cases, so it is sensible to hide it in advanced mode to indirectly imply it is not that important for most usecases.

https://github.com/opnsense/core/issues/8707#issuecomment-2900338317

For: https://github.com/opnsense/core/issues/8707