### PR TITLE
Firewall: Rules:  Migration assistant - add export option and guidance for migrations to the new mvc system.

### DIFF
--- a/plist
+++ b/plist
@@ -308,6 +308,7 @@
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterUtilController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/GroupController.php
+/usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/MigrationController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/NptController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/OneToOneController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/SourceNatController.php
@@ -315,6 +316,7 @@
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/DNatController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/FilterController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/GroupController.php
+/usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/MigrationController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/NptController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/OneToOneController.php
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Firewall/SourceNatController.php
@@ -967,6 +969,7 @@
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/category.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/dnat_rule.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+/usr/local/opnsense/mvc/app/views/OPNsense/Firewall/firewall_migration.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/group.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/npt_rule.volt
 /usr/local/opnsense/mvc/app/views/OPNsense/Firewall/onat_rule.volt
@@ -1154,6 +1157,7 @@
 /usr/local/opnsense/scripts/filter/lib/alias/uri.py
 /usr/local/opnsense/scripts/filter/lib/states.py
 /usr/local/opnsense/scripts/filter/list_divert_sockets.php
+/usr/local/opnsense/scripts/filter/list_legacy_rules.php
 /usr/local/opnsense/scripts/filter/list_non_mvc_rules.php
 /usr/local/opnsense/scripts/filter/list_osfp.py
 /usr/local/opnsense/scripts/filter/list_pfsync.py

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/MigrationController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/MigrationController.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace OPNsense\Firewall\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Core\ConfigMaintenance;
+
+class MigrationController extends ApiControllerBase
+{
+    public function downloadRulesAction()
+    {
+        if ($this->request->isGet()) {
+            $data = json_decode((new Backend())->configdRun('filter list legacy_rules') ?? '', true) ?? [];
+            $this->exportCsv($data);
+        }
+    }
+
+    public function flushAction()
+    {
+        if ($this->request->isPost()) {
+            (new ConfigMaintenance())->delItem('filter.rule');
+            Config::getInstance()->save();
+            return ["status" => "ok"];
+        } else {
+            return ['status' => 'failed'];
+        }
+    }
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/MigrationController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/MigrationController.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace OPNsense\Firewall;
+
+class MigrationController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->pick('OPNsense/Firewall/firewall_migration');
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -329,8 +329,13 @@ class MenuSystem
         }
 
         // add interfaces to "Firewall: Rules" menu tab...
+        $this->appendItem('Firewall.Rules', 'Migration', [
+                'url' => '/ui/firewall/migration',
+                'fixedname' => sprintf("<i class='fa fa-fw fa-gears'> </i> %s", gettext('Migration assistant')),
+                'order' => 0,
+        ]);
         $iftargets['fw'] = array_merge(['FloatingRules' => gettext('Floating')], $iftargets['fw']);
