### PR TITLE
vpn/ipsec: Add default value to make_before_break that retains original behavior before strongswan 6.0.0

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/IPsec.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/IPsec</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>OPNsense IPsec</description>
     <items>
         <general>
@@ -60,7 +60,10 @@
             </ignore_acquire_ts>
             <install_routes type="BooleanField"/>
             <cisco_unity type="BooleanField"/>
-            <make_before_break type="BooleanField"/>
+            <make_before_break type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </make_before_break>
             <retransmit_tries type="IntegerField"/>
             <retransmit_timeout type="NumericField"/>
             <retransmit_base type="NumericField"/>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9078