### PR TITLE
captive portal: case insensitive MAC parsing

### DIFF
--- a/src/opnsense/scripts/captiveportal/cp-background-process.py
+++ b/src/opnsense/scripts/captiveportal/cp-background-process.py
@@ -97,7 +97,7 @@ class CPBackgroundProcess(object):
         cpzones = self._conf_zone_info
         for zoneid in cpzones:
             for conf_section in ['allowedaddresses', 'allowedmacaddresses']:
-                for address in cpzones[zoneid][conf_section]:
+                for address in (a.lower() for a in cpzones[zoneid][conf_section]):
                     if conf_section.find('mac') == -1:
                         sessions = self.db.sessions_per_address(zoneid, ip_address=address)
                         ip_address = address
@@ -126,7 +126,7 @@ class CPBackgroundProcess(object):
                         PF.remove_from_table(zoneid, dbclient['ipAddress'])
                         self.db.del_client(zoneid, dbclient['sessionId'], 'NAS-Request')
                 elif dbclient['authenticated_via'] == '---mac---' \
-                        and dbclient['macAddress'] not in cpzones[zoneid]['allowedmacaddresses']:
+                        and dbclient['macAddress'] not in (a.lower() for a in cpzones[zoneid]['allowedmacaddresses']):
                         if dbclient['ipAddress'] != '':
                             PF.remove_from_table(zoneid, dbclient['ipAddress'])
                         self.db.del_client(zoneid, dbclient['sessionId'], 'NAS-Request')


### PR DESCRIPTION
Fixes https://github.com/opnsense/core/issues/9216

There shouldn't be any existing entries in the database, as capitalized MACs would never have worked.

Putting this under review as this may also be fixed on the model layer.

Related to https://github.com/opnsense/core/pull/9202