### PR TITLE
automation/filter: If rule is moved before another rule, use half of the available distance as new sequence number

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -303,8 +303,9 @@ class FilterController extends FilterBaseController
                  * found our target, which will be the sources new place,
                  * reserve the full distance to facilitate for a swap.
                  **/
-                $selected_id = (int)$record->sequence->asFloat();
-                $record->sequence = (string)($prev_sequence + $distance);
+                $selected_id = ($distance >= 2)
+                    ? $prev_sequence + intdiv($distance, 2)
+                    : $record->sequence->asFloat();
                 $target_node = $record;
             } elseif ($uuid == $selected_uuid) {
                 $selected_node = $record;


### PR DESCRIPTION
… If that is not possible, use the same sequence number as the target. (Sequence has no unique constraint)

Fixes: https://github.com/opnsense/core/issues/8607