### PR TITLE
mvc: Add validation for selecting username as CN without setting any authentication

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -135,7 +135,7 @@ class OpenVPN extends BaseModel
                 }
                 if (!$instance->username_as_common_name->isEmpty() && $instance->authmode->isEmpty()) {
                     $messages->appendMessage(new Message(
-                        gettext('Username as CN requires an authentication mode.'),
+                        gettext('Username as CN requires one or more authentication modes.'),
                         $key . ".authmode"
                     ));
                 }


### PR DESCRIPTION
Added validation to openvpn to ensure a user can't select username as CN without setting any authentication when adding/editing an openvpn instance.

Fixes: #9850 