### PR TITLE
dnsmasq: Allow disabling local for DHCP domains

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml
@@ -155,6 +155,12 @@
         <help>To ensure that all names have a domain part, there must be a default domain specified when DHCP FQDN is set. Leave empty to use the system domain.</help>
     </field>
     <field>
+        <id>dnsmasq.dhcp.local</id>
+        <label>DHCP local domain</label>
+        <type>checkbox</type>
+        <help>Sets all DHCP domains as local. This will configure this DNS server as authoritative; it will not forward queries to any upstream servers for these domains.</help>
+    </field>
+    <field>
         <id>dnsmasq.dhcp.lease_max</id>
         <label>DHCP max leases</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>/dnsmasq</mount>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <items>
         <enable type="BooleanField"/>
         <regdhcp type="BooleanField"/>
@@ -55,6 +55,10 @@
                 <IsDNSName>Y</IsDNSName>
                 <IpAllowed>N</IpAllowed>
             </domain>
+            <local type="BooleanField">
+                <Required>Y</Required>
+                <Default>1</Default>
+            </local>
             <lease_max type="IntegerField">
                 <MinimumValue>0</MinimumValue>
             </lease_max>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -45,7 +45,7 @@ cname={{ host.cnames }},{{ host.host }}{% if host.domain %}.{{ host.domain }}{% 
 {% if dnsmasq.dhcp.fqdn == '1' %}
 dhcp-fqdn
 domain={{dnsmasq.dhcp.domain|default(system.domain)}}
-{%     if helpers.exists('dnsmasq.dhcp_ranges') %}
+{%     if helpers.exists('dnsmasq.dhcp_ranges') and dnsmasq.dhcp.local == '1' %}
 {%     do all_local_domains.append(dnsmasq.dhcp.domain | default(system.domain)) %}
 {%         for dhcp_range in helpers.toList('dnsmasq.dhcp_ranges') %}
 {%             if dhcp_range.domain %}


### PR DESCRIPTION
If dnsmasq is the first DNS server in line, and you do not want to use a unique DHCP domain, forcing the DHCP domain to be local breaks all upstream queries for it. This might be wanted if you forward from Unbound to dnsmasq since it fixes DNS loops, but if dnsmasq is your primary forwarding resolver, it knows what to forward and what to answer.

Mostly from reddit and opnsense forum feedback, it caught more than one user offguard.

Most recent example: https://www.reddit.com/r/opnsense/comments/1mk16y1/dnsmasq_not_forwarding_local_domain_queries/