### PR TITLE
ui: flatten nested containers for grid inclusion

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -256,12 +256,11 @@ class ControllerBase extends ControllerRoot
                             $record['label'] = gettext((string)$item);
                             break;
                         case 'id':
+                            $parts = explode('.', (string)$item);
                             if (!empty($root)) {
-                                $parts = explode('.', (string)$item);
                                 $record['column-id'] = implode('.', array_slice($parts, array_search($root, $parts) + 1));
                             } else {
-                                $tmp = explode('.', (string)$item);
-                                $record['column-id'] = end($tmp);
+                                $record['column-id'] = end($parts);
                             }
                             break;
                     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -235,7 +235,7 @@ class ControllerBase extends ControllerRoot
      * Extract grid fields from form definition
      * @return array
      */
-    public function getFormGrid($formname, $grid_id = null, $edit_alert_id = null)
+    public function getFormGrid($formname, $grid_id = null, $edit_alert_id = null, $root = null)
     {
         /* collect all fields, sort by sequence */
         $all_data = [];
@@ -256,8 +256,13 @@ class ControllerBase extends ControllerRoot
                             $record['label'] = gettext((string)$item);
                             break;
                         case 'id':
-                            $tmp = explode('.', (string)$item);
-                            $record['column-id'] = end($tmp);
+                            if (!empty($root)) {
+                                $parts = explode('.', (string)$item);
+                                $record['column-id'] = implode('.', array_slice($parts, array_search($root, $parts) + 1));
+                            } else {
+                                $tmp = explode('.', (string)$item);
+                                $record['column-id'] = end($tmp);
+                            }
                             break;
                     }
                 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/DhcpController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/DhcpController.php
@@ -55,7 +55,7 @@ class DhcpController extends \OPNsense\Base\IndexController
         $this->view->formGridSubnet = $this->getFormGrid("dialogSubnet4");
 
         $this->view->formDialogReservation = $this->getForm("dialogReservation4");
-        $this->view->formGridReservation = $this->getFormGrid("dialogReservation4");
+        $this->view->formGridReservation = $this->getFormGrid("dialogReservation4", null, null, 'reservation');
 
         $this->view->formDialogPeer = $this->getForm("dialogPeer4");
         $this->view->formGridPeer = $this->getFormGrid("dialogPeer4");

--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -169,7 +169,7 @@ class UIModelGrid
     {
         if (is_array($node)) {
             foreach($node as $key => $value) {
-                yield from $this->flatten($value, $key);
+                yield from $this->flatten($value, ltrim($path . '.' . $key, '.'));
             }
         } else {
             yield $path => $node;

--- a/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php
@@ -121,27 +121,9 @@ class UIModelGrid
                     continue;
                 }
 
-                $flatten = function($input) {
-                    $result = [];
-                    $stack = [$input];
-
-                    while (!empty($stack)) {
-                        $current = array_pop($stack);
-                        foreach ($current as $key => $value) {
-                            if (is_array($value)) {
-                                $stack[] = $value;
-                            } else {
-                                $result[$key] = $value;
-                            }
-                        }
-                    }
-
-                    return $result;
-                };
-
                 // parse rows, because we may need to convert some (list) items we need to know the actual content
                 // before searching. We flatten the resulting array in case of nested containers
-                $row = $flatten(array_merge(['uuid' => $record->getAttributes()['uuid']], $record->getNodeContent()));
+                $row = iterator_to_array($this->flatten(array_merge(['uuid' => $record->getAttributes()['uuid']], $record->getNodeContent())));
 
                 // if a search phrase is provided, use it to search in all requested fields
                 $search_clauses = preg_split('/\s+/', $searchPhrase);
@@ -181,5 +163,16 @@ class UIModelGrid
         $result['current'] = (int)$currentPage;
 
         return $result;
+    }
+
+    private function flatten($node, $path='')
+    {
+        if (is_array($node)) {
+            foreach($node as $key => $value) {
+                yield from $this->flatten($value, $key);
+            }
+        } else {
+            yield $path => $node;
+        }
     }
 }

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -1162,6 +1162,8 @@ class UIBootgrid {
             resizable: "header",
             placeholder: this.placeholder[0],
             layout: 'fitColumns',
+            // tabulator uses "." for nested field access, disable this behavior since our keys can contain a dot.
+            nestedFieldSeparator:false,
             columns: this._parseColumns(),
 
             /* SERVER-SIDE OPTIONS */


### PR DESCRIPTION
Continuation of https://github.com/opnsense/core/commit/a0bc7adda95876937ea0ba9c3d5542bfb741ffdb and https://github.com/opnsense/core/commit/66b0488a99a6dc6bf763cb440c65b5d37c847c27.

Because https://github.com/opnsense/core/blob/66b0488a99a6dc6bf763cb440c65b5d37c847c27/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php#L260 always picks the last key regardless of depth, and because our model does not allow nested ArrayFields, this should be safe to do.

