### PR TITLE
vpn/openvpn: Add nopool directive

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -164,6 +164,16 @@
         </grid_view>
     </field>
     <field>
+        <id>instance.nopool</id>
+        <label>No Pool</label>
+        <type>checkbox</type>
+        <style>role role_server_tun role_server_ovpn</style>
+        <help>Do not set up a dynamic pool for the server directive. IP addresses will only be pushed to a client if specified in a CSO, or they can be statically set in the client configuration.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>instance.bridge_gateway</id>
         <label>Bridge gateway</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -600,7 +600,7 @@ class OpenVPN extends BaseModel
                             $options['ifconfig'] = "{$ip1} {$ip2}";
                             $options['ifconfig-pool'] = "{$ip2} {$ip3}";
                         } else {
-                            $options['server'] = $parts[0] . " " . $mask;
+                            $options['server'] = $parts[0] . " " . $mask . ($node->nopool == '1' ? ' nopool' : '');
                         }
                     } elseif ((string)$node->dev_type == 'tap') {
                         if (!$node->bridge_gateway->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -600,7 +600,10 @@ class OpenVPN extends BaseModel
                             $options['ifconfig'] = "{$ip1} {$ip2}";
                             $options['ifconfig-pool'] = "{$ip2} {$ip3}";
                         } else {
-                            $options['server'] = $parts[0] . " " . $mask . ($node->nopool == '1' ? ' nopool' : '');
+                            $options['server'] = $parts[0] . " " . $mask;
+                            if ($node->nopool->isEqual('1')) {
+                                $options['server'] .=  ' nopool';
+                            }
                         }
                     } elseif ((string)$node->dev_type == 'tap') {
                         if (!$node->bridge_gateway->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -160,6 +160,7 @@
                     <NetMaskRequired>Y</NetMaskRequired>
                     <ValidationMessage>Please specify a valid network segment in CIDR notation.</ValidationMessage>
                 </server_ipv6>
+                <nopool type="BooleanField"/>
                 <bridge_gateway type="NetworkField">
                     <WildcardEnabled>N</WildcardEnabled>
                 </bridge_gateway>


### PR DESCRIPTION
A mix of dynamic and cso enabled clients can cause IP duplication in the pool. With nopool, only CSO will manage all addresses, clients without a CSO will not receive an IP address.

Fixes: https://github.com/opnsense/core/issues/8857