### PR TITLE
mvc: Add validation for using both gateway and reply-to in rules [new]

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
@@ -267,10 +267,10 @@ class Filter extends BaseModel
                                 $rule->{'divert-to'}->__reference
                             ));
                         }
-                        if (!$rule->{'gateway'}->isEmpty() && !$rule->{'replyto'}->isEmpty()) {
+                        if (!$rule->gateway->isEmpty() && !$rule->replyto->isEmpty()) {
                             $messages->appendMessage(new Message(
                                 gettext('You can not assign a reply-to destination to a rule that uses a gateway.'),
-                                $rule->{'replyto'}->__reference
+                                $rule->replyto->__reference
                             ));
                         }
                     }


### PR DESCRIPTION
Added validation to rules [new] to ensure a user can't select both a gateway and reply-to destination when adding/editing a firewall rule.

Fixes: #9842 