### PR TITLE
Normalize case when checking dnsmasq is_reserved

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
@@ -83,7 +83,7 @@ class LeasesController extends ApiControllerBase
             if (!empty($host->hwaddr)) {
                 foreach (explode(',', (string)$host->hwaddr) as $hwaddr) {
                     if (!empty($hwaddr)) {
-                        $reservedKeys[] = $hwaddr;
+                        $reservedKeys[] = strtolower($hwaddr);
                     }
                 }
             }


### PR DESCRIPTION
Static hosts with uppercase hardware addresses were erroneously reported as dynamic in the Leases UI. Querying leases from dnsmasq returns them normalized to lowercase, but reading directly from the config reports whatever case the user entered.

I tested this on my live box. I'm very unfamiliar with both PHP and opnsense's codebase, but I think this change is safe since the reservedKeys array isn't used for anything but this comparison and thus nothing else is depending on this matching the case in the configuration.