### PR TITLE
Update system_gateway_groups.php, Fatal Error on Gateway Group Deletion

### DIFF
--- a/src/www/system_gateway_groups.php
+++ b/src/www/system_gateway_groups.php
@@ -38,7 +38,7 @@ $a_gateways = (new \OPNsense\Routing\Gateways())->gatewaysIndexedByName();
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['act']) && $_POST['act'] == "del" ) {
         if (!empty($a_gateway_groups[$_POST['id']])) {
-            if (!empty($config['filter']['rule'])) {
+            if (isset($config['filter']['rule']) && is_array($config['filter']['rule'])) {
                 foreach ($config['filter']['rule'] as $idx => $rule) {
                     if (isset($rule['gateway']) && $rule['gateway'] == $a_gateway_groups[$_POST['id']]['name']) {
                         unset($config['filter']['rule'][$idx]['gateway']);


### PR DESCRIPTION
When deleting gateway group i was getting fatal error on multiple devices. I dont know when it started. This involves opnsense installation from v22 updated all the way to v26.1.2. Unable to delete gateway groups as a result.

Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /usr/local/www/system_gateway_groups.php:41 Stack trace: #0 {main} thrown in /usr/local/www/system_gateway_groups.php on line 41 

Did some research, appeared to be an empty filter rule this code could not handle and resulted in fatal error.

Rewrote logic.