### PR TITLE
bootgrid: add default row count field, and increase default max rows

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -197,6 +197,17 @@ class UIBootgrid {
     }
 
     initialize() {
+        if (!this.options.rowCount.includes(this.options.defaultRowCount)) {
+            let splice_index = 0;
+
+            for (let i = 0; i < this.options.rowCount.length; i++) {
+                if (this.options.rowCount[i] === true) { continue; }
+                if (this.options.rowCount[i] > this.options.defaultRowCount) { splice_index = i; break; }
+            };
+
+            this.options.rowCount.splice(splice_index, 0, this.options.defaultRowCount);
+        }
+
         this.persistence = localStorage.getItem(`tabulator-${this.persistenceID}-persistence`);
         if (!this.persistence || this.options.static) {
             // If the user didn't change anything on the table, assume we start blank

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -124,7 +124,7 @@ class UIBootgrid {
         this.options = {
             sorting: true,
             selection: true,
-            defaultRowCount: 25,
+            defaultRowCount: 50,
             rowCount: [10, 15, 25, 50, 100, 250, 500, 1000, true],
             remoteGridView: false, // parse gridview from <thead> or via ajax?
             formatters: {

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -496,6 +496,18 @@ class UIBootgrid {
         return template.replace(/{{ctx\.(\w+)}}/g, (_, key) => key in ctx ? ctx[key] : '');
     }
 
+    _getFriendlyRowCount(count) {
+        try {
+            let countNum = Number(count);
+            let countFriendly = countNum === this.options.defaultRowCount ? `default (${count})` : count;
+            countFriendly = count === true ? this._translate('all') : countFriendly;
+            return countFriendly;
+
+        } catch {
+            return count
+        }
+    }
+
     /**
      *
      * @returns array of column objects in tabulator-format based on this.gridView and this.options
@@ -976,14 +988,14 @@ class UIBootgrid {
         if (this.curRowCount === 'true') {
             this.curRowCount = true;
         }
-        $(`#${this.id}-rowcount-text`).text(this.curRowCount === true ? this._translate('all') : this.curRowCount);
+        $(`#${this.id}-rowcount-text`).text(this._getFriendlyRowCount(this.curRowCount));
 
         this.options.rowCount.forEach((count) => {
             let item = $(`
                 <li data-action="${count}"
                     class="${count.toString() === this.curRowCount.toString() ? 'active' : ''}"
                     aria-selected="${count.toString() === this.curRowCount.toString() ? 'true' : 'false'}">
-                    <a>${count === true ? this._translate('all') : count}</a>
+                    <a>${this._getFriendlyRowCount(count)}</a>
                 </li>
             `).on('click', (e) => {
                 e.preventDefault();
@@ -999,7 +1011,7 @@ class UIBootgrid {
                     localStorage.setItem(`${this.persistenceID}-rowCount`, this.curRowCount);
                     this.table.setPageSize(newRowCount);
 
-                    $(`#${this.id}-rowcount-text`).text(newRowCount === true ? this._translate('all') : newRowCount);
+                    $(`#${this.id}-rowcount-text`).text(this._getFriendlyRowCount(newRowCount));
 
                     $.each($(`#${this.id}-rowcount-items li`), (i, value) => {
                         let $li = $(value);

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -499,8 +499,10 @@ class UIBootgrid {
     _getFriendlyRowCount(count) {
         try {
             let countNum = Number(count);
-            let countFriendly = countNum === this.options.defaultRowCount ? `default (${count})` : count;
-            countFriendly = count === true ? this._translate('all') : countFriendly;
+
+            let countFriendly = count === true ? this._translate('all') : count;
+            countFriendly = countNum === this.options.defaultRowCount ? `${countFriendly} (default)` : countFriendly;
+
             return countFriendly;
 
         } catch {

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -124,7 +124,8 @@ class UIBootgrid {
         this.options = {
             sorting: true,
             selection: true,
-            rowCount: [7, 14, 20, 50, 100, true],
+            defaultRowCount: 25,
+            rowCount: [10, 15, 25, 50, 100, 250, 500, 1000, true],
             remoteGridView: false, // parse gridview from <thead> or via ajax?
             formatters: {
                 ...this._internalFormatters()
@@ -960,7 +961,7 @@ class UIBootgrid {
         }
 
         // Rowcount
-        this.curRowCount = localStorage.getItem(`${this.persistenceID}-rowCount`) || this.options.rowCount[0];
+        this.curRowCount = localStorage.getItem(`${this.persistenceID}-rowCount`) || this.options.defaultRowCount;
         if (this.curRowCount === 'true') {
             this.curRowCount = true;
         }


### PR DESCRIPTION
this PR:
- adds a `defaultRowCount` option to bootgrid
  - with logic to add `defaultRowCount` to `rowCount` if it's not there
- changes the default values for `rowCount`
- adds `_getFriendlyRowCount(count)` to be used when displaying row count

Fixes: #8913