### PR TITLE
dnsmasq: Add checkbox to hosts that can set domains as local

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
@@ -16,6 +16,16 @@
         <help>Domain of the host, e.g. example.com</help>
     </field>
     <field>
+        <id>host.local</id>
+        <label>Local</label>
+        <type>checkbox</type>
+        <help>Set the above domain as local. This will configure this DNS server as authoritative; it will not forward queries to any upstream servers for this domain.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
         <id>host.ip</id>
         <label>IP addresses</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -83,6 +83,7 @@
                 <Mask>/^(?:(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$/i</Mask>
                 <ValidationMessage>A valid domain must be specified.</ValidationMessage>
             </domain>
+            <local type="BooleanField"/>
             <ip type="NetworkField">
                 <Required>Y</Required>
                 <NetMaskAllowed>N</NetMaskAllowed>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -29,19 +29,29 @@ no-dhcp-interface={{helpers.physical_interfaces(dnsmasq.dhcp.no_interface.split(
 dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 {% endif %}
 
-{% if helpers.exists('dnsmasq.dhcp_ranges') and dnsmasq.dhcp.fqdn == '1' %}
+{% set all_local_domains = [] %}
+{% for host in helpers.toList('dnsmasq.hosts') %}
+{%     if host.local == '1' and host.domain %}
+{%         do all_local_domains.append(host.domain) %}
+{%     endif %}
+{% endfor %}
+{% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
 domain={{dnsmasq.dhcp.domain|default(system.domain)}}
+{%     if helpers.exists('dnsmasq.dhcp_ranges') %}
+{%     do all_local_domains.append(dnsmasq.dhcp.domain | default(system.domain)) %}
+{%         for dhcp_range in helpers.toList('dnsmasq.dhcp_ranges') %}
+{%             if dhcp_range.domain %}
+{%             do all_local_domains.append(dhcp_range.domain) %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endif %}
+{% if all_local_domains %}
 # This tells dnsmasq that a domain is local and it may answer queries from /etc/hosts
 # or DHCP but should never forward queries on that domain to any upstream servers.
-{%     set dhcp_domains = [dnsmasq.dhcp.domain|default(system.domain)] %}
-{%     for dhcp_range in helpers.toList('dnsmasq.dhcp_ranges') %}
-{%         if dhcp_range.domain %}
-{%             do dhcp_domains.append(dhcp_range.domain) %}
-{%         endif %}
-{%     endfor %}
-{%     for dhcp_domain in dhcp_domains|unique %}
-local=/{{ dhcp_domain }}/
+{%     for domain in all_local_domains | unique %}
+local=/{{ domain }}/
 {%     endfor %}
 {% endif %}
 


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8726

Couple it with the dhcp-range domain dataset to ensure a unique dataset for all local domains.

This enables users to set domains as local in classic host overrides, if they want dnsmasq to handle this domain exclusively.

This should give flexibility for almost all dns forwarding scenarios.