### PR TITLE
unbound: improve reporting

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overview.volt
@@ -439,28 +439,28 @@
 
             $('#top, #top-blocked').fadeOut(200); 
     
-        ajaxGet('/api/unbound/overview/totals/' + maxDomains, {}, function(data, status) {
-            $('.top-item').remove();
+            ajaxGet('/api/unbound/overview/totals/' + maxDomains, {}, function(data, status) {
+                $('.top-item').remove();
 
-            $('#totalCounter').html(data.total);
-            $('#blockedCounter').html(data.blocked.total + " (" + data.blocked.pcnt + "%)");
-            $('#sizeCounter').html(data.blocklist_size);
-            $('#resolvedCounter').html(data.resolved.total + " (" + data.resolved.pcnt + "%)");
+                $('#totalCounter').html(data.total);
+                $('#blockedCounter').html(data.blocked.total + " (" + data.blocked.pcnt + "%)");
+                $('#sizeCounter').html(data.blocklist_size);
+                $('#resolvedCounter').html(data.resolved.total + " (" + data.resolved.pcnt + "%)");
 
-            createTopList('top', data.top, 'pass', new Set(data.blocklisted_domains), maxDomains);
-            createTopList('top-blocked', data.top_blocked, 'block', new Set(data.whitelisted_domains), maxDomains);
+                createTopList('top', data.top, 'pass', new Set(data.blocklisted_domains), maxDomains);
+                createTopList('top-blocked', data.top_blocked, 'block', new Set(data.whitelisted_domains), maxDomains);
 
-            $('#top li:nth-child(even)').addClass('odd-bg');
-            $('#top-blocked li:nth-child(even)').addClass('odd-bg');
+                $('#top li:nth-child(even)').addClass('odd-bg');
+                $('#top-blocked li:nth-child(even)').addClass('odd-bg');
 
-            $('#bannersub').html("Starting from " + (new Date(data.start_time * 1000)).toLocaleString());
+                $('#bannersub').html("Starting from " + (new Date(data.start_time * 1000)).toLocaleString());
 
-            $dropdownToggle.css({'width': '', 'height': '', 'display': '', 'align-items': '', 'justify-content': ''}).html(originalHtml);
+                $dropdownToggle.css({'width': '', 'height': '', 'display': '', 'align-items': '', 'justify-content': ''}).html(originalHtml);
         
-            $dropdown.prop('disabled', false).selectpicker('refresh');
-            $('#top, #top-blocked').fadeIn(200);
-        });
-    }
+                $dropdown.prop('disabled', false).selectpicker('refresh');
+                $('#top, #top-blocked').fadeIn(200);
+            });
+        }
 
         function reset_tooltips() {
             $(".block-domain").attr('title', "{{ lang._('Block Domain') }}").tooltip({container: 'body', trigger: 'hover'});


### PR DESCRIPTION
Closes: https://github.com/opnsense/core/issues/9040

This PR improves the Unbound DNS reporting overview by adding a toggle between 10 and 50 entries.

This, among other things, is extremely useful in situations where most of the top 10 domains are occupied by "misbehaving devices" constantly doing DNS requests for the same thing (requests to controllers, API calls, etc).

Open to improve it in any way you believe is best.

