### PR TITLE
firewall/automation: Consolidate the stats column into a combined always visible one, implement cache invalidation via refresh button

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -458,4 +458,17 @@ class FilterController extends FilterBaseController
 
         return $result;
     }
+
+    public function flushInspectCacheAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['status' => 'error', 'message' => gettext('Invalid request method')];
+        }
+
+        // The "!" prelude flushes any cached script_output before execution
+        (new Backend())->configdRun('!filter rule stats');
+
+        return ['status' => 'ok'];
+    }
+
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -610,48 +610,13 @@
     </field>
     <!-- Not exposed in dialog, do not exist in model, only for grid -->
     <field>
-        <id>rule.evaluations</id>
-        <label>Evaluations</label>
+        <id>rule.statistics</id>
+        <label>Statistics</label>
         <type>ignore</type>
         <grid_view>
-            <visible>false</visible>
             <sortable>false</sortable>
-            <label>Stats - Evaluations</label>
+            <formatter>statistics</formatter>
             <sequence>115</sequence>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.states</id>
-        <label>States</label>
-        <type>ignore</type>
-        <grid_view>
-            <visible>false</visible>
-            <sortable>false</sortable>
-            <label>Stats - States</label>
-            <sequence>116</sequence>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.packets</id>
-        <label>Packets</label>
-        <type>ignore</type>
-        <grid_view>
-            <visible>false</visible>
-            <sortable>false</sortable>
-            <label>Stats - Packets</label>
-            <sequence>117</sequence>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.bytes</id>
-        <label>Bytes</label>
-        <type>ignore</type>
-        <grid_view>
-            <visible>false</visible>
-            <sortable>false</sortable>
-            <label>Stats - Bytes</label>
-            <sequence>118</sequence>
-            <formatter>bytes</formatter>
         </grid_view>
     </field>
     <field>

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -98,7 +98,7 @@ message:request pf rules
 [diag.top]
 command:/usr/local/opnsense/scripts/filter/pftop.py
 type:script_output
-cache_ttl:30
+cache_ttl:600
 message:request pftop statistics
 
 [diag.info]

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -46,6 +46,32 @@
  }
 
 /**
+ * format large numbers into short notation (e.g. 1.2K, 3.4M, 2.1B)
+ * @param value numeric value to format
+ * @param decimals decimal places (optional)
+ * @return string
+ */
+function numberFormat(value, decimals)
+{
+    if (decimals === undefined) {
+        decimals = 1;
+    }
+    const num = parseFloat(value);
+    if (isNaN(num) || num === 0) {
+        return "";
+    }
+
+    const k = 1000;
+    const units = ["", "K", "M", "B", "T"];
+    const i = Math.floor(Math.log(Math.abs(num)) / Math.log(k));
+
+    const scaled = num / Math.pow(k, i);
+    const formatted = scaled.toFixed(decimals).replace(/\.0$/, "");
+
+    return formatted + units[i];
+}
+
+/**
  * save form to server
  * @param url endpoint url
  * @param formid parent id to grep input data from


### PR DESCRIPTION
Proposal to fix the issue with showing and hiding columns in the most minimal way.

- Stat column always shows
- It shows icons for each type of stat, but only if that stat has data
- A refresh button in the same column can invalidate the cache via https://github.com/opnsense/core/commit/27bd8125

Reference to alternative: https://github.com/opnsense/core/pull/9239