### PR TITLE
bootgrid: Fix expandGroupBy() call to use correct context

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -1854,7 +1854,7 @@ class UIBootgrid {
                         } else {
                             $("#" + editDlg).change();
                         }
-                        expandGroupBy(editDlg);
+                        this.expandGroupBy(editDlg);
                         this._reload(true);
                         this.showSaveAlert(event);
                         saveDlg.find('i').removeClass("fa fa-spinner fa-pulse");


### PR DESCRIPTION
Small fix for: https://github.com/opnsense/core/commit/e2ed3138a5ad3d2f207501954a9193b1ce061fa2