### PR TITLE
Revert "Services: ISC DHCPv4: hide menu items when dnsmasq is enabled…

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -172,27 +172,6 @@ class MenuSystem
     }
 
     /**
-     * temporary legacy glue to remove isc dhcp4 settings when not enabled and Dnsmasq is configured as dhcp
-     * @return boolean
-     */
-
-    private function isc_v4_enabled($if)
-    {
-        $config = Config::getInstance()->object();
-        if (isset($config->dhcpd) && isset($config->dhcpd->$if) && !empty((string)$config->dhcpd->$if->enable)) {
-            /* still configured on interface */
-            return true;
-        } elseif (isset($config->dnsmasq) && empty((string)$config->dnsmasq->enable)) {
-            /* dnsmasq not configured at all */
-            return true;
-        } elseif (isset($config->dnsmasq) && !empty((string)$config->dnsmasq->interface)) {
-            /* dnsmasq configured, but only on selected interfaces */
-            return !in_array($if, explode(',', $config->dnsmasq->interface));
-        }
-        return false;
-    }
-
-    /**
      * construct a new menu
      * @throws MenuInitException
      */
@@ -261,10 +240,7 @@ class MenuSystem
                 }
                 // "Services: DHCPv[46]" menu tab:
                 if (empty($node->virtual) && isset($node->enable)) {
-                    if (
-                        $this->isc_v4_enabled($key) &&
-                        !empty(filter_var($node->ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))
-                    ) {
+                    if (!empty(filter_var($node->ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))) {
                         $iftargets['dhcp4'][$key] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
                     }
                     if (!empty(filter_var($node->ipaddrv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) || (string)$node->ipaddrv6 == 'track6' || (string)$node->ipaddrv6 == 'idassoc6') {


### PR DESCRIPTION
… to improve "out of the box" experience. closes https://github.com/opnsense/core/issues/8329"

We are not hiding v6 now and since ISC-DHCP is not in the core system we can go back to the normal way.

This reverts commit 0d6aa56527c60be14e6e626e5d0728108110cf2f.

PR: https://www.reddit.com/r/opnsense/comments/1qxqru9/comment/o42nx7v/