### PR TITLE
Fix infinite CARP VIP duplication in HA sync with nosync flag

### DIFF
--- a/src/etc/inc/xmlrpc/legacy.inc
+++ b/src/etc/inc/xmlrpc/legacy.inc
@@ -87,7 +87,8 @@ function merge_config_attributes(&$cnf_source, &$cnf_dest, $path = '')
 {
     foreach ($cnf_source as $cnf_key => &$cnf_value) {
         if (is_array($cnf_value)) {
-            $path = empty($path) ? $cnf_key : sprintf('%s.%s', $path, $cnf_key);
+            // do not mutate $path for siblings
+            $currentPath = empty($path) ? $cnf_key : sprintf('%s.%s', $path, $cnf_key);
             $no_sync_items = [];
             if (
                 !isset($cnf_dest[$cnf_key]) || !is_array($cnf_dest[$cnf_key]) || // new
@@ -95,7 +96,7 @@ function merge_config_attributes(&$cnf_source, &$cnf_dest, $path = '')
                 (count($cnf_dest[$cnf_key]) > 0 && isset($cnf_dest[$cnf_key]['@attributes']['uuid'])) // mvc array
             ) {
                 /* gather items with nosync set, exclude records with implicit order (legacy) */
-                $exclude_nosync = in_array($path, ['filter.rule', 'nat.rule', 'nat.outbound.rule']);
+                $exclude_nosync = in_array($currentPath, ['filter.rule', 'nat.rule', 'nat.outbound.rule']);
                 if (!$exclude_nosync && isset($cnf_dest[$cnf_key]) && is_array($cnf_dest[$cnf_key])) {
                     foreach ($cnf_dest[$cnf_key] as $record) {
                         if (!empty($record['nosync'])) {
@@ -106,7 +107,7 @@ function merge_config_attributes(&$cnf_source, &$cnf_dest, $path = '')
                 // (re)set destination array when new or containing a sequenced list of items
                 $cnf_dest[$cnf_key] = [];
             }
-            merge_config_attributes($cnf_value, $cnf_dest[$cnf_key], $path);
+            merge_config_attributes($cnf_value, $cnf_dest[$cnf_key], $currentPath);
             if (!empty($no_sync_items)) {
                 /* append nosync items, local ones on-top */
                 $cnf_dest[$cnf_key] = array_merge($no_sync_items, $cnf_dest[$cnf_key]);
@@ -165,37 +166,77 @@ function restore_config_section_xmlrpc($new_config)
     // save old config
     $old_config = $config;
 
-    $vhidVipsInNewConfig = [];
+    // Filter incoming VIPs: remove nosync and invalid entries in one pass
     if (isset($new_config['virtualip']['vip'])) {
-        foreach ($new_config['virtualip']['vip'] as $vip) {
-            $vhidVipsInNewConfig[get_unique_vip_key($vip)] = $vip;
-        }
+        $new_config['virtualip']['vip'] = filter_valid_vips(
+            $new_config['virtualip']['vip'],
+            $strict = true,
+            $filter_nosync = true
+        );
+        
+        // Build map for quick lookups
+        $vhidVipsInNewConfig = build_vip_map($new_config['virtualip']['vip']);
+    } else {
+        $vhidVipsInNewConfig = [];
     }
 
     $vipbackup = [];
     $oldvips = [];
+    
     if (isset($new_config['virtualip']['vip']) && isset($config['virtualip']['vip'])) {
+        // Use non-strict validation for local VIPs to preserve legacy configs
+        // Only check that mode and interface exist, not mode-specific fields
+        $config['virtualip']['vip'] = filter_valid_vips($config['virtualip']['vip'], $strict = false);
+        
         foreach ($config['virtualip']['vip'] as $vipindex => $vip) {
             $vipKey = get_unique_vip_key($vip);
+            
             if (!empty($vip['vhid']) && empty($vip['nosync'])) {
-                // rc.filter_synchronize only sends CARP VIPs and IP Aliases with a VHID. Keep the rest like it was.
+                // rc.filter_synchronize only sends CARP VIPs and IP Aliases with a VHID
                 $oldvips[$vipKey] = $vip;
-                // Remove entries that are present locally, but are not present in the new config.
+                // Remove entries that are present locally, but not in new config
                 if (!array_key_exists($vipKey, $vhidVipsInNewConfig)) {
                     unset($config['virtualip']['vip'][$vipindex]);
                 }
             } elseif (!isset($vhidVipsInNewConfig[$vipKey])) {
+                // Keep local-only VIPs (including local nosync)
                 $vipbackup[$vipKey] = $vip;
             }
         }
     }
 
-    // merge config attributes.
+    // merge config attributes
     merge_config_attributes($new_config, $config);
 
-    if (count($vipbackup) > 0) {
-        // if $new_config contained VIPs and the old config contained VIPs with no VHID, prepend original VIPs
-        array_unshift($config['virtualip']['vip'], array_values($vipbackup));
+    if (!empty($vipbackup)) {
+        // Prepend original local VIPs (flatten correctly)
+        $config['virtualip']['vip'] = array_merge(
+            array_values($vipbackup), 
+            $config['virtualip']['vip'] ?? []
+        );
+    }
+
+    // Deduplicate VIPs by uuid or unique key
+    if (isset($config['virtualip']['vip']) && is_array($config['virtualip']['vip'])) {
+        $vip_map = [];
+        $duplicate_count = 0;
+        
+        foreach ($config['virtualip']['vip'] as $vip) {
+            $k = !empty($vip['uuid']) ? 'uuid:' . $vip['uuid'] : 'key:' . get_unique_vip_key($vip);
+            
+            if (!isset($vip_map[$k])) {
+                $vip_map[$k] = $vip;
+            } else {
+                $duplicate_count++;
+                syslog(LOG_INFO, "restore_config_section_xmlrpc: Duplicate VIP {$k} - keeping first (local), dropping duplicate");
+            }
+        }
+        
+        if ($duplicate_count > 0) {
+            syslog(LOG_NOTICE, "restore_config_section_xmlrpc: Removed {$duplicate_count} duplicate VIP(s) during HA sync");
+        }
+        
+        $config['virtualip']['vip'] = array_values($vip_map);
     }
 
     /* Log what happened */
@@ -211,19 +252,26 @@ function restore_config_section_xmlrpc($new_config)
 
         if (isset($config['virtualip']['vip'])) {
             foreach ($config['virtualip']['vip'] as $vip) {
+                // VIPs are already validated, safe to use directly
                 $vipKey = get_unique_vip_key($vip);
+                
                 if (!empty($vip['vhid']) && isset($oldvips[$vipKey])) {
                     $is_changed = false;
-                    foreach (['password', 'advskew', 'subnet', 'subnet_bits', 'advbase'] as $chk_key) {
-                        if ($oldvips[$vipKey][$chk_key] != $vip[$chk_key]) {
+                    // Check all critical fields for changes
+                    $check_fields = ['password', 'advskew', 'subnet', 'subnet_bits', 'advbase', 'vhid'];
+                    foreach ($check_fields as $chk_key) {
+                        $old_val = $oldvips[$vipKey][$chk_key] ?? null;
+                        $new_val = $vip[$chk_key] ?? null;
+                        if ($old_val != $new_val) {
                             $is_changed = true;
+                            syslog(LOG_INFO, "restore_config_section_xmlrpc: VIP {$vipKey} field '{$chk_key}' changed from '{$old_val}' to '{$new_val}'");
                             break;
                         }
                     }
                     if (!$is_changed) {
                         unset($oldvips[$vipKey]);
                         if (does_vip_exist($vip)) {
-                            continue; // Skip reconfiguring this VIP since nothing has changed.
+                            continue; // Skip reconfiguring this VIP since nothing has changed
                         }
                     }
                 }
@@ -266,11 +314,109 @@ function restore_config_section_xmlrpc($new_config)
     return true;
 }
 
+/**
+ * Validate that a VIP has the minimum required fields
+ * @param array $vip VIP configuration array
+ * @param bool $strict If true, performs mode-specific validation
+ * @return bool true if valid, false otherwise
+ */
+function validate_vip_structure($vip, $strict = true)
+{
+    if (!is_array($vip)) {
+        return false;
+    }
+    
+    // Required fields for all VIPs
+    if (!isset($vip['mode']) || $vip['mode'] === '' || 
+        !isset($vip['interface']) || $vip['interface'] === '') {
+        return false;
+    }
+    
+    // Mode-specific validation (optional)
+    if ($strict) {
+        switch ($vip['mode']) {
+            case 'carp':
+                if (!isset($vip['vhid']) || !isset($vip['password'])) {
+                    return false;
+                }
+                // Fall through to check subnet
+            case 'ipalias':
+            case 'proxyarp':
+                if (!isset($vip['subnet']) || !isset($vip['subnet_bits'])) {
+                    return false;
+                }
+                break;
+        }
+    }
+    
+    return true;
+}
+
 function get_unique_vip_key($vip)
 {
-    if ($vip['mode'] === 'carp') {
-        return "{$vip['mode']}_{$vip['interface']}_vip{$vip['vhid']}";
+    $mode = $vip['mode'] ?? 'unknown';
+    $interface = $vip['interface'] ?? 'unknown';
+    $vhid = $vip['vhid'] ?? '';
+    
+    if ($mode === 'carp') {
+        $key = "{$mode}_{$interface}_vip{$vhid}";
     } else {
-        return "{$vip['mode']}_{$vip['interface']}_vip{$vip['vhid']}_{$vip['subnet']}_{$vip['subnet_bits']}";
+        $subnet = $vip['subnet'] ?? '';
+        $subnet_bits = $vip['subnet_bits'] ?? '';
+        $key = "{$mode}_{$interface}_vip{$vhid}_{$subnet}_{$subnet_bits}";
     }
+    
+    // If key is too generic (missing critical fields), add UUID or hash for uniqueness
+    if ($key === "{$mode}_{$interface}_vip__" || $key === "{$mode}_{$interface}_vip") {
+        if (!empty($vip['uuid'])) {
+            $key .= '_' . $vip['uuid'];
+        } else {
+            // Fallback: hash the entire VIP for uniqueness
+            $key .= '_' . substr(md5(json_encode($vip)), 0, 8);
+        }
+    }
+    
+    return $key;
+}
+
+/**
+ * Filter and validate VIP array, removing invalid entries
+ * @param array $vips Array of VIP configurations
+ * @param bool $strict Perform strict validation
+ * @param bool $filter_nosync Remove nosync VIPs
+ * @return array Validated and filtered VIPs
+ */
+function filter_valid_vips($vips, $strict = true, $filter_nosync = false)
+{
+    if (!is_array($vips)) {
+        return [];
+    }
+    
+    return array_values(array_filter($vips, function ($vip) use ($strict, $filter_nosync) {
+        if (!validate_vip_structure($vip, $strict)) {
+            syslog(LOG_WARNING, 'filter_valid_vips: Filtering out invalid VIP: ' . json_encode($vip));
+            return false;
+        }
+        
+        if ($filter_nosync && !empty($vip['nosync'])) {
+            return false;
+        }
+        
+        return true;
+    }));
+}
+
+/**
+ * Build a map of VIPs indexed by their unique key
+ * @param array $vips Array of VIP configurations
+ * @return array Associative array with unique keys
+ */
+function build_vip_map($vips)
+{
+    $map = [];
+    foreach ($vips as $vip) {
+        // Assumes VIPs are already validated
+        $map[get_unique_vip_key($vip)] = $vip;
+    }
+    return $map;
 }


### PR DESCRIPTION
Fixes [#8911](https://github.com/opnsense/core/issues/8911) 

Resolves critical bug where CARP VIPs with nosync set on both nodes would duplicate exponentially (1→2→4→8...) with each HA sync cycle.

Root cause: Config merge preserved nosync VIPs, then backup prepended them again, with no deduplication. Each sync doubled the VIP count.

Solution:
- Add VIP deduplication after merge (by UUID or unique key)
- Keep first occurrence (local VIPs take priority)
- Centralize validation with strict/non-strict modes
- Add helper functions for filtering, validation, and mapping
- Fix path mutation bug in merge_config_attributes()

Also improves backward compatibility and adds comprehensive logging.