### PR TITLE
Services: Captive Portal - Change button type to submit to allow return/enter key usage on login

### DIFF
--- a/src/opnsense/scripts/captiveportal/htdocs_default/index.html
+++ b/src/opnsense/scripts/captiveportal/htdocs_default/index.html
@@ -148,7 +148,7 @@
 							<h2 class="form-signin-heading">Please sign in</h2>
 							<input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus autocomplete="none" autocapitalize="none" autocorrect="off">
 							<input type="password" autocomplete="new-password" id="inputPassword" class="form-control" placeholder="Password" required>
-							<button class="btn" id="signin" type="button">Sign in</button>
+							<button class="btn" id="signin" type="submit">Sign in</button>
 						</form>
 					</div>
 					<!-- User option 2: login needed, without username, password -->


### PR DESCRIPTION
The HTML button type has been changed to submit.
This allows you to use the return/enter key to submit the login form.

closes #9098 