### PR TITLE
Firewall: Settings: Advanced: Change label from port forward to destination NAT

### DIFF
--- a/src/www/system_advanced_firewall.php
+++ b/src/www/system_advanced_firewall.php
@@ -334,7 +334,7 @@ include("head.inc");
                 <td style="width:78%"></td>
               </tr>
               <tr>
-                <td><a id="help_for_natreflection" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reflection for port forwards");?></td>
+                <td><a id="help_for_natreflection" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Reflection for destination NAT");?></td>
                 <td>
                   <input name="natreflection" type="checkbox" id="natreflection" value="yes" <?= !empty($pconfig['natreflection']) ? 'checked="checked"' : '' ?>/>
                   <div class="hidden" data-for="help_for_natreflection">


### PR DESCRIPTION
Only bounce the translation of the label, the help text can stay as it is in my opinion.

For: https://github.com/opnsense/core/pull/9473