### PR TITLE
dnsmasq: Add command in leases view to create dhcp reservations

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
@@ -81,6 +81,10 @@
                         return moment.unix(row[column.id]).local().format('YYYY-MM-DD HH:mm:ss');
                     },
                     "commands": function (column, row) {
+                        if (row.is_reserved === true) {
+                            return '';
+                        }
+
                         const query = new URLSearchParams({
                             host: row.hostname || '',
                             ip: row.address || '',
@@ -90,9 +94,10 @@
 
                         const url = `/ui/dnsmasq/settings#hosts?${query}`;
 
+                        // Do not open in new tab so the button vanished when going back to leases tab
                         return `
                             <button type="button" class="btn btn-xs"
-                                onclick="window.open('${url}', '_blank', 'noopener,noreferrer')"
+                                onclick="window.location.href = '${url}'"
                                 title="{{ lang._('Add Reservation') }}">
                                 <i class="fa fa-fw fa-plus"></i>
                             </button>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
@@ -80,6 +80,24 @@
                     "timestamp": function (column, row) {
                         return moment.unix(row[column.id]).local().format('YYYY-MM-DD HH:mm:ss');
                     },
+                    "commands": function (column, row) {
+                        const query = new URLSearchParams({
+                            host: row.hostname || '',
+                            ip: row.address || '',
+                            hwaddr: row.hwaddr || '',
+                            client_id: row.client_id || ''
+                        }).toString();
+
+                        const url = `/ui/dnsmasq/settings#hosts?${query}`;
+
+                        return `
+                            <button type="button" class="btn btn-xs"
+                                onclick="window.open('${url}', '_blank', 'noopener,noreferrer')"
+                                title="{{ lang._('Add Reservation') }}">
+                                <i class="fa fa-fw fa-plus"></i>
+                            </button>
+                        `;
+                    }
                 }
             }
         });
@@ -122,6 +140,7 @@
                 <th data-column-id="client_id" data-type="string" data-formatter="overflowformatter">{{ lang._('DUID') }}</th>
                 <th data-column-id="expire" data-type="string" data-formatter="timestamp">{{ lang._('Expire') }}</th>
                 <th data-column-id="hostname" data-type="string" data-formatter="overflowformatter">{{ lang._('Hostname') }}</th>
+                <th data-column-id="commands" data-formatter="commands" data-sortable="false" data-width="6em">{{ lang._('Commands') }}</th>
             </tr>
         </thead>
         <tbody>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -224,6 +224,28 @@
             }
         });
 
+        // Autofill dhcp reservation with URL hash
+        if (window.location.hash.startsWith('#hosts?')) {
+            const params = new URLSearchParams(window.location.hash.split('?')[1]);
+
+            // Switch to hosts tab
+            $('a[href="#hosts"]').one('shown.bs.tab', () => {
+                // Wait for grid to be ready
+                $('#{{ formGridHostOverride["table_id"] }}').one('loaded.rs.jquery.bootgrid', function () {
+                    // Wait for dialog to be ready
+                    $('#{{ formGridHostOverride["edit_dialog_id"] }}').one('opnsense_bootgrid_mapped', () => {
+                        if (params.has('host')) $('#host\\.host').val(params.get('host'));
+                        if (params.has('ip')) $('#host\\.ip').trigger('tokenize:tokens:add', [params.get('ip'), params.get('ip')]);
+                        if (params.has('client_id')) $('#host\\.client_id').val(params.get('client_id'));
+                        if (params.has('hwaddr')) $('#host\\.hwaddr').trigger('tokenize:tokens:add', [params.get('hwaddr'), params.get('hwaddr')]);
+                        history.replaceState(null, null, window.location.pathname + '#hosts');
+                    });
+
+                    $(this).find('.command-add').trigger('click');
+                });
+            }).tab('show');
+        }
+
     });
 </script>
 


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8720

- Adds a command button to the leases view that refers to the hosts tab
- Open add dialog and insert hostname, ip address, mac address, client id via url hash
- Tracks which lease is already registered by comparing it to the host data in the model
- Shows and hides the add button depending on that

It refers directly to force the button to vanish as soon as users go back into the leases view after having created a reservation.