### PR TITLE
Services: Dnsmasq DNS & DHCP: Add automatic RDNSS option when none is configured

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -289,7 +289,8 @@ set:{{ host.set_tag|replace('-', '') }},
 {%-     endif +%}
 {% endfor %}
 
-{% set has_default=[] %}
+{% set has_default_v4=[] %}
+{% set has_default_v6=[] %}
 {% for option in helpers.toList('dnsmasq.dhcp_options') %}
 {%     if option.type == "set" %}
 {%     set all_tags = [] %}
@@ -309,7 +310,10 @@ option6:{{ option.option6 }}{% if option.value %},{{ option.value }}{% endif %}
 {{ option.option }}{% if option.value %},{{ option.value }}{% endif %}
 {%- endif +%}
 {%     if not option.tag and not option.interface and option.option == '6' %}
-{%         do has_default.append(1) %}
+{%         do has_default_v4.append(1) %}
+{%     endif %}
+{%     if not option.tag and not option.interface and option.option6 == '23' %}
+{%         do has_default_v6.append(1) %}
 {%     endif %}
 {%     elif option.type == "match" %}
 dhcp-match=set:{{ option.set_tag.replace('-','') }},
@@ -321,9 +325,13 @@ option6:{{ option.option6 }}{% if option.value %},{{ option.value }}{% endif %}
 {%     endif %}
 {% endfor %}
 
-{% if not has_default %}
-# default dns mapped to this server (0.0.0.0)
+{% if not has_default_v4 %}
+# default IPv4 DNS mapped to this server (0.0.0.0)
 dhcp-option=6,0.0.0.0
+{% endif %}
+{% if not has_default_v6 %}
+# default IPv6 DNS mapped to this server (::)
+dhcp-option=option6:23,[::]
 {% endif %}
 
 {% for boot in helpers.toList('dnsmasq.dhcp_boot') %}


### PR DESCRIPTION
For: https://github.com/opnsense/core/issues/9155

Dnsmasq uses option6 23 for both Router Advertisements via RDNSS option and in DHCPv6 as dns-server option. For the default configuration, it is beneficial to handle these the same as the DHCPv4 default to align with user expectations and ease configuring the defaults for Router Advertisements.
