### PR TITLE
interfaces: make Dnsmasq the default IPv6 provider

### DIFF
--- a/src/etc/config.xml.sample
+++ b/src/etc/config.xml.sample
@@ -95,8 +95,8 @@
     </dhcp_ranges>
     <dhcp_ranges>
       <interface>lan</interface>
-      <start_addr>::100</start_addr>
-      <end_addr>::199</end_addr>
+      <start_addr>::1000</start_addr>
+      <end_addr>::2000</end_addr>
       <constructor>lan</constructor>
       <ra_mode>slaac</ra_mode>
     </dhcp_ranges>


### PR DESCRIPTION
For: https://github.com/opnsense/core/issues/9155

An additional DHCP range constructs RA from the LAN prefix. LAN requires track interface for this to work. ra-stateless will set the A bit, allowing clients to use SLAAC and optionally receive another address other options via DHCPv6. The RDNSS option will be offered via eaf7630.

This is just a starting point so we can see whats needed.