### PR TITLE
OpenVPN: add support for pushing excluded routes via net_gateway

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -518,6 +518,17 @@ Set to 0 to disable, remember to change your client as well.
         </grid_view>
     </field>
     <field>
+        <id>instance.push_excluded_routes</id>
+        <label>Excluded routes</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Specify routes to be excluded from the VPN tunnel. Traffic to these destinations will use the client’s existing default IP gateway (net_gateway) instead. Concretely, new routes will be added on the client system so that these destinations are sent via the user’s usual default gateway. Note: this feature is not supported on all client systems.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <type>header</type>
         <label>Miscellaneous</label>
     </field>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -765,7 +765,7 @@ class OpenVPN extends BaseModel
                 }
 
                 // routes (ipv4, ipv6 local or push)
-                foreach (['route', 'push_route'] as $type) {
+                foreach (['route', 'push_route', 'push_excluded_routes'] as $type) {
                     foreach (explode(',', (string)$node->$type) as $item) {
                         if (empty($item)) {
                             continue;
@@ -778,6 +778,8 @@ class OpenVPN extends BaseModel
                         }
                         if ($type == 'push_route') {
                             $options['push'][] = "\"{$target_fieldname} $item\"";
+                        } elseif ($type == 'push_excluded_routes') {
+                            $options['push'][] = "\"{$target_fieldname} $item net_gateway\"";
                         } else {
                             $options[$target_fieldname][] = $item;
                         }

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -173,6 +173,10 @@
                     <AsList>Y</AsList>
                     <WildcardEnabled>N</WildcardEnabled>
                 </push_route>
+                <push_excluded_routes type="NetworkField">
+                    <AsList>Y</AsList>
+                    <WildcardEnabled>N</WildcardEnabled>
+                </push_excluded_routes>
                 <cert type="CertificateField"/>
                 <crl type="CertificateField">
                     <type>crl</type>


### PR DESCRIPTION
This patch introduces a new `push_excluded_routes` option in the OpenVPN instance dialog. It allows administrators to define routes that should be excluded from the VPN tunnel and instead use the client’s existing default gateway (`net_gateway`).

Changes include:
- Added `instance.push_excluded_routes` field to dialogInstance.xml.
- Extended OpenVPN model to process `push_excluded_routes` and append `net_gateway` to the pushed route options.
- Defined `push_excluded_routes` as a NetworkField in OpenVPN.xml.

This provides a convenient way to push split-exclusion routes, ensuring specific traffic is routed via the client’s pre-existing default gateway.

Fixes: #8537