### PR TITLE
radvd: When Base6Interface constructor is used, use its primary address for ifcfgipv6

### DIFF
--- a/src/etc/inc/plugins.inc.d/radvd.inc
+++ b/src/etc/inc/plugins.inc.d/radvd.inc
@@ -149,7 +149,6 @@ function radvd_configure_do($verbose = false, $ignorelist = [])
 
         $carp_mode = false;
         $src_addr = false;
-
         $ifcfgipv6 = null;
 
         if (!$entry->AdvRASrcAddress->isEmpty()) {


### PR DESCRIPTION
There will not always be a primary address on the advertising interface when Base6Interface is used.

Since this new case only executes if ifcfgipv6 is not already containing an AdvRASrcAddress, it's a minimal change that should not mess with any existing setups.

The automatic RDNSS option will become the Base6Interface IPv6 address this way.

Fixes: https://github.com/opnsense/core/issues/9687