### PR TITLE
Trim whitespace from tokens before tokenising

### DIFF
--- a/src/opnsense/www/js/tokenize2.js
+++ b/src/opnsense/www/js/tokenize2.js
@@ -282,6 +282,8 @@
      */
     Tokenize2.prototype.tokenAdd = function(value, text, force){
 
+        text = text.trim();
+        value = value.trim();
         text = text || value;
         selector_value = $.escapeSelector(value);
         force = force || false;


### PR DESCRIPTION
Previously if you pasted an IP or similar in whitespace on either side it will automatically put it into a token box and then error on save.

The only way to fix that is to paste into an editor, fix the data and then copy-paste back into opnsense. This should trim before tokenizing the data

Fixes: https://github.com/opnsense/core/issues/9438