### PR TITLE
mvc: optimize legacy config loading in isArraySequential()

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
@@ -91,9 +91,9 @@ class Config extends Singleton
      * @param &array $arrayData array structure to check
      * @return bool
      */
-    private function isArraySequential(&$arrayData)
+    private function isArraySequential($arrayData)
     {
-        return is_array($arrayData) && ctype_digit(implode('', array_keys($arrayData)));
+        return is_array($arrayData) && array_is_list($arrayData);
     }
 
     /**


### PR DESCRIPTION
Since PHP8.1, we have access to `array_is_list()`, which can possibly replace the logic in `isArraySequential`. Profiling shows this function call is a hotspot in config files (in my test this was ~80.000 lines or about ~2.6M in file size).

Isolating just the `toArray()` function call, the following timings apply: 
Timing old:

`3.93 real 3.87 user 0.05 sys`

Timing new:

`0.83 real 0.79 user 0.03 sys`

Which is roughly a ~373% performance increase, making scripts using `config.inc` includes a lot faster.

`array_is_list()` is slightly different, and only accepts arrays for which the keys start at `0`. Tracing all the code paths:

1. `$result[$xmlNodeName] = $tmpNode;` should produce keys such as `["@attributes", "title", "item", "item@attributes", ...]`, for which `isArraySequential` should always return `false` according to the old logic, same for `array_is_list()`
2. 
```
$result[$xmlNodeName] = array();
$result[$xmlNodeName][] = $old_content;
```
produces a valid new list, indexed with `0`, returning `true` from both old & new methods.
3. If `$forceList[$xmlNodeName]` is set, we hit
```
$result[$xmlNodeName] = array();
$result[$xmlNodeName][] = $tmpNode;
```
Again, resulting in a clean and properly indexed array.
4. In all other cases, we do `$result[$xmlNodeName][] = $tmpNode;`. Which also can only provide a valid index.

One edge case is that the old method returns `false` for empty arrays, whereas `array_is_list()` returns `true`. As far as I can see, `isArraySequential` is only called when in the `children` branch and `isset($result[$xmlNodeName])` is `true`, though I'm not 100% sure this can be an empty array.


The last part is the usage in `fromArray()`, where to my knowledge the reverse of `toArray()` applies, so these can only be clean indexed arrays.
