### PR TITLE
Firewall: Rules [new] - hide legacy option after migration 

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -329,14 +329,28 @@ class MenuSystem
         }
 
         // add interfaces to "Firewall: Rules" menu tab...
-        $this->appendItem('Firewall.Rules', 'Migration', [
-                'url' => '/ui/firewall/migration',
-                'fixedname' => sprintf("<i class='fa fa-fw fa-gears'> </i> %s", gettext('Migration assistant')),
-                'order' => 0,
-        ]);
-        $iftargets['fw'] = array_merge(['FloatingRules' => gettext('Floating')], $iftargets['fw']);
+        $has_legacy_fw = !empty($config->filter?->rule?->count());
+        $has_mvc_fw = !empty($config->OPNsense?->Firewall?->Filter?->rules?->count());
+        if ($has_legacy_fw) {
+            $this->appendItem('Firewall.Rules', 'Migration', [
+                    'url' => '/ui/firewall/migration',
+                    'fixedname' => sprintf("<i class='fa fa-fw fa-gears'> </i> %s", gettext('Migration assistant')),
+                    'order' => 0,
+            ]);
+            $iftargets['fw'] = array_merge(['FloatingRules' => gettext('Floating')], $iftargets['fw']);
+        }
         $ordid = 1;
         foreach ($iftargets['fw'] as $key => $descr) {
+            if ($has_mvc_fw && !$has_legacy_fw) {
+                /* only search */
+                $this->appendItem('Firewall.Rule', $key, [
+                    'url' => '/ui/firewall/filter/#interface=' . $key,
+                    'fixedname' => $descr,
+                    'order' => $ordid++,
+                ]);
+                continue;
+            }
+            /* legacy rules */
             $this->appendItem('Firewall.Rules', $key, [
                 'url' => '/firewall_rules.php?if=' . $key,
                 'fixedname' => $descr,


### PR DESCRIPTION
(when there's at least a new rule and no legacy rules exist).

This cleans up the menu and prevents existing users from loosing access to their rules. 