### PR TITLE
replace self-closing select element

### DIFF
--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -858,7 +858,7 @@ $.fn.replaceInputWithSelector = function (data, multiple=false) {
     this.new_item = function() {
         let $div = $("<div/>");
         let $table = $('<table style="max-width: 348px"/>');
-        let $select = $('<select data-live-search="true" data-size="5" data-width="348px"/>');
+        let $select = $('<select name="' + that[0].name + '" data-live-search="true" data-size="5" data-width="348px"></select>');
         if (multiple) {
             $select.attr('multiple', 'multiple');
         }


### PR DESCRIPTION
This is a _potential_ fix (as in "works for me...") to the browser console errors in Edge with a certain combination of settings. I'm no UI developer, so this may not be the best fix.

It also re-uses the name of the originating `input` element that dynamically generates the `select` so that for any future issues, the error message will become more actionable than an empty name:

```
Form submission failed, as the <SELECT> element named '' was implicitly closed by reaching the end of the file. Please add an explicit end tag ('</SELECT>')
```

I've tested on my own firewall by

- `opnsense-patch -a g-a-c -r opnsense-core 80ec133`
- Using MS Edge `138.0.3351.95` with `edge://flags/#enable-experimental-web-platform-features` enabled (which seems to be the trigger, causing the browser to be more strict?)
- Creating a new rule and saving it successfully
  - LAN interface
  - all fields have default values apart from the description so I could see what worked and what didn't
- Verifying that a different browser (Vivaldi `7.5.3735.54`) **without** experimental features is **also** still able to create and save a new rule

Fixes: #8311 