### PR TITLE
ipfw: properly synchronize load order

### DIFF
--- a/plist
+++ b/plist
@@ -99,7 +99,7 @@
 /usr/local/etc/rc.halt
 /usr/local/etc/rc.ipfw
 /usr/local/etc/rc.ipfw.flush_all
-/usr/local/etc/rc.ipfw.postload
+/usr/local/etc/rc.ipfw.post
 /usr/local/etc/rc.linkup
 /usr/local/etc/rc.loader
 /usr/local/etc/rc.loader.d/00-banner
@@ -1252,6 +1252,7 @@
 /usr/local/opnsense/scripts/shaper/dummynet_stats.py
 /usr/local/opnsense/scripts/shaper/lib/__init__.py
 /usr/local/opnsense/scripts/shaper/setup.sh
+/usr/local/opnsense/scripts/shaper/sync_fw_hooks.py
 /usr/local/opnsense/scripts/shaper/update_tables
 /usr/local/opnsense/scripts/shell/banner.php
 /usr/local/opnsense/scripts/shell/defaults.php

--- a/src/etc/rc.ipfw
+++ b/src/etc/rc.ipfw
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2015 Deciso B.V.
+# Copyright (c) 2015-2025 Deciso B.V.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,10 +31,5 @@
 ipfw -q /usr/local/etc/ipfw.rules
 # load tables
 /usr/local/opnsense/scripts/shaper/update_tables
-
-if [ ! -f /tmp/ipfw.firstload ]; then
-	# we need to make sure ipfw is loaded as last
-	touch /tmp/ipfw.firstload
-	pfctl -d
-	pfctl -e
-fi
+# synchronize ipfw/pf load order
+/usr/local/opnsense/scripts/shaper/sync_fw_hooks.py

--- a/src/etc/rc.ipfw.post
+++ b/src/etc/rc.ipfw.post
@@ -1,5 +1,5 @@
 #!/bin/sh
-#    Copyright (c) 2015 Deciso B.V.
+#    Copyright (c) 2015-2025 Deciso B.V.
 #    All rights reserved.
 #
 #    Redistribution and use in source and binary forms, with or without
@@ -25,8 +25,15 @@
 
 #    flush ipfw rules when ipfw is not active anymore, avoid administrative down and still having rules loaded
 
+#    this script is executed after ipfw start/stop (after ipfw_poststart() or ipfw_poststop() as well)
+#    to make sure we are hooked after the standard rc sysctl toggle (net.inet.ip.fw.enable=0/1),
+#    ensuring 'pfilctl heads' reflects reality.
+
 . /etc/rc.conf.d/ipfw
 
 if [ "$firewall_enable" != "YES" ]; then
 	/sbin/ipfw -f flush
+else
+    # synchronize ipfw/pf load order
+    /usr/local/opnsense/scripts/shaper/sync_fw_hooks.py
 fi

--- a/src/opnsense/scripts/shaper/sync_fw_hooks.py
+++ b/src/opnsense/scripts/shaper/sync_fw_hooks.py
@@ -1,0 +1,98 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2025 Deciso B.V.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+    --------------------------------------------------------------------------------------
+    Synchronize firewall heads ordering. This script should only be called after
+    ipfw has been enabled.
+"""
+
+import subprocess
+import sys
+
+if __name__ == '__main__':
+    try:
+        val = subprocess.run(['/sbin/sysctl', 'net.inet.ip.fw.enable'], capture_output=True, text=True, check=True)
+        enabled = val.stdout.strip().split(':')[1].strip()
+        if enabled != '1':
+            # ipfw not enabled, this script shouldn't have been called
+            sys.exit()
+    except subprocess.CalledProcessError as e:
+        # module not loaded or different generic error
+        sys.exit()
+
+    sp = subprocess.run(['/sbin/pfilctl', 'heads'], capture_output=True, text=True)
+
+    ipv6_hooks, ipv4_hooks = {'in': [], 'out': []}, {'in': [], 'out': []}
+    section = None
+
+    for line in sp.stdout.splitlines():
+        stripped = line.strip()
+        parts = stripped.split()
+
+        if "inet6" in stripped:
+            section = "ipv6"
+            continue
+        elif "inet" in stripped:
+            section = "ipv4"
+            continue
+
+        if section and parts and parts[0] in ("In", "Out"):
+            dir = parts[0].lower()
+            fw = parts[1].split(':')[0]
+            if section == "ipv6":
+                ipv6_hooks[dir].append(fw)
+            elif section == "ipv4":
+                ipv4_hooks[dir].append(fw)
+        else:
+            section = None
+
+    cmds = []
+
+    for ver, hooks in (("4", ipv4_hooks), ("6", ipv6_hooks)):
+        fam    = "ipfw:default" + ("" if ver == "4" else "6")
+        proto  = "inet" + ("" if ver == "4" else "6")
+        for dir_flag, opt in (("in", "-i"), ("out", "-o")):
+            lst = hooks[dir_flag]
+            has = "ipfw" in lst
+            # if absent, we need to append
+            if not has:
+                cmds.append(["link", f"-a{dir_flag[0]}", fam, proto])
+            else:
+                # if exactly two entries and ipfw is at the wrong spot, re‐order
+                idx = 0 if dir_flag == "in"  else 1
+                if len(lst) == 2 and lst[idx] == "ipfw":
+                    # first unlink, then link
+                    cmds.append(["unlink", opt, fam, proto])
+                    cmds.append(["link",   f"-a{dir_flag[0]}", fam, proto])
+
+    for args in cmds:
+        full = ["/sbin/pfilctl"] + args
+        try:
+            subprocess.run(full, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            # XXX logging, but where?
+            pass

--- a/src/opnsense/service/conf/actions.d/actions_ipfw.conf
+++ b/src/opnsense/service/conf/actions.d/actions_ipfw.conf
@@ -1,5 +1,5 @@
 [reload]
-command:/etc/rc.d/ipfw enabled && /etc/rc.d/ipfw start || ( /etc/rc.d/ipfw onestop || true ); /usr/local/etc/rc.ipfw.postload || true
+command:/etc/rc.d/ipfw enabled && /etc/rc.d/ipfw start || ( /etc/rc.d/ipfw onestop || true ); /usr/local/etc/rc.ipfw.post || true
 parameters:
 type:script
 message:restarting ipfw


### PR DESCRIPTION
The main change introduced by https://github.com/opnsense/core/commit/3bf818348ca7e306ab4fd5e80a9eca68f98c2167 includes logic to disable ipfw (`onestop`) if the rc template has been reloaded with `firewall_enable="NO"`. Previously, it was assumed that if ipfw was started for the first time (either during boot or an initial configuration), ipfw wouldn't be turned off again as long as the device was active. A stop didn't exist, and a reload simply did a `start`, not a restart or stop). During this event, pf was turned off & on to make sure ipfw was loaded first.

Since `ipfw` can now be turned off, but we probably don't want to disable & re-enable `pf` everytime we reconfigure the `shaper`, it's probably best to configure this dynamically via `pfilctl`. By only touching the `ipfw` heads, we prevent unlinking/linking the `pf` heads, making sure `pf` statys functional at all times.

This PR defines a script that does the synchronization, assuming ipfw is enabled - we execute this on 2 events:
- during boot, when the rc system initialized ipfw.
- on an ipfw reload via configd, which unconditionally executes the `rc.ipfw.post` script (previously postload).