### PR TITLE
automation/filter: Do not reload the grid during reconfigureAct

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -508,10 +508,10 @@
         });
 
         // Populate category selectpicker
-        function populateCategoriesSelectpicker(callback) {
+        function populateCategoriesSelectpicker() {
             const currentSelection = $("#category_filter").val();
 
-            $("#category_filter").fetch_options(
+            return $("#category_filter").fetch_options(
                 '/api/firewall/filter/list_categories',
                 {},
                 function (data) {
@@ -545,10 +545,6 @@
                     if (currentSelection?.length) {
                         $("#category_filter").val(currentSelection).selectpicker('refresh');
                     }
-
-                    if (typeof callback === "function") {
-                        callback();
-                    }
                 },
                 true  // render_html
             );
@@ -561,8 +557,8 @@
         let reconfigureActInProgress = false;
 
         // Populate interface selectpicker
-        function populateInterfaceSelectpicker(callback) {
-            $('#interface_select').fetch_options(
+        function populateInterfaceSelectpicker() {
+            return $('#interface_select').fetch_options(
                 '/api/firewall/filter/get_interface_list',
                 {},
                 function (data) {
@@ -612,9 +608,6 @@
                     }
                     interfaceInitialized = true;
 
-                    if (typeof callback === "function") {
-                        callback();
-                    }
                 },
                 true  // render_html to show counts as badges
             );
@@ -730,8 +723,8 @@
                 reconfigureActInProgress = true;
 
                 Promise.all([
-                    new Promise(populateInterfaceSelectpicker),
-                    new Promise(populateCategoriesSelectpicker)
+                    populateInterfaceSelectpicker(),
+                    populateCategoriesSelectpicker()
                 ]).then(() => {
                     reconfigureActInProgress = false;
                 });

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -719,9 +719,11 @@
         $('#category_filter').parent().find('.dropdown-toggle').prepend('<i class="fa fa-tag" style="margin-right: 6px;"></i>');
 
         $("#reconfigureAct").SimpleActionButton({
-            onAction(data, status) {
+            onPreAction() {
                 reconfigureActInProgress = true;
-
+                return $.Deferred().resolve();
+            },
+            onAction(data, status) {
                 Promise.all([
                     populateInterfaceSelectpicker(),
                     populateCategoriesSelectpicker()

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -725,7 +725,8 @@
                 Promise.all([
                     populateInterfaceSelectpicker(),
                     populateCategoriesSelectpicker()
-                ]).then(() => {
+                ])
+                .finally(() => {
                     reconfigureActInProgress = false;
                 });
             }


### PR DESCRIPTION
Since we call functions to repopulate the selectpickers during the reconfigureAct they triggered the changed events to reload the bootgrid and change the url hash. A new variable was introduced that tracks the reconfigureActInProgress and prevents spurious reloads during it. After the selectpickers have been repopulated with their preserved values, a promise is returned which sets the reconfigureActInProgress to false, unlocking the normal change event behavior during selecpicker usage.


Essentially this prevents the grid reloading and the url hash resetting, each apply would boot the user back to Floating rules with resetted selectpickers.

Refines this: https://github.com/opnsense/core/pull/8898