### PR TITLE
Bootgrid: allow multi word tooltips

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -1124,8 +1124,8 @@ class UIBootgrid {
             }
 
             const title = typeof command?.title === "function"
-                ? `title=${command?.title()}`
-                : `title=${command?.title}` ?? '';
+                ? `title="${command?.title()}"`
+                : `title="${command?.title}"` ?? '';
 
             const $element = $(`
                 <button type="button" class="btn btn-xs ${key === 'add' ? 'btn-primary' : 'btn-default'} command-${key} bootgrid-tooltip" ${title}>
@@ -1648,8 +1648,8 @@ class UIBootgrid {
 
                     if (has_option) {
                         let title = typeof command?.title === "function"
-                            ? `title=${command?.title(cell)}`
-                            : `title=${command?.title}` ?? '';
+                            ? `title="${command?.title(cell)}"`
+                            : `title="${command?.title}"` ?? '';
 
                         html.push(`
                             <button type="button"


### PR DESCRIPTION
Since version 26.x, it hasn't been possible to have command tooltips contain content with multiple words. Here, my command is set up with the title 'Flush aliases'.
```js
                'flush-aliases': {
                    'title': "{{ lang._('Flush aliases') }}",
                    'classname': "fa fa-fw fa-trash",
                    'sequence': 500,
                },
```
<img width="85" height="69" alt="image" src="https://github.com/user-attachments/assets/1951343f-4364-4922-9aac-6d53895d2f86" />

You can only see 'Flush'.

Adding quotes to the title resolving lines will resolve the issue.
<img width="93" height="61" alt="image" src="https://github.com/user-attachments/assets/3fa304a5-f694-4800-8fe8-253e2829ecfc" />
