### PR TITLE
core/snapshot: Add missing timestamp formatter

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/forms/snapshot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/forms/snapshot.xml
@@ -31,5 +31,8 @@
         <id>created</id>
         <label>Created</label>
         <type>ignore</type>
+        <grid_view>
+            <formatter>timestamp</formatter>
+        </grid_view>
     </field>
 </form>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9059