### PR TITLE
mvc: disable Dnsmasq/Unbound template generation; closes #8888

### DIFF
--- a/src/etc/inc/plugins.inc.d/dnsmasq.inc
+++ b/src/etc/inc/plugins.inc.d/dnsmasq.inc
@@ -178,7 +178,6 @@ function dnsmasq_configure_do($verbose = false)
 
     _dnsmasq_add_host_entries();
 
-    /* XXX: cleanup, should have been run, but interface changes during boot or wizard are messing things up */
     configd_run('template reload OPNsense/Dnsmasq');
 
     mwexec('/usr/local/etc/rc.d/dnsmasq start');

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -102,7 +102,7 @@ function unbound_optimization()
     return $optimization;
 }
 
-function _unbound_service_mount_sync($umount = false)
+function unbound_service_mount_sync($umount = false)
 {
     $mountpoints = [
         '/var/unbound/dev' => [
@@ -148,7 +148,7 @@ function _unbound_service_mount_sync($umount = false)
     }
 }
 
-function _unbound_service_stop()
+function unbound_service_stop()
 {
     $mdl = new \OPNsense\Unbound\Unbound();
 
@@ -167,12 +167,6 @@ function _unbound_service_stop()
     killbypid('/var/run/unbound.pid');
 }
 
-function unbound_service_stop()
-{
-    _unbound_service_stop();
-    _unbound_service_mount_sync(true);
-}
-
 function unbound_generate_config()
 {
     global $config;
@@ -187,7 +181,8 @@ function unbound_generate_config()
     foreach ($dirs as $dir) {
         mwexecf('/bin/mkdir -p %s', "/var/unbound{$dir}");
     }
-    _unbound_service_mount_sync();
+
+    unbound_service_mount_sync();
 
     $optimization = unbound_optimization();
 
@@ -394,7 +389,6 @@ EOD;
     chmod($root_hints_tmp, 0644);
     rename($root_hints_tmp, '/var/unbound/root.hints');
 
-    /* XXX: cleanup, should have been run, but interface changes during boot or wizard are messing things up */
     configd_run('template reload OPNsense/Unbound/*');
 }
 
@@ -451,12 +445,12 @@ function unbound_configure_do($verbose = false, $interface_map = null)
         return;
     }
 
+    unbound_service_stop();
+
     if (!unbound_enabled()) {
-        unbound_service_stop();
+        unbound_service_mount_sync(true);
         return;
     }
-
-    _unbound_service_stop();
 
     service_log('Starting Unbound DNS...', $verbose);
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/ServiceController.php
@@ -37,7 +37,8 @@ use OPNsense\Base\ApiMutableServiceControllerBase;
 class ServiceController extends ApiMutableServiceControllerBase
 {
     protected static $internalServiceClass = '\OPNsense\Dnsmasq\Dnsmasq';
-    protected static $internalServiceTemplate = 'OPNsense/Dnsmasq';
+    /* XXX for legacy template refresh only */
+    //protected static $internalServiceTemplate = 'OPNsense/Dnsmasq';
     protected static $internalServiceEnabled = 'enable';
     protected static $internalServiceName = 'dnsmasq';
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -35,14 +35,16 @@ use OPNsense\Core\Backend;
 class ServiceController extends ApiMutableServiceControllerBase
 {
     protected static $internalServiceClass = '\OPNsense\Unbound\Unbound';
-    protected static $internalServiceTemplate = 'OPNsense/Unbound/*';
+    /* XXX for legacy template refresh only */
+    //protected static $internalServiceTemplate = 'OPNsense/Unbound/*';
     protected static $internalServiceEnabled = 'general.enabled';
     protected static $internalServiceName = 'unbound';
 
     public function dnsblAction()
     {
         $backend = new Backend();
-        $backend->configdRun('template reload ' . escapeshellarg(static::$internalServiceTemplate));
+        /* XXX currently hardcoded to not cause side effect of $internalServiceTemplate use */
+        $backend->configdRun('template reload OPNsense/Unbound/*');
         $response = $backend->configdRun(static::$internalServiceName . ' dnsbl');
         return array('status' => $response);
     }


### PR DESCRIPTION
There are two things to consider:

1. Stopping does not alter the templates because the (re)start code is in charge of doing the templates, which is not called when a service is disabled.

2. That actually lead to an Unbound bug on stop where the file system is unmounted, but that should only happen when the service is disabled.  This runs into issue 1. again, but it's better to leave the system mounted until the backend kicks in again unmounting it anyway.