### PR TITLE
dns/unbound: Add ipset support

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
@@ -396,4 +396,28 @@
             Number of hosts for which information is cached.
         </help>
     </field>
+    <field>
+        <type>header</type>
+        <label>Ipset Settings</label>
+    </field>
+    <field>
+        <id>unbound.advanced.ipset_alias_v4</id>
+        <label>Ipset Alias IPv4</label>
+        <type>dropdown</type>
+        <help>Choose an "external (advanced)" type alias from "Firewall - Aliases". Whenever a client successfully resolves the domain, the resolved IP addresses will be automatically added to the chosen alias. Adding a domain will also add all IP addresses of resolved subdomains. Please note that DNS record TTL is not evaluated; once an IP address is added, it will stay permanently, or until manually flushed in "Firewall - Diagnostics - Aliases", or until removed automatically when setting an expiration on the alias.</help>
+    </field>
+    <field>
+        <id>unbound.advanced.ipset_alias_v6</id>
+        <label>Ipset Alias IPv6</label>
+        <type>dropdown</type>
+        <help>Choose an "external (advanced)" type alias from "Firewall - Aliases". Whenever a client successfully resolves the domain, the resolved IP addresses will be automatically added to the chosen alias. Adding a domain will also add all IP addresses of resolved subdomains. Please note that DNS record TTL is not evaluated; once an IP address is added, it will stay permanently, or until manually flushed in "Firewall - Diagnostics - Aliases", or until removed automatically when setting an expiration on the alias.</help>
+    </field>
+    <field>
+        <id>unbound.advanced.ipset_domains</id>
+        <label>Ipset Domains</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Enter one or multiple domains to add to the above aliases.</help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -128,6 +128,17 @@
             <infrakeepprobing type="BooleanField"/>
             <infracachenumhosts type="NumericField"/>
             <unwantedreplythreshold type="NumericField"/>
+            <ipset_alias_v4 type="JsonKeyValueStoreField">
+                <ConfigdPopulateAct>unbound list ipset_alias</ConfigdPopulateAct>
+            </ipset_alias_v4>
+            <ipset_alias_v6 type="JsonKeyValueStoreField">
+                <ConfigdPopulateAct>unbound list ipset_alias</ConfigdPopulateAct>
+            </ipset_alias_v6>
+            <ipset_domains type="HostnameField">
+                <AsList>Y</AsList>
+                <FieldSeparator>,</FieldSeparator>
+                <IsDNSName>Y</IsDNSName>
+            </ipset_domains>
         </advanced>
         <acls>
             <default_action type="OptionField">

--- a/src/opnsense/service/conf/actions.d/actions_unbound.conf
+++ b/src/opnsense/service/conf/actions.d/actions_unbound.conf
@@ -71,6 +71,12 @@ parameters:
 type:script_output
 message:list local data
 
+[list.ipset_alias]
+command:/usr/local/opnsense/scripts/dns/ipset_alias.php
+type:script_output
+message:request external aliases for ipset
+cache_ttl:60
+
 [cache]
 command:/usr/local/opnsense/scripts/unbound/cache.sh
 parameters:%s

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/+TARGETS
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/+TARGETS
@@ -5,5 +5,6 @@ safesearch.conf:/usr/local/etc/unbound.opnsense.d/safesearch.conf
 dot.conf:/usr/local/etc/unbound.opnsense.d/dot.conf
 private_domains.conf:/var/unbound/private_domains.conf
 domainoverrides.conf:/usr/local/etc/unbound.opnsense.d/domainoverrides.conf
+ipset.conf:/usr/local/etc/unbound.opnsense.d/ipset.conf
 unbound_dhcpd.conf:/usr/local/etc/unbound_dhcpd.conf
 dnsbl_module.py:/var/unbound/dnsbl_module.py

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/ipset.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/ipset.conf
@@ -1,0 +1,18 @@
+{% if OPNsense.unboundplus.advanced.ipset_alias_v4 or OPNsense.unboundplus.advanced.ipset_alias_v6 %}
+server:
+    module-config: "ipset validator iterator"
+{%     if OPNsense.unboundplus.advanced.ipset_domains %}
+
+{%-         for domain in OPNsense.unboundplus.advanced.ipset_domains.split(',') %}
+    local-zone: "{{ domain }}" ipset
+{%          endfor %}
+{%     endif %}
+
+ipset:
+{%     if OPNsense.unboundplus.advanced.ipset_alias_v4 %}
+    name-v4: "{{ OPNsense.unboundplus.advanced.ipset_alias_v4 }}"
+{%     endif %}
+{%     if OPNsense.unboundplus.advanced.ipset_alias_v6 %}
+    name-v6: "{{ OPNsense.unboundplus.advanced.ipset_alias_v6 }}"
+{%     endif %}
+{% endif %}

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/ipset.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/ipset.conf
@@ -2,10 +2,9 @@
 server:
     module-config: "ipset validator iterator"
 {%     if OPNsense.unboundplus.advanced.ipset_domains %}
-
-{%-         for domain in OPNsense.unboundplus.advanced.ipset_domains.split(',') %}
+{%         for domain in OPNsense.unboundplus.advanced.ipset_domains.split(',') %}
     local-zone: "{{ domain }}" ipset
-{%          endfor %}
+{%         endfor %}
 {%     endif %}
 
 ipset:


### PR DESCRIPTION
Requires plumbing from: https://github.com/opnsense/core/pull/8791

Cherry picked into its own PR so the dnsmasq one can move along until Unbound is decided.