### PR TITLE
mvc: extend base_bootgrid_table with grid_commands

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
@@ -113,7 +113,7 @@
                     grid_user.bootgrid('reload');
                 }
             });
-        })
+        });
 
         let grid_apikey = $("#grid-apikey").UIBootgrid({
             search:'/api/auth/user/search_api_key/',

--- a/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Auth/user.volt
@@ -107,7 +107,13 @@
                     }
                 }
             }
-        });
+        }).on('load.rs.jquery.bootgrid', function() {
+            $("#upload_users").SimpleFileUploadDlg({
+                onAction: function(){
+                    grid_user.bootgrid('reload');
+                }
+            });
+        })
 
         let grid_apikey = $("#grid-apikey").UIBootgrid({
             search:'/api/auth/user/search_api_key/',
@@ -158,21 +164,14 @@
             }
         });
 
-        $("#download_users").click(function(e){
-            e.preventDefault();
-            window.open("/api/auth/user/download");
-        });
-        $("#upload_users").SimpleFileUploadDlg({
-            onAction: function(){
-                grid_user.bootgrid('reload');
-            }
-        });
-
         $('.datepicker').datepicker({format: 'mm/dd/yyyy'});
         /* format  authorizedkeys */
         $("#user\\.authorizedkeys").css('max-width', 'inherit').prop('wrap', 'off');
 
-        $("#grid-user-buttons").children().insertAfter($("#{{ formGridUser['table_id'] }} tfoot [data-action='deleteSelected']"));
+        $("#{{formGridUser['table_id']}}").on('click', '#download_users', function(e) {
+            e.preventDefault();
+            window.open("/api/auth/user/download");
+        });
     });
 
 </script>
@@ -194,22 +193,33 @@
     <li><a data-toggle="tab" href="#apikeys" id="tab_apikeys"> {{ lang._('ApiKeys') }} </a></li>
 </ul>
 
-<div id="grid-user-buttons" style="display: none;">
-    <button
-        id="upload_users"
-        type="button"
-        data-title="{{ lang._('Import Users') }}"
-        data-endpoint='/api/auth/user/upload'
-        title="{{ lang._('Import csv') }}"
-        data-toggle="tooltip"
-        class="btn btn-xs btn-user-action"
-    ><span class="fa fa-fw fa-upload"></span></button>&nbsp;
-    <button id="download_users" type="button" title="{{ lang._('Export as csv') }}" data-toggle="tooltip"  class="btn btn-xs btn-user-action"><span class="fa fa-fw fa-table"></span></button>
-</div>
-
 <div class="tab-content content-box">
     <div id="user" class="tab-pane fade in active">
-        {{ partial('layout_partials/base_bootgrid_table', formGridUser + {'command_width': '9em'})}}
+        {{
+            partial('layout_partials/base_bootgrid_table', formGridUser + {
+                'command_width': '9em',
+                'grid_commands': {
+                    'upload_users': {
+                        'class': 'btn btn-xs btn-user-action',
+                        'icon_class': 'fa fa-fw fa-upload',
+                        'title': lang._('Import csv'),
+                        'data': {
+                            'title': lang._('Import Users'),
+                            'endpoint': '/api/auth/user/upload',
+                            'toggle': 'tooltip'
+                        }
+                    },
+                    'download_users': {
+                        'class': 'btn btn-xs btn-user-action',
+                        'icon_class': 'fa fa-fw fa-table',
+                        'title': lang._('Export as csv'),
+                        'data': {
+                            'toggle': 'tooltip'
+                        }
+                    }
+                }
+            })
+        }}
     </div>
     <div id="apikeys" class="tab-pane fade in">
         <table id="grid-apikey" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogUser">

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -110,7 +110,7 @@
                         }
                     }
 
-                    // host grid needs custom commands
+                    // host grid needs custom commands (upload/download)
                     if (['host'].includes(grid_id)) {
                         $("#{{formGridHostOverride['table_id']}}").on('click', '#download_hosts', function(e){
                             e.preventDefault();

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -109,6 +109,22 @@
                             $('#tag_select_container').show();
                         }
                     }
+
+                    // host grid needs custom commands
+                    if (['host'].includes(grid_id)) {
+                        $("#{{formGridHostOverride['table_id']}}").on('click', '#download_hosts', function(e){
+                            e.preventDefault();
+                            window.open("/api/dnsmasq/settings/download_hosts");
+                        });
+
+                        all_grids[grid_id].on('load.rs.jquery.bootgrid', function() {
+                            $("#upload_hosts").SimpleFileUploadDlg({
+                                onAction: function(){
+                                    $("#{{formGridHostOverride['table_id']}}").bootgrid('reload');
+                                }
+                            });
+                        })
+                    }
                 });
             }
         });
