### PR TITLE
OpenVPN: Allow Nonce Validation to be disabled when using OCSP

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -299,6 +299,19 @@
         </grid_view>
     </field>
     <field>
+        <id>instance.ocsp_nonce</id>
+        <label>OCSP Nonce validation</label>
+        <style>role role_server</style>
+        <advanced>true</advanced>
+        <type>checkbox</type>
+        <help>When your OCSP Responder does not support Nonce Validation, a warning is returned and validation fails.</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
         <id>instance.cert_depth</id>
         <label>Certificate Depth</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
@@ -611,7 +611,7 @@ class Store
      * @param $serial serial number to check
      * @return array
      */
-    public static function ocsp_validate($ca_filename, $serial)
+    public static function ocsp_validate($ca_filename, $serial, $nonce = true)
     {
         if (!is_file($ca_filename)) {
             return [
@@ -633,8 +633,8 @@ class Store
             $verdict_pass = false;
             $result = exec(
                 exec_safe(
-                    "%s ocsp -resp_no_certs -timeout 10 -nonce -CAfile %s -issuer %s -url %s -serial %s 2>&1",
-                    ['/usr/bin/openssl', $ca_filename, $ca_filename, $ocsp_uri, $serial]
+                    "%s ocsp -resp_no_certs -timeout 10 %s -CAfile %s -issuer %s -url %s -serial %s 2>&1",
+                    ['/usr/bin/openssl', $nonce ? '-nonce' : '-no_nonce', $ca_filename, $ca_filename, $ocsp_uri, $serial]
                 ),
                 $output,
                 $retval

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -435,6 +435,7 @@ class OpenVPN extends BaseModel
                     'digest' => (string)$node->auth,
                     'description' => (string)$node->description,
                     'use_ocsp' => !$node->use_ocsp->isEmpty(),
+                    'ocsp_nonce' => !$node->ocsp_no_nonce->isEmpty(),
                     // legacy only (backwards compatibility)
                     'crypto' => (string)$node->{'data-ciphers-fallback'},
                 ];
@@ -479,6 +480,7 @@ class OpenVPN extends BaseModel
                         'digest' => (string)$item->digest,
                         'interface' => (string)$item->interface,
                         'use_ocsp' => false,
+                        'ocsp_nonce' => true,
                     ];
                 }
             }

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -207,6 +207,10 @@
                     <Default>0</Default>
                     <Required>Y</Required>
                 </use_ocsp>
+                <ocsp_nonce type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </ocsp_nonce>
                 <auth type="OptionField">
                     <BlankDesc>OpenVPN default</BlankDesc>
                     <OptionValues>

--- a/src/opnsense/scripts/openvpn/tls_verify.php
+++ b/src/opnsense/scripts/openvpn/tls_verify.php
@@ -46,7 +46,7 @@ function do_verify($serverid)
         return "Certificate depth {$certificate_depth} exceeded max allowed depth of {$allowed_depth}.";
     } elseif ($a_server['use_ocsp'] && $certificate_depth == 0) {
         $serial = getenv('tls_serial_' . $certificate_depth);
-        $ocsp_response = OPNsense\Trust\Store::ocsp_validate("/var/etc/openvpn/instance-" . $serverid . ".ca", $serial);
+        $ocsp_response = OPNsense\Trust\Store::ocsp_validate("/var/etc/openvpn/instance-" . $serverid . ".ca", $serial, $a_server['ocsp_nonce']);
         if (!$ocsp_response['pass']) {
             return sprintf(
                 "[serial : %s] @ %s - %s (%s)",


### PR DESCRIPTION
Hi,

Here is an implementation of Nonce validation disabling, initially proposed by the author of OCSP validation: https://github.com/opnsense/core/pull/7082#issue-2045378161

> Additionally there might be some more settings that should be at least considered if they should be configurable:
nonce usage (https://www.openssl.org/docs/man3.0/man3/OCSP_check_nonce.html)

Validation is done this way, by checking if the first line is an OK response (`$output` corresponds to the lines)
https://github.com/opnsense/core/blob/5eddbce452d36dad8883a785f1f2fa7f42820c6c/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php#L646

In cases where the OCSP Responder does not support Nonce, a response of this type is returned
```
# openssl ocsp -resp_no_certs -timeout 10 -nonce -CAfile $OCSP_CA -issuer $OCSP_CA -url $OCSP_URL -serial 463050772713033790379517141507295683732909432205
WARNING: no nonce in response
Response verify OK
463050772713033790379517141507295683732909432205: good
	This Update: Sep 25 14:33:37 2025 GMT
	Next Update: Sep 26 02:33:37 2025 GMT
```

By changing the `-nonce` parameter to `-no_nonce`, we get a request that can be parsed correctly
```
# openssl ocsp -resp_no_certs -timeout 10 -no_nonce -CAfile $OCSP_CA -issuer $OCSP_CA -url $OCSP_URL -serial 463050772713033790379517141507295683732909432205
Response verify OK
463050772713033790379517141507295683732909432205: good
	This Update: Sep 25 14:33:42 2025 GMT
	Next Update: Sep 26 02:33:42 2025 GMT
```

I use the OCSP Responder integrated into Vault community (Hashicorp).