### PR TITLE
dnsmasq: Add optional subnet mask to dhcp-range to satisfy dhcp relay requirements

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -24,6 +24,17 @@
         <help>End of the range.</help>
     </field>
     <field>
+        <id>range.subnet_mask</id>
+        <label>Subnet Mask</label>
+        <type>text</type>
+        <hint>automatic</hint>
+        <style>style_dhcpv4</style>
+        <help>Leave empty (recommended) and the subnet mask will be auto-calculated from the interface or the network class of the start address. If a DHCP relay forwards IPv4 DHCP Discovers to Dnsmasq, setting a subnet mask is required in most cases.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>range.constructor</id>
         <label>Constructor</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.php
@@ -289,6 +289,15 @@ class Dnsmasq extends BaseModel
                 );
             }
 
+            if (!$range->subnet_mask->isEmpty() && $is_static) {
+                $messages->appendMessage(
+                    new Message(
+                        gettext("Static only accepts a starting address."),
+                        $key . ".subnet_mask"
+                    )
+                );
+            }
+
             if ($range->interface->isEmpty() && !$range->ra_mode->isEmpty()) {
                 $messages->appendMessage(
                     new Message(

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -195,6 +195,11 @@
             <end_addr type=".\RangeAddressField">
                 <NetMaskAllowed>N</NetMaskAllowed>
             </end_addr>
+            <subnet_mask type="NetworkField">
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <AddressFamily>ipv4</AddressFamily>
+                <ValidationMessage>Please enter a valid IPv4 subnet mask like 255.255.255.0</ValidationMessage>
+            </subnet_mask>
             <constructor type="InterfaceField"/>
             <mode type="OptionField">
                 <OptionValues>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -199,6 +199,9 @@ set:{{dhcp_range.set_tag|replace('-','')}},
 {%- if dhcp_range.mode -%}
 {{dhcp_range.mode}},
 {%- endif -%}
+{%- if dhcp_range.subnet_mask -%}
+{{dhcp_range.subnet_mask}},
+{%- endif -%}
 {{ 'infinite' if dhcp_range.lease_time == '0' else dhcp_range.lease_time|default('86400') }}
 {% else %}
 {# IPv6 range and RA #}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8924

Past me already prepared style_dhcpv4 :)

https://github.com/opnsense/core/blob/372deda756669b71c0c32303db7b8b8b1c8f42f3/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt#L161