### PR TITLE
shaper: combine dnctl/ipfw setup and fix setup order (continuation of…

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -167,8 +167,7 @@ function filter_configure_sync($verbose = false, $load_aliases = true)
     $fobj = new \OPNsense\Core\FileObject('/tmp/rules.debug', 'a+', 0600, LOCK_EX);
 
     /* kickstart dnctl regardless of shaping configuration */
-    mwexec('/etc/rc.d/dnctl start', true);
-    configd_run('ipfw reload');
+    mwexec('/usr/local/opnsense/scripts/shaper/start.sh', true);
 
     ifgroup_setup();
 

--- a/src/opnsense/scripts/shaper/start.sh
+++ b/src/opnsense/scripts/shaper/start.sh
@@ -24,9 +24,17 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# sysctl settings, use sysctl.kld.d since this setup script is called
-# before module load through rc, meaning the sysctls don't exist yet.
-cat <<EOF > /etc/sysctl.kld.d/dummynet.conf
-net.inet.ip.dummynet.io_fast=1
-net.inet.ip.dummynet.hash_size=256
-EOF
+SERVICE=${1}
+DNCTL="/etc/rc.d/dnctl start"
+IPFW="/etc/rc.d/ipfw enabled && /etc/rc.d/ipfw start || ( /etc/rc.d/ipfw onestop || true ); /usr/local/etc/rc.ipfw.post || true"
+
+if [ $# -eq 0 ]; then
+    ${DNCTL}
+    ${IPFW}
+elif [ ${SERVICE} = "dnctl" ]; then
+    ${DNCTL}
+elif [ ${SERVICE} = "ipfw" ]; then
+    ${IPFW}
+else
+    exit 1
+fi

--- a/src/opnsense/service/conf/actions.d/actions_ipfw.conf
+++ b/src/opnsense/service/conf/actions.d/actions_ipfw.conf
@@ -1,5 +1,5 @@
 [reload]
-command:/etc/rc.d/ipfw enabled && /etc/rc.d/ipfw start || ( /etc/rc.d/ipfw onestop || true ); /usr/local/etc/rc.ipfw.post || true
+command:/usr/local/opnsense/scripts/shaper/start.sh ipfw
 parameters:
 type:script
 message:restarting ipfw

--- a/src/opnsense/service/conf/actions.d/actions_shaper.conf
+++ b/src/opnsense/service/conf/actions.d/actions_shaper.conf
@@ -1,5 +1,5 @@
 [reload]
-command:/etc/rc.d/dnctl start
+command:/usr/local/opnsense/scripts/shaper/start.sh dnctl
 parameters:
 errors:no
 type:script


### PR DESCRIPTION
… eae56a725dc97c1d8fb0d368072a579e695fb186)

this has the added benefit that a call through configd won't be necesary anymore.

while here, dnctl_setup seems to be executed before the dummynet module load on bootup. fix this by deferring the sysctl values.