### PR TITLE
dnsmasq: Change domain_type default to range to retain current default logic

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -197,7 +197,7 @@
                     <interface>Interface</interface>
                     <range>Range</range>
                 </OptionValues>
-                <Default>interface</Default>
+                <Default>range</Default>
                 <Required>Y</Required>
             </domain_type>
             <domain type="HostnameField">


### PR DESCRIPTION
This prevents changing existing setups with a new (unexpected) default.

For: https://github.com/opnsense/core/pull/8814