### PR TITLE
Allow inline # comments in all alias types (network/host/port)

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -151,7 +151,6 @@ function filter_core_get_port_alias($aliasname, $aliases = [], $aliasObject = nu
     $aliasObject = $aliasObject == null ? (new \OPNsense\Firewall\Alias(true)) : $aliasObject;
     foreach ($aliasObject->aliasIterator() as $aliased) {
         if ($aliasname == $aliased['name'] && $aliased['type'] == 'port' && !empty($aliased['enabled'])) {
-
             foreach ($aliased['content'] as $address) {
             /* Original
                 if (in_array($address, $all_aliases)) {
@@ -166,11 +165,11 @@ function filter_core_get_port_alias($aliasname, $aliases = [], $aliasObject = nu
                     $response[] = $address;
                 }
                 */
-                // Remove all after first #
-                if (strpos($address, '#') !== false) {
-                    $address = preg_replace('/\s*#.*$/', '', $address);
-                }
+                // Split on comma and Remove all after first #
                 foreach (explode(',', $address) as $value) {
+                    if (strpos($value, '#') !== false) {
+                        $value = preg_replace('/\s*#.*$/', '', $value);
+                    }
                     $value = trim($value);
                     if ($value === '') {
                         continue;
@@ -187,7 +186,7 @@ function filter_core_get_port_alias($aliasname, $aliases = [], $aliasObject = nu
                         $response[] = $value;
                     }
                 }
-               // Remove all after first #
+               // Split on comma and Remove all after first #
             }
         }
     }

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -286,8 +286,8 @@ class Util
         foreach (self::$aliasObject->aliasIterator() as $node) {
             if (!empty($name) && (string)$node['name'] == $name && $node['type'] == 'port') {
                 $aliases[] = $name;
-                /* Original
                 foreach ($node['content'] as $address) {
+                /* Original
                     if (Util::isAlias($address)) {
                         if (!in_array($address, $aliases)) {
                             foreach (Util::getPortAlias($address, $aliases) as $port) {
@@ -301,12 +301,11 @@ class Util
                     }
                 }
                 */
-                foreach ($node['content'] as $address) {
-                    // Remove all after first #
-                    if (strpos($address, '#') !== false) {
-                        $address = preg_replace('/\s*#.*$/', '', $address);
-                    }
+                    // Split on comma and Remove all after first #
                     foreach (explode(',', $address) as $value) {
+                        if (strpos($value, '#') !== false) {
+                            $value = preg_replace('/\s*#.*$/', '', $value);
+                        }
                         $value = trim($value);
                         if ($value === '') {
                             continue;
@@ -323,8 +322,8 @@ class Util
                             $result[] = $value;
                         }
                     }
+                    // /Split on comma and Remove all after first #
                 }
-                // /Remove all after first #
             }
         }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasContentField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasContentField.php
@@ -95,11 +95,10 @@ class AliasContentField extends BaseField
     private function getItems($data)
     {
         foreach (explode($this->separatorchar, $data) as $row) {
-            // Remove all after first #
-            if (strpos($row, '#') !== false) {
-                $row = preg_replace('/\s*#.*$/', '', $row);
-            }
             foreach (explode(',', $row) as $value) {
+                if (strpos($value, '#') !== false) {
+                    $value = preg_replace('/\s*#.*$/', '', $value);
+                }
                 $value = trim($value);
                 if ($value !== '') {
                     yield $value;

--- a/src/opnsense/scripts/filter/lib/alias/__init__.py
+++ b/src/opnsense/scripts/filter/lib/alias/__init__.py
@@ -193,16 +193,14 @@ class Alias(object):
                     address_parser = self.get_parser()
                     if address_parser:
                         for item in self.items():
-                            # Remove all after first #
-                            if '#' in item:
-                                item = item.split('#', 1)[0]
+                            # Split on comma and Remove all after first #
                             for value in item.split(','):
+                                if '#' in value:
+                                    value = value.split('#', 1)[0]
                                 value = value.strip()
                                 if not value:
                                     continue
-                                for address in address_parser.iter_addresses(value):
-                                    self._resolve_content.add(address)
-                            # /Remove all after first #
+                            # /Split on comma and Remove all after first #
                             for address in address_parser.iter_addresses(item):
                                 self._resolve_content.add(address)
                         # resolve hostnames (async) if there are any in the collected set


### PR DESCRIPTION
Summary:
This PR makes it possible to use inline comments (with '#') on every alias type (host/network/port) both in the WebUI and during runtime rule generation.

Modified:
- src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/AliasContentField.php : WebUI validation
- src/opnsense/scripts/filter/lib/alias/__init__.py : backend Python, ensures addresses/networks ignore comments
- src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php : PHP alias expansion
- src/etc/inc/filter.lib.inc : legacy/compat port alias expansion, strips comments from port lines

All patches use preg_replace('/\s*#.*$/', '', $line) logic per line, and ignore empty/commented lines.

How to test:
1. Create an alias (any type) and add lines like '192.168.1.1 # test' or '1234 # http'.
2. Save, Apply, and verify ports/addresses/networks are present in live rules and diagnostics, but comment text is ignored.

Fixes longstanding community requests for better in-place documentation of firewall configs.