-        $ordid = 0;
+        $ordid = 1;
         foreach ($iftargets['fw'] as $key => $descr) {
             $this->appendItem('Firewall.Rules', $key, [
                 'url' => '/firewall_rules.php?if=' . $key,

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/firewall_migration.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/firewall_migration.volt
@@ -1,0 +1,98 @@
+
+<script>
+    $(document).ready(function() {
+        $("#remove_rules").click(function(){
+          BootstrapDialog.show({
+              type:BootstrapDialog.TYPE_WARNING,
+              title: '{{ lang._('Flush') }}',
+              message: "{{ lang._('Are you sure you want to remove all legacy firewall rules.') }}",
+              buttons: [{
+                  label: '{{ lang._('Yes') }}',
+                  action: function(dialogRef){
+                      dialogRef.close();
+                      $("#flushAct_progress").addClass("fa fa-spinner fa-pulse");
+                      ajaxCall("/api/firewall/migration/flush", {}, function(data,status) {
+                            window.location = '/ui/firewall/filter/';
+                      });
+
+                  }
+              },{
+                  label: '{{ lang._('No') }}',
+                  action: function(dialogRef){
+                      dialogRef.close();
+                  }
+              }]
+          });
+        });
+    });
+</script>
+<style>
+    div.miglist {
+        counter-reset: list-number;
+        margin:10px;
+    }
+    div.miglist div:before {
+        counter-increment: list-number;
+        content: counter(list-number);
+
+        margin-right: 10px;
+        margin-bottom:10px;
+        width:30px;
+        height:30px;
+        display:inline-flex;
+        align-items:center;
+        justify-content: center;
+        font-size:14px;
+        background-color:#d7385e;
+        border-radius:50%;
+        color:#fff;
+    }
+ </style>
+<pre>
+{{ lang._('
+    To switch from the legacy rules to the new rules interface, a migration is needed.
+    As this can be a risky operation, manual intervention is required.
+
+    This module assist you in moving your rules to the new application and offers pointers to
+    various components available to guide you through the process.
+
+    When using a ZFS based setup, you can use snapshots to revert back to the old situation when accidents happen,
+    The other option is to use configuration history to undo changes or backup your configuration [1].
+
+    To prevent being locked out during the process, enable the anti-lockout rule and make sure to access the machine
+    via your LAN interface [2].
+
+    With all preparations in place, we can export the rules into a format our new rules interface understands [3].
+
+    {tip} Use a tool like Microsoft Excel to inspect and modify rules in the csv file before importing them or when certain validations fail.
+
+    Now we can import the exsiting rules into the new user interface [4].
+
+    After validating the rules are as expected, you can remove all legacy rules via [5] which forwards you to the new rules page after completion.
+
+') }}
+</pre>
+<div class="tab-content content-box">
+    <div class="miglist">
+        <div> <i class="fa fa-fw fa-book"></i>
+              <a target="_new" href="https://docs.opnsense.org/manual/snapshots.html">{{ lang._('Snapshots')}} /
+              <a target="_new" href="https://docs.opnsense.org/manual/backups.html#history">{{ lang._('Configuration history')}}</a>
+        </div>
+        <div>
+            <i class="fa fa-fw fa-check"></i>
+            <a target="_new" href="/system_advanced_firewall.php">{{ lang._('Deselect anti-lockout in advanced settings')}}</a>
+        </div>
+        <div>
+            <i class="fa fa-fw fa-file-csv"></i>
+            <a href="/api/firewall/migration/download_rules" >{{ lang._('Export current rules')}}</a>
+        </div>
+        <div>
+            <i class="fa fa-fw fa-upload"></i>
+            <a target="_new" href="/ui/firewall/filter/" >{{ lang._('Import rules using the button in the grid footer')}}</a>
+        </div>
+        <div>
+            <i class="fa fa-fw fa-trash"></i>
+            <a id="remove_rules" style="cursor: pointer;">{{ lang._('Remove all legacy rules')}}</a>
+        </div>
+    </div>
+</div>

--- a/src/opnsense/scripts/filter/list_legacy_rules.php
+++ b/src/opnsense/scripts/filter/list_legacy_rules.php
@@ -1,0 +1,142 @@
+#!/usr/local/bin/php
+<?php
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * simple wrapper to convert legacy rules into usable data for our MVC implementation
+ */
+
+require_once('config.inc');
+require_once('filter.inc');
+
+$result = [];
+if (!empty($config['filter']['rule'])) {
+    $icmp6types = [
+        'unreach' => '1',
+        'toobig' => '2',
+        'timex' => '3',
+        'paramprob' => '4',
+        'echoreq' => '128',
+        'echorep' => '129',
+        'listqry' => '130',
+        'listenrep' => '131',
+        'listendone' => '132',
+        'routersol' => '133',
+        'routeradv' => '134',
+        'neighbrsol' => '135',
+        'neighbradv' => '136',
+        'redir' => '137',
+        'routrrenum' => '138',
+        'niqry' => '139',
+        'nirep' => '140',
+        'mtraceresp' => '200',
+        'mtrace' => '201'
+    ];
+    /* sort and make sure uuid's exist */
+    filter_rules_sort();
+    $sequence = 1;
+    foreach ($config['filter']['rule'] as $rule) {
+        $target_rule = [
+            '@uuid' => $rule['@attributes']['uuid'],
+            'enabled' => !empty($rule['disable']) ? '1' : '0',
+            'statetype' => !empty($rule['statetype']) ? explode(' ', $rule['statetype'])[0] : 'keep',
+            'state-policy' => $rule['state-policy'] ?? '',
+            'sequence' => $sequence,
+            'action' => $rule['type'] ?? 'pass',
+            'quick' => !empty($rule['quick']) ? '1' : '0',
+            'interfacenot' => !empty($rule['interfacenot']) ? '1' : '0',
+            'interface' => $rule['interface'] ?? '',
+            'direction' => !empty($rule['direction']) ? $rule['direction'] : 'in',
+            'ipprotocol' => $rule['ipprotocol'] ?? 'inet',
+            'protocol' => !empty($rule['protocol']) ? strtoupper($rule['protocol']) : 'any',
+            'icmptype' => $rule['icmptype'] ?? '',
+            'icmp6type' => '',
+            'gateway' => $rule['gateway'] ?? '',
+            'replyto' => $rule['reply-to'] ?? '',
+            'disablereplyto' => !empty($rule['disablereplyto']) ? '1' : '0',
+            'log' => !empty($rule['log']) ? '1' : '0',
+            'allowopts' => !empty($rule['allowopts']) ? '1' : '0',
+            'nosync' => !empty($rule['nosync']) ? '1' : '0',
+            'nopfsync' => !empty($rule['nopfsync']) ? '1' : '0',
+            'statetimeout' => $rule['statetimeout'] ?? '',
+            'max-src-nodes' => $rule['max-src-nodes'] ?? '',
+            'max-src-states' => $rule['max-src-states'] ?? '',
+            'max-src-conn' => $rule['max-src-conn'] ?? '',
+            'max' => $rule['max'] ?? '',
+            'max-src-conn-rate' => $rule['max-src-conn-rate'] ?? '',
+            'max-src-conn-rates' => $rule['max-src-conn-rates'] ?? '',
+            'overload' => $rule['overload'] ?? '',
+            'adaptivestart' => $rule['adaptivestart'] ?? '',
+            'adaptiveend' => $rule['adaptiveend'] ?? '',
+            'prio' => $rule['prio'] ?? '',
+            'set-prio' => $rule['set-prio'] ?? '',
+            'set-prio-low' => $rule['set-prio-low'] ?? '',
+            'tag' => $rule['tag'] ?? '',
+            'tagged' => $rule['tagged'] ?? '',
+            'tcpflags1' => $rule['tcpflags1'] ?? '',
+            'tcpflags2' => $rule['tcpflags2'] ?? '',
+            'categories' => $rule['categories'] ?? '',
+            'sched' => $rule['sched'] ?? '',
+            'tos' => $rule['tos'] ?? '',
+            'shaper1' => $rule['shaper1'] ?? '',
+            'shaper2' => $rule['shaper2'] ?? '',
+            'description' => $rule['descr'] ?? '',
+        ];
+        if (!isset($rule['quick'])) {
+            $target_rule['quick'] = !empty($rule['floating']) ? '0' : '1';
+        }
+        foreach (['source', 'destination'] as $field) {
+            if (!empty($rule[$field])) {
+                $target_rule[$field . '_not'] = !empty($rule[$field]['not']) ? "1" : "0";
+                if (!empty($rule[$field]['any'])) {
+                    $target_rule[$field . '_net'] = 'any';
+                } elseif (!empty($rule[$field]['network'])) {
+                    $target_rule[$field . '_net'] = $rule[$field]['network'];
+                } else {
+                    $target_rule[$field . '_net'] = $rule[$field]['address'] ?? '';
+                }
+                $target_rule[$field . '_port'] = $rule[$field]['port'] ?? '';
+                $target_rule[$field . '_port'] = str_replace('-any', '-65535', $target_rule[$field . '_port']);
+                $target_rule[$field . '_port'] = str_replace('any-', '1-', $target_rule[$field . '_port']);
+            }
+        }
+        if (!empty($rule['icmp6-type'])) {
+            $items = [];
+            foreach (explode(',', $rule['icmp6-type']) as $item) {
+                if (isset($icmp6types[$item])) {
+                    $items[] = $icmp6types[$item];
+                }
+            }
+            $target_rule['icmp6type'] = implode(',', $items);
+        }
+
+
+        $result[] = $target_rule;
+        $sequence += 10;
+    }
+}
+echo json_encode($result);

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -54,6 +54,13 @@ parameters:
 type:script_output
 message:request active rule ids and descriptions
 
+[list.legacy_rules]
+command:/usr/local/opnsense/scripts/filter/list_legacy_rules.php
+parameters:
+type:script_output
+message:dump legacy rules in mvc format
+
+
 [list.pfsync]
 command:/usr/local/opnsense/scripts/filter/list_pfsync.py
 parameters: %s

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -60,7 +60,6 @@ parameters:
 type:script_output
 message:dump legacy rules in mvc format
 
-
 [list.pfsync]
 command:/usr/local/opnsense/scripts/filter/list_pfsync.py
 parameters: %s


### PR DESCRIPTION
Add new "Firewall: Rules: Migration assistant" to help people moving to our new mvc based firewall system by offering a couple of simple steps for exporting the old rules into a csv file and importing them into the new system. When all rules are migrated the user may drop all old ones using the ConfigMaintenance module used in "defaults".

There's one small issue remaining in fbegin.inc as it doesn't render the icon correctly due to VisibleName being escaped currently (which isn't the case in our mvc template).

closes https://github.com/opnsense/core/issues/9579