### PR TITLE
dnsmasq: Move dhcp boot into own tab

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Menu/Menu.xml
@@ -6,9 +6,10 @@
           <Hosts order="30" url="/ui/dnsmasq/settings#hosts"/>
           <Dhcpranges VisibleName="DHCP ranges" order="50" url="/ui/dnsmasq/settings#dhcpranges"/>
           <Dhcpoptions VisibleName="DHCP options" order="60" url="/ui/dnsmasq/settings#dhcpoptions"/>
-          <Dhcptags VisibleName="DHCP tags" order="65" url="/ui/dnsmasq/settings#dhcptags"/>
-          <Leases order="80" url="/ui/dnsmasq/leases"/>
-          <LogFile VisibleName="Log File" order="90" url="/ui/diagnostics/log/core/dnsmasq"/>
+          <Dhcpboot VisibleName="DHCP boot" order="70" url="/ui/dnsmasq/settings#dhcpboot"/>
+          <Dhcptags VisibleName="DHCP tags" order="80" url="/ui/dnsmasq/settings#dhcptags"/>
+          <Leases order="90" url="/ui/dnsmasq/leases"/>
+          <LogFile VisibleName="Log File" order="100" url="/ui/diagnostics/log/core/dnsmasq"/>
         </Dnsmasq>
     </Services>
 </menu>

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -58,7 +58,10 @@
                     grid_ids = ["{{formGridDHCPrange['table_id']}}"];
                     break;
                 case '#dhcpoptions':
-                    grid_ids = ["{{formGridDHCPoption['table_id']}}", "{{formGridDHCPboot['table_id']}}"];
+                    grid_ids = ["{{formGridDHCPoption['table_id']}}"];
+                    break;
+                case '#dhcpboot':
+                    grid_ids = ["{{formGridDHCPboot['table_id']}}"];
                     break;
             }
             /* grid action selected, load or refresh target grid */
@@ -114,25 +117,12 @@
                                 },
                             }
                         });
-                        /* insert headers when multiple grids exist on a single tab */
-                        let header = $("#" + grid_id + "-header");
-                        if (grid_id === 'option' ) {
-                            header.find('div.actionBar').parent().prepend(
-                                $('<td id="heading-wrapper" class="col-sm-2 theading-text">{{ lang._('Options') }}</div>')
-                            );
-                        } else if (grid_id == 'boot') {
-                            header.find('div.actionBar').parent().prepend(
-                                $('<td id="heading-wrapper" class="col-sm-2 theading-text">{{ lang._('Boot') }}</div>')
-                            );
-                        } else if (grid_id == 'host') {
-                            all_grids[grid_id].find("tfoot td:last").append($("#hosts_tfoot_append > button").detach());
-                        }
                     } else {
                         all_grids[grid_id].bootgrid('reload');
 
                     }
                     // insert tag selectpicker in all grids that use tags or interfaces, boot excluded cause two grids in same tab
-                    if (!['domain', 'boot'].includes(grid_id)) {
+                    if (!['domain'].includes(grid_id)) {
                         let header = $("#" + grid_id + "-header");
                         let $actionBar = header.find('.actionBar');
                         if ($actionBar.length) {
@@ -221,7 +211,6 @@
 
         $('#tag_select').change(function () {
             Object.keys(all_grids).forEach(function (grid_id) {
-                // boot is not excluded here, as it reloads in same tab as options
                 if (!['domain'].includes(grid_id)) {
                     all_grids[grid_id].bootgrid('reload');
                 }
@@ -319,6 +308,7 @@
     <li><a data-toggle="tab" href="#hosts">{{ lang._('Hosts') }}</a></li>
     <li><a data-toggle="tab" href="#dhcpranges">{{ lang._('DHCP ranges') }}</a></li>
     <li><a data-toggle="tab" href="#dhcpoptions">{{ lang._('DHCP options') }}</a></li>
+    <li><a data-toggle="tab" href="#dhcpboot">{{ lang._('DHCP boot') }}</a></li>
     <li><a data-toggle="tab" href="#dhcptags">{{ lang._('DHCP tags') }}</a></li>
 </ul>
 
@@ -362,10 +352,12 @@
     <div id="dhcpranges" class="tab-pane fade in">
         {{ partial('layout_partials/base_bootgrid_table', formGridDHCPrange)}}
     </div>
-    <!-- Tab: DHCP [boot] Options -->
+    <!-- Tab: DHCP Options -->
     <div id="dhcpoptions" class="tab-pane fade in">
         {{ partial('layout_partials/base_bootgrid_table', formGridDHCPoption)}}
-        <hr/>
+    </div>
+    <!-- Tab: DHCP Boot -->
+    <div id="dhcpboot" class="tab-pane fade in">
         {{ partial('layout_partials/base_bootgrid_table', formGridDHCPboot)}}
     </div>
     <!-- Tab: DHCP Tags -->


### PR DESCRIPTION
Since the inclusion of groupBy (https://github.com/opnsense/core/commit/e2ed3138a5ad3d2f207501954a9193b1ce061fa2) changes the look and feel, having two of these grouped grids in the same view can be overwhelming.