### PR TITLE
automation/filter: Filter out empty category names

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -143,11 +143,10 @@ class FilterController extends FilterBaseController
             /* frontend can format categories with colors */
             if (!empty($record['categories'])) {
                 $catnames = array_map('trim', explode(',', $record['categories']));
-                $record['category_colors'] = array_map(fn($name) => $catcolors[$name], $catnames);
+                $record['category_colors'] = array_map(fn($name) => $catcolors[$name], array_filter($catnames));
             } else {
                 $record['category_colors'] = [];
             }
-
 
             if (empty($record['legacy'])) {
                 /* mvc already filtered */


### PR DESCRIPTION
Small fix for: https://github.com/opnsense/core/issues/8902

Prevents this when a category has been deleted but is still resolved in the grid:

```
[02-Jul-2025 14:56:49 Etc/UTC] ErrorException: Undefined array key "" in /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php:146
```