### PR TITLE
interface/vip: Add generalized grid formatter that uses existing style declarations

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/VipController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/VipController.php
@@ -35,5 +35,41 @@ class VipController extends \OPNsense\Base\IndexController
         $this->view->pick('OPNsense/Interface/vip');
         $this->view->formDialogVip = $this->getForm("dialogVip");
         $this->view->formGridVip = $this->getFormGrid("dialogVip");
+        $this->view->modeStyleFlat = $this->getModeStyleFlatMap($this->view->formDialogVip);
     }
+
+    /**
+     * Return a flat map string of field names to allowed modes based on their styles.
+     * Type is used to decide between boolean and text formatter in volt template
+     * ("vhid=carp,ipalias|checkbox;advbase=carp|text")
+     * Consumed by bootgrid formatter to automatically hide column fields based on mode
+     */
+    protected function getModeStyleFlatMap(array $form): string
+    {
+        $entries = [];
+
+        foreach ($form as $field) {
+            if (!isset($field['style'], $field['id'], $field['type'])) {
+                continue;
+            }
+
+            $parts = explode('.', $field['id']);
+            $fieldName = end($parts);
+            $type = $field['type'];
+
+            $modes = [];
+            foreach (explode(' ', $field['style']) as $style) {
+                if (str_starts_with($style, 'mode_')) {
+                    $modes[] = substr($style, 5);
+                }
+            }
+
+            if (!empty($modes)) {
+                $entries[] = "{$fieldName}=" . implode(',', $modes) . "|{$type}";
+            }
+        }
+
+        return implode(';', $entries);
+    }
+
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVip.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVip.xml
@@ -48,6 +48,7 @@
             but can be configured as unicast address when multicast can not be used (for example with cloud providers)
         </help>
         <grid_view>
+            <formatter>modeFormatter</formatter>
             <visible>false</visible>
             <sequence>8</sequence>
         </grid_view>
@@ -63,6 +64,7 @@
             but can be configured as unicast address when multicast can not be used (for example with cloud providers)
         </help>
         <grid_view>
+            <formatter>modeFormatter</formatter>
             <visible>false</visible>
             <sequence>9</sequence>
         </grid_view>
@@ -75,7 +77,7 @@
       <style>mode mode_proxyarp</style>
       <grid_view>
         <type>boolean</type>
-        <formatter>boolean</formatter>
+        <formatter>modeFormatter</formatter>
         <visible>false</visible>
         <sequence>10</sequence>
       </grid_view>
@@ -88,7 +90,7 @@
       <style>mode mode_carp mode_ipalias</style>
       <grid_view>
         <type>boolean</type>
-        <formatter>boolean</formatter>
+        <formatter>modeFormatter</formatter>
         <visible>false</visible>
         <sequence>11</sequence>
       </grid_view>
@@ -110,6 +112,7 @@
         <style>mode mode_carp mode_ipalias</style>
         <help>Enter the VHID group that the machines will share.</help>
         <grid_view>
+            <formatter>modeFormatter</formatter>
             <sequence>2</sequence>
             <width>8em</width>
         </grid_view>
@@ -121,6 +124,7 @@
         <style>mode mode_carp</style>
         <help>Specifies the base of the advertisement interval in seconds. The acceptable values are 1 to 255.</help>
         <grid_view>
+            <formatter>modeFormatter</formatter>
             <sequence>3</sequence>
             <width>6em</width>
         </grid_view>
@@ -135,6 +139,7 @@
           It is specified in 1/256 of seconds.  The acceptable values are 0 to 254.
         </help>
         <grid_view>
+            <formatter>modeFormatter</formatter>
             <sequence>4</sequence>
         </grid_view>
     </field>
@@ -146,7 +151,7 @@
         <style>mode mode_carp mode_ipalias</style>
         <grid_view>
             <type>boolean</type>
-            <formatter>boolean</formatter>
+            <formatter>modeFormatter</formatter>
             <visible>false</visible>
         </grid_view>
     </field>


### PR DESCRIPTION
… in dialogVip to hide and show the same fields based on selected type, e.g. CARP only shows carp related fields in the grid all else will be empty string.

