### PR TITLE
Firewall: Fix delete_selected firewall states

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_states.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_states.volt
@@ -34,6 +34,7 @@
         let grid_states = $("#grid-states").UIBootgrid(
                 {   search:'/api/diagnostics/firewall/query_states',
                     del:'/api/diagnostics/firewall/del_state/',
+                    datakey: 'id',
                     options:{
                         virtualDOM: true,
                         formatters:{


### PR DESCRIPTION
Without the datakey option the delete_selected command will try to use the non-existing property "uuid" of the selected rows.