### PR TITLE
firewall/category: Add HTML based standardized color input to form

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
@@ -60,24 +60,6 @@ class CategoryController extends ApiMutableModelControllerBase
         return $result;
     }
 
-    /* The model validates the color for without # */
-    private function getCategoryOverlay(): array
-    {
-        $overlay = [];
-
-        if (
-            $this->request->isPost() &&
-            $this->request->hasPost("category")
-        ) {
-            $color = $this->request->getPost("category")['color'] ?? '';
-            if (str_starts_with($color, '#')) {
-                $overlay['color'] = substr($color, 1);
-            }
-        }
-
-        return $overlay;
-    }
-
     /**
      * Update category with given properties
      * @param string $uuid internal id
@@ -96,7 +78,7 @@ class CategoryController extends ApiMutableModelControllerBase
                 $this->getModel()->refactor($old_name, $new_name);
             }
         }
-        return $this->setBase("category", "categories.category", $uuid, $this->getCategoryOverlay());
+        return $this->setBase("category", "categories.category", $uuid);
     }
 
     /**
@@ -108,7 +90,7 @@ class CategoryController extends ApiMutableModelControllerBase
      */
     public function addItemAction()
     {
-        return $this->addBase("category", "categories.category", $this->getCategoryOverlay());
+        return $this->addBase("category", "categories.category");
     }
 
     /**
@@ -119,13 +101,7 @@ class CategoryController extends ApiMutableModelControllerBase
      */
     public function getItemAction($uuid = null)
     {
-        $result = $this->getBase("category", "categories.category", $uuid);
-
-        if (!empty($result['category']['color'])) {
-            $result['category']['color'] = '#' . ltrim($result['category']['color'], '#');
-        }
-
-        return $result;
+        return $this->getBase("category", "categories.category", $uuid);
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/CategoryController.php
@@ -60,6 +60,24 @@ class CategoryController extends ApiMutableModelControllerBase
         return $result;
     }
 
