### PR TITLE
dnsmasq: Set default to empty lease time for dhcp-host which results in auto calculated defaults

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
@@ -69,7 +69,7 @@
         <id>host.lease_time</id>
         <label>Lease time</label>
         <type>text</type>
-        <hint>86400</hint>
+        <hint>default</hint>
         <help>Defines how long the addresses (leases) given out by the server are valid (in seconds). Set 0 for infinite.</help>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -230,7 +230,9 @@ set:{{ host.set_tag|replace('-', '') }},
 {%-     if host.host -%}
 {%- if host.ip -%},{% endif -%}{{ host.host }}
 {%-     endif -%}
-,{{ 'infinite' if host.lease_time == '0' else host.lease_time|default('86400') }}
+{%-     if host.lease_time -%}
+,{{ 'infinite' if host.lease_time == '0' else host.lease_time }}
+{%-     endif -%}
 {%-     if host.ignore|default('0') == '1' -%}
 ,ignore
 {%-     endif +%}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8740