### PR TITLE
KEA DHCPv6 static mappings DNS registration domain name

### DIFF
--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -118,6 +118,18 @@ function kea_staticmap($proto = null, $valid_addresses = true, $ifconfig_details
                 }
             }
 
+            // Use the first search list domain for DNS registration
+            if ($proto == 6) {
+                $subnet_node = $keamdl->getNodeByReference("subnets.subnet6.{$reservation->subnet}");
+                if ($subnet_node) {
+                    if (!empty((string)$reservation->domain_search)) {
+                        $domain = explode(',', (string)$reservation->domain_search)[0];
+                    } elseif (!empty((string)$subnet_node->option_data->domain_search)) {
+                        $domain = explode(',', (string)$subnet_node->option_data->domain_search)[0];
+                    }
+                }
+            }
+
             $entry = [
                 'descr' => $description,
                 'domain' => $domain,

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
@@ -30,7 +30,7 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <separator>,</separator>
-        <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names.</help>
+        <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names. The first domain in this list will also be used for DNS registration of this host if enabled. If empty, the first domain in the interface's domain search list will be used. If this is empty, too, the system domain will be used.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -59,7 +59,7 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <separator>,</separator>
-        <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names.</help>
+        <help>Specifies a ´search list´ of Domain Names to be used by the client to locate not-fully-qualified domain names. The first domain in this list will also be used for DNS registration of DHCP static mappings (if enabled).</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>


### PR DESCRIPTION
KEA DHCPv6 static mappings DNS registration domain name

DHCPv6 static mappings being DNS registered with the routers domain name is limiting.  Use the first search list domain for DNS registration.

Unbound requires reload.