### PR TITLE
mvc: BaseListField: shared implementation of $internalStaticOptionList

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/AuthGroupField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/AuthGroupField.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2015-2019 Deciso B.V.
+ * Copyright (C) 2015-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,25 +32,19 @@ use OPNsense\Core\Config;
 
 class AuthGroupField extends BaseListField
 {
-    /**
-     * @var array collected options
-     */
-    private static $internalStaticOptionList = array();
-
-    /**
-     * generate validation data (list of certificates)
-     */
     protected function actionPostLoadingEvent()
     {
-        if (empty(self::$internalStaticOptionList)) {
+        if (!$this->hasStaticOptions()) {
             $cnf = Config::getInstance()->object();
+            $data = [];
             if (isset($cnf->system->group)) {
                 foreach ($cnf->system->group as $group) {
-                    self::$internalStaticOptionList[(string)$group->gid] = (string)$group->name;
+                    $data[(string)$group->gid] = (string)$group->name;
                 }
-                natcasesort(self::$internalStaticOptionList);
+                natcasesort($data);
             }
+            $this->setStaticOptions($data);
         }
-        $this->internalOptionList = self::$internalStaticOptionList;
+        $this->internalOptionList = $this->getStaticOptions();
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseListField.php
@@ -57,6 +57,32 @@ abstract class BaseListField extends BaseField
     protected $internalMultiSelect = false;
 
     /**
+     * statically cached options per inherited classtype
+     */
+    protected static $internalStaticOptList = [];
+
+    protected function hasStaticOptions(): bool
+    {
+        return !empty(self::$internalStaticOptList[static::class]);
+    }
+
+    protected function getStaticOptions(): array
+    {
+        return self::$internalStaticOptList[static::class] ?? [];
+    }
+
+    protected function setStaticOptions(array $data)
+    {
+        return self::$internalStaticOptList[static::class] = $data;
+    }
+
+    protected function resetStaticOptions()
+    {
+        return self::$internalStaticOptList[static::class] = [];
+    }
+
+
+    /**
      * {@inheritdoc}
      */
     protected function defaultValidationMessage()


### PR DESCRIPTION
Proof of concept for https://github.com/opnsense/core/issues/9816

Wrap static access in protected functions which ensures content is static per inherited class:

hasStaticOptions()
getStaticOptions()
setStaticOptions(array)
resetStaticOptions()