### PR TITLE
openvpn: Adding options for legacy ciphers

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -242,18 +242,56 @@
                 <data-ciphers type="OptionField">
                     <Multiple>Y</Multiple>
                     <OptionValues>
-                        <AES-256-CBC>AES-256-CBC</AES-256-CBC>
-                        <AES-128-GCM>AES-128-GCM</AES-128-GCM>
-                        <AES-256-GCM>AES-256-GCM</AES-256-GCM>
-                        <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
+                        <Recommended>
+                            <AES-128-GCM>AES-128-GCM</AES-128-GCM>
+                            <AES-192-GCM>AES-192-GCM</AES-192-GCM>
+                            <AES-256-GCM>AES-256-GCM</AES-256-GCM>
+                            <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
+                        </Recommended>
+                        <Legacy>
+                            <AES-128-CBC>AES-128-CBC</AES-128-CBC>
+                            <AES-192-CBC>AES-192-CBC</AES-192-CBC>
+                            <AES-256-CBC>AES-256-CBC</AES-256-CBC>
+                            <AES-128-CFB>AES-128-CFB</AES-128-CFB>
+                            <AES-192-CFB>AES-192-CFB</AES-192-CFB>
+                            <AES-256-CFB>AES-256-CFB</AES-256-CFB>
+                            <AES-128-CFB1>AES-128-CFB1</AES-128-CFB1>
+                            <AES-192-CFB1>AES-192-CFB1</AES-192-CFB1>
+                            <AES-256-CFB1>AES-256-CFB1</AES-256-CFB1>
+                            <AES-128-CFB8>AES-128-CFB8</AES-128-CFB8>
+                            <AES-192-CFB8>AES-192-CFB8</AES-192-CFB8>
+                            <AES-256-CFB8>AES-256-CFB8</AES-256-CFB8>
+                            <AES-128-OFB>AES-128-OFB</AES-128-OFB>
+                            <AES-192-OFB>AES-192-OFB</AES-192-OFB>
+                            <AES-256-OFB>AES-256-OFB</AES-256-OFB>
+                        </Legacy>
                     </OptionValues>
                 </data-ciphers>
                 <data-ciphers-fallback type="OptionField">
                     <OptionValues>
-                        <AES-256-CBC>AES-256-CBC</AES-256-CBC>
-                        <AES-128-GCM>AES-128-GCM</AES-128-GCM>
-                        <AES-256-GCM>AES-256-GCM</AES-256-GCM>
-                        <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
+                        <Recommended>
+                            <AES-128-GCM>AES-128-GCM</AES-128-GCM>
+                            <AES-192-GCM>AES-192-GCM</AES-192-GCM>
+                            <AES-256-GCM>AES-256-GCM</AES-256-GCM>
+                            <CHACHA20-POLY1305>CHACHA20-POLY1305</CHACHA20-POLY1305>
+                        </Recommended>
+                        <Legacy>
+                            <AES-128-CBC>AES-128-CBC</AES-128-CBC>
+                            <AES-192-CBC>AES-192-CBC</AES-192-CBC>
+                            <AES-256-CBC>AES-256-CBC</AES-256-CBC>
+                            <AES-128-CFB>AES-128-CFB</AES-128-CFB>
+                            <AES-192-CFB>AES-192-CFB</AES-192-CFB>
+                            <AES-256-CFB>AES-256-CFB</AES-256-CFB>
+                            <AES-128-CFB1>AES-128-CFB1</AES-128-CFB1>
+                            <AES-192-CFB1>AES-192-CFB1</AES-192-CFB1>
+                            <AES-256-CFB1>AES-256-CFB1</AES-256-CFB1>
+                            <AES-128-CFB8>AES-128-CFB8</AES-128-CFB8>
+                            <AES-192-CFB8>AES-192-CFB8</AES-192-CFB8>
+                            <AES-256-CFB8>AES-256-CFB8</AES-256-CFB8>
+                            <AES-128-OFB>AES-128-OFB</AES-128-OFB>
+                            <AES-192-OFB>AES-192-OFB</AES-192-OFB>
+                            <AES-256-OFB>AES-256-OFB</AES-256-OFB>
+                        </Legacy>
                     </OptionValues>
                 </data-ciphers-fallback>
                 <tls_key type="ModelRelationField">


### PR DESCRIPTION
This adds some ciphers as options for OpenVPN Servers, and groups the options into recommended and legacy. It adds 128/192/256 Bit Versions of AES-x-CBC/CFB/CFB1/CFB8/OFB under Legacy, and AES-192-GCM under Recommended.

All of these Ciphers are still supported by the OpenVPN Server on OPNsense.

Note: Even though AES-256-CBC was added previously in commit 62d0c4e, it was added to the Legacy group. As according to the commit message, it was added for legacy compatibility.

I tested these changes on my OPNsense Instance and they all seem to work fine.