### PR TITLE
firewall: Change toggle_log icon to help visibility of enabled/disabled status

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/dnat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/dnat_rule.volt
@@ -159,11 +159,7 @@
                                 title="${row.log == '1'
                                     ? '{{ lang._("Disable Logging") }}'
                                     : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw
-                                    ${row.log == '1'
-                                        ? 'fa-bell'
-                                        : 'fa-bell-slash'}">
-                                </i>
+                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
                             </button>
 
                             <button type="button" class="btn btn-xs btn-default command-edit

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -268,11 +268,7 @@
                                 title="${row.log == '1'
                                     ? '{{ lang._("Disable Logging") }}'
                                     : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw
-                                    ${row.log == '1'
-                                        ? 'fa-bell'
-                                        : 'fa-bell-slash'}">
-                                </i>
+                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
                             </button>
 
                             <button type="button" class="btn btn-xs btn-default command-edit

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/npt_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/npt_rule.volt
@@ -145,11 +145,7 @@
                                 title="${row.log == '1'
                                     ? '{{ lang._("Disable Logging") }}'
                                     : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw
-                                    ${row.log == '1'
-                                        ? 'fa-bell'
-                                        : 'fa-bell-slash'}">
-                                </i>
+                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
                             </button>
 
                             <button type="button" class="btn btn-xs btn-default command-edit

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/onat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/onat_rule.volt
@@ -145,11 +145,7 @@
                                 title="${row.log == '1'
                                     ? '{{ lang._("Disable Logging") }}'
                                     : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw
-                                    ${row.log == '1'
-                                        ? 'fa-bell'
-                                        : 'fa-bell-slash'}">
-                                </i>
+                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
                             </button>
 
                             <button type="button" class="btn btn-xs btn-default command-edit

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/snat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/snat_rule.volt
@@ -145,11 +145,7 @@
                                 title="${row.log == '1'
                                     ? '{{ lang._("Disable Logging") }}'
                                     : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw
-                                    ${row.log == '1'
-                                        ? 'fa-bell'
-                                        : 'fa-bell-slash'}">
-                                </i>
+                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
                             </button>
 
                             <button type="button" class="btn btn-xs btn-default command-edit


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/9693

I also had issues seeing enabled and disabled after using it for a while, had to always use the tooltip.

I think this is the best solution, though open for feedback for other fa-icons.

<img width="610" height="723" alt="image" src="https://github.com/user-attachments/assets/bb445d7b-a69b-4b14-9948-aefc98a4dcd1" />


