### PR TITLE
ui: fix language selection for low vertical resolution screens

### DIFF
--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -368,7 +368,7 @@ $( document ).ready(function() {
             <tr>
               <td><a id="help_for_language" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Language");?></td>
               <td>
-                <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="8"
+                <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="10">
 <?php
                   foreach (get_locale_list() as $lcode => $ldesc):?>
                   <option value="<?=$lcode;?>" <?= $lcode == $pconfig['language'] ? 'selected="selected"' : '' ?>>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -368,7 +368,7 @@ $( document ).ready(function() {
             <tr>
               <td><a id="help_for_language" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Language");?></td>
               <td>
-                <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="10"
+                <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="8"
 <?php
                   foreach (get_locale_list() as $lcode => $ldesc):?>
                   <option value="<?=$lcode;?>" <?= $lcode == $pconfig['language'] ? 'selected="selected"' : '' ?>>

--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -368,7 +368,7 @@ $( document ).ready(function() {
             <tr>
               <td><a id="help_for_language" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Language");?></td>
               <td>
-                <select name="language" class="selectpicker" data-style="btn-default">
+                <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="10"
 <?php
                   foreach (get_locale_list() as $lcode => $ldesc):?>
                   <option value="<?=$lcode;?>" <?= $lcode == $pconfig['language'] ? 'selected="selected"' : '' ?>>

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 /*
  * Copyright (C) 2017-2018 Franco Fichtner <franco@opnsense.org>
  * Copyright (C) 2014-2015 Deciso B.V.

--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -1,5 +1,5 @@
 <?php
-
+ 
 /*
  * Copyright (C) 2017-2018 Franco Fichtner <franco@opnsense.org>
  * Copyright (C) 2014-2015 Deciso B.V.
@@ -224,7 +224,7 @@ $( document ).ready(function() {
                   <tr>
                     <td><a id="help_for_language" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Language");?></td>
                     <td>
-                      <select name="language" class="selectpicker" data-style="btn-default">
+                      <select name="language" class="selectpicker" data-style="btn-default" data-dropup-auto="true" data-size="10">
                         <option value="" <?= empty($pconfig['language']) ? "selected='selected'" : '' ?>><?=gettext('System defaults') ?></option>
 <?php foreach (get_locale_list() as $lcode => $ldesc): ?>
                         <option value="<?= html_safe($lcode) ?>" <?= $lcode == $pconfig['language'] ? 'selected="selected"' : '' ?>><?= $ldesc ?></option>


### PR DESCRIPTION
Language selection in system_general.php and system_usermanager_passwordmg.php is broken for low vertical resolution screens, very common on laptops.

This PR fixes it without causing issues on bigger screens.

Before:

<img width="1915" height="861" alt="Screenshot 2025-08-05 212141" src="https://github.com/user-attachments/assets/30cf6bdd-2b38-4792-b1db-98b64ec37dfc" />

<img width="1610" height="693" alt="Screenshot 2025-08-05 212721" src="https://github.com/user-attachments/assets/3631dd11-c28b-47c7-b048-5b623987c650" />

After:

<img width="1916" height="753" alt="Screenshot 2025-08-05 220644" src="https://github.com/user-attachments/assets/3575a5cf-ce3c-40fb-9be6-0089ec2ff6e0" />

<img width="1908" height="812" alt="Screenshot 2025-08-05 212551" src="https://github.com/user-attachments/assets/b77a9fb4-54ed-47e1-96e3-0fad048a6338" />
