### PR TITLE
Firewall: Aliases - Replace invalid unicode chars.

### DIFF
--- a/src/opnsense/scripts/filter/lib/alias/uri.py
+++ b/src/opnsense/scripts/filter/lib/alias/uri.py
@@ -80,7 +80,7 @@ class UriParser(BaseContentParser):
                 req.raw.decode_content = True
                 stime = time.time()
                 if self._type == 'urljson':
-                    data = req.raw.read().decode()
+                    data = req.raw.read().decode(errors='replace')
                     syslog.syslog(syslog.LOG_NOTICE, 'fetch alias url %s (bytes: %s)' % (url, len(data)))
                     # also support existing a.b format by prefixing [.], only raise exceptions on original input
                     jqc = None
@@ -101,7 +101,7 @@ class UriParser(BaseContentParser):
                             for address in super().iter_addresses(raw_address):
                                 yield address
                 else:
-                    lines = req.raw.read().decode().splitlines()
+                    lines = req.raw.read().decode(errors='replace').splitlines()
                     syslog.syslog(syslog.LOG_NOTICE, 'fetch alias url %s (lines: %s)' % (url, len(lines)))
                     for line in lines:
                         for raw_address in self._parse_line(line):


### PR DESCRIPTION
When fetching URL Tables, replace invalid unicode characters with unicode replacement characters instead of failing.