### PR TITLE
gui: keyboard shortcuts for advanced and help

### DIFF
--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -1,5 +1,4 @@
 <!doctype html>
-<!doctype html>
 <html lang="{{ langcode|safe }}" class="no-js">
   <head>
 

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -1,4 +1,5 @@
 <!doctype html>
+<!doctype html>
 <html lang="{{ langcode|safe }}" class="no-js">
   <head>
 
@@ -95,6 +96,7 @@
                 initFormHelpUI();
                 initFormAdvancedUI();
                 addMultiSelectClearUI();
+                initGlobalOpenShortcuts();
 
                 updateSystemStatus();
 

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -496,14 +496,17 @@ function initGlobalOpenShortcuts() {
         const tag = (t.tagName || '').toLowerCase();
         if (tag === 'input' || tag === 'textarea' || tag === 'select' || t.isContentEditable) return;
 
+        const $context = $('.modal:visible, .ui-dialog:visible, [role="dialog"]:visible').last();
+        const searchContext = $context.length > 0 ? $context : $(document);
+
         if (e.key === 'a' || e.key === 'A') {
-            const $adv = $('[id*="show_advanced"]').first();
+            const $adv = searchContext.find('[id*="show_advanced"]').first();
             if ($adv.length) {
                 $adv.click();
                 e.preventDefault();
             }
         } else if (e.key === 'h' || e.key === 'H') {
-            const $help = $('[id*="show_all_help"]').first();
+            const $help = searchContext.find('[id*="show_all_help"]').first();
             if ($help.length) {
                 $help.click();
                 e.preventDefault();

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -487,6 +487,32 @@ function initFormAdvancedUI() {
 }
 
 /**
+ * handle keyboard shortcuts for toggling advanced and help
+ */
+function initGlobalOpenShortcuts() {
+    $(document).off('keydown.opnsenseGlobalOpenToggles').on('keydown.opnsenseGlobalOpenToggles', function (e) {
+        if (e.ctrlKey || e.altKey || e.metaKey) return;
+        const t = e.target;
+        const tag = (t.tagName || '').toLowerCase();
+        if (tag === 'input' || tag === 'textarea' || tag === 'select' || t.isContentEditable) return;
+
+        if (e.key === 'a' || e.key === 'A') {
+            const $adv = $('[id*="show_advanced"]').first();
+            if ($adv.length) {
+                $adv.click();
+                e.preventDefault();
+            }
+        } else if (e.key === 'h' || e.key === 'H') {
+            const $help = $('[id*="show_all_help"]').first();
+            if ($help.length) {
+                $help.click();
+                e.preventDefault();
+            }
+        }
+    });
+}
+
+/**
  * standard dialog when information is required, wrapper around BootstrapDialog
  */
 function stdDialogInform(title, message, close, callback, type, cssClass) {


### PR DESCRIPTION
Closes: https://github.com/opnsense/core/issues/9084

This would be useful both in no mouse situations and in boosting productivity, enabling users to toggle quickly between states.

"a" = advanced mode

"h" = full help