### PR TITLE
Fix: Correct service name translations in dashboard widget

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/ServiceController.php
@@ -53,7 +53,7 @@ class ServiceController extends ApiControllerBase
                     'id' => $service['name'] . (array_key_exists('id', $service) ? '/' . $service['id'] : ''),
                     'locked' => !empty($service['locked']) || !empty($service['nocheck']) ? 1 : 0,
                     'running' => strpos($service['status'], 'is running') !== false ? 1 : 0,
-                    'description' => $service['description'],
+                    'description' => gettext($service['description']),
                     'name' => $service['name'],
                 ];
                 $records[] = $record;


### PR DESCRIPTION
Hi,

I've fixed the translations of the service names shown in the "Services" widget on the dashboard.

Originally, the translations were defined in `src/etc/inc/core.inc`, but they were not applied because the language system is not initialized at that stage — there's no user context available yet.

Since the widget retrieves the translated strings directly via the API, the translations are now properly applied in that context.

However, I’ve left the `gettext()` calls in `core.inc` so that the strings are still included in the `.po` files and can be translated through the usual localization process.

Best regards,  
Tobias