### PR TITLE
UI: restore canvas state in health graph

### DIFF
--- a/src/opnsense/www/js/opnsense_health.js
+++ b/src/opnsense/www/js/opnsense_health.js
@@ -162,6 +162,8 @@ class HealthGraph {
                         ctx.stroke();
                     }
                 });
+
+                ctx.restore(); // restore canvas state
             }
         };
 


### PR DESCRIPTION
Fixed health graph bug on Firefox causing graph to shrink after hovering over it for an extended amount of time. The problem was caused by ctx.save() being called repeatedly during hovering. This caused a rendering degradation, because Firefox is stricter about canvas state stack growth. Added ctx.restore() so every save state gets restored and removed from the stack so the canvas doesn't accumulate state. Graph behaves properly on Chrome and Firefox now.

Fixes #9528 