### PR TITLE
Kea: enable affinity through gui

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
@@ -33,6 +33,18 @@
         <help>Defines how long the addresses (leases) given out by the server are valid (in seconds)</help>
     </field>
     <field>
+        <id>dhcpv4.general.kaffinity</id>
+        <label>Lease Affinity</label>
+        <type>checkbox</type>
+        <help>Provides the means to assign the same lease to a returning client after its lease has expired</help>
+    </field>
+    <field>
+        <id>dhcpv4.general.hold_reclaimed_time</id>
+        <label>Affinity lifetime</label>
+        <type>text</type>
+        <help>Defines for how long a returning client will be able to keep the same lease (in seconds)</help>
+    </field>
+    <field>
         <id>dhcpv4.general.fwrules</id>
         <label>Firewall rules</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -207,6 +207,19 @@ class KeaDhcpv4 extends BaseModel
         return $result;
     }
 
+    private function getExpiredLeasesProcessingConfig()
+    {
+            if (empty((string)$this->general->kaffinity)) {
+            return null;
+        }
+
+        return [
+            'reclaim-timer-wait-time' => 10,
+            'hold-reclaimed-time' => (int)$this->general->hold_reclaimed_time->__toString(),
+            'flush-reclaimed-timer-wait-time' => 25
+        ];
+    }
+
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp4.conf')
     {
         $cnf = [
@@ -238,6 +251,10 @@ class KeaDhcpv4 extends BaseModel
                 'subnet4' => $this->getConfigSubnets(),
             ]
         ];
+        $expiredLeasesConfig = $this->getExpiredLeasesProcessingConfig();
+            if ($expiredLeasesConfig !== null) {
+                $cnf['Dhcp4']['expired-leases-processing'] = $expiredLeasesConfig;
+            }
         if (!(new KeaCtrlAgent())->general->enabled->isEmpty()) {
             $cnf['Dhcp4']['hooks-libraries'] = [];
             $cnf['Dhcp4']['hooks-libraries'][] = [

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>
@@ -28,6 +28,15 @@
                     <raw>raw</raw>
                 </OptionValues>
             </dhcp_socket_type>
+            <kaffinity type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </kaffinity>
+            <hold_reclaimed_time type="IntegerField">
+                <default>28800</default>
+                <Required>Y</Required>
+                <MinimumValue>0</MinimumValue>
+            </hold_reclaimed_time>
         </general>
         <ha>
             <enabled type="BooleanField">


### PR DESCRIPTION
Closes: https://github.com/opnsense/core/issues/9094

Affinity is a useful option that enables clients to reclaim their lease. Εven though KEA has a multitude of options, and manual setup is recommended for most of them, this is useful to enough people both in the business and home verticals to warrant a GUI entry.

https://kea.readthedocs.io/en/stable/arm/lease-expiration.html

@fichtner Now you are officially 4 PRs behind :)