### PR TITLE
Update interfaces.php

### DIFF
--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -844,7 +844,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         if (!empty($pconfig['spoofmac']) && !is_macaddr($pconfig['spoofmac'])) {
             $input_errors[] = gettext("A valid MAC address must be specified.");
         }
-
+        
+        if (empty($pconfig['mtu'])){
+            $pconfig['mtu'] = 1500;
+        }
+        
         if (!empty($pconfig['mtu'])) {
             $mtu_low = 576;
             $mtu_high = 65535;


### PR DESCRIPTION
We found that if we change the MTU of an interface (ex 2000), it works, but if, after that, we remove the MTU and leave the field empty, it does nothing and it left the old value (in our case, 2000). To change that, I had a control to check if MTU is empty, and in that case, we set the value to 1500, the default value