### PR TITLE
interfaces/overview: Fix flags in interface details, do not show hex code but parsed flags

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php
@@ -273,6 +273,9 @@ class OverviewController extends ApiControllerBase
                     $stats = $ifinfo['statistics'];
                     unset($ifinfo['statistics']);
 
+                    // keep parsed flags from $ifinfo
+                    unset($stats['flags']);
+
                     $ifinfo = array_merge($ifinfo, $stats);
                 }
 


### PR DESCRIPTION
Before patch:

<img width="643" height="357" alt="image" src="https://github.com/user-attachments/assets/3a06c23b-6d8d-4ba0-a537-95e6b52c8067" />

After patch:

<img width="631" height="429" alt="image" src="https://github.com/user-attachments/assets/732439ff-28c5-40c0-8238-68aa2fba2ed6" />
