### PR TITLE
Update Opnsense Sidebar

### DIFF
--- a/src/opnsense/www/js/opnsense_theme.js
+++ b/src/opnsense/www/js/opnsense_theme.js
@@ -179,7 +179,7 @@ $(document).ready(function () {
     $(window).on('resize', function () {
         const winHeight = $(window).height();
         const winWidth  = $(window).width();
-        const tooSmall  = winHeight < navHeight || winWidth < 1000;
+        const tooSmall  = winHeight < navHeight || winWidth < 760;
 
         if (tooSmall && !isSidebarHidden()) {
             navigation.addClass('col-sidebar-hidden');
@@ -203,7 +203,7 @@ $(document).ready(function () {
     // --- Init: check viewport on page load before showing sidebar ---
     const initHeight = $(window).height();
     const initWidth  = $(window).width();
-    const tooSmallOnLoad = initHeight < navHeight || initWidth < 1000;
+    const tooSmallOnLoad = initHeight < navHeight || initWidth < 760;
 
     if (tooSmallOnLoad) {
         navigation.addClass('col-sidebar-hidden');


### PR DESCRIPTION
**Fix:**

Upon loading, $(window).height() and $(window).width() are immediately checked – the same condition as in the resize handler (navHeight / 760px).

If the viewport is too small → the sidebar is hidden, mouse events are disabled, and the toggle button is hidden.
If the viewport is large enough → normal behavior as usual (including the localStorage preset).

**Readability & Structure**

var consistently replaced with const/let
Helpful functions like isSidebarLeft() and isSidebarHidden() extracted to avoid duplicate hasClass calls transition_duration → setTransitionDuration, mouse_events_off → offMouseEvents (clearer names)

**Performance**

jQuery selectors are cached only once (e.g., toggle_btn, allLayers, aLayers, divLayers)

$.each(document.styleSheets, ...) replaced with modern Array.from(...).some(...) – shorter and terminates early toggle_sidebar_loaded check with early return instead of deeply nested if block

**Redundancy Reduction**

Duplicate calls consolidated in event handlers Repeated offMouseEvents()/transition_duration() calls in Resize handler consolidates winWidth directly from $(window).width() instead of via win variable

@fichtner I've taken the sidebar to a whole new level. Tested a thousand times. Works flawlessly. It would be great if we could release this version with the next update, as it also fixes a problem that's currently present. See description. Thanks, Rene