### PR TITLE
Update fw_log.volt

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/fw_log.volt
@@ -1430,6 +1430,8 @@
                     <option value="50">50</option>
                     <option value="75">75</option>
                     <option value="100">100</option>
+                    <option value="30000">30000</option>
+                    <option value="80000">80000</option>
                 </select>
                 <label>{{ lang._('Table size') }}</label>
             </div>
@@ -1438,6 +1440,7 @@
                     <option value="10000">10000</option>
                     <option value="20000">20000</option>
                     <option value="30000">30000</option>
+                    <option value="80000">80000</option>
                 </select>
                 <label>{{ lang._('History size') }}</label>
             </div>


### PR DESCRIPTION
Add additional needed live log value amounts for 30k and 80k respectively to traverse a longer time in the past. Please consider.

In the past versions there were more options to go back in time much further in opnsense. Since the new version this has been reduced, but the new interface is much faster. Can you consider these values so I dont need to manually edit the file myself after every update?

Kind regards
Peter