### PR TITLE
Unbound: Hyperlocal root config

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/advanced.xml
@@ -54,7 +54,18 @@
             Only use if you know what you are doing.
         </help>
     </field>
-        <field>
+    <field>
+        <id>unbound.advanced.hyperlocalroot</id>
+        <label>Hyperlocal Root</label>
+        <type>checkbox</type>
+        <help>
+            Download and maintain local copies of the root zone, .arpa, and
+            .root-servers.net as recommended by RFC 8806. This improves the
+            privacy and performance of recursive queries by keeping these zones
+            locally instead of querying external root servers.
+        </help>
+    </field>
+    <field>
         <id>unbound.advanced.outgoingnumtcp</id>
         <label>Outgoing TCP Buffers</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -72,6 +72,7 @@
             <serveexpiredttlreset type="BooleanField"/>
             <serveexpiredclienttimeout type="NumericField"/>
             <qnameminstrict type="BooleanField"/>
+            <hyperlocalroot type="BooleanField"/>
             <extendedstatistics type="BooleanField"/>
             <logqueries type="BooleanField"/>
             <logreplies type="BooleanField"/>

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/+TARGETS
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/+TARGETS
@@ -3,6 +3,7 @@ advanced.conf:/var/unbound/advanced.conf
 blocklists.conf:/usr/local/etc/unbound/unbound-blocklists.conf
 safesearch.conf:/usr/local/etc/unbound.opnsense.d/safesearch.conf
 dot.conf:/usr/local/etc/unbound.opnsense.d/dot.conf
+hyperlocal_root.conf:/usr/local/etc/unbound.opnsense.d/hyperlocal_root.conf
 private_domains.conf:/var/unbound/private_domains.conf
 domainoverrides.conf:/usr/local/etc/unbound.opnsense.d/domainoverrides.conf
 unbound_dhcpd.conf:/usr/local/etc/unbound_dhcpd.conf

--- a/src/opnsense/service/templates/OPNsense/Unbound/core/hyperlocal_root.conf
+++ b/src/opnsense/service/templates/OPNsense/Unbound/core/hyperlocal_root.conf
@@ -1,0 +1,62 @@
+{% if not helpers.empty('OPNsense.unboundplus.advanced.hyperlocalroot') %}
+auth-zone:
+    name: "."
+
+    primary: "lr-e.b.isi.edu"
+    primary: "lr-w.b.isi.edu"
+    primary: "lr-lax.b.isi.edu"
+    primary: "b.root-servers.net"
+    primary: "c.root-servers.net"
+    primary: "d.root-servers.net"
+    primary: "f.root-servers.net"
+    primary: "g.root-servers.net"
+    primary: "k.root-servers.net"
+    primary: "lax.xfr.dns.icann.org"
+    primary: "iad.xfr.dns.icann.org"
+
+    fallback-enabled: yes
+    for-downstream: no
+    for-upstream: yes
+    zonefile: "/var/unbound/local_root.zone"
+
+auth-zone:
+    name: "arpa."
+
+    primary: "lr-e.b.isi.edu"
+    primary: "lr-w.b.isi.edu"
+    primary: "lr-lax.b.isi.edu"
+    primary: "b.root-servers.net"
+    primary: "c.root-servers.net"
+    primary: "d.root-servers.net"
+    primary: "f.root-servers.net"
+    primary: "g.root-servers.net"
+    primary: "k.root-servers.net"
+    primary: "lax.xfr.dns.icann.org"
+    primary: "iad.xfr.dns.icann.org"
+
+    fallback-enabled: yes
+    for-downstream: no
+    for-upstream: yes
+    zonefile: "/var/unbound/local_arpa.zone"
+
+auth-zone:
+    name: "root-servers.net."
+
+    primary: "lr-e.b.isi.edu"
+    primary: "lr-w.b.isi.edu"
+    primary: "lr-lax.b.isi.edu"
+    primary: "b.root-servers.net"
+    primary: "c.root-servers.net"
+    primary: "d.root-servers.net"
+    primary: "f.root-servers.net"
+    primary: "g.root-servers.net"
+    primary: "k.root-servers.net"
+    primary: "lax.xfr.dns.icann.org"
+    primary: "iad.xfr.dns.icann.org"
+
+    fallback-enabled: yes
+    for-downstream: no
+    for-upstream: yes
+    zonefile: "/var/unbound/local_rootservers.zone"
+
+{% endif %}


### PR DESCRIPTION
RFC 8806 recommends running a local replica of the root zone (and localroot.isi.edu advocates additional zones) in order to provide improved performance and privacy for users of a recursive resolver. By fetching the full zone once (via AXFR) and periodically updating it (via IXFR), recursives generate less load on the root servers and satisfy their own queries more quickly.

This adds a checkbox in the Advanced section of the Unbound config that, if checked, injects the appropriate config to host local copies of `.`, `.arpa.`, and `.root-servers.net.`.