### PR TITLE
Fix OpenVPN client config for MikroTik OpenVPN server

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -337,7 +337,7 @@
         <label>Data Ciphers</label>
         <type>select_multiple</type>
         <advanced>true</advanced>
-        <style>selectpicker role role_server</style>
+        <style>selectpicker</style>
         <help>Restrict the allowed ciphers to be negotiated to the ciphers in this list.</help>
         <grid_view>
             <visible>false</visible>
@@ -346,9 +346,9 @@
     <field>
         <id>instance.data-ciphers-fallback</id>
         <label>Data Ciphers Fallback</label>
-        <type>dropdown</type>
+        <type>select_multiple</type>
         <advanced>true</advanced>
-        <style>selectpicker role role_server</style>
+        <style>selectpicker</style>
         <help>
             Configure a cipher that is used to fall back to if we could not determine which cipher the peer is willing to use.
             This option should only be needed to connect to peers that are running OpenVPN 2.3 or older versions,

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -238,6 +238,7 @@
                     <OptionValues>
                         <AES-256-GCM>AES-256-GCM</AES-256-GCM>
                         <AES-128-GCM>AES-128-GCM</AES-128-GCM>
+                        <AES-256-CBC>AES-256-CBC</AES-256-CBC>
                         <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
                     </OptionValues>
                 </data-ciphers>
@@ -245,6 +246,7 @@
                     <OptionValues>
                         <AES-256-GCM>AES-256-GCM</AES-256-GCM>
                         <AES-128-GCM>AES-128-GCM</AES-128-GCM>
+                        <AES-256-CBC>AES-256-CBC</AES-256-CBC>
                         <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
                     </OptionValues>
                 </data-ciphers-fallback>


### PR DESCRIPTION
MikroTik provides OpenVPN with a very old OpenSSL version. If it is used as a server, the OPNsense version cannot be configured to connect to it as the required cipher cannot be selected on the web interface.

Also the form hides those entries from the user in the client configuration.

Also improve the UI slightly. Data Ciphers and Data Ciphers Fallback use different select styles currently, which makes it look strange.