### PR TITLE
Reduce font size in ThermalSensors tooltip to prevent text clipping

### DIFF
--- a/src/opnsense/www/js/widgets/ThermalSensors.js
+++ b/src/opnsense/www/js/widgets/ThermalSensors.js
@@ -137,6 +137,9 @@ export default class ThermalSensors extends BaseWidget {
                         filter: function(tooltipItem) {
                             return tooltipItem.datasetIndex === 0;
                         },
+                        bodyFont: {
+                           size: 9
+                        },
                         callbacks: {
                             label: (tooltipItem) => {
                                 let idx = tooltipItem.dataIndex;


### PR DESCRIPTION
Tested on OPNsense 25.1.7_4
The exact URL of the GUI page involved: /ui/core/dashboard
A list of steps to replicate the bug: 
1. Go to /ui/core/dashboard 
2. mouse hover over the temperature bar inside the Thermal Sensor Widget.

Before fix:
![{D8D42724-DEC5-4F8E-99A5-B17B34330CF2}](https://github.com/user-attachments/assets/53e32d11-df69-4330-a5dd-b958d8661b85)

After fix:
![{EE9E99DC-849D-4615-93D8-6627673720DF}](https://github.com/user-attachments/assets/c1f9af17-3a6a-48cb-99a6-9a7bd1da3a6e)
