### PR TITLE
kea: Use hostwatch as ndp source in kea_prefix_watcher script

### DIFF
--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -100,6 +100,7 @@ class Hostwatch:
             return self._def_local_db[mac]
 
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('filename',


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9619