### PR TITLE
vpn/wireguard: Add diagnostics and log file ACL

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/ACL/ACL.xml
@@ -1,6 +1,6 @@
 <acl>
    <page-wireguard-config>
-      <name>VPN: WireGuard</name>
+      <name>VPN: WireGuard: Configuration</name>
       <patterns>
          <pattern>ui/wireguard/*</pattern>
          <pattern>api/wireguard/server/*</pattern>
@@ -9,4 +9,18 @@
          <pattern>api/wireguard/service/*</pattern>
       </patterns>
    </page-wireguard-config>
+   <page-wireguard-diagnostics>
+      <name>VPN: WireGuard: Status</name>
+      <patterns>
+         <pattern>ui/wireguard/diagnostics/*</pattern>
+         <pattern>api/wireguard/service/*</pattern>
+      </patterns>
+   </page-wireguard-diagnostics>
+   <page-wireguard-logs>
+      <name>VPN: WireGuard: Log</name>
+      <patterns>
+         <pattern>ui/diagnostics/log/core/wireguard/*</pattern>
+         <pattern>api/diagnostics/log/core/wireguard/*</pattern>
+      </patterns>
+   </page-wireguard-logs>
 </acl>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/8960

There is a little overlap between the config and diagnostics ACL in UI paths.
That could be tweaked as well by limiting the ui path to `ui/wireguard/general/*` but it would change current behavior of the `page-wireguard-config` ACL.