### PR TITLE
Aliases: map network alias keys to their corresponding values in getDescription()

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/NetworkAliasField.php
@@ -98,10 +98,27 @@ class NetworkAliasField extends BaseListField
      */
     public function getDescription()
     {
-        if (isset($this->internalOptionList[(string)$this])) {
-            return $this->internalOptionList[(string)$this];
+        $value = (string)$this;
+        $data = $this->internalOptionList;
+
+        if (str_contains($value, ',')) {
+            // map a csv string of keys to their corresponding descriptions
+            $keys = explode(',', $value);
+
+            return implode(',', array_map(function($key) use ($data) {
+                if (isset($data[$key])) {
+                    return $data[$key];
+                }
+            }, $keys));
         }
-        return (string)$this;
+
+        if (isset($data[$value])) {
+            // single key, single value
+            return $data[$value];
+        }
+
+        // just the key
+        return $value;
     }
 
     /**


### PR DESCRIPTION
Since we are now including descriptive and non-descriptive values in the API, this does not fully match with fields where this behavior is overridden. This commit changes:

```
            "destination_net": "opt7ip,opt8ip",

            "destination_net": "opt7ip",
            "%destination_net": "lo6 address",
```
to:
```
            "destination_net": "opt7ip,opt8ip",
            "%destination_net": "lo6 address,lo7 address",

            "destination_net": "opt7ip",
            "%destination_net": "lo6 address",
```