### PR TITLE
UI: Fixed broken link in modal header

### DIFF
--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -481,7 +481,7 @@ $(document).ready(function() {
     if (isset($restart_webgui) && $restart_webgui): ?>
         BootstrapDialog.show({
             type:BootstrapDialog.TYPE_INFO,
-            title: <?= json_encode($savemsg) ?>,
+            title: <?= json_encode(get_std_save_message()) ?>,
             closable: false,
             message: '<?= html_safe(gettext('The web GUI is reloading at the moment, please wait...')) ?>' +
                 ' <i class="fa fa-cog fa-spin"></i><br /><br />' +

--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -481,7 +481,7 @@ $(document).ready(function() {
     if (isset($restart_webgui) && $restart_webgui): ?>
         BootstrapDialog.show({
             type:BootstrapDialog.TYPE_INFO,
-            title: '<?= html_safe($savemsg) ?>',
+            title: <?= json_encode($savemsg) ?>,
             closable: false,
             message: '<?= html_safe(gettext('The web GUI is reloading at the moment, please wait...')) ?>' +
                 ' <i class="fa fa-cog fa-spin"></i><br /><br />' +


### PR DESCRIPTION
Fixed a broken link that appears in a modal header when you enable high availability and change deployment type in System: Settings: Administration. The issue was caused by html_safe() not being able to parse the link correctly. This is resolved by using json_encode() instead.

Fixes: #9856 