### PR TITLE
Firewall: NAT: Destination NAT: Allow well known ports in local-port

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/DNat.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/DNat.xml
@@ -67,6 +67,7 @@
             </destination>
             <target type="NetworkAliasField"/>
             <local-port type="PortField">
+                <EnableWellKnown>Y</EnableWellKnown>
                 <EnableAlias>Y</EnableAlias>
                 <ValidationMessage>Please specify a valid port number or alias.</ValidationMessage>
             </local-port>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -514,7 +514,6 @@
             // local-port in DNAT does not support port ranges, so we replace the label for clarity
             const singlePortOnly = $.extend(true, {}, data);
             singlePortOnly.single.label = "{{ lang._('Single port') }}";
-            delete singlePortOnly.ports;
 
             $(".port_selector").each(function () {
                 const opts = $(this).is('#row_rule\\.local-port .port_selector')


### PR DESCRIPTION
Seems to work for me:

```
root@opn-dev-02:/src/git/core # pfctl -s nat

rdr inet proto tcp from 127.0.0.1 port = https to 127.0.0.1 port = ftp -> 127.0.0.1 port 993
```

<img width="914" height="1197" alt="image" src="https://github.com/user-attachments/assets/2974ab18-02e0-417d-a4ed-f8164ae0ab02" />