+    /* The model validates the color for without # */
+    private function getCategoryOverlay(): array
+    {
+        $overlay = [];
+
+        if (
+            $this->request->isPost() &&
+            $this->request->hasPost("category")
+        ) {
+            $color = $this->request->getPost("category")['color'] ?? '';
+            if (str_starts_with($color, '#')) {
+                $overlay['color'] = substr($color, 1);
+            }
+        }
+
+        return $overlay;
+    }
+
     /**
      * Update category with given properties
      * @param string $uuid internal id
@@ -78,7 +96,7 @@ class CategoryController extends ApiMutableModelControllerBase
                 $this->getModel()->refactor($old_name, $new_name);
             }
         }
-        return $this->setBase("category", "categories.category", $uuid);
+        return $this->setBase("category", "categories.category", $uuid, $this->getCategoryOverlay());
     }
 
     /**
@@ -90,7 +108,7 @@ class CategoryController extends ApiMutableModelControllerBase
      */
     public function addItemAction()
     {
-        return $this->addBase("category", "categories.category");
+        return $this->addBase("category", "categories.category", $this->getCategoryOverlay());
     }
 
     /**
@@ -101,7 +119,13 @@ class CategoryController extends ApiMutableModelControllerBase
      */
     public function getItemAction($uuid = null)
     {
-        return $this->getBase("category", "categories.category", $uuid);
+        $result = $this->getBase("category", "categories.category", $uuid);
+
+        if (!empty($result['category']['color'])) {
+            $result['category']['color'] = '#' . ltrim($result['category']['color'], '#');
+        }
+
+        return $result;
     }
 
     /**

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/categoryEdit.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/categoryEdit.xml
@@ -2,9 +2,9 @@
     <field>
         <id>category.color</id>
         <label>Color</label>
-        <type>text</type>
-        <style>pick-a-color</style>
-        <help>pick a color to use.</help>
+        <type>color</type>
+        <style>color-picker</style>
+        <help>Pick a color to use</help>
         <grid_view>
             <formatter>color</formatter>
             <width>100</width>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/categoryEdit.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/categoryEdit.xml
@@ -4,7 +4,7 @@
         <label>Color</label>
         <type>color</type>
         <style>color-picker</style>
-        <help>Pick a color to use</help>
+        <help>pick a color to use.</help>
         <grid_view>
             <formatter>color</formatter>
             <width>100</width>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/category.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/category.volt
@@ -25,9 +25,6 @@
  #}
 
 {% set theme_name = ui_theme|default('opnsense') %}
-<link rel="stylesheet" type="text/css" href="{{ cache_safe(theme_file_or_default('/css/pick-a-color-1.2.3.min.css', theme_name)) }}">
-<script src="{{ cache_safe('/ui/js/pick-a-color-1.2.3.min.js') }}"></script>
-<script src="{{ cache_safe('/ui/js/tinycolor-1.4.1.min.js') }}"></script>
 
 <script>
 
@@ -53,29 +50,15 @@
 
                 }
         );
-        $(".pick-a-color").pickAColor({
-            showSpectrum: true,
-            showSavedColors: true,
-            saveColorsPerElement: true,
-            fadeMenuToggle: true,
-            showAdvanced : false,
-            showBasicColors: true,
-            showHexInput: true,
-            allowBlank: true,
-            inlineDropdown: true
-        });
-        $("#category\\.color").change(function(){
-            // update color picker
-            $(this).blur().blur();
-        });
 
     });
 
 </script>
 
 <style>
-    .modal-body {
-        min-height: 410px;
+    .color-picker {
+        width: 32px !important;
+        padding: 3px !important;
     }
 </style>
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/category.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/category.volt
@@ -24,8 +24,6 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-{% set theme_name = ui_theme|default('opnsense') %}
-
 <script>
 
     $( document ).ready(function() {

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -37,6 +37,7 @@
  #                   select_multiple    multiple item select from dropdown
  #                   hidden             hidden fields not for user interaction
  #                   info               static text (help icon, no input or editing)
+ #                   color              color picker for selecting a color
  # label       :   attribute label (visible text)
  # size        :   size (width in characters) attribute if applicable
  # height      :   height (length in characters) attribute if applicable
@@ -115,6 +116,8 @@
             <textarea class="{{style|default('')}}" rows="{{height|default("5")}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} aria-label="{{label|safe}}"></textarea>
         {% elseif type == "info" %}
             <span  class="{{style|default('')}}" id="{{ id }}"></span>
+        {% elseif type == "color" %}
+            <input type="color" class="form-control {{style|default('')}}" id="{{ id }}" {{ readonly|default(false) ? 'readonly="readonly"' : '' }} aria-label="{{label|safe}}">
         {% endif %}
         {% if help|default(false) %}
             <div class="hidden" data-for="help_for_{{ id }}">

--- a/src/opnsense/www/js/opnsense.js
+++ b/src/opnsense/www/js/opnsense.js
@@ -96,6 +96,9 @@ function getFormData(parent) {
                 } else if (sourceNode.hasClass("json-data")) {
                     // deserialize the field content - used for JS maintained fields
                     node[keypart] = sourceNode.data('data');
+                } else if (sourceNode.prop("type") === "color") {
+                    // strip leading '#' for backend compatibility
+                    node[keypart] = sourceNode.val().startsWith("#") ? sourceNode.val().substring(1) : sourceNode.val();
                 } else {
                     node[keypart] = sourceNode.val();
                 }
@@ -196,6 +199,12 @@ function setFormData(parent,data) {
                     } else if (targetNode.hasClass('json-data')) {
                         // if the input field is JSON data, serialize the data into the field
                         targetNode.data('data', node[keypart]);
+                    } else if (targetNode.prop("type") === "color") {
+                        // color inputs get '#' prefix
+                        if (typeof node[keypart] === "string" && !node[keypart].startsWith("#")) {
+                            node[keypart] = "#" + node[keypart];
+                        }
+                        targetNode.val(val);
                     } else if (targetNode.attr('type') !== 'file') {
                         // regular input type
                         targetNode.val(htmlDecode(node[keypart]));

--- a/src/opnsense/www/js/opnsense.js
+++ b/src/opnsense/www/js/opnsense.js
@@ -98,7 +98,8 @@ function getFormData(parent) {
                     node[keypart] = sourceNode.data('data');
                 } else if (sourceNode.prop("type") === "color") {
                     // strip leading '#' for backend compatibility
-                    node[keypart] = sourceNode.val().startsWith("#") ? sourceNode.val().substring(1) : sourceNode.val();
+                    const val = sourceNode.val();
+                    node[keypart] = val.startsWith("#") ? val.substring(1) : val;
                 } else {
                     node[keypart] = sourceNode.val();
                 }
@@ -201,8 +202,9 @@ function setFormData(parent,data) {
                         targetNode.data('data', node[keypart]);
                     } else if (targetNode.prop("type") === "color") {
                         // color inputs get '#' prefix
-                        if (typeof node[keypart] === "string" && !node[keypart].startsWith("#")) {
-                            node[keypart] = "#" + node[keypart];
+                        let val = node[keypart];
+                        if (typeof val === "string" && !val.startsWith("#")) {
+                            val = "#" + val;
                         }
                         targetNode.val(val);
                     } else if (targetNode.attr('type') !== 'file') {


### PR DESCRIPTION
Just as an idea since the javascript dependency looks unmaintained.

This lets the browser render the color input.

It gets appended to body which is nice.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color
Chrome on Macbook:
![image](https://github.com/user-attachments/assets/6362bd41-487a-4795-8922-97dda8e31319)

Link: https://github.com/opnsense/core/pull/8858

