### PR TITLE
unbound: clean up marker and size files, closes #9489

### DIFF
--- a/src/opnsense/scripts/unbound-dnsbl/lib/dnsbl.py
+++ b/src/opnsense/scripts/unbound-dnsbl/lib/dnsbl.py
@@ -66,7 +66,7 @@ class DNSBL:
             self._load_dnsbl()
 
     def _load_dnsbl(self):
-        last_state = self.dnsbl is not None
+        last_state = (self.dnsbl is not None)
 
         if not self._dnsbl_exists():
             self.dnsbl = None
@@ -96,7 +96,7 @@ class DNSBL:
         if os.path.exists(self.warn_file):
             os.remove(self.warn_file)
 
-        if last_state != self.dnsbl is not None:
+        if last_state != (self.dnsbl is not None):
             with open(self.size_file, 'w') as sfile:
                 sfile.write(str(len(self.dnsbl['data'])) if self.dnsbl else '0')
 


### PR DESCRIPTION
This turned ino a larger shift, as there were some nitpicks:

- the size file didn't update to 0 in cases where the blocklist wasn't available
- the `self.dnsbl` variable wasn't cleaned up in cases where the state changed to unavailable