### PR TITLE
Fix SNAT isEnabled check

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/snat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/snat_rule.volt
@@ -172,7 +172,7 @@
                         if (row.isGroup || !rowId.includes('-')) {
                             return '';
                         }
-                        const isEnabled = row[column.id] === "0";
+                        const isEnabled = row[column.id] === "1";
                         return `
                             <span class="fa fa-fw ${isEnabled ? 'fa-check-square-o' : 'fa-square-o text-muted'} bootgrid-tooltip command-toggle"
                                 style="cursor: pointer;"


### PR DESCRIPTION
This change fixes the isEnabled check for the Source NAT table to check that the "enabled" field of each SNAT row is equal to 1 instead of 0. This prevents misleading checkbox and tooltip values on the "firewall>NAT>Source Nat" page and makes their behavior match that of other rule tables.

Before:
<img width="526" height="264" alt="Screenshot From 2026-02-18 19-27-23" src="https://github.com/user-attachments/assets/18cc49e3-7b0e-4509-a5a8-0dd8723e25ab" />

After:
<img width="526" height="264" alt="Screenshot From 2026-02-18 19-27-36" src="https://github.com/user-attachments/assets/456a7c9d-c1cc-4e38-b2e4-d97ee8866c12" />

