### PR TITLE
dnsmasq: Fix empty dhcp option value spawning stray comma

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -287,9 +287,9 @@ set:{{ host.set_tag|replace('-', '') }},
 dhcp-option{% if option.force == '1' %}-force{% endif -%}=
 {%- if all_tags %}{{ all_tags|join(',') }},{% endif -%}
 {%- if option.option6 -%}
-option6:{{ option.option6 }},{{ option.value }}
+option6:{{ option.option6 }}{% if option.value %},{{ option.value }}{% endif %}
 {%- else -%}
-{{ option.option }},{{ option.value }}
+{{ option.option }}{% if option.value %},{{ option.value }}{% endif %}
 {%- endif +%}
 {%     if not option.tag and not option.interface and option.option == '6' %}
 {%         do has_default.append(1) %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8925