### PR TITLE
mvc: use getNodeContent to gather grid data

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -126,23 +126,14 @@ class UIModelGrid
                 $row = [];
                 $row['uuid'] = $record->getAttributes()['uuid'];
                 $content = $record->getNodeContent();
-                foreach ($content as $field => $val) {
-                    $key = substr($field, 1);
-                    if (str_starts_with($field, '$') && in_array($key, $fields)) {
-                        $row[$key] = $val;
-                        if ($content[$key] !== $val) {
-                            /**
-                             * getNodeContent() returns "$<key>" for description values
-                             * this would break API compat if we're returning this directly,
-                             * so swap the two around:
-                             *
-                             * [key] => "Descriptive (translated) value"
-                             * [$key] => "value used in config"
-                             *
-                             * only do this if the two values don't match, unconditionally including it
-                             * would double API response size.
-                             */
-                            $row[$field] = $content[$key];
+                foreach ($fields as $fieldname) {
+                    if (array_key_exists($fieldname, $content)) {
+                        $row[$fieldname] = $content[$fieldname];
+
+                        $descr = '$' . $fieldname;
+                        if (array_key_exists($descr, $content) && $content[$descr] !== $content[$fieldname]) {
+                            // descriptive/translated value available
+                            $row[$descr] = $content[$descr];
                         }
                     }
                 }

--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -125,9 +125,24 @@ class UIModelGrid
                 // before searching.
                 $row = [];
                 $row['uuid'] = $record->getAttributes()['uuid'];
-                foreach ($fields as $fieldname) {
-                    if ($record->$fieldname != null) {
-                        $row[$fieldname] = $record->$fieldname->getDescription();
+                $content = $record->getNodeContent();
+                foreach ($content as $field => $val) {
+                    if (str_starts_with($field, '$') && in_array($key = substr($field, 1), $fields)) {
+                        $row[$key] = $val;
+                        if ($content[$key] !== $val) {
+                            /**
+                             * getNodeContent() returns "$<key>" for description values
+                             * this would break API compat if we're returning this directly,
+                             * so swap the two around:
+                             *
+                             * [key] => "Descriptive (translated) value"
+                             * [$key] => "value used in config"
+                             *
+                             * only do this if the two values don't match, unconditionally including it
+                             * would double API response size.
+                             */
+                            $row[$field] = $content[$key];
+                        }
                     }
                 }
 

--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -127,7 +127,8 @@ class UIModelGrid
                 $row['uuid'] = $record->getAttributes()['uuid'];
                 $content = $record->getNodeContent();
                 foreach ($content as $field => $val) {
-                    if (str_starts_with($field, '$') && in_array($key = substr($field, 1), $fields)) {
+                    $key = substr($field, 1);
+                    if (str_starts_with($field, '$') && in_array($key, $fields)) {
                         $row[$key] = $val;
                         if ($content[$key] !== $val) {
                             /**

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -1412,7 +1412,9 @@ class UIBootgrid {
                     this._onCellRendered(cell, formatterParams);
                 });
 
-                return cell.getValue();
+                const key = `$${cell.getColumn().getDefinition().field}`;
+                const data = cell.getData();
+                return data[key] ?? cell.getValue();
             },
             commands: (cell, formatterParams, onRendered) => {
                 let html = [];


### PR DESCRIPTION
This allows us to include keyable data that is unaffected by translations, making sure that we can format grid cells properly based on the actual value.

Builds on https://github.com/opnsense/core/commit/23c09fc4d

fwiw, `$` as a prefix may not be optimal so leaving this open for discussion