### PR TITLE
firewall/automation: Do not allow source_net destination_net selectpickers to grow infinitely

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -885,6 +885,12 @@
         pointer-events: none;
     }
 
+    /* Do not allow Source/Destination selectpickers to grow infinitely */
+    #row_rule\.source_net .bootstrap-select > .dropdown-toggle,
+    #row_rule\.destination_net .bootstrap-select > .dropdown-toggle {
+        max-width: 348px;
+    }
+
 </style>
 
 <div class="tab-content content-box">


### PR DESCRIPTION
This seems to be a contained issue to only these two selectpickers

Fixes: https://github.com/opnsense/core/issues/9150