### PR TITLE
firewall/automation: Tweak the grid headers

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -12,7 +12,7 @@
             <width>50</width>
             <type>boolean</type>
             <formatter>rowtoggle</formatter>
-            <sequence>10</sequence>
+            <sequence>5</sequence>
             <align>center</align>
             <sortable>false</sortable>
         </grid_view>
@@ -23,7 +23,7 @@
         <type>info</type>
         <help>The order in which rules are being processed.</help>
         <grid_view>
-            <sequence>20</sequence>
+            <sequence>10</sequence>
             <visible>false</visible>
             <!-- The sequence order of firewall rules is absolute, no other field shall be sorted -->
             <order>asc</order>
@@ -36,7 +36,7 @@
         <type>text</type>
         <help>The order in which rules are being processed. Please note that this is not a unique identifier, the system will automatically recalculate the ruleset when rule positions are changed with the available "Move rule before this rule" button.</help>
         <grid_view>
-            <sequence>20</sequence>
+            <sequence>15</sequence>
             <visible>false</visible>
             <sortable>false</sortable>
         </grid_view>
@@ -51,6 +51,7 @@
             <sortable>false</sortable>
             <formatter>category</formatter>
             <sequence>1</sequence>
+            <width>80</width>
         </grid_view>
     </field>
     <field>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -142,25 +142,25 @@
 
                 headerFormatters: {
                     enabled: function (column) {
-                        return '<input type="checkbox" disabled style="pointer-events: none;" />';
+                        return '<i class="fa-solid fa-fw fa-check-square" data-toggle="tooltip" title="{{ lang._('Enabled') }}"></i>';;
                     },
                     interface: function (column) {
-                        return '<i class="fa-solid fa-fw fa-network-wired" data-toggle="tooltip" data-placement="right" title="{{ lang._('Network Interface') }}"></i>';
+                        return '<i class="fa-solid fa-fw fa-network-wired" data-toggle="tooltip" title="{{ lang._('Network interface') }}"></i>';
                     },
                     evaluations: function (column) {
-                        return '<i class="fa-solid fa-fw fa-bullseye" data-toggle="tooltip" data-placement="left" title="{{ lang._('Number of rule evaluations') }}"></i>';
+                        return '<i class="fa-solid fa-fw fa-bullseye" data-toggle="tooltip" title="{{ lang._('Number of rule evaluations') }}"></i>';
                     },
                     states: function (column) {
-                        return '<i class="fa-solid fa-fw fa-chart-line" data-toggle="tooltip" data-placement="left" title="{{ lang._('Current active states for this rule') }}"></i>';
+                        return '<i class="fa-solid fa-fw fa-chart-line" data-toggle="tooltip" title="{{ lang._('Current active states for this rule') }}"></i>';
                     },
                     packets: function (column) {
-                        return '<i class="fa-solid fa-fw fa-box" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total packets matched by this rule') }}"></i>';
+                        return '<i class="fa-solid fa-fw fa-box" data-toggle="tooltip" title="{{ lang._('Total packets matched by this rule') }}"></i>';
                     },
                     bytes: function (column) {
-                        return '<i class="fa-solid fa-fw fa-database" data-toggle="tooltip" data-placement="left" title="{{ lang._('Total bytes matched by this rule') }}"></i>';
+                        return '<i class="fa-solid fa-fw fa-database" data-toggle="tooltip" title="{{ lang._('Total bytes matched by this rule') }}"></i>';
                     },
                     categories: function (column) {
-                        return '<i class="fa-solid fa-fw fa-tag" data-toggle="tooltip" data-placement="left" title="{{ lang._("Categories") }}"></i> {{ lang._("Categories") }}';
+                        return '<i class="fa-solid fa-fw fa-tag" data-toggle="tooltip" title="{{ lang._("Categories") }}"></i>';
                     },
                 },
                 formatters:{


### PR DESCRIPTION
- Tooltips are always body so data placement can be removed.
- Make categories column smaller, remove header text.
- Fix sequence of some columns.