@@ -121,16 +137,6 @@
             },
             onAction: function(data, status) {
                 updateServiceControlUI('dnsmasq');
-            }
-        });
-
-        $("#download_hosts").click(function(e){
-            e.preventDefault();
-            window.open("/api/dnsmasq/settings/download_hosts");
-        });
-        $("#upload_hosts").SimpleFileUploadDlg({
-            onAction: function(){
-                $("#{{formGridHostOverride['table_id']}}").bootgrid('reload');
             }
         });
 
@@ -267,19 +273,6 @@
     }
 </style>
 
-<div style="display: none;" id="hosts_tfoot_append">
-    <button
-        id="upload_hosts"
-        type="button"
-        data-title="{{ lang._('Import hosts') }}"
-        data-endpoint='/api/dnsmasq/settings/upload_hosts'
-        title="{{ lang._('Import csv') }}"
-        data-toggle="tooltip"
-        class="btn btn-xs"
-    ><span class="fa fa-fw fa-upload"></span></button>
-    <button id="download_hosts" type="button" title="{{ lang._('Export as csv') }}" data-toggle="tooltip"  class="btn btn-xs"><span class="fa fa-fw fa-table"></span></button>
-</div>
-
 <div id="tag_select_container" class="btn-group" style="display: none;">
     <button type="button" id="tag_select_clear" class="btn btn-default" title="{{ lang._('Clear Selection') }}">
         <i id="tag_select_icon" class="fa fa-fw fa-filter"></i>
@@ -305,7 +298,31 @@
     </div>
     <!-- Tab: Hosts -->
     <div id="hosts" class="tab-pane fade in">
-        {{ partial('layout_partials/base_bootgrid_table', formGridHostOverride + {'command_width': '8em'} )}}
+        {{
+            partial('layout_partials/base_bootgrid_table', formGridHostOverride + {
+                'command_width': '8em',
+                'grid_commands': {
+                    'upload_hosts': {
+                        'title': lang._('Import csv'),
+                        'class': 'btn btn-xs',
+                        'icon_class': 'fa fa-fw fa-upload',
+                        'data': {
+                            'title': lang._('Import hosts'),
+                            'endpoint': '/api/dnsmasq/settings/upload_hosts',
+                            'toggle': 'tooltip'
+                        }
+                    },
+                    'download_hosts': {
+                        'title': lang._('Export as csv'),
+                        'class': 'btn btn-xs',
+                        'icon_class': 'fa fa-fw fa-table',
+                        'data': {
+                            'toggle': 'tooltip'
+                        }
+                    }
+                }
+            })
+        }}
     </div>
     <!-- Tab: Domains -->
     <div id="domains" class="tab-pane fade in">

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -58,7 +58,13 @@
                 add:'/api/kea/dhcpv4/add_reservation/',
                 del:'/api/kea/dhcpv4/del_reservation/'
             }
-        );
+        ).on('load.rs.jquery.bootgrid', function() {
+            $("#upload_reservations").SimpleFileUploadDlg({
+                onAction: function(){
+                    grid_reservations.bootgrid('reload');
+                }
+            });
+        })
 
         $("#{{formGridPeer['table_id']}}").UIBootgrid(
             {   search:'/api/kea/dhcpv4/search_peer',
@@ -80,43 +86,9 @@
             }
         });
 
