### PR TITLE
Added support for client-side DNS over TLS/HTTPS/QUIC

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -274,10 +274,7 @@ function unbound_generate_config()
             (isset($dots['client_tls_enabled']) and ($dots['client_tls_enabled'] == '1')) or
             (isset($dots['client_tls_enabled']) and ($dots['client_tls_enabled'] == '1')))) {
             $cert_refid = $dots['cert'][0];
-            $tls_settings .= "# before loop\n";
             $certs = $config['cert'];
-            $num = count($certs);
-            $tls_settings .= "# Certs configured: $num\n";
             foreach ($certs as $cert) {
                 if ($cert_refid == $cert['refid']) {
                     $tls_settings .= "# Certificate refid: $cert_refid\n";

--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -235,6 +235,7 @@ function unbound_generate_config()
     }
 
     $bindints = '';
+    $tls_settings = '';
     if (!empty($general['active_interface'])) {
         $active_interfaces = explode(',', $general['active_interface']);
         array_unshift($active_interfaces, 'lo0');
@@ -260,7 +261,82 @@ function unbound_generate_config()
     } else {
         $bindints .= "interface: 0.0.0.0\n";
         $bindints .= "interface: ::\n";
-        $bindints .= "interface-automatic: yes\n";
+        /* $bindints .= "interface-automatic: yes\n"; */
+	/* Changed to no, otherwise DNS over TLS ports will not work */
+        $bindints .= "interface-automatic: no\n";
+
+        $dots = config_read_array('OPNsense', 'unboundplus', 'dots');
+
+        $cert_pem_filename = '/var/unbound/server_dots.pem';
+        $cert_key_filename = '/var/unbound/server_dots.key';
+	if ((isset($dots['cert']) and ($dots['cert'] != '')) and
+           ((isset($dots['client_tls_enabled']) and ($dots['client_tls_enabled'] == '1')) or
+            (isset($dots['client_tls_enabled']) and ($dots['client_tls_enabled'] == '1')) or
+            (isset($dots['client_tls_enabled']) and ($dots['client_tls_enabled'] == '1')))) {
+            $cert_refid = $dots['cert'][0];
+            $tls_settings .= "# before loop\n";
+            $certs = $config['cert'];
+            $num = count($certs);
+            $tls_settings .= "# Certs configured: $num\n";
+            foreach ($certs as $cert) {
+                if ($cert_refid == $cert['refid']) {
+                    $tls_settings .= "# Certificate refid: $cert_refid\n";
+                    /* generate cert pem file */
+                    $pem_content = trim(str_replace("\n\n", "\n", str_replace(
+                        "\r", "", base64_decode($cert['crt'])
+                    )));
+                    $pem_content .= "\n";
+
+                    /* generate key file */
+                    $key_content .= trim(str_replace("\n\n", "\n",
+                        str_replace("\r", "", base64_decode($cert['prv']))
+                    ));
+                    $key_content .= "\n";
+
+                    /* append chain to pem */
+                    $cert_pem_content .= $pem_content;
+                    if (!empty($cert['caref'])) {
+                        $caref = $cert['caref'];
+                        $cas = $config['ca'];
+                        foreach ($cas as $ca) {
+                            if ($caref == $ca['refid']) {
+                                $ca_content = trim(str_replace("\n\n", "\n",
+                                    str_replace("\r", "", base64_decode($ca['crt']))
+                                ));
+                                $cert_pem_content .= $ca_content;
+                            }
+                        }
+                    }
+                    file_put_contents($cert_pem_filename, $cert_pem_content);
+                    chmod($cert_pem_filename, 0600);
+
+                    file_put_contents($cert_key_filename, $key_content);
+                    chmod($cert_key_filename, 0600);
+                }
+            }
+            $tls_settings .= "tls-service-pem: $cert_pem_filename\n";
+            $tls_settings .= "tls-service-key: $cert_key_filename\n";
+        }
+        if (isset($dots['client_tls_enabled']) and $dots['client_tls_enabled'] == '1') {
+            /* $client_tls_enabled = $dots['client_tls_enabled']; */
+            $tls_settings .= "tls-port: 853\n";
+            $bindints .= "interface: 0.0.0.0@853\n";
+            $bindints .= "interface: ::0@853\n";
+	}
+	if ((isset($dots['client_https_enabled']) and $dots['client_https_enabled'] == '1') and
+	    (isset($dots['client_https_port']) and $dots['client_https_port'] != '')) {
+            $client_https_enabled = $dots['client_https_enabled'];
+            $https_port = $dots['client_https_port'];
+	    if (is_numeric($https_port)) {
+                $tls_settings .= "https-port: $https_port\n";
+                $bindints .= "interface: 0.0.0.0@$https_port\n";
+                $bindints .= "interface: ::0@$https_port\n";
+            }
+	}
+        if (isset($dots['client_quic_enabled']) and $dots['client_quic_enabled'] == '1') {
+            $client_quic_enabled = $dots['client_quic_enabled'];
+            $tls_settings .= "quic-port: 853\n";
+	}
     }
 
     $outgoingints = '';
@@ -362,6 +438,9 @@ module-config: "{$module_config}"
 {$anchor_file}
 {$forward_local}
 {$dns64_config}
+
+# TLS Settings
+{$tls_settings}
 
 # Interface IP(s) to bind to
 {$bindints}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/DotController.php
@@ -36,6 +36,7 @@ class DotController extends IndexController
     {
         $this->view->selected_forward = "";
         $this->view->forwardingForm = $this->getForm('forwarding');
+        $this->view->clientDotForm = $this->getForm('clientDot');
 
         $this->view->formDialogEdit = $this->getForm('dialogDot');
         $this->view->formGridDot = $this->getFormGrid('dialogDot');

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/ForwardController.php
@@ -40,6 +40,6 @@ class ForwardController extends IndexController
         $this->view->formDialogEdit = $this->getForm('dialogDot');
         $this->view->formGridDot = $this->getFormGrid('dialogDot');
 
-        $this->view->pick('OPNsense/Unbound/dot');
+        $this->view->pick('OPNsense/Unbound/forwarding');
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/clientDot.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/forms/clientDot.xml
@@ -1,0 +1,37 @@
+<form>
+    <field>
+        <id>unbound.dots.client_tls_enabled</id>
+        <label>Enable DNS over TLS for local clients</label>
+        <type>checkbox</type>
+	<style>client-dnsovertls-enabled</style>
+        <help>If enabled, unbound will serve DNS over TLS on port 853.</help>
+    </field>
+    <field>
+        <id>unbound.dots.client_https_enabled</id>
+        <label>Enable DNS over HTTPS for local clients</label>
+        <type>checkbox</type>
+	<style>client-dnsoverhttps-enabled</style>
+        <help>If enabled, unbound will serve DNS over HTTPS.</help>
+    </field>
+    <field>
+        <id>unbound.dots.client_https_port</id>
+        <label>Set port for DNS over HTTPS for local clients</label>
+        <type>text</type>
+	<style>client-dnsoverhttps-port</style>
+        <help>Will enable DNS over HTTPS on specified port.</help>
+    </field>
+    <field>
+        <id>unbound.dots.client_quic_enabled</id>
+        <label>Enable DNS over QUIC for local clients</label>
+        <type>checkbox</type>
+	<style>client-dnsoverquic-enabled</style>
+        <help>If enabled, unbound will serve DNS over QUIC on port 853.</help>
+    </field>
+    <field>
+        <id>unbound.dots.cert</id>
+        <label>Certificate</label>
+        <type>dropdown</type>
+	<style>client-dots-cert-selected</style>
+        <help>Certificate used for DNS over TLS (clientDot.xml)</help>
+    </field>
+</form>

--- a/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Unbound/Unbound.xml
@@ -247,6 +247,26 @@
             <enabled type="BooleanField"/>
         </forwarding>
         <dots>
+            <client_tls_enabled type="BooleanField">
+                <Required>Y</Required>
+                <Default>1</Default>
+            </client_tls_enabled>
+            <client_https_enabled type="BooleanField">
+                <Required>Y</Required>
+                <Default>1</Default>
+            </client_https_enabled>
+            <client_https_port type="PortField">
+                <Required>N</Required>
+                <Default>11443</Default>
+            </client_https_port>
+            <client_quic_enabled type="BooleanField">
+                <Required>Y</Required>
+                <Default>1</Default>
+            </client_quic_enabled>
+            <cert type="CertificateField">
+                <Type>cert</Type>
+                <Required>N</Required>
+            </cert>
             <dot type="ArrayField">
                 <enabled type="BooleanField">
                     <Required>Y</Required>


### PR DESCRIPTION
Added client-side support for DNS over TLS/HTTPS/QUIC:

<img width="748" height="364" alt="image" src="https://github.com/user-attachments/assets/4640c8eb-2e5b-430b-a0da-801ce3491778" />

This is my first major PR and I'm still struggling with some parts of the OPNsense UI stack, so there will certainly be some rough edges (or things that should be done another way).

For now I was only able to test DNS over TLS, but as the other options came "for free" I also added them.

The former "DNS over TLS" is now available under the "To remote DNS servers" tab.

If something needs to be done differently / fixed, just let me know.