### PR TITLE
Firewall: Rules [new]: Escape selector in rule_protocol

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -875,9 +875,11 @@
         });
 
         // Hide additional protocol settings in dialog, e.g., ICMP types
-        $("#rule\\.protocol").change(function() {
-            $(".rule_protocol:not(div)").closest('tr').hide();
-            $(".protocol_"+$(this).val().toLowerCase()+':not(div)').closest('tr').show();
+        $('#rule\\.protocol').change(function() {
+            $('.rule_protocol:not(div)').closest('tr').hide();
+            $('.' + $.escapeSelector('protocol_' + $(this).val().toLowerCase()) + ':not(div)')
+                .closest('tr')
+                .show();
         });
 
         // Dynamically add fa icons to selectpickers


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9640

```
Uncaught Error: Syntax error, unrecognized expression: .protocol_tcp/udp:not(div)
```