### PR TITLE
System: rename sudoers file to make it more sortable

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Auth/+TARGETS
+++ b/src/opnsense/service/templates/OPNsense/Auth/+TARGETS
@@ -1,6 +1,7 @@
 ipsec.pam:/etc/pam.d/ipsec
 motd:/var/run/motd
 sshd.pam:/etc/pam.d/sshd
-sudoers:/usr/local/etc/sudoers.d/opnsense
+sudoers:/usr/local/etc/sudoers.d/20-opnsense
+sudoers.deprecated:/usr/local/etc/sudoers.d/opnsense
 system.pam:/etc/pam.d/system
 csh.cshrc:/etc/csh.cshrc

--- a/src/opnsense/service/templates/OPNsense/Auth/sudoers.deprecated
+++ b/src/opnsense/service/templates/OPNsense/Auth/sudoers.deprecated
@@ -1,0 +1,2 @@
+# DEPRECATED: This file is retained for reference only.
+#             See 20-sudoers for current configuration.


### PR DESCRIPTION
Fixes #8930

Just a simple rename, to make it easier to add more "sudoers" files before and after.