### PR TITLE
Firewall: Rules [new]: The SKIP icmp type is not a valid name for pf, most likely a bug. Number would work.

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -116,7 +116,7 @@
                             <ipv6-here>IPv6 i-am-here</ipv6-here>
                             <mobregreq>Mobile registration request</mobregreq>
                             <mobregrep>Mobile registration reply</mobregrep>
-                            <skip>SKIP</skip>
+                            <!-- <skip>SKIP</skip> is valid but pf does not like the name, number would work -->
                         </Deprecated>
                     </OptionValues>
                 </icmptype>


### PR DESCRIPTION
Doesnt work:
```There were error(s) loading the rules: /tmp/rules.debug:230: syntax error - The line in question reads [230]: pass in quick inet proto icmp from {any} to {any} icmp-type {skip} keep state label "4bcf8573-1db7-428f-80c5-6bd25d6ba04b"```

Works:
```pass in quick inet proto icmp from {any} to {any} icmp-type {39} keep state label "e552e61c-5054-4daa-b2be-c288ec0b6e45"```