### PR TITLE
diagnostics/packetcapture: Fix permission of capture zip file for wwwonly strict security mode

### DIFF
--- a/src/opnsense/scripts/interfaces/capture.py
+++ b/src/opnsense/scripts/interfaces/capture.py
@@ -234,5 +234,6 @@ if __name__ == '__main__':
 
         # always set file ownership for strict security mode
         os.chown(result['filename'], pwd.getpwnam("wwwonly").pw_uid, grp.getgrnam("wheel").gr_gid)
+        os.chmod(result['filename'], 0o640)
 
     print (ujson.dumps(result))


### PR DESCRIPTION
Otherwise the packet capture is zipped as root and download fails since its not owned by wwwonly. (When strict security mode is enabled)