### PR TITLE
kea: Add scope ID to prefix watcher link local address to fix route add

### DIFF
--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -90,7 +90,8 @@ class Hostwatch:
         for row in ujson.loads(out).get("rows", []):
             # [ifname, mac, ip]
             if ipaddress.ip_address(row[2]).is_link_local:
-                self._def_local_db[row[1]] = row[2]
+                # link local requires scope ID here, otherwise route add will fail
+                self._def_local_db[row[1]] = f"{row[2]}%{row[0]}"
 
     def get(self, mac):
         if mac not in self._def_local_db:


### PR DESCRIPTION
I think in my recent refactor I totally forgot about the scopeID being a requirement to add a route with a link local address:

https://github.com/opnsense/core/commit/c827a02ef6ce0aa12ee54c24e6f538e118dda54d

Possible PR: https://forum.opnsense.org/index.php?topic=50849.msg260073#msg260073

Tested database content again, now with scopeID:

```
  00:15:5d:00:ad:23 -> fe80::36e1:a9ff:fe4b:ed40%hn0
  00:15:5d:00:ad:34 -> fe80::215:5dff:fe00:ad34%hn0
  f4:90:ea:01:3d:c9 -> fe80::f690:eaff:fe01:3dc9%hn1
```