### PR TITLE
Add DNS field to Kea DHCP4 Reservations

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
@@ -24,6 +24,12 @@
         <help>Offer a hostname to the client</help>
     </field>
     <field>
+        <id>reservation.dns_servers</id>
+        <label>DNS servers</label>
+        <type>text</type>
+        <help>DNS server IP addresses, comma separated (e.g. 8.8.8.8,8.8.4.4). Leave blank to use subnet defaults.</help>
+    </field>
+    <field>
         <id>reservation.description</id>
         <label>Description</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
@@ -24,15 +24,114 @@
         <help>Offer a hostname to the client</help>
     </field>
     <field>
-        <id>reservation.dns_servers</id>
-        <label>DNS servers</label>
-        <type>text</type>
-        <help>DNS server IP addresses, comma separated (e.g. 8.8.8.8,8.8.4.4). Leave blank to use subnet defaults.</help>
-    </field>
-    <field>
         <id>reservation.description</id>
         <label>Description</label>
         <type>text</type>
         <help>You may enter a description here for your reference (not parsed).</help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>DHCP option data</label>
+    </field>
+    <field>
+        <id>reservation.option_data.routers</id>
+        <label>Routers (gateway)</label>
+        <type>select_multiple</type>
+        <style>tokenize option_data_autocollect</style>
+        <allownew>true</allownew>
+        <help>Default gateways to offer to the clients</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.static_routes</id>
+        <label>Static routes</label>
+        <type>text</type>
+        <help>Static routes that the client should install in its routing cache, defined as dest-ip1,router-ip1,dest-ip2,router-ip2</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.domain_name_servers</id>
+        <label>DNS servers</label>
+        <type>select_multiple</type>
+        <style>tokenize option_data_autocollect</style>
+        <allownew>true</allownew>
+        <help>DNS servers to offer to the clients</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.domain_name</id>
+        <label>Domain name</label>
+        <type>text</type>
+        <help>The domain name to offer to the client, set to this firewall's domain name when left empty</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.domain_search</id>
+        <label>Domain search</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <separator>,</separator>
+        <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.ntp_servers</id>
+        <label>NTP servers</label>
+        <type>select_multiple</type>
+        <style>tokenize option_data_autocollect</style>
+        <allownew>true</allownew>
+        <help>Specifies a list of IP addresses indicating NTP (RFC 5905) servers available to the client.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.time_servers</id>
+        <label>Time servers</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Specifies a list of RFC 868 time servers available to the client.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.next_server</id>
+        <label>Next server</label>
+        <type>text</type>
+        <help>Next server IP address</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.tftp_server_name</id>
+        <label>TFTP server</label>
+        <type>text</type>
+        <help>TFTP server address or fqdn</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>reservation.option_data.boot_file_name</id>
+        <label>TFTP bootfile name</label>
+        <type>text</type>
+        <help>Boot filename to request</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -184,15 +184,29 @@ class KeaDhcpv4 extends BaseModel
                     $res['hw-address'] = str_replace('-', ':', $reservation->hw_address);
                 }
                 
