### PR TITLE
dhcp/kea: The subnets must be unique, so they cannot be grouped

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -70,6 +70,12 @@
                     <NetMaskRequired>Y</NetMaskRequired>
                     <AddressFamily>ipv4</AddressFamily>
                     <Required>Y</Required>
+                    <Constraints>
+                        <check001>
+                            <type>UniqueConstraint</type>
+                            <ValidationMessage>Subnet must be unique.</ValidationMessage>
+                        </check001>
+                    </Constraints>
                 </subnet>
                 <next_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -62,6 +62,12 @@
                     <NetMaskRequired>Y</NetMaskRequired>
                     <AddressFamily>ipv6</AddressFamily>
                     <Required>Y</Required>
+                    <Constraints>
+                        <check001>
+                            <type>UniqueConstraint</type>
+                            <ValidationMessage>Subnet must be unique.</ValidationMessage>
+                        </check001>
+                    </Constraints>
                 </subnet>
                 <allocator type="OptionField">
                     <BlankDesc>Default</BlankDesc>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -61,7 +61,6 @@
                 grid_ids.forEach(function (grid_id) {
                     if (all_grids[grid_id] === undefined) {
                         const isGroupedGrid = [
-                            "{{formGridSubnet['table_id']}}",
                             "{{formGridReservation['table_id']}}"
                         ].includes(grid_id);
                         all_grids[grid_id] = $("#" + grid_id).UIBootgrid({
@@ -73,9 +72,7 @@
                             tabulatorOptions: {
                                 groupBy: !isGroupedGrid
                                     ? false
-                                    : (grid_id === "{{formGridSubnet['table_id']}}"
-                                        ? "subnet"
-                                        : "%subnet"),
+                                    : "%subnet",
                                 groupHeader: (value, count, data, group) => {
                                     const icons = {
                                         subnet: '<i class="fa fa-fw fa-ethernet fa-sm text-info"></i>',

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
@@ -64,7 +64,6 @@
                 grid_ids.forEach(function (grid_id) {
                     if (all_grids[grid_id] === undefined) {
                         const isGroupedGrid = [
-                            "{{formGridSubnet['table_id']}}",
                             "{{formGridPDPool['table_id']}}",
                             "{{formGridReservation['table_id']}}"
                         ].includes(grid_id);
@@ -77,9 +76,7 @@
                             tabulatorOptions: {
                                 groupBy: !isGroupedGrid
                                     ? false
-                                    : (grid_id === "{{formGridSubnet['table_id']}}"
-                                        ? "subnet"
-                                        : "%subnet"),
+                                    : "%subnet",
                                 groupHeader: (value, count, data, group) => {
                                     const icons = {
                                         subnet: '<i class="fa fa-fw fa-ethernet fa-sm text-info"></i>',


### PR DESCRIPTION
The subnets must be unique, so they cannot be grouped

Add a unique constraint and remove the tabulator GroupBy from subnet4 and subnet6

Relates to: https://github.com/opnsense/core/commit/cc2fa5ff1f30167a06a2500effb0f22a1cb41202