### PR TITLE
firewall/automation: Hide and unhide statistics without triggering tabulator persistence event

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -61,7 +61,7 @@
         $('#toggle_inspect_button').toggleClass('active btn-primary', inspectEnabled);
 
         function updateStatisticColumns() {
-            grid.bootgrid(inspectEnabled ? "setColumns" : "unsetColumns", ['statistics'], true);
+            grid.bootgrid(inspectEnabled ? "setColumns" : "unsetColumns", ['statistics']);
         }
 
         // read interface from URL hash once, for the first grid load

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -2040,22 +2040,22 @@ class UIBootgrid {
         this._destroyTable();
     }
 
-    setColumns(columns, silent = false) {
+    setColumns(columns) {
         this.table.getColumns().forEach((col) => {
             const def = col.getDefinition();
             if (columns.includes(def.field)) {
-                col._silentToggle = silent;
+                col._silentToggle = true;
                 col.show();
                 delete col._silentToggle;
             }
         });
     }
 
-    unsetColumns(columns, silent = false) {
+    unsetColumns(columns) {
         this.table.getColumns().forEach((col) => {
             const def = col.getDefinition();
             if (columns.includes(def.field)) {
-                col._silentToggle = silent;
+                col._silentToggle = true;
                 col.hide();
                 delete col._silentToggle;
             }


### PR DESCRIPTION
Add transient `_silentToggle` marker to Tabulator columns so `columnVisibilityChanged` events triggered by scripted show/hide operations (e.g. inspect toggle) do not set the persistence flag.