### PR TITLE
Feat: added IPv6 bracket helpers for templates

### DIFF
--- a/src/opnsense/service/modules/addons/template_helpers.py
+++ b/src/opnsense/service/modules/addons/template_helpers.py
@@ -151,6 +151,23 @@ class Helpers(object):
             result.append(self.getNodeByTag('interfaces.'+name+'.if'))
         return list(filter(None, result))
 
+
+    def getBracketedIp(self, str):
+        """ returns ipv6 addresses with brackets else returns original
+        :param tag: tag in dot notation (section.item)
+        :return: boolean
+        """
+        if self.is_ipv6(str):
+            return "[" + str + "]"
+        return str
+
+    @staticmethod
+    def is_ipv6(str):
+        try:
+            return ipaddress.ip_address(str).version == 6
+        except ValueError:
+            return False
+
     @staticmethod
     def getIPNetwork(network):
         """

--- a/src/opnsense/service/modules/addons/template_helpers.py
+++ b/src/opnsense/service/modules/addons/template_helpers.py
@@ -165,7 +165,7 @@ class Helpers(object):
     def is_ipv6(str):
         try:
             return ipaddress.ip_address(str).version == 6
-        except ValueError:
+        except:
             return False
 
     @staticmethod

--- a/src/opnsense/service/modules/addons/template_helpers.py
+++ b/src/opnsense/service/modules/addons/template_helpers.py
@@ -152,7 +152,7 @@ class Helpers(object):
         return list(filter(None, result))
 
 
-    def getBracketedIp(self, str):
+    def get_bracketed_ip(self, str):
         """ returns ipv6 addresses with brackets else returns original
         :param tag: tag in dot notation (section.item)
         :return: boolean


### PR DESCRIPTION
some programs want IPv6 addresses in brackets especially if it's an address and a port like `[2001:db8::1]:8080` so i made a helper for that it takes in a string and puts it it brackets if it's an IPv6 address