### PR TITLE
bootgrid: Double default row count

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -124,7 +124,7 @@ class UIBootgrid {
         this.options = {
             sorting: true,
             selection: true,
-            rowCount: [7, 14, 20, 50, 100, true],
+            rowCount: [14, 7, 20, 50, 100, true],
             remoteGridView: false, // parse gridview from <thead> or via ajax?
             formatters: {
                 ...this._internalFormatters()

--- a/src/opnsense/www/js/opnsense_bootgrid_plugin.js
+++ b/src/opnsense/www/js/opnsense_bootgrid_plugin.js
@@ -127,7 +127,7 @@ $.fn.UIBootgrid = function (params) {
             ajax: true,
             selection: true,
             multiSelect: true,
-            rowCount:[7,14,20,50,100,-1],
+            rowCount:[14,7,20,50,100,-1],
             url: params['search'],
             initialSearchPhrase: "",
             ajaxSettings: {


### PR DESCRIPTION
This would be the lowest hanging fruit I think.

We have to be at least a bit reservative since there are pages with two grids below each other.

Fixes: https://github.com/opnsense/core/issues/8913