### PR TITLE
typo

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -21,7 +21,7 @@
         <id>subnet4.match-client-id</id>
         <label>Match client-id</label>
         <type>checkbox</type>
-        <help>By default KEA uses client-identifiers in stead of MAC addresses to locate clients, disabling this option
+        <help>By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option
         changes back to matching on MAC address which is used by most dhcp implementations.</help>
         <grid_view>
             <type>boolean</type>


### PR DESCRIPTION
Corrected typo: "in stead" => "instead" in GUI.