### PR TITLE
Fixes #8736 properly fill dns subject alternative names from existing certificates

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
@@ -459,7 +459,7 @@ class Store
                     $altnames[$target][] = $parts[1];
                 }
                 foreach ($altnames as $key => $values) {
-                    $result[$target] = implode("\n", $values);
+                    $result[$key] = implode("\n", $values);
                 }
             }
 


### PR DESCRIPTION
Hi,
Fixes #8736
I noticed that SANs do not properly get "saved", I traced the problem to a single line logic error when parsing existing certificates.

This maybe also fixes #8116 ?


