### PR TITLE
Fix visibility of update button

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/firmware.volt
@@ -842,7 +842,7 @@
                             <tr>
                                 <td></td>
                                 <td style="white-space:nowrap;vertical-align:middle;">
-                                    <button class="btn btn-info" id="upgrade"><i class="fa fa-check"></i> {{ lang._('Update') }}</button>
+                                    <button class="btn btn-primary" id="upgrade"><i class="fa fa-check"></i> {{ lang._('Update') }}</button>
                                     <button class='btn btn-warning' id="upgrade_maj"><i class="fa fa-check"></i> {{ lang._('Upgrade') }}</button>
                                     <button class="btn btn-default" id="upgrade_cancel"><i class="fa fa-times"></i> {{ lang._('Cancel') }}</button>
                                 </td>


### PR DESCRIPTION
I am using the theme "os-theme-solarized-community" from the "mimugmail" repo. After checking for updates, I noticed the update button is nearly invisible in light and dark mode.
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-40-36" src="https://github.com/user-attachments/assets/98f99d75-62f8-45e0-8979-e5942d8666c5" />
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-40-43" src="https://github.com/user-attachments/assets/0ad4aefb-4b01-442f-9918-3f55f30cbb56" />

I suggest to change the button class from `btn-info` to `btn-primary`.
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-41-07" src="https://github.com/user-attachments/assets/927256ee-b665-4ae7-99e8-b6c0c37cc87a" />
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-41-11" src="https://github.com/user-attachments/assets/e27ba588-71da-4844-83e1-1b59d51be680" />

This is how the default opnsense themes will look like after the change:
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-42-17" src="https://github.com/user-attachments/assets/634b8ddd-c7c7-41a6-9c88-809b8658fc0a" />
<img width="487" height="130" alt="Bildschirmfoto vom 2025-11-12 10-43-28" src="https://github.com/user-attachments/assets/c7f9f612-ab18-40e8-a58b-47d2dc686cac" />
