### PR TITLE
Unbound: Add "ISC" to "Register DHCP Static Mappings"

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/general.xml
@@ -59,7 +59,7 @@
     </field>
     <field>
         <id>unbound.general.regdhcpstatic</id>
-        <label>Register DHCP Static Mappings</label>
+        <label>Register ISC DHCP Static Mappings</label>
         <type>checkbox</type>
         <help>
             <![CDATA[If this option is set, then DHCP static mappings will be registered in Unbound, so that their name can be resolved.


### PR DESCRIPTION
To sync it with the docs https://docs.opnsense.org/manual/unbound.html It's not entirely clear that this is for ISC DHCP only.