### PR TITLE
Update 20-ppp to also stop PPPoE connections for CARP temporarily disabled

### DIFF
--- a/src/etc/rc.syshook.d/carp/20-ppp
+++ b/src/etc/rc.syshook.d/carp/20-ppp
@@ -36,7 +36,7 @@ $type = !empty($argv[2]) ? $argv[2] : '';
 
 $a_hasync = &config_read_array('hasync');
 if (!empty($a_hasync['disconnectppps'])) {
-    if ($type != 'MASTER' && $type != 'BACKUP') {
+    if ($type != 'MASTER' && $type != 'BACKUP' && $type != 'INIT') {
        log_msg("Carp '$type' event unknown from source '{$subsystem}'");
        exit(1);
     } elseif (!strstr($subsystem, '@')) {
@@ -51,7 +51,7 @@ if (!empty($a_hasync['disconnectppps'])) {
             foreach($config['interfaces'] as $ifkey => $interface) {
                 if ($ppp['if'] == $interface['if']) {
                     log_msg("{$iface} is connected to ppp interface {$ifkey} set new status {$type}");
-                    if ($type == 'BACKUP') {
+                    if ($type == 'BACKUP' || $type == 'INIT') {
                         interface_suspend($ifkey);
                     } else {
                         interface_ppps_configure($ifkey);


### PR DESCRIPTION
20-ppp only stops the PPPoE connection when the associated CARP interfaces goes into “BACKUP” mode, but not when manually setting Temporarily Disable CARP under Interfaces -> Virtual IPS -> Status. This is bad for debugging/testing as well as intentionally taking a firewall into standby, e.g. in preparation of applying in update. This change takes PPPoE down in 'INIT' mode as well (which is the case when temporarily disabling CARP).

The first version this has been tried with was 24.1.5_3, but I still use it with the current 25.7.6. No breaking changes with an influence on this patch seem to have happened during that time.

More context is described at https://www.mayrhofer.eu.org/post/opnsense-pppoe-ha/.