### PR TITLE
dnsmasq: Allow either empty IP or empty hostname for dhcp-host entries.

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -182,6 +182,10 @@ function _dnsmasq_add_host_entries()
     foreach ($dnsmasqcfg['hosts'] as $host) {
         /* The host.ip field supports multiple IPv4 and IPv6 addresses */
         foreach (explode(',', $host['ip']) as $ip) {
+            /* we allow empty IPs for dhcp-host entries */
+            if (empty($ip)) {
+                continue;
+            }
             /* skip partial IPv6 addresses */
             if (str_starts_with($ip, '::')) {
                 continue;

--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -181,9 +181,9 @@ function _dnsmasq_add_host_entries()
 
     foreach ($dnsmasqcfg['hosts'] as $host) {
         /* The host.ip field supports multiple IPv4 and IPv6 addresses */
-        foreach (explode(',', $host['ip']) as $ip) {
-            /* skip empty IPs and partial IPv6 addresses */
-            if (empty($ip) || str_starts_with($ip, '::')) {
+        foreach (array_filter(explode(',', $host['ip'])) as $ip) {
+            /* skip partial IPv6 addresses */
+            if (str_starts_with($ip, '::')) {
                 continue;
             }
             if (empty($host['host'])) {

--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -182,12 +182,8 @@ function _dnsmasq_add_host_entries()
     foreach ($dnsmasqcfg['hosts'] as $host) {
         /* The host.ip field supports multiple IPv4 and IPv6 addresses */
         foreach (explode(',', $host['ip']) as $ip) {
-            /* we allow empty IPs for dhcp-host entries */
-            if (empty($ip)) {
-                continue;
-            }
-            /* skip partial IPv6 addresses */
-            if (str_starts_with($ip, '::')) {
+            /* skip empty IPs and partial IPv6 addresses */
+            if (empty($ip) || str_starts_with($ip, '::')) {
                 continue;
             }
             if (empty($host['host'])) {

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -78,7 +78,7 @@ class Dnsmasq extends BaseModel
             // all dhcp-host IP addresses must be unique, host overrides can have duplicate IP addresses
             if ($is_dhcp) {
                 $tmp_ipv4_cnt = 0;
-                foreach (explode(',', (string)$host->ip) as $ip) {
+                foreach (array_filter(explode(',', (string)$host->ip)) as $ip) {
                     // We allow empty IPs for dhcp-host entries
                     if (empty($ip)) {
                         continue;

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -100,39 +100,18 @@ class Dnsmasq extends BaseModel
                 }
 
                 if ($host->host->isEmpty() && $host->ip->isEmpty()) {
-                    $messageText = gettext("Either a hostname or IP address must be provided for DHCP reservations.");
-
-                    $messages->appendMessage(
-                        new Message($messageText, $key . ".host")
-                    );
-                    $messages->appendMessage(
-                        new Message($messageText, $key . ".ip")
-                    );
+                    $messageText = gettext("At least a hostname or IP address must be provided for DHCP reservations.");
+                    $messages->appendMessage(new Message($messageText, $key . ".host"));
+                    $messages->appendMessage(new Message($messageText, $key . ".ip"));
                 }
 
             }
 
             if (!$is_dhcp) {
-                if ($host->host->isEmpty()) {
-                    $messages->appendMessage(
-                        new Message(
-                            gettext(
-                                "Hostname is required for host overrides."
-                            ),
-                            $key . ".host"
-                        )
-                    );
-                }
-
-                if ($host->ip->isEmpty()) {
-                    $messages->appendMessage(
-                        new Message(
-                            gettext(
-                                "IP address is required for host overrides."
-                            ),
-                            $key . ".ip"
-                        )
-                    );
+                if ($host->host->isEmpty() || $host->ip->isEmpty()) {
+                    $messageText = gettext("Both hostname and IP address are required for host overrides.");
+                    $messages->appendMessage(new Message($messageText, $key . ".host"));
+                    $messages->appendMessage(new Message($messageText, $key . ".ip"));
                 }
             }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -59,7 +59,7 @@ class Dnsmasq extends BaseModel
         $usedDhcpIpAddresses = [];
         foreach ($this->hosts->iterateItems() as $host) {
             if (!$host->hwaddr->isEmpty() || !$host->client_id->isEmpty()) {
-                foreach (explode(',', (string)$host->ip) as $ip) {
+                foreach (array_filter(explode(',', (string)$host->ip)) as $ip) {
                     if (empty($ip)) {
                         continue;
                     }

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -60,9 +60,6 @@ class Dnsmasq extends BaseModel
         foreach ($this->hosts->iterateItems() as $host) {
             if (!$host->hwaddr->isEmpty() || !$host->client_id->isEmpty()) {
                 foreach (array_filter(explode(',', (string)$host->ip)) as $ip) {
-                    if (empty($ip)) {
-                        continue;
-                    }
                     $usedDhcpIpAddresses[$ip] = isset($usedDhcpIpAddresses[$ip]) ? $usedDhcpIpAddresses[$ip] + 1 : 1;
                 }
             }
@@ -79,10 +76,6 @@ class Dnsmasq extends BaseModel
             if ($is_dhcp) {
                 $tmp_ipv4_cnt = 0;
                 foreach (array_filter(explode(',', (string)$host->ip)) as $ip) {
-                    // We allow empty IPs for dhcp-host entries
-                    if (empty($ip)) {
-                        continue;
-                    }
                     $tmp_ipv4_cnt += (strpos($ip, ':') === false) ? 1 : 0;
                     if ($usedDhcpIpAddresses[$ip] > 1) {
                         $messages->appendMessage(
@@ -105,9 +98,7 @@ class Dnsmasq extends BaseModel
                     $messages->appendMessage(new Message($messageText, $key . ".ip"));
                 }
 
-            }
-
-            if (!$is_dhcp) {
+            } else {
                 if ($host->host->isEmpty() || $host->ip->isEmpty()) {
                     $messageText = gettext("Both hostname and IP address are required for host overrides.");
                     $messages->appendMessage(new Message($messageText, $key . ".host"));

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -84,7 +84,6 @@
                 <ValidationMessage>A valid domain must be specified.</ValidationMessage>
             </domain>
             <ip type="NetworkField">
-                <Required>Y</Required>
                 <NetMaskAllowed>N</NetMaskAllowed>
                 <FieldSeparator>,</FieldSeparator>
                 <AsList>Y</AsList>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -212,11 +212,11 @@ id:{{ host.client_id }},
 {%-     if host.set_tag -%}
 set:{{ host.set_tag|replace('-', '') }},
 {%-     endif -%}
-{%-     for ip in host.ip.split(',')|map('trim')  if host.ip -%}
+{%-     for ip in (host.ip | default('')).split(',') | map('trim') if ip -%}
 {{ '[' ~ ip ~ ']' if ':' in ip else ip  }}{%- if not loop.last %},{% endif %}
 {%-     endfor -%}
 {%-     if host.host -%}
-,{{ host.host }}
+{%- if host.ip -%},{% endif -%}{{ host.host }}
 {%-     endif -%}
 ,{{ 'infinite' if host.lease_time == '0' else host.lease_time|default('86400') }}
 {%-     if host.ignore|default('0') == '1' -%}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -212,9 +212,11 @@ id:{{ host.client_id }},
 {%-     if host.set_tag -%}
 set:{{ host.set_tag|replace('-', '') }},
 {%-     endif -%}
-{%-     for ip in host.ip.split(',') | map('trim') if host.ip -%}
+{%-     if host.ip -%}
+{%-         for ip in host.ip.split(',') | map('trim') -%}
 {{ '[' ~ ip ~ ']' if ':' in ip else ip  }}{%- if not loop.last %},{% endif %}
-{%-     endfor -%}
+{%-         endfor -%}
+{%-     endif -%}
 {%-     if host.host -%}
 {%- if host.ip -%},{% endif -%}{{ host.host }}
 {%-     endif -%}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -212,7 +212,7 @@ id:{{ host.client_id }},
 {%-     if host.set_tag -%}
 set:{{ host.set_tag|replace('-', '') }},
 {%-     endif -%}
-{%-     for ip in (host.ip | default('')).split(',') | map('trim') if ip -%}
+{%-     for ip in host.ip.split(',') | map('trim') if host.ip -%}
 {{ '[' ~ ip ~ ']' if ':' in ip else ip  }}{%- if not loop.last %},{% endif %}
 {%-     endfor -%}
 {%-     if host.host -%}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8703

Please take a good look at the validation.

Please improve it if necessary, and test it.

I have tested it, and generated the correct configuration file with a wide range of inputs, but this feels like a delicate change that needs some thoughts, also if we want it.