### PR TITLE
vpn/wireguard: Add debug flag to instances, can be set without restarting service, send logs to wireguard log

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -119,7 +119,7 @@
         <id>server.debug</id>
         <label>Debug Log</label>
         <type>checkbox</type>
-        <help>Enable the debug flag on this wireguard interface for enhanced error logging.</help>
+        <help>Enable the debug flag on this instance for enhanced error logging.</help>
         <grid_view>
             <visible>false</visible>
             <type>boolean</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -115,4 +115,15 @@
             <visible>false</visible>
         </grid_view>
     </field>
+    <field>
+        <id>server.debug</id>
+        <label>Debug Log</label>
+        <type>checkbox</type>
+        <help>Enable the debug flag on this wireguard interface for enhanced error logging.</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -66,6 +66,10 @@
                     <Multiple>Y</Multiple>
                     <ValidationMessage>Choose a peer.</ValidationMessage>
                 </peers>
+                <debug type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </debug>
                 <cnfFilename type="TextField" volatile="true"/>
                 <statFilename type="TextField" volatile="true"/>
                 <interface type="TextField" volatile="true"/>

--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/wireguard/server</mount>
     <description>WireGuard instance configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <servers>
             <server type=".\ServerField">

--- a/src/opnsense/scripts/wireguard/wg-service-control.php
+++ b/src/opnsense/scripts/wireguard/wg-service-control.php
@@ -59,14 +59,6 @@ function get_vhid_status()
 }
 
 /**
- * idempotent: sets either "debug" or "-debug" without affecting link state
- */
-function wg_apply_debug_flag(string $iface, string $enabled): void
-{
-    mwexecf('/sbin/ifconfig %s %sdebug', [$iface, $enabled === '1' ? '' : '-']);
-}
-
-/**
  * mimic wg-quick behaviour, but bound to our config
  */
 function wg_start($server, $fhandle, $ifcfgflag = 'up', $reload = false)
@@ -88,7 +80,7 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up', $reload = false)
         mwexecf('/sbin/ifconfig %s mtu %s', [$server->interface, $server->mtu]);
     }
 
-    wg_apply_debug_flag($server->interface->getValue(), $server->debug->getValue());
+    mwexecf('/sbin/ifconfig %s %sdebug', [$server->interface->getValue(), $server->debug->getValue() === '1' ? '' : '-']);
 
     if (empty((string)$server->disableroutes)) {
         /**
@@ -318,9 +310,6 @@ if (isset($opts['h']) || empty($args) || !in_array($args[0], ['start', 'stop', '
 
                             mwexecf('/sbin/ifconfig %s %s', [$node->interface, $carp_if_flag]);
                         }
-
-                        wg_apply_debug_flag($node->interface->getValue(), $node->debug->getValue());
-
                         break;
                 }
                 flock($statHandle, LOCK_UN);

--- a/src/opnsense/scripts/wireguard/wg-service-control.php
+++ b/src/opnsense/scripts/wireguard/wg-service-control.php
@@ -61,22 +61,9 @@ function get_vhid_status()
 /**
  * idempotent: sets either "debug" or "-debug" without affecting link state
  */
-function wg_apply_debug_flag(string $iface, string $enabled, string $name): void
+function wg_apply_debug_flag(string $iface, string $enabled): void
 {
-    $debugEnabled = ($enabled === '1');
-
-    mwexecf('/sbin/ifconfig %s %sdebug', [$iface, $debugEnabled ? '' : '-']);
-
-    if ($debugEnabled) {
-        syslog(
-            LOG_NOTICE,
-            sprintf(
-                "wireguard instance %s (%s): debug mode ENABLED",
-                $name,
-                $iface
-            )
-        );
-    }
+    mwexecf('/sbin/ifconfig %s %sdebug', [$iface, $enabled === '1' ? '' : '-']);
 }
 
 /**
@@ -101,7 +88,7 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up', $reload = false)
         mwexecf('/sbin/ifconfig %s mtu %s', [$server->interface, $server->mtu]);
     }
 
-    wg_apply_debug_flag($server->interface->getValue(), $server->debug->getValue(), $server->name->getValue());
+    wg_apply_debug_flag($server->interface->getValue(), $server->debug->getValue());
 
     if (empty((string)$server->disableroutes)) {
         /**
@@ -332,9 +319,7 @@ if (isset($opts['h']) || empty($args) || !in_array($args[0], ['start', 'stop', '
                             mwexecf('/sbin/ifconfig %s %s', [$node->interface, $carp_if_flag]);
                         }
 
-                        if (does_interface_exist($node->interface->getValue())) {
-                            wg_apply_debug_flag($node->interface->getValue(), $node->debug->getValue(), $node->name->getValue());
-                        }
+                        wg_apply_debug_flag($node->interface->getValue(), $node->debug->getValue());
 
                         break;
                 }

--- a/src/opnsense/scripts/wireguard/wg-service-control.php
+++ b/src/opnsense/scripts/wireguard/wg-service-control.php
@@ -58,6 +58,7 @@ function get_vhid_status()
     return $vhids;
 }
 
+
 /**
  * mimic wg-quick behaviour, but bound to our config
  */

--- a/src/opnsense/service/templates/OPNsense/Syslog/local/wireguard.conf
+++ b/src/opnsense/service/templates/OPNsense/Syslog/local/wireguard.conf
@@ -3,4 +3,5 @@
 ###################################################################
 filter f_local_wireguard {
     program("wireguard");
+    or (program("kernel") and message("wg[0-9]+:"));
 };

--- a/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -13,6 +13,7 @@
 # MTU = {{ server_list.mtu|default('') }}
 # disableroutes = {{server_list.disableroutes}}
 # gateway = {{server_list.gateway}}
+# debug = {{ server_list.debug }}
 
 [Interface]
 PrivateKey = {{ server_list.privkey }}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9234