### PR TITLE
system: use is_int() with array_key_first() in toArray() and fromArray() #9485

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
@@ -118,7 +118,7 @@ class Config extends Singleton
                     $old_content = $result[$xmlNodeName];
                     // check if array content is associative, move items to new list
                     // (handles first item of specific type)
-                    if (!is_array($old_content) || !array_is_list($old_content)) {
+                    if (!is_array($old_content) || !is_int(array_key_first($old_content))) {
                         $result[$xmlNodeName] = array();
                         $result[$xmlNodeName][] = $old_content;
                     }
@@ -240,10 +240,10 @@ class Config extends Singleton
                     }
                 }
                 continue;
-            } elseif (is_numeric($itemKey)) {
+            } elseif (is_int($itemKey)) {
                 // recurring tag (content), use parent tagname.
                 $childNode = $node->addChild($parentTagName);
-            } elseif (is_array($itemValue) && array_is_list($itemValue)) {
+            } elseif (is_array($itemValue) && is_int(array_key_first($itemValue))) {
                 // recurring tag, skip placeholder.
                 $childNode = $node;
             } else {


### PR DESCRIPTION
The approximation of the magic here is that we are looking for array
elements created by a natural append `[] =` or equivalent which has
an integer key of  a rough range of 0 to count() - 1, but not always as
we can see from the ticket.

Since `unset()` breaks the pledge of sequential lists and makes
`array_is_list()` fail. Instead get a single key we can do a strict type
check on so that we are as likely to succeed as was the case before
the change in 7ee3b2c51659. It's also fast. ;)