### PR TITLE
Firewall: Rules [new]: Statistics column is responsive now

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -652,7 +652,6 @@
         <grid_view>
             <formatter>statistics</formatter>
             <sequence>115</sequence>
-            <min-width>200</min-width>
         </grid_view>
     </field>
     <field>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -550,14 +550,9 @@
                             return "";
                         }
 
-                        // Split into two vertical rows
-                        const firstGroup  = parts.slice(0, 2).join(" ");
-                        const secondGroup = parts.slice(2).join(" ");
-
                         return `
                             <div class="stats-cell">
-                                <div>${firstGroup}</div>
-                                <div>${secondGroup}</div>
+                                ${parts.join("")}
                             </div>
                         `;
                     },
@@ -1045,11 +1040,20 @@
 
     .stats-cell {
         display: flex;
-        flex-direction: column;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        align-items: center;
+        container-type: inline-size;
     }
 
-    .stats-cell div {
-        gap: 6px;
+    .stats-cell > span {
+        white-space: nowrap;
+    }
+
+    @container (max-width: 160px) {
+        .stats-cell > span {
+            flex: 1 1 50%;
+        }
     }
 
 </style>


### PR DESCRIPTION
This keeps the icon all neatly below each other in 4 rows, but if enough horizontal space is given they are allowed to flex out and take the full space.

- Safes additional space on small screens
<img width="1441" height="332" alt="image" src="https://github.com/user-attachments/assets/0f7052c2-fa1d-4842-b285-e503d4e5ea76" />

- Allows large screens to show more
<img width="2885" height="238" alt="image" src="https://github.com/user-attachments/assets/226493f2-8b5e-478b-b466-68bee4bcfb7e" />


Fixes: https://github.com/opnsense/core/issues/9674