### PR TITLE
Fix filename in kea dhcp6 manual help.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
@@ -14,7 +14,7 @@
         <label>Manual config</label>
         <type>checkbox</type>
         <advanced>true</advanced>
-        <help>Disable configuration file generation and manage the file (/usr/local/etc/kea/kea-dhcp4.conf) manually.</help>
+        <help>Disable configuration file generation and manage the file (/usr/local/etc/kea/kea-dhcp6.conf) manually.</help>
     </field>
     <field>
         <type>header</type>


### PR DESCRIPTION
Wrong filename used in kea dhcp6 Manual config file help.