-        /**
-         * Reservations csv download and upload
-         */
-        const $tfoot = grid_reservations.find("tfoot td:last");
-        $tfoot.append(`
-            <button
-                id="upload_reservations"
-                type="button"
-                data-title="{{ lang._('Import reservations') }}"
-                data-endpoint='/api/kea/dhcpv4/upload_reservations'
-                title="{{ lang._('Import csv') }}"
-                data-toggle="tooltip"
-                class="btn btn-xs"
-            >
-                <span class="fa fa-fw fa-upload"></span>
-            </button>
-        `);
-        $tfoot.append(`
-            <button
-                id="download_reservations"
-                type="button"
-                title="{{ lang._('Export as csv') }}"
-                data-toggle="tooltip"
-                class="btn btn-xs"
-            >
-                <span class="fa fa-fw fa-table"></span>
-            </button>
-        `);
-
-        $("#download_reservations").click(function(e){
+        $("#{{formGridReservation['table_id']}}").on('click', '#download_reservations', function(e){
             e.preventDefault();
             window.open("/api/kea/dhcpv4/download_reservations");
-        });
-        $("#upload_reservations").SimpleFileUploadDlg({
-            onAction: function(){
-                grid_reservations.bootgrid('reload');
-            }
         });
 
         /**
@@ -150,8 +122,6 @@
                 }
             });
         });
-
-
     });
 </script>
 
@@ -172,7 +142,31 @@
     </div>
     <!-- reservations -->
     <div id="reservations" class="tab-pane fade in">
-        {{ partial('layout_partials/base_bootgrid_table', formGridReservation + {'command_width': '8em'} )}}
+        {{
+            partial('layout_partials/base_bootgrid_table', formGridReservation + {
+                'command_width': '8em',
+                'grid_commands': {
+                    'upload_reservations': {
+                        'title': lang._('Import csv'),
+                        'class': 'btn btn-xs',
+                        'icon_class': 'fa fa-fw fa-upload',
+                        'data': {
+                            'title': lang._('Import Reservations'),
+                            'endpoint': '/api/kea/dhcpv4/upload_reservations',
+                            'toggle': 'tooltip'
+                        }
+                    },
+                    'download_reservations': {
+                        'title': lang._('Export as csv'),
+                        'class': 'btn btn-xs',
+                        'icon_class': 'fa fa-fw fa-table',
+                        'data': {
+                            'tooltip': 'toggle'
+                        }
+                    }
+                }
+            })
+        }}
     </div>
     <!-- HA - peers -->
     <div id="ha-peers" class="tab-pane fade in">

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -161,7 +161,7 @@
                         'class': 'btn btn-xs',
                         'icon_class': 'fa fa-fw fa-table',
                         'data': {
-                            'tooltip': 'toggle'
+                            'toggle': 'tooltip'
                         }
                     }
                 }

--- a/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
@@ -21,6 +21,14 @@
                 <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default">
                     <span class="fa fa-trash-o fa-fw"></span>
                 </button>
+                {% for id, cmd in grid_commands|default({}) %}
+                    <button id="{{id}}" type="button" class="{{cmd['class']|default('')}}" title="{{cmd['title']|default('')}}"
+                        {% for key, data in cmd['data']|default({}) %}
+                        data-{{key}}="{{data}}"
+                        {% endfor %}>
+                        <span class="{{cmd['icon_class']|default('')}}"></span>
+                    </button>
+                {% endfor %}
             </td>
         </tr>
     </tfoot>

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -177,7 +177,10 @@
                     $("#system_status").show();
                 });
                 // enable bootstrap tooltips
-                $('[data-toggle="tooltip"]').tooltip();
+                $('body').tooltip({
+                    selector: '[data-toggle="tooltip"]',
+                    container: 'body'
+                })
 
                 // fix menu scroll position on page load
                 $(".list-group-item.active").each(function(){

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -605,6 +605,8 @@ class UIBootgrid {
                 this._populateColumnSelection();
                 this.navigationRendered = true;
             }
+
+            this.$element.trigger("load.rs.jquery.bootgrid", []);
         });
 
         this.table.on('dataLoading', () => {

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -603,10 +603,9 @@ class UIBootgrid {
             if (!this.navigationRendered) {
                 this._renderFooter();
                 this._populateColumnSelection();
+                this.$element.trigger("load.rs.jquery.bootgrid", []);
                 this.navigationRendered = true;
             }
-
-            this.$element.trigger("load.rs.jquery.bootgrid", []);
         });
 
         this.table.on('dataLoading', () => {


### PR DESCRIPTION
Since the rendering of the table is now asynchronous, and because of general backwards incompatibility, custom buttons that were injected after UIBootgrid initialization don't show up anymore in with the new wrapper.

This commit attempts to generalize the problem by moving custom grid commands to the `base_bootgrid_table` partial, while keeping the responsibility of interaction local to the page at hand.

Because constructs such as `SimpleFileUploadDlg` cannot be delegated, move this into an event handler that fires when we know the UI has rendered.

In the long term it would make more sense to move this logic to the tabulator wrapper instead, but this requires the UI to be fully decoupled from the template.