### PR TITLE
ids: Fix /ui/ids#download_settings tab not loading with tabulator

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
@@ -358,12 +358,13 @@ class SettingsController extends ApiMutableModelControllerBase
 
     /**
      * List all installable rules including current status
-     * @return array|mixed list of items when $id is null otherwise the selected item is returned
+     * @return array list of items when $id is null otherwise the selected item is returned
      * @throws \Exception
      */
     public function listRulesetsAction()
     {
-        return $this->searchRecordsetBase($this->listInstallableRules(), null, 'description');
+        // Tabulator expects an array for rows, not an object
+        return $this->searchRecordsetBase($this->listInstallableRules(), null, 'description')['rows'];
     }
 
     /**


### PR DESCRIPTION
Fixes this error:

```
RowManager.js:251 Data Loading Error - Unable to process data due to invalid data type 
Expecting: array 
Received:  object 
Data:      Object
```

There is no pagination here, so this was the simplest fix, just return the row array that tabulator expects.