### PR TITLE
#8834/#8835: allow CSR to be downloaded from Sytem/Trust/Certificates

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CaController.php
@@ -235,7 +235,7 @@ class CaController extends ApiMutableModelControllerBase
             $node = $this->getModel()->getNodeByReference('ca.' . $uuid);
             $result['descr'] = $node !== null ? (string)$node->descr : '';
             if ($node === null || empty((string)$node->crt_payload)) {
-                $result['error'] = gettext('Misssing certificate');
+                $result['error'] = gettext('Missing certificate');
             } elseif ($type == 'crt') {
                 $result['status'] = 'ok';
                 $result['payload'] = (string)$node->crt_payload;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
@@ -307,7 +307,7 @@ class CertController extends ApiMutableModelControllerBase
             $node = $this->getModel()->getNodeByReference('cert.' . $uuid);
             $result['descr'] = $node !== null ? (string)$node->descr : '';
             if ($node === null || (empty((string)$node->crt_payload)) && empty((string)$node->csr_payload))) {
-                $result['error'] = gettext('Misssing certificate');
+                $result['error'] = gettext('Missing certificate');
             } elseif ($type == 'csr') {
                 $result['status'] = 'ok';
                 $result['payload'] = (string)$node->csr_payload;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CertController.php
@@ -306,8 +306,11 @@ class CertController extends ApiMutableModelControllerBase
         if ($this->request->isPost() && !empty($uuid)) {
             $node = $this->getModel()->getNodeByReference('cert.' . $uuid);
             $result['descr'] = $node !== null ? (string)$node->descr : '';
-            if ($node === null || empty((string)$node->crt_payload)) {
+            if ($node === null || (empty((string)$node->crt_payload)) && empty((string)$node->csr_payload))) {
                 $result['error'] = gettext('Misssing certificate');
+            } elseif ($type == 'csr') {
+                $result['status'] = 'ok';
+                $result['payload'] = (string)$node->csr_payload;
             } elseif ($type == 'crt') {
                 $result['status'] = 'ok';
                 $result['payload'] = (string)$node->crt_payload;

--- a/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Trust/cert.volt
@@ -85,6 +85,7 @@
                         let $container = $("<div style='height:150px;'/>");
                         let $type = $("<select id='download_type'/>");
                         let $password = $("<input id='download_password' type='password'/>");
+                        $type.append($("<option value='csr'/>").text('Certificate Signing Request'));
                         $type.append($("<option value='crt'/>").text('Certificate'));
                         $type.append($("<option value='prv'/>").text('Private key'));
                         $type.append($("<option value='pkcs12' selected=selected/>").text('PKCS #12'));


### PR DESCRIPTION
Although you can create a CSR in the OPNsense web UI, you cannot download one. User @Zewwy from IRC was trying and getting silent failures because the UI doesn't have an option for it. You can choose the following options

- Certificate (silent failure, the CSR has no certificate body)
- PKCS12 (silent failure, the CSR has no certificate body)
- Private key (works fine, the private key is generated alongside the CSR)

This PR adds the "Certificate Signing Request" option into the download box, and when this option is used the API serves up the CSR payload

Fixes: #8834, #8835