### PR TITLE
dnsmasq: Swap Hosts and Domains tab for consistency reasons

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
@@ -2,8 +2,8 @@
     <Services>
         <Dnsmasq VisibleName="Dnsmasq DNS &amp; DHCP" cssClass="fa fa-tags fa-fw">
           <General order="10" url="/ui/dnsmasq/settings#general"/>
+          <Domains order="15" url="/ui/dnsmasq/settings#domains"/>
           <Hosts order="20" url="/ui/dnsmasq/settings#hosts"/>
-          <Domains order="30" url="/ui/dnsmasq/settings#domains"/>
           <Dhcpranges VisibleName="DHCP ranges" order="50" url="/ui/dnsmasq/settings#dhcpranges"/>
           <Dhcpoptions VisibleName="DHCP options" order="60" url="/ui/dnsmasq/settings#dhcpoptions"/>
           <Dhcptags VisibleName="DHCP tags" order="65" url="/ui/dnsmasq/settings#dhcptags"/>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -284,8 +284,8 @@
 <!-- Navigation bar -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
-    <li><a data-toggle="tab" href="#hosts">{{ lang._('Hosts') }}</a></li>
     <li><a data-toggle="tab" href="#domains">{{ lang._('Domains') }}</a></li>
+    <li><a data-toggle="tab" href="#hosts">{{ lang._('Hosts') }}</a></li>
     <li><a data-toggle="tab" href="#dhcpranges">{{ lang._('DHCP ranges') }}</a></li>
     <li><a data-toggle="tab" href="#dhcpoptions">{{ lang._('DHCP options') }}</a></li>
     <li><a data-toggle="tab" href="#dhcptags">{{ lang._('DHCP tags') }}</a></li>


### PR DESCRIPTION
Hosts is more related to DHCP than Domains.

In Hosts, a selectpicker for tags is shown, in Domains hidden.

This is just something that personally bugs me when clicking around.

Clicking from the Tab "Hosts" to "Domain" to "DHCP ranges" just feels kinda inconsistent.

PR can be ignored if too much micro management.