### PR TITLE
dnsmasq: Add CNAME configuration option to host overrides

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogHostOverride.xml
@@ -35,11 +35,22 @@
     </field>
     <field>
         <id>host.aliases</id>
-        <label>Aliases</label>
+        <label>Alias Records</label>
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help>list of aliases (fqdn)</help>
+        <help>Adds additional static A, AAAA and PTR records for the given alternative names (FQDN). Please note that these records are only created if IP addresses are configured in this host entry.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>host.cnames</id>
+        <label>CNAME Records</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Adds additional CNAME records for the given alternative names (FQDN). Useful if this host entry has dynamic IPv4 and partial IPv6 addresses, as the CNAME record will point to the name instead of static IP addresses.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -137,7 +137,7 @@ class Dnsmasq extends BaseModel
                 }
             }
 
-            foreach (array_filter(explode(',', (string)$host->cnames)) as $cname) {
+            foreach ($host->cnames->getValues() as $cname) {
                 if ($usedHostCnames[$cname] > 1) {
                     $messages->appendMessage(
                         new Message(

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -74,10 +74,6 @@ class Dnsmasq extends BaseModel
                 $usedHostFqdns[$fqdn] = true;
             }
 
-            foreach (array_filter(explode(',', (string)$host->aliases)) as $alias) {
-                $usedHostFqdns[$alias] = true;
-            }
-
             foreach (array_filter(explode(',', (string)$host->cnames)) as $cname) {
                 $usedHostCnames[$cname] = ($usedHostCnames[$cname] ?? 0) + 1;
             }
@@ -145,7 +141,7 @@ class Dnsmasq extends BaseModel
                 if ($usedHostCnames[$cname] > 1) {
                     $messages->appendMessage(
                         new Message(
-                            sprintf(gettext("'%s' is already used by another host override."), $cname),
+                            sprintf(gettext("CNAME '%s' is already in use by a host override."), $cname),
                             $key . ".cnames"
                         )
                     );
@@ -154,7 +150,7 @@ class Dnsmasq extends BaseModel
                 if (isset($usedHostFqdns[$cname])) {
                     $messages->appendMessage(
                         new Message(
-                            sprintf(gettext("'%s' must not overlap with any existing host or alias in any host override."), $cname),
+                            sprintf(gettext("CNAME '%s' overlaps with a host and domain combination in a host override."), $cname),
                             $key . ".cnames"
                         )
                     );

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -74,7 +74,7 @@ class Dnsmasq extends BaseModel
                 $usedHostFqdns[$fqdn] = true;
             }
 
-            foreach (array_filter(explode(',', (string)$host->cnames)) as $cname) {
+            foreach ($host->cnames->getValues() as $cname) {
                 $usedHostCnames[$cname] = ($usedHostCnames[$cname] ?? 0) + 1;
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -89,6 +89,11 @@
                 <NetMaskAllowed>N</NetMaskAllowed>
                 <AsList>Y</AsList>
             </ip>
+            <cnames type="HostnameField">
+                <AsList>Y</AsList>
+                <IsDNSName>Y</IsDNSName>
+                <IpAllowed>N</IpAllowed>
+            </cnames>
             <client_id type="TextField">
                 <Mask>/^(?:\*|(?:[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2})+))$/</Mask>
                 <ValidationMessage>Value must be a colon-separated hexadecimal sequence (e.g., 01:02:f3) or "*".</ValidationMessage>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -38,6 +38,9 @@ dhcp-lease-max={{dnsmasq.dhcp.lease_max}}
 {%     if host.host == '*' %}
 {%         do all_wildcard_hosts.append(host) %}
 {%     endif %}
+{%     if host.cnames and host.host %}
+cname={{ host.cnames }},{{ host.host }}{% if host.domain %}.{{ host.domain }}{% endif +%}
+{%     endif %}
 {% endfor %}
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn


### PR DESCRIPTION
It is more useful than expected:

- Services that are IPv6 only, use DHCPv6 via dynamic partial IPv6 addresses can only have alternative names with CNAMEs
- Services that are dynamic IPv4, have a dhcp-host without IPv4 address set, can only have an alias with CNAMEs

Hosting virtual hosts on a webserver with dynamic IPv6 addresses need CNAMEs.

Fixes: https://github.com/opnsense/core/issues/8821

known error states (crash):

```
1.
cname=example4.com
 
dnsmasq: bad CNAME at line 12 of /usr/local/etc/dnsmasq.conf
 
2.
cname=example2.com,example.com
cname=example2.com,example.com
 
dnsmasq: duplicate CNAME at line 11 of /usr/local/etc/dnsmasq.conf
 
3.
cname=example3.com,example.com
cname=example.com,example3.com
 
dnsmasq: CNAME loop involving example.com
```

Allowed (no crash):

```
1.
host-record=example.com,192.168.1.1
cname=example.com,example3.com

2.
host-record=example.com,192.168.1.1
cname=example3.com,example.com