### PR TITLE
firewall/automation: Prevent multiple grid reloads on initial page load

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -553,6 +553,13 @@
 
         });
 
+        // Track if user has actually changed a dropdown, or it was the controller
+        let interfaceInitialized = false;
+        let categoryInitialized = false;
+
+        // Do not reload the grid when selectpickers get refreshed during the reconfigureAct
+        let reconfigureActInProgress = false;
+
         // Populate category selectpicker
         function populateCategoriesSelectpicker() {
             const currentSelection = $("#category_filter").val();
@@ -591,16 +598,11 @@
                     if (currentSelection?.length) {
                         $("#category_filter").val(currentSelection).selectpicker('refresh');
                     }
+                    categoryInitialized = true;
                 },
                 true  // render_html
             );
         }
-
-        // Track if user has actually changed the interface dropdown, or it was the controller
-        let interfaceInitialized = false;
-
-        // Do not reload the grid when selectpickers get refreshed during the reconfigureAct
-        let reconfigureActInProgress = false;
 
         // Populate interface selectpicker
         function populateInterfaceSelectpicker() {
@@ -648,6 +650,7 @@
                             $('#interface_select').val(ifaceFromHash).selectpicker('refresh');
                             // Skip grid reload during reconfigureAct
                             if (!reconfigureActInProgress) {
+                                console.log("bootgrid reload populateInterfaceSelectpicker");
                                 grid.bootgrid('reload');
                             }
                         }
@@ -664,19 +667,20 @@
         // move selectpickers into action bar
         $("#interface_select_container").detach().insertBefore('#{{formGridFilterRule["table_id"]}}-header > .row > .actionBar > .search');
         $('#interface_select').on('changed.bs.select', function () {
-            // Only update URL hash when user has changed the dropdown, and never during reconfigureAct
+            // Skip grid reload during reconfigureAct and initial page load
             if (!interfaceInitialized || reconfigureActInProgress) return;
 
             const hashVal = encodeURIComponent($(this).val() ?? '');
             history.replaceState(null, null, `#interface=${hashVal}`);
-
+            console.log("bootgrid reload interface_select changed");
             grid.bootgrid('reload');
         });
 
         $("#type_filter_container").detach().insertAfter("#interface_select_container");
         $("#category_filter").on('changed.bs.select', function(){
-            // Skip grid reload during reconfigureAct
-            if (reconfigureActInProgress) return;
+            // Skip grid reload during reconfigureAct and initial page load
+            if (!categoryInitialized || reconfigureActInProgress) return;
+            console.log("bootgrid reload category_filter changed");
             grid.bootgrid('reload');
         });
 
@@ -686,6 +690,7 @@
             localStorage.setItem("firewall_rule_inspect", inspectEnabled ? "1" : "0");
             $(this).toggleClass('active btn-primary', inspectEnabled);
             updateStatisticColumns();
+            console.log("bootgrid reload toggle_inspect_button changed");
             grid.bootgrid("reload");
         });
 
@@ -695,6 +700,7 @@
             localStorage.setItem("firewall_rule_tree", treeViewEnabled ? "1" : "0");
             $(this).toggleClass('active btn-primary', treeViewEnabled);
             $("#tree_expand_container").toggle(treeViewEnabled);
+            console.log("bootgrid reload tree_toggle_button changed");
             grid.bootgrid("reload");
         });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -65,6 +65,10 @@
         let inspectEnabled = localStorage.getItem("firewall_rule_inspect") === "1";
         $('#toggle_inspect_button').toggleClass('active btn-primary', inspectEnabled);
 
+        // read interface from URL hash once, for the first grid load
+        const hashMatchInterface = window.location.hash.match(/(?:^#|&)interface=([^&]+)/);
+        let pendingUrlInterface = hashMatchInterface ? decodeURIComponent(hashMatchInterface[1]) : null;
+
         // Lives outside the grid, so the logic of the response handler can be changed after grid initialization
         function dynamicResponseHandler(resp) {
             // convert the flat rows into a tree view (if enabled)
@@ -125,9 +129,12 @@
                     if ( $('#category_filter').val().length > 0) {
                         request['category'] = $('#category_filter').val();
                     }
-                    // Add interface selectpicker
+                    // Add interface selectpicker, or fall back to hash for the first load
                     let selectedInterface = $('#interface_select').val();
-                    if (selectedInterface && selectedInterface.length > 0) {
+                    if ((!selectedInterface || selectedInterface.length === 0) && pendingUrlInterface) {
+                        request['interface'] = pendingUrlInterface;
+                        pendingUrlInterface = null; // consume the hash so it is not used again
+                    } else if (selectedInterface && selectedInterface.length > 0) {
                         request['interface'] = selectedInterface;
                     }
                     if (inspectEnabled) {
@@ -648,11 +655,6 @@
                         const allOptions = Object.values(data).flatMap(group => group.items.map(i => i.value));
                         if (allOptions.includes(ifaceFromHash)) {
                             $('#interface_select').val(ifaceFromHash).selectpicker('refresh');
-                            // Skip grid reload during reconfigureAct
-                            if (!reconfigureActInProgress) {
-                                console.log("bootgrid reload populateInterfaceSelectpicker");
-                                grid.bootgrid('reload');
-                            }
                         }
                     }
                     interfaceInitialized = true;

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -674,7 +674,6 @@
 
             const hashVal = encodeURIComponent($(this).val() ?? '');
             history.replaceState(null, null, `#interface=${hashVal}`);
-            console.log("bootgrid reload interface_select changed");
             grid.bootgrid('reload');
         });
 
@@ -682,7 +681,6 @@
         $("#category_filter").on('changed.bs.select', function(){
             // Skip grid reload during reconfigureAct and initial page load
             if (!categoryInitialized || reconfigureActInProgress) return;
-            console.log("bootgrid reload category_filter changed");
             grid.bootgrid('reload');
         });
 
@@ -692,7 +690,6 @@
             localStorage.setItem("firewall_rule_inspect", inspectEnabled ? "1" : "0");
             $(this).toggleClass('active btn-primary', inspectEnabled);
             updateStatisticColumns();
-            console.log("bootgrid reload toggle_inspect_button changed");
             grid.bootgrid("reload");
         });
 
@@ -702,7 +699,6 @@
             localStorage.setItem("firewall_rule_tree", treeViewEnabled ? "1" : "0");
             $(this).toggleClass('active btn-primary', treeViewEnabled);
             $("#tree_expand_container").toggle(treeViewEnabled);
-            console.log("bootgrid reload tree_toggle_button changed");
             grid.bootgrid("reload");
         });
 


### PR DESCRIPTION
Prevents all instances of this warning:

``DataLoader.js:57 Data Load Response Blocked - An active data load request was blocked by an attempt to change table data while the request was being made``

- Safeguard Category selectpicker on initial page load
- Fast path for URL hash, read and consume it once on page load without going through the interface selectpicker first

This improves performance.

Fixes: https://github.com/opnsense/core/issues/9148