### PR TITLE
dhcp/kea: exit prefix watcher if no lease file exists

### DIFF
--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -32,6 +32,7 @@ import os
 import time
 import subprocess
 import syslog
+import sys
 
 
 def yield_log_records(filename, poll_interval=5):
@@ -45,6 +46,7 @@ def yield_log_records(filename, poll_interval=5):
         filenames = ['%s.2' % filename, '%s.1' % filename, filename]
 
     for fn in (x for x in filenames if os.path.exists(x)):
+        fhandle = None
         lstpos = None
         header = {}
         while True:
@@ -105,6 +107,9 @@ if __name__ == '__main__':
     prefixes = {}
     syslog.openlog('kea-dhcp6', facility=syslog.LOG_LOCAL4)
     syslog.syslog(syslog.LOG_NOTICE, "startup kea prefix watcher")
+    if not os.path.isfile(inputargs.filename):
+        syslog.syslog(syslog.LOG_ERR, "lease file does not exist: %s" % inputargs.filename)
+        sys.exit(1)
     ndp = NDP()
     for record in yield_log_records(inputargs.filename):
         # IA_PD: type 2, prefix_len <= 64 - the delegated prefix


### PR DESCRIPTION
For: https://github.com/opnsense/core/issues/9619

Fixes:
```
FileNotFoundError: [Errno 2] No such file or directory: '/var/db/kea/kea-leases6.csv'
^^^^^^^^^^^
if lstpos is None or (os.path.isfile(fn) and os.fstat(fhandle.fileno()).st_ino != os.stat(fn).st_ino):
File "/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py", line 51, in yield_log_records
for record in yield_log_records(inputargs.filename):
File "/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py", line 109, in <module>
Traceback (most recent call last):
```

Clean exit is the best choice here. The watcher will be restarted on a new apply or kea service restart.