### PR TITLE
dnsmasq: Add tabulator groupBy functionality to group by interfaces and tags

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPboot.xml
@@ -4,12 +4,18 @@
         <label>Interface</label>
         <type>dropdown</type>
         <help>This adds a single interface as tag so this DHCP boot option can match the interface of a DHCP range.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>boot.tag</id>
         <label>Tag</label>
         <type>select_multiple</type>
         <help>If the optional tags are given then this option is only sent when all the tags are matched. Can be optionally combined with an interface tag.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>boot.filename</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPoption.xml
@@ -23,6 +23,10 @@
         <type>dropdown</type>
         <style>selectpicker style_set</style>
         <help>This adds a single interface as tag so this DHCP option can match the interface of a DHCP range.</help>
+        <grid_view>
+            <sequence>10</sequence>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>option.tag</id>
@@ -30,6 +34,10 @@
         <type>select_multiple</type>
         <help>If the optional tags are given then this option is only sent when all the tags are matched. Can be optionally combined with an interface tag.</help>
         <style>selectpicker style_set</style>
+        <grid_view>
+            <sequence>20</sequence>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>option.set_tag</id>
@@ -37,6 +45,10 @@
         <type>dropdown</type>
         <help>Tag to set for requests matching this range which can be used to selectively match DHCP options</help>
         <style>selectpicker style_match</style>
+        <grid_view>
+            <sequence>30</sequence>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>option.value</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/dialogDHCPrange.xml
@@ -4,12 +4,18 @@
         <label>Interface</label>
         <type>dropdown</type>
         <help>Interface to serve this range</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>range.set_tag</id>
         <label>Tag [set]</label>
         <type>dropdown</type>
         <help>Optional tag to set for requests matching this range which can be used to selectively match DHCP options</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>range.start_addr</id>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -71,6 +71,39 @@
                             'set':'/api/dnsmasq/settings/set_' + grid_id + '/',
                             'add':'/api/dnsmasq/settings/add_' + grid_id + '/',
                             'del':'/api/dnsmasq/settings/del_' + grid_id + '/',
+                            tabulatorOptions: {
+                                groupBy: [
+                                    "{{formGridDHCPrange['table_id']}}",
+                                    "{{formGridDHCPoption['table_id']}}",
+                                    "{{formGridDHCPboot['table_id']}}"
+                                ].includes(grid_id)
+                                    ? [
+                                        // 1st level group by interface
+                                        "%interface",
+                                        // 2nd level group by tag
+                                        row => row["%tag"] || row["%set_tag"] || ""
+                                    ]
+                                    : false,
+                                groupHeader: (value, count, data, group) => {
+                                    const isNested = group.getParentGroup() !== false;
+
+                                    // For %tag / %set_tag groups: suppress empty group headers
+                                    if (isNested && !value) {
+                                        return '';
+                                    }
+
+                                    // For %interface groups: show "Any" when value is empty
+                                    const displayValue = !isNested && !value ? "{{ lang._('Any') }}" : value;
+
+                                    const icons = {
+                                        tag: '<i class="fa fa-tag text-primary"></i>',
+                                        interface: '<i class="fa fa-ethernet text-info"></i>',
+                                    };
+
+                                    const key = isNested ? 'tag' : 'interface';
+                                    return `${icons[key]} ${displayValue}`;
+                                },
+                            },
                             options: {
                                 triggerEditFor: getUrlHash('edit'),
                                 initialSearchPhrase: getUrlHash('search'),
@@ -271,6 +304,14 @@
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }
+    /* Trick to hide empty groupBy header rows */
+    .tabulator-group.tabulator-group-level-1:has(> .tabulator-group-toggle:only-child) {
+        display: none;
+    }
+    .tabulator-row.tabulator-group span {
+        color: inherit !important;
+    }
+
 </style>
 
 <div id="tag_select_container" class="btn-group" style="display: none;">


### PR DESCRIPTION
Groups by interface on first level, and by tags on second level (if they exist)

<img width="1431" height="949" alt="image" src="https://github.com/user-attachments/assets/a52c6ba2-ca42-4f72-903c-de21820383f8" />
