### PR TITLE
openvpn: account for CARP status in start and restart cases as well

### DIFF
--- a/src/opnsense/scripts/openvpn/ovpn_service_control.php
+++ b/src/opnsense/scripts/openvpn/ovpn_service_control.php
@@ -165,8 +165,7 @@ if (isset($opts['h']) || empty($args) || !in_array($args[0], ['start', 'stop', '
             $destroy_if = !empty($instance_stats['dev_type']) && $instance_stats['dev_type'] != $node->dev_type;
             $carp_down = false;
             if ((string)$node->role == 'client' && !empty($vhids[(string)$node->carp_depend_on])) {
-                $status = $vhids[(string)$node->carp_depend_on];
-                $carp_down = $status == 'BACKUP' || $status == 'INIT'; /* consider up if DISABLED */
+                $carp_down = $vhids[(string)$node->carp_depend_on] != 'MASTER';
             }
             switch ($action) {
                 case 'stop':


### PR DESCRIPTION
This also inverts the logic such that DISABLED is considered UP as well.

The original logic was likely a deliberate choice, so putting this up as a PR to see if this is valid.

Fixes https://github.com/opnsense/core/issues/9266