### PR TITLE
bootgrid: Raise rowCount default to 50 as y-overflow handles this gracefully

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/log.volt
@@ -53,7 +53,6 @@
               sorting:false,
               rowSelect: false,
               selection: false,
-              rowCount:[20,50,100,200,500,1000,5000],
               virtualDOM: true,
               labels: {
                   infos: "{{ lang._('Showing %s to %s') | format('{{ctx.start}}','{{ctx.end}}') }}"

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/settings.volt
@@ -97,8 +97,6 @@
                             options: {
                                 triggerEditFor: getUrlHash('edit'),
                                 initialSearchPhrase: getUrlHash('search'),
-                                // Remove pagination from GroupBy
-                                rowCount: isGroupedGrid ? [-1] : undefined,
                                 requestHandler: function(request) {
                                     const selectedTags = $('#tag_select').val();
                                     if (selectedTags && selectedTags.length > 0) {

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/alias_util.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/alias_util.volt
@@ -14,7 +14,6 @@
                     let grid = $('#alias_content').UIBootgrid({
                         search: '/api/firewall/alias_util/list/' + $(this).val(),
                         options: {
-                            rowCount: [20, 50, 100, 200, -1],
                             formatters: {
                                 commands: function (column, row) {
                                     return '<button type="button" class="btn btn-xs btn-default delete-ip bootgrid-tooltip" title="{{ lang._('Delete') }}" data-row-id="' + row.ip + '"><span class="fa fa-fw fa-trash-o"></span></button>';

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -118,7 +118,6 @@
             },
             options: {
                 responsive: true,
-                rowCount: [100,200,500,1000,-1],
                 initialSearchPhrase: getUrlHash('search'),
                 triggerEditFor: getUrlHash('edit'),
                 requestHandler: function(request){

--- a/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IDS/index.volt
@@ -318,7 +318,6 @@ POSSIBILITY OF SUCH DAMAGE.
                             set:'/api/ids/settings/set_rule/',
                             options:{
                                 requestHandler:addRuleFilters,
-                                rowCount:[10, 25, 50,100,500,1000] ,
                                 formatters:{
                                     rowtoggle: function (column, row) {
                                         var toggle = " <button type=\"button\" class=\"btn btn-xs btn-default command-edit bootgrid-tooltip\" data-row-id=\"" + row.sid + "\"><span class=\"fa fa-pencil fa-fw\"></span></button> ";
@@ -409,7 +408,6 @@ POSSIBILITY OF SUCH DAMAGE.
                         options:{
                             multiSelect:false,
                             selection:false,
-                            rowCount: [7,50,100,250,500,1000,5000],
                             requestHandler:addAlertQryFilters,
                             labels: {
                                 infos: "{{ lang._('Showing %s to %s') | format('{{ctx.start}}','{{ctx.end}}') }}"

--- a/src/opnsense/mvc/app/views/OPNsense/IPsec/tunnels.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/IPsec/tunnels.volt
@@ -149,6 +149,7 @@
               formatters: formatters,
               multiSelect: false,
               rowSelect: true,
+              rowCount: [7, 20, 50, 100, 200, 500, -1],
               selection: true
           }
       }).on("selected.rs.jquery.bootgrid", function(e, rows) {
@@ -175,6 +176,7 @@
           toggle: '/api/ipsec/tunnel/toggle_phase2/',
           options: {
               formatters: formatters,
+              rowCount: [7, 20, 50, 100, 200, 500, -1],
               useRequestHandlerOnGet: true,
               requestHandler: function(request) {
                   let ids = $("#grid-phase1").bootgrid("getSelectedRows");

--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/overrides.volt
@@ -37,6 +37,7 @@ $( document ).ready(function() {
             selection: true,
             multiSelect: false,
             rowSelect: true,
+            rowCount: [7, 20, 50, 100, 200, 500, -1],
             stickySelect: true,
             formatters: {
                 "mxformatter": function (column, row) {
@@ -71,6 +72,7 @@ $( document ).ready(function() {
             selection: true,
             multiSelect: true,
             rowSelect: true,
+            rowCount: [7, 20, 50, 100, 200, 500, -1],
             useRequestHandlerOnGet: true,
             requestHandler: function(request) {
                 let uuids = $("#{{formGridHostOverride['table_id']}}").bootgrid("getSelectedRows");

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -129,7 +129,7 @@ class UIBootgrid {
             disableScroll: false,
             sorting: true,
             selection: true,
-            rowCount: [7, 14, 20, 50, 100, true],
+            rowCount: [50, 100, 200, 500, 1000, true], // tabulator y-overflows, no need for low defaults
             remoteGridView: false, // parse gridview from <thead> or via ajax?
             formatters: {
                 ...this._internalFormatters()


### PR DESCRIPTION
ensure low initial rowcount for master detail grids, clean up some scattered rowcounts in views