### PR TITLE
bootgrid: Add tabulatorOptions to translateCompatOptions()

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -108,6 +108,13 @@
             add:'/api/firewall/filter/add_rule/',
             del:'/api/firewall/filter/del_rule/',
             toggle:'/api/firewall/filter/toggle_rule/',
+            tabulatorOptions : {
+                // tell Tabulator to render a tree
+                dataTree              : true,
+                dataTreeChildField    : "children",
+                dataTreeStartExpanded : true,
+                dataTreeElementColumn : "categories",
+            },
             options: {
                 responsive: true,
                 rowCount: [20,50,100,200,500,1000,-1],
@@ -127,12 +134,6 @@
                     }
                     return request;
                 },
-                // tell Tabulator to render a tree
-                treeView           : true,
-                treeChildField     : "children",
-                treeStartExpanded  : true,
-                treeElementColumn  : "categories",
-
                 // convert the flat rows into a tree view
                 responseHandler: dynamicResponseHandler,
 

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -253,18 +253,6 @@ class UIBootgrid {
             this.options.stickySelect = true;
         }
 
-        // Tree view compatibility
-        if (bootGridOptions?.treeView ?? false) {
-            this.compatOptions['dataTree'] = true;
-            this.compatOptions['dataTreeChildField'] = bootGridOptions.treeChildField || "children";
-            this.compatOptions['dataTreeStartExpanded'] = bootGridOptions.treeStartExpanded ?? false;
-
-            // Optional: set the column where the tree icon appears
-            if (bootGridOptions.treeElementColumn) {
-                this.compatOptions['dataTreeElementColumn'] = bootGridOptions.treeElementColumn;
-            }
-        }
-
         if (bootGridOptions?.triggerEditFor ?? null) {
             this.options.triggerEditFor = bootGridOptions.triggerEditFor;
         }
@@ -435,6 +423,8 @@ class UIBootgrid {
         if (this.options.virtualDOM) {
             this.compatOptions['renderVertical'] = 'virtual';
         }
+
+        this.tabulatorOptions = compatOptions.tabulatorOptions ??= {};
 
         return this;
     }


### PR DESCRIPTION
Can be used to pass tabulator specific options transparently through without defining them all individually