### PR TITLE
monitor: skip state killing when no viable failover target exists

### DIFF
--- a/src/etc/rc.syshook.d/monitor/20-recover
+++ b/src/etc/rc.syshook.d/monitor/20-recover
@@ -37,8 +37,10 @@ $affected_gateways = !empty($argv[1]) ? explode(',', $argv[1]) : [];
 
 $metered_found_prios = ['inet' => 256, 'inet6' => 256];
 $metered_gws = ['inet' => [], 'inet6' => []];
+$all_statuses = return_gateways_status();
+$has_viable_target = !empty(array_filter($all_statuses, function ($s) { return strpos($s['status'], 'down') === false; }));
 
-foreach (return_gateways_status() as $status) {
+foreach ($all_statuses as $status) {
     if (strpos($status['status'], 'down') !== false) {
         /* recover monitors stuck in down state ignoring "force_down" */
         if ($status['status'] == 'down') {
@@ -46,8 +48,12 @@ foreach (return_gateways_status() as $status) {
         }
         /* kill states for all down transitions including "force_down" */
         if (!empty($status['monitor_killstates']) && in_array($status['name'], $affected_gateways)) {
-            $uuid = trim(configdp_run('filter kill gateway_states', [$status['gateway']], true));
-            log_msg("ROUTING: killing states for unreachable gateway {$status['name']} [$uuid]", LOG_NOTICE);
+            if ($has_viable_target) {
+                $uuid = trim(configdp_run('filter kill gateway_states', [$status['gateway']], true));
+                log_msg("ROUTING: killing states for unreachable gateway {$status['name']} [$uuid]", LOG_NOTICE);
+            } else {
+                log_msg("ROUTING: preserving states for {$status['name']} (no viable failover target)", LOG_NOTICE);
+            }
         }
     } else {
         /* collect "metered" gateways for all non-down status reports */


### PR DESCRIPTION
**Important notices**

- [X] I have read the contributing guide lines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I am convinced that my issue is new after having checked both open and closed issues at https://github.com/opnsense/core/issues?q=is:issue

**Describe the change**

When a gateway goes down, the 20-recover monitor hook kills all states for that gateway — even when no other gateway is available to failover to. When the only other gateway and its interface are both disabled, this destroys active connections on the only working gateway with zero benefit, causing self-inflicted outages.

The system already acknowledges this situation in its own logs:

    ROUTING: ignoring down gateways: WAN_DHCP, USB5GPHONE_DHCP

Yet it still kills states for WAN_DHCP immediately after.

**The fix**

Two lines added before the existing loop to pre-scan `return_gateways_status()` for any non-down gateway. One `if` wrapper around the existing kill call to skip it when no viable target exists. No new functions, no new imports, no structural changes.

When states are preserved, the decision is logged:

    ROUTING: preserving states for WAN_DHCP (no viable failover target)

When a viable target does exist, behavior is completely unchanged.

**Ref:** #9789 (closed), previous PR #9823 (closed — this is a simplified resubmission with minimal changes)