### PR TITLE
Fix GPS coordinate display on NTP status page

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Ntpd/status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Ntpd/status.volt
@@ -62,7 +62,7 @@
         });
 
         ajaxGet('/api/ntpd/service/gps', {}, function (data, status) {
-            const gps = data.gps || data || {};
+            const gps = data.gps || {};
             const container = document.getElementById('gps-content');
 
             if (!gps.ok) {


### PR DESCRIPTION
It looks like this controller was refactor and new format returns data in top level object instead of gps property

<img width="1323" height="440" alt="image" src="https://github.com/user-attachments/assets/2d2b1d66-bb48-4477-b1a2-3f5856cd62d2" />


