### PR TITLE
dnsmasq: Implement domain_type to select between adding domain to range or interface

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -133,7 +133,7 @@
         <id>range.domain</id>
         <label>Domain</label>
         <type>text</type>
-        <help>Offer this domain to dhcp clients.</help>
+        <help>Offer this domain to DHCP clients.</help>
     </field>
     <field>
         <id>range.nosync</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -124,7 +124,7 @@
         <type>dropdown</type>
         <style>selectpicker</style>
         <advanced>true</advanced>
-        <help>Choose if the domain will only match clients in this range, or all clients in any subnets on the selected interface. If you create both IPv4 and IPv6 ranges, setting this to interface on both ranges is recommended.</help>
+        <help>Choose if the domain will only match clients in this range, or all clients in any subnets on the selected interface. If you create both IPv4 and IPv6 ranges, setting this to "Interface" on both ranges is recommended.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -119,10 +119,21 @@
         </grid_view>
     </field>
     <field>
+        <id>range.domain_type</id>
+        <label>Domain Type</label>
+        <type>dropdown</type>
+        <style>selectpicker</style>
+        <advanced>true</advanced>
+        <help>Choose if the domain will only match clients in this range, or all clients in any subnets on the selected interface. If you create both IPv4 and IPv6 ranges, setting this to interface on both ranges is recommended.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>range.domain</id>
         <label>Domain</label>
         <type>text</type>
-        <help>Offer the specified domain to machines in this range.</help>
+        <help>Offer this domain to dhcp clients.</help>
     </field>
     <field>
         <id>range.nosync</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -151,19 +151,17 @@ class Dnsmasq extends BaseModel
                 }
             }
 
-            if (!$range->domain->isEmpty() && !$range->domain_type->isEmpty()) {
-                if (isset($usedDhcpDomains[(string)$range->domain])) {
-                    $typesUsed = array_unique($usedDhcpDomains[(string)$range->domain]);
+            if (!$range->domain->isEmpty() && isset($usedDhcpDomains[(string)$range->domain])) {
+                $typesUsed = array_unique($usedDhcpDomains[(string)$range->domain]);
 
-                    if (in_array('interface', $typesUsed) && in_array('range', $typesUsed)) {
-                        $messages->appendMessage(
-                            new Message(
-                                sprintf(gettext("The domain '%s' cannot be used with both types 'Interface' and 'Range'."),
-                                (string)$range->domain),
-                                $key . ".domain"
-                            )
-                        );
-                    }
+                if (in_array('interface', $typesUsed) && in_array('range', $typesUsed)) {
+                    $messages->appendMessage(
+                        new Message(
+                            sprintf(gettext("The domain '%s' cannot be used with both types 'Interface' and 'Range'."),
+                            (string)$range->domain),
+                            $key . ".domain"
+                        )
+                    );
                 }
             }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -65,6 +65,14 @@ class Dnsmasq extends BaseModel
             }
         }
 
+        $usedDhcpDomains = [];
+        foreach ($this->dhcp_ranges->iterateItems() as $range) {
+            if ($range->domain->isEmpty()) {
+                continue;
+            }
+            $usedDhcpDomains[(string)$range->domain][] = (string)$range->domain_type;
+        }
+
         foreach ($this->hosts->iterateItems() as $host) {
             if (!$validateFullModel && !$host->isFieldChanged()) {
                 continue;
@@ -123,13 +131,40 @@ class Dnsmasq extends BaseModel
             $start_inet = strpos($range->start_addr, ':') !== false ? 'inet6' : 'inet';
             $end_inet = strpos($range->end_addr, ':') !== false ? 'inet6' : 'inet';
             $key = $range->__reference;
-            if (!$range->domain->isEmpty() && $range->end_addr->isEmpty()) {
-                $messages->appendMessage(
-                    new Message(
-                        gettext("Can only configure a domain when a full range (including end) is specified."),
-                        $key . ".domain"
-                    )
-                );
+            if (!$range->domain->isEmpty()) {
+                if ((string)$range->domain_type === 'range' && $range->end_addr->isEmpty()) {
+                    $messages->appendMessage(
+                        new Message(
+                            gettext("Can only configure a domain of type 'Range' when a full range (including end) is specified."),
+                            $key . ".end_addr"
+                        )
+                    );
+                }
+
+                if ((string)$range->domain_type === 'interface' && $range->interface->isEmpty()) {
+                    $messages->appendMessage(
+                        new Message(
+                            gettext("A domain of type 'Interface' requires an interface to be selected."),
+                            $key . ".interface"
+                        )
+                    );
+                }
+            }
+
+            if (!$range->domain->isEmpty() && !$range->domain_type->isEmpty()) {
+                if (isset($usedDhcpDomains[(string)$range->domain])) {
+                    $typesUsed = array_unique($usedDhcpDomains[(string)$range->domain]);
+
+                    if (in_array('interface', $typesUsed) && in_array('range', $typesUsed)) {
+                        $messages->appendMessage(
+                            new Message(
+                                sprintf(gettext("The domain '%s' cannot be used with both types 'Interface' and 'Range'."),
+                                (string)$range->domain),
+                                $key . ".domain"
+                            )
+                        );
+                    }
+                }
             }
 
             if ($start_inet != $end_inet && !$range->end_addr->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>/dnsmasq</mount>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <items>
         <enable type="BooleanField"/>
         <regdhcp type="BooleanField"/>
@@ -192,6 +192,14 @@
                 <MaximumValue>64</MaximumValue>
             </prefix_len>
             <lease_time type="IntegerField"/>
+            <domain_type type="OptionField">
+                <OptionValues>
+                    <interface>Interface</interface>
+                    <range>Range</range>
+                </OptionValues>
+                <Default>interface</Default>
+                <Required>Y</Required>
+            </domain_type>
             <domain type="HostnameField">
                 <IsDNSName>Y</IsDNSName>
                 <IpAllowed>N</IpAllowed>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -216,9 +216,13 @@ constructor:{{helpers.physical_interface(dhcp_range.constructor)}},
 {{ dhcp_range.prefix_len|default('64') }},{{ 'infinite' if dhcp_range.lease_time == '0' else dhcp_range.lease_time|default('86400') }}
 {% endif %}
 
-{% if dhcp_range.domain %}
-domain={{ dhcp_range.domain }},{{dhcp_range.start_addr}},{{dhcp_range.end_addr}}
-{% endif %}
+{%  if dhcp_range.domain %}
+{%      if dhcp_range.domain_type == 'interface' %}
+domain={{ dhcp_range.domain }},{{ helpers.physical_interface(dhcp_range.interface) }}
+{%      elif dhcp_range.domain_type == 'range' %}
+domain={{ dhcp_range.domain }},{{ dhcp_range.start_addr }},{{ dhcp_range.end_addr }}
+{%      endif %}
+{%  endif %}
 
 {#- Only gets added if a custom ra_mode is chosen, otherwise the global defaults of enable-ra are used. -#}
 {% if dhcp_range.ra_mode and dhcp_range.interface %}

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -216,13 +216,13 @@ constructor:{{helpers.physical_interface(dhcp_range.constructor)}},
 {{ dhcp_range.prefix_len|default('64') }},{{ 'infinite' if dhcp_range.lease_time == '0' else dhcp_range.lease_time|default('86400') }}
 {% endif %}
 
-{%  if dhcp_range.domain %}
+{% if dhcp_range.domain %}
 {%      if dhcp_range.domain_type == 'interface' %}
 domain={{ dhcp_range.domain }},{{ helpers.physical_interface(dhcp_range.interface) }}
 {%      elif dhcp_range.domain_type == 'range' %}
 domain={{ dhcp_range.domain }},{{ dhcp_range.start_addr }},{{ dhcp_range.end_addr }}
 {%      endif %}
-{%  endif %}
+{% endif %}
 
 {#- Only gets added if a custom ra_mode is chosen, otherwise the global defaults of enable-ra are used. -#}
 {% if dhcp_range.ra_mode and dhcp_range.interface %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8797

It works in my test, now A and AAAA records for the same DHCPv4 and DHCPv6 client are finally appearing under their respective dhcp domain. PTR works as well for both.

The type is "Interface" per default, as its the most sane default. "Range" is more for edge cases.

Nothing has to be deduplicated, dnsmasq doesnt care if a domain entry exists twice with the same data.
Everything else is validated via the model.