-                // Add domain-name-servers option if specified
-                if (!$reservation->dns_servers->isEmpty()) {
-                    if (!isset($res['option-data'])) {
-                        $res['option-data'] = [];
+                // Add DHCP option-data elements for reservations
+                foreach ($reservation->option_data->iterateItems() as $key => $value) {
+                    $target_fieldname = str_replace('_', '-', $key);
+                    if ((string)$value != '') {
+                        if ($key == 'static_routes') {
+                            $value = implode(',', array_map('trim', explode(',', $value)));
+                        }
+                        if (!isset($res['option-data'])) {
+                            $res['option-data'] = [];
+                        }
+                        $res['option-data'][] = [
+                            'name' => $target_fieldname,
+                            'data' => (string)$value
+                        ];
+                    } elseif ($key == 'domain_name') {
+                        if (!isset($res['option-data'])) {
+                            $res['option-data'] = [];
+                        }
+                        $res['option-data'][] = [
+                            'name' => $target_fieldname,
+                            'data' => (string)Config::getInstance()->object()->system->domain
+                        ];
                     }
-                    $res['option-data'][] = [
-                        'name' => 'domain-name-servers',
-                        'data' => (string)$reservation->dns_servers
-                    ];
                 }
 
                 $record['reservations'][] = $res;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -183,6 +183,17 @@ class KeaDhcpv4 extends BaseModel
                 if (!$reservation->hw_address->isEmpty()) {
                     $res['hw-address'] = str_replace('-', ':', $reservation->hw_address);
                 }
+                
+                // Add domain-name-servers option if specified
+                if (!$reservation->dns_servers->isEmpty()) {
+                    if (!isset($res['option-data'])) {
+                        $res['option-data'] = [];
+                    }
+                    $res['option-data'][] = [
+                        'name' => 'domain-name-servers',
+                        'data' => (string)$reservation->dns_servers
+                    ];
+                }
 
                 $record['reservations'][] = $res;
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -156,11 +156,49 @@
                 <hostname type="HostnameField">
                     <IsDNSName>Y</IsDNSName>
                 </hostname>
-                <dns_servers type="TextField">
-                    <Mask>/^(?:(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\s*,\s*(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))*)?$/</Mask>
-                    <ValidationMessage>Please enter valid IPv4 addresses separated by commas (e.g., 8.8.8.8,8.8.4.4)</ValidationMessage>
-                </dns_servers>
                 <description type="DescriptionField"/>
+                <option_data>
+                    <domain_name_servers type="NetworkField">
+                        <NetMaskAllowed>N</NetMaskAllowed>
+                        <AddressFamily>ipv4</AddressFamily>
+                        <AsList>Y</AsList>
+                        <FieldSeparator>,</FieldSeparator>
+                    </domain_name_servers>
+                    <domain_search type="HostnameField">
+                        <IpAllowed>N</IpAllowed>
+                        <FieldSeparator>,</FieldSeparator>
+                        <AsList>Y</AsList>
+                        <ValidationMessage>Please specify a valid list of domains</ValidationMessage>
+                    </domain_search>
+                    <routers type="NetworkField">
+                        <NetMaskAllowed>N</NetMaskAllowed>
+                        <AddressFamily>ipv4</AddressFamily>
+                        <AsList>Y</AsList>
+                        <FieldSeparator>,</FieldSeparator>
+                    </routers>
+                    <static_routes type=".\KeaStaticRoutesField"/>
+                    <domain_name type="HostnameField">
+                        <IpAllowed>N</IpAllowed>
+                    </domain_name>
+                    <ntp_servers type="NetworkField">
+                        <NetMaskAllowed>N</NetMaskAllowed>
+                        <AddressFamily>ipv4</AddressFamily>
+                        <AsList>Y</AsList>
+                        <FieldSeparator>,</FieldSeparator>
+                    </ntp_servers>
+                    <time_servers type="NetworkField">
+                        <NetMaskAllowed>N</NetMaskAllowed>
+                        <AddressFamily>ipv4</AddressFamily>
+                        <AsList>Y</AsList>
+                        <FieldSeparator>,</FieldSeparator>
+                    </time_servers>
+                    <tftp_server_name type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </tftp_server_name>
+                    <boot_file_name type="TextField">
+                        <Mask>/^([^\n"])*$/u</Mask>
+                    </boot_file_name>
+                </option_data>
             </reservation>
         </reservations>
         <ha_peers>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -156,6 +156,10 @@
                 <hostname type="HostnameField">
                     <IsDNSName>Y</IsDNSName>
                 </hostname>
+                <dns_servers type="TextField">
+                    <Mask>/^(?:(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\s*,\s*(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))*)?$/</Mask>
+                    <ValidationMessage>Please enter valid IPv4 addresses separated by commas (e.g., 8.8.8.8,8.8.4.4)</ValidationMessage>
+                </dns_servers>
                 <description type="DescriptionField"/>
             </reservation>
         </reservations>


### PR DESCRIPTION
Added DNS field to Kea DHCP4 Reservations.

Utilizes masking instead of tokeniation for UI consistency.

Tested on 25.1.9_2

Kea reference for options: https://kea.readthedocs.io/en/kea-2.0.0/arm/dhcp4-srv.html#dhcp4-std-options