### PR TITLE
Make "Reset zoom" translatable

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
@@ -144,7 +144,7 @@
 	</div>
 
 	<div id="health-header" class="panel-heading centered">
-        <button id="reset-zoom" class="btn btn-primary" style="align-self: flex-end;">Reset zoom</button>
+        <button id="reset-zoom" class="btn btn-primary" style="align-self: flex-end;">{{ lang._('Reset zoom') }}</button>
 
         <div class="label-select-pair">
             <label for="health-category-select"><b>{{ lang._('Category') }}</b></label>


### PR DESCRIPTION
This pull request updates the "Reset zoom" button label in the Health module to support internationalization.

Change summary:
Replaced the hardcoded string "Reset zoom" with {{ lang._('Reset zoom') }} in the Volt template