### PR TITLE
firewall/automation: Improve responsiveness via minWidth() and @media for action row

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -29,6 +29,7 @@
             <!-- The sequence order of firewall rules is absolute, no other field shall be sorted -->
             <order>asc</order>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -41,6 +42,7 @@
             <sequence>15</sequence>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -65,6 +67,9 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -75,6 +80,7 @@
         <grid_view>
             <sequence>110</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -99,6 +105,7 @@
             <formatter>interfaces</formatter>
             <sequence>25</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -137,6 +144,9 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -157,6 +167,7 @@
         <grid_view>
             <sequence>35</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -167,6 +178,7 @@
             <formatter>any</formatter>
             <sequence>40</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -197,6 +209,7 @@
             <formatter>alias</formatter>
             <sequence>50</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -209,6 +222,7 @@
             <sequence>60</sequence>
             <sortable>false</sortable>
             <formatter>alias</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -229,6 +243,7 @@
             <formatter>alias</formatter>
             <sequence>70</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -241,6 +256,7 @@
             <sequence>80</sequence>
             <sortable>false</sortable>
             <formatter>alias</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -261,6 +277,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -272,6 +289,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -282,6 +300,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -298,6 +317,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -313,6 +333,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -324,6 +345,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -335,6 +357,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -346,6 +369,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -360,6 +384,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -371,6 +396,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -382,6 +408,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -393,6 +420,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -404,6 +432,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -415,6 +444,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -430,6 +460,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -443,6 +474,7 @@
             <formatter>boolean</formatter>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -459,6 +491,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -470,6 +503,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -487,6 +521,7 @@
             <formatter>any</formatter>
             <sequence>100</sequence>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -501,6 +536,7 @@
             <formatter>boolean</formatter>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -516,6 +552,7 @@
             <visible>false</visible>
             <sortable>false</sortable>
             <formatter>default</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -532,6 +569,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -548,6 +586,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -562,6 +601,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -572,6 +612,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -595,6 +636,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -606,6 +648,7 @@
         <grid_view>
             <visible>false</visible>
             <sortable>false</sortable>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <!-- Not exposed in dialog, do not exist in model, only for grid -->
@@ -618,6 +661,7 @@
             <sortable>false</sortable>
             <label>Stats - Evaluations</label>
             <sequence>115</sequence>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -629,6 +673,7 @@
             <sortable>false</sortable>
             <label>Stats - States</label>
             <sequence>116</sequence>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -640,6 +685,7 @@
             <sortable>false</sortable>
             <label>Stats - Packets</label>
             <sequence>117</sequence>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>
@@ -652,6 +698,7 @@
             <label>Stats - Bytes</label>
             <sequence>118</sequence>
             <formatter>bytes</formatter>
+            <min-width>120</min-width>
         </grid_view>
     </field>
     <field>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -921,7 +921,6 @@
             justify-content: flex-start;
             align-items: stretch;
             gap: 8px;
-            width: 1024px;
             max-width: 100%;
         }
 
@@ -965,7 +964,11 @@
             gap: 8px;
             flex: 1 1 100%;
         }
-        #dialogFilterRule-header #dialogFilterRule-actions-group .btn {
+
+        #dialogFilterRule-header #dialogFilterRule-actions-group .btn,
+        #dialogFilterRule-header #dialogFilterRule-actions-group .btn-group,
+        #dialogFilterRule-header #dialogFilterRule-actions-group .dropdown,
+        #dialogFilterRule-header #dialogFilterRule-actions-group .bootstrap-select {
             flex: 1;
         }
     }
@@ -976,11 +979,11 @@
     <!-- filters -->
     <div class="hidden">
         <div id="type_filter_container" class="btn-group">
-            <select id="category_filter" data-title="{{ lang._('Categories') }}" class="selectpicker" data-live-search="true" data-size="30" multiple data-width="300px" data-container="body">
+            <select id="category_filter" data-title="{{ lang._('Categories') }}" class="selectpicker" data-live-search="true" data-size="30" multiple data-width="200px" data-container="body">
             </select>
         </div>
         <div id="interface_select_container" class="btn-group">
-            <select id="interface_select" class="selectpicker" data-live-search="true" data-size="30" data-width="300px" data-container="body">
+            <select id="interface_select" class="selectpicker" data-live-search="true" data-size="30" data-width="200px" data-container="body">
             </select>
         </div>
         <div id="inspect_toggle_container" class="btn-group">

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -912,6 +912,64 @@
         opacity: 0.4;
     }
 
+    /* Small viewport layout for action bar */
+    @media (max-width: 1024px) {
+        /* Header lane fixed width */
+        #dialogFilterRule-header .actionBar {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            align-items: stretch;
+            gap: 8px;
+            width: 1024px;
+            max-width: 100%;
+        }
+
+        /* Default: Each child gets its own row (unless grouped) */
+        #dialogFilterRule-header .actionBar > * {
+            flex: 1 1 100%;
+            margin: 0;
+            float: none !important;
+            display: flex;
+        }
+
+        /* Make inner elements stretch fully */
+        #dialogFilterRule-header .actionBar .bootstrap-select,
+        #dialogFilterRule-header .actionBar .bootstrap-select > .dropdown-toggle,
+        #dialogFilterRule-header .actionBar .btn,
+        #dialogFilterRule-header .actionBar .search .input-group,
+        #dialogFilterRule-header .actionBar .search .form-control {
+            flex: 1;
+            width: 100% !important;
+            max-width: 100% !important;
+        }
+
+        /* Inspect + Tree + Expand share one row, equal widths */
+        #dialogFilterRule-header #inspect_toggle_container,
+        #dialogFilterRule-header #tree_toggle_container,
+        #dialogFilterRule-header #tree_expand_container {
+            flex: 1 1 0;
+            display: flex;
+        }
+
+        /* Search: Own row, stretches full width */
+        #dialogFilterRule-header .actionBar .search {
+            flex: 1 1 100%;
+        }
+
+        /* Action buttons: Equal widths on one row */
+        #dialogFilterRule-header #dialogFilterRule-actions-group {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            gap: 8px;
+            flex: 1 1 100%;
+        }
+        #dialogFilterRule-header #dialogFilterRule-actions-group .btn {
+            flex: 1;
+        }
+    }
+
 </style>
 
 <div class="tab-content content-box">

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -486,6 +486,8 @@ class UIBootgrid {
                     visible: data.visible ?? true,
                     sequence: data.sequence ?? null,
                     width: val.width,
+                    minWidth: data.minWidth ?? null,
+                    maxWidth: data.maxWidth ?? null,
                     editable: false,
                     sortable: data.sortable ?? true
                 }
@@ -563,8 +565,16 @@ class UIBootgrid {
                 // lock the width in place
                 col['minWidth'] = field.width;
                 col['maxWidth'] = field.width;
-            } else if (field.width) {
-                col['width'] = field.width;
+            } else {
+                if (field.width) {
+                    col['width'] = field.width;
+                }
+                if (field.minWidth) {
+                    col['minWidth'] = field.minWidth;
+                }
+                if (field.maxWidth) {
+                    col['maxWidth'] = field.maxWidth;
+                }
             }
 
             result.push(col);


### PR DESCRIPTION
Fixes: 

https://github.com/opnsense/core/issues/9238

Now it works nice on small screens too (e.g. tablets)

minWidth() makes sure no column collapses below a certain floor, making it scrollable vertically while maintaining the information level needed to make it usable.

<img width="482" height="824" alt="image" src="https://github.com/user-attachments/assets/3e3fa9ab-134f-44b3-a86e-49d9c2687ba6" />
