### PR TITLE
interfaces: drop redundant updates in rtsold_resolvconf.sh

### DIFF
--- a/src/opnsense/scripts/interfaces/rtsold_resolvconf.sh
+++ b/src/opnsense/scripts/interfaces/rtsold_resolvconf.sh
@@ -65,6 +65,19 @@ if [ "${1}" = "-a" ]; then
 		fi
 	done
 
+	# compare to the existing configuration and drop redundant updates
+	for value in $(/usr/local/sbin/ifctl -i ${ifname} -6n); do
+		cur_nameservers="${cur_nameservers} -a ${value}"
+	done
+	for value in $(/usr/local/sbin/ifctl -i ${ifname} -6s); do
+		cur_searchlist="${cur_searchlist} -a ${value}"
+	done
+	cur_rasrca="$(/usr/local/sbin/ifctl -i ${ifname} -6r)"
+	if [ "${nameservers}" = "${cur_nameservers}" -a "${searchlist}" = "${cur_searchlist}" -a "${rasrca}" = "${cur_rasrca}" ]; then
+		echo "Redundant update ignored."
+		exit 0
+	fi
+
 	/usr/local/sbin/ifctl -i ${ifname} -6nd ${nameservers}
 	/usr/local/sbin/ifctl -i ${ifname} -6sd ${searchlist}
 	/usr/local/sbin/ifctl -i ${ifname} -6rd -a ${rasrca}

--- a/src/opnsense/scripts/interfaces/rtsold_resolvconf.sh
+++ b/src/opnsense/scripts/interfaces/rtsold_resolvconf.sh
@@ -45,6 +45,8 @@ if grep -q "^interface ${ifname%%:slaac} " /var/etc/radvd.conf; then
 	exit 0
 fi
 
+need_update=1
+
 # ${1} indicates whether DNS information should be added or deleted.
 
 if [ "${1}" = "-a" ]; then
@@ -65,27 +67,17 @@ if [ "${1}" = "-a" ]; then
 		fi
 	done
 
-	# compare to the existing configuration and drop redundant updates
-	for value in $(/usr/local/sbin/ifctl -i ${ifname} -6n); do
-		cur_nameservers="${cur_nameservers} -a ${value}"
-	done
-	for value in $(/usr/local/sbin/ifctl -i ${ifname} -6s); do
-		cur_searchlist="${cur_searchlist} -a ${value}"
-	done
-	cur_rasrca="$(/usr/local/sbin/ifctl -i ${ifname} -6r)"
-	if [ "${nameservers}" = "${cur_nameservers}" -a "${searchlist}" = "${cur_searchlist}" -a "${rasrca}" = "${cur_rasrca}" ]; then
-		echo "Redundant update ignored."
-		exit 0
-	fi
-
-	/usr/local/sbin/ifctl -i ${ifname} -6nd ${nameservers}
-	/usr/local/sbin/ifctl -i ${ifname} -6sd ${searchlist}
-	/usr/local/sbin/ifctl -i ${ifname} -6rd -a ${rasrca}
+	need_update=""
+	/usr/local/sbin/ifctl -i ${ifname} -6nu ${nameservers} && need_update=1
+	/usr/local/sbin/ifctl -i ${ifname} -6su ${searchlist} && need_update=1
+	/usr/local/sbin/ifctl -i ${ifname} -6ru -a ${rasrca} && need_update=1
 elif [ "${1}" = "-d" ]; then
 	/usr/local/sbin/ifctl -i ${ifname} -6nd
 	/usr/local/sbin/ifctl -i ${ifname} -6sd
 	/usr/local/sbin/ifctl -i ${ifname} -6rd
 fi
 
-# remove slaac suffix here to reload correct interface
-/usr/local/sbin/configctl -d interface newipv6 ${ifname%%:slaac}
+if [ -n "${need_update}" ]; then
+	# remove slaac suffix here to reload correct interface
+	/usr/local/sbin/configctl -d interface newipv6 ${ifname%%:slaac}
+fi


### PR DESCRIPTION
This reduces system churn (e.g. resolv.conf rewrites and dnsmasq reloads) from WAN RAs.

Fixes #8759