### PR TITLE
dnsmasq: Improve Firewall alias (ipset) validations

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Dnsmasq/Dnsmasq.xml
@@ -130,11 +130,10 @@
                 <Required>Y</Required>
                 <ValidationMessage>Please enter a value between 1 and 99999.</ValidationMessage>
             </sequence>
-            <domain type="HostnameField">
-                <HostWildcardAllowed>Y</HostWildcardAllowed>
-                <IsDNSName>Y</IsDNSName>
-                <IpAllowed>N</IpAllowed>
+            <domain type=".\HostnameField">
                 <Required>Y</Required>
+                <IsDomain>Y</IsDomain>
+                <IsWildcardAllowed>Y</IsWildcardAllowed>
             </domain>
             <ipset type="ModelRelationField">
                 <Model>
@@ -144,7 +143,7 @@
                         <display>name</display>
                         <filters>
                             <type>/^[Ee]xternal.*/</type>
-                            <name>/^(?!bogons$|bogonsv6$|virusprot$|sshlockout$|__captiveportal.*).*/</name>
+                            <name>/^(?!bogons$|bogonsv6$|virusprot$|sshlockout$|__.*).*/</name>
                         </filters>
                     </aliases>
                 </Model>

--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -125,12 +125,16 @@ bogus-priv
 
 {# Domain Overrides can be sorted by sequence to support strict order #}
 {% for override in helpers.toList('dnsmasq.domainoverrides', sortBy='sequence', sortAs='int') %}
+{#    Empty IP means to block forwarding for that domain, but forwarding is a requirement for ipset #}
+{#    That is why generating the server is skipped for entries with ipset set but empty IP. #}
+{%    if override.ip or not override.ipset %}
 server=/{{override.domain}}/{{override.ip}}{%if override.port %}#{{override.port}}{% endif %}{%if override.srcip %}@{{override.srcip}}{% endif +%}
+{%        if not helpers.exists('system.webgui.nodnsrebindcheck') %}
+rebind-domain-ok=/{{ override.domain }}/
+{%        endif %}
+{%    endif %}
 {%    if override.ipset %}
 ipset=/{{override.domain}}/{{helpers.getUUID(override.ipset).name}}
-{%    endif %}
-{%    if not helpers.exists('system.webgui.nodnsrebindcheck') %}
-rebind-domain-ok=/{{override.domain}}/
 {%    endif %}
 {% endfor %}
 


### PR DESCRIPTION
Closes: https://github.com/opnsense/core/issues/9263

- domain in domainoverrides is changed to the strict HostnameField introduced in 2d2781c to disallow the use of "#" which would add all resolved domains to an ipset alias. The overall strictness of the field now matches hosts.

Fixes: https://github.com/opnsense/core/issues/9262

- dnsmasq.conf template does not render server and rebind-domain-ok for entries anymore which are just a domain and the Firewall alias (ipset). Before this change, it would generate a server with an empty IP, which means blocking forwarding. Firewall alias (ipset) needs forwarding to function, otherwise it fails for the chosen domain.

Unrelated to the above tickets, but fixed regardless:

- ipset ModelRelationField got a name filter adjustment, to exclude all system defined external aliases that start with __