### PR TITLE
firewall/automation: Fix alias ip address search

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -215,7 +215,10 @@ class FilterController extends FilterBaseController
         $ORG_REQ = $_REQUEST;
         unset($_REQUEST['rowCount']);
         unset($_REQUEST['current']);
-        unset($_REQUEST['searchPhrase']);
+        if ($show_all) {
+            /* searchBase should not filter here since we later search for IP addresses in aliases */
+            unset($_REQUEST['searchPhrase']);
+        }
         $filterset = $this->searchBase("rules.rule", null, "sort_order", $filter_funct_mvc)['rows'];
 
         /* only fetch internal and legacy rules when 'show_all' is set */


### PR DESCRIPTION
I only unset the searchPhrase when show_all is enabled. This means when Inspect is disabled, there will be no performance penalty in searchBase.