### PR TITLE
dnsmasq: Update help on multiple tags usage (all tags must match)

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
@@ -9,7 +9,7 @@
         <id>boot.tag</id>
         <label>Tag</label>
         <type>select_multiple</type>
-        <help>Only offer this boot image to the clients matched by the given tag. Can be optionally combined with an interface tag.</help>
+        <help>If the optional tags are given then this option is only sent when all the tags are matched. Can be optionally combined with an interface tag.</help>
     </field>
     <field>
         <id>boot.filename</id>


### PR DESCRIPTION
This should be self-explanatory — I was confused with how tags would work, I somehow assumed any of the selected tags would match, but that's not the case, as all tags must match if more than one is selected, per dnsmasq documentation: 

```
Each configuration line containing one or more tag:<tag> constructs applies when all its tags exist on the request. That is:

Configuration tag:A applies to a request set:tagged A.

Configuration tag:B applies to a request set:tagged B.

Configuration tag:A+B doesn't apply to a request set:tagged A.

Configuration tag:A+B doesn't apply to a request set:tagged B.

Configurations tag:A+B, tag:A, tag:B apply to a request set:tagged A+B.
```