### PR TITLE
Enable TRIM support for non-(S)ATA disks

### DIFF
--- a/src/etc/rc
+++ b/src/etc/rc
@@ -116,8 +116,8 @@ while read FS_PART FS_MNT FS_TYPE FS_MORE; do
 
 	# trim fun if possible
 	if [ -n "${FS_DEV}" ]; then
-		FS_TRIM=$(camcontrol identify ${FS_DEV} | grep TRIM | awk '{ print $5; }')
-		if [ "${FS_TRIM}" = "yes" ]; then
+		FS_TRIM=$(diskinfo -v ${FS_DEV} | grep TRIM | awk '{ print $1; }')
+		if [ "${FS_TRIM}" = "Yes" ]; then
 			if echo "${FS_MORE}" | grep -iq notrim; then
 				# appending "# notrim" to the /etc/fstab entry
 				# will allow to strip trim and leave it disabled


### PR DESCRIPTION
Currently, the rc script invokes `camcontrol identify` to check whether a disk supports TRIM and if so, enables TRIM for the UFS rootfs.

However, `camcontrol identify` only supports (S)ATA disks - it sends an ATA identify command to the disk.
If the disk is SCSI / SAS, VirtIO etc., the test fails. As a result, TRIM remains disabled on all non-(S)ATA disk.

This patch replaces `camcontrol identify` with `diskinfo -v`, which should work on all disks.