### PR TITLE
feat: allow to override default shell

### DIFF
--- a/src/sbin/opnsense-shell
+++ b/src/sbin/opnsense-shell
@@ -24,6 +24,8 @@ CMD_SETADDR="/usr/local/opnsense/scripts/shell/setaddr.php"
 CMD_SETPORTS="/usr/local/opnsense/scripts/shell/setports.php"
 CMD_SHELL="/bin/csh"
 
+[ -f /etc/opnsense-shell ] && . /etc/opnsense-shell
+
 # rc.d may call this while being root using `su -m user -c ...'
 # and it has arguments to pass through to the shell.  It creates
 # a problem for us as su(1) assumes a full root shell and has no


### PR DESCRIPTION
With this simple change, it is possible to override the default shell for menu item 8 in `opnsense-shell`.

To use bash instead of csh, create a file called `/etc/opnsense-shell` and add the following:

```
CMD_SHELL="/usr/local/bin/bash"
```

As Franco mentioned this has currently no documentation. I see this as a starting point for a discussion.
But it's easy to either add a comment to the file or add it to the official documentation.

On the other side, I suspect that mostly people who are familiar with Unix/Linux and the commandline would want to use a different shell than the default. For those people I don't think any documentation is necessary. They see that the shell for root is `/usr/local/sbin/opnsense-shell` and check out that file, which will lead them to `/etc/opnsense-shell`.
(This is how I found out which shell is used when choosing item 8.)

This change also does not have any checks, whether the shell (or its path) is valid. It's easy to add that too, but in that case it won't be a one-liner.

My only goal with this PR is to be able to change the shell w/o having to patch the file every single time there is an update.

It won't break any existing installations, but allows people to replace the shell. All this without any maintenance burden.