### PR TITLE
Add HA/CARP safety for PPP link startup

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1338,6 +1338,39 @@ EOD;
         @unlink('/var/spool/lock/LCK..' . basename($port));
     }
 
+    /*
+     * HA/CARP safety for PPP links:
+     * If "Disconnect dialup interfaces" is enabled, only allow PPP startup
+     * when at least one underlying parent interface is currently CARP MASTER.
+     *
+     * This prevents a rebooted BACKUP node from starting PPPoE later in boot
+     * after the CARP hook has already tried (too early) to suspend it.
+     */
+    if (!empty($config['hasync']['disconnectppps'])) {
+      $carp_master = false;
+
+      foreach ($ports as $port) {
+        $ifconfig_out = shell_exec('/sbin/ifconfig ' . escapeshellarg($port) . ' 2>/dev/null');
+        if (!is_string($ifconfig_out)) {
+          continue;
+        }
+
+        if (preg_match('/\bcarp:\s+MASTER\b/m', $ifconfig_out)) {
+          $carp_master = true;
+          break;
+        }
+      }
+
+      if (!$carp_master) {
+        log_msg(
+          "interface_ppps_configure() skipped for {$interface} " .
+          "(disconnectppps enabled, no parent interface is CARP MASTER)",
+          LOG_NOTICE
+        );
+        return;
+      }
+    }
+
     /* precaution for post-start 'up' check */
     legacy_interface_flags($ifcfg['if'], 'down', false);
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1339,36 +1339,36 @@ EOD;
     }
 
     /*
-     * HA/CARP safety for PPP links:
-     * If "Disconnect dialup interfaces" is enabled, only allow PPP startup
-     * when at least one underlying parent interface is currently CARP MASTER.
+     * In HA mode with disconnectppps enabled, only start PPP when at least
+     * one underlying parent interface is currently CARP MASTER.
      *
-     * This prevents a rebooted BACKUP node from starting PPPoE later in boot
-     * after the CARP hook has already tried (too early) to suspend it.
+     * During boot, the CARP hook may already have processed a BACKUP event
+     * before the PPP pseudo-interface exists. Without this guard, the later
+     * normal startup path can still start PPP on a BACKUP node.
      */
     if (!empty($config['hasync']['disconnectppps'])) {
-      $carp_master = false;
+        $carp_master = false;
 
-      foreach ($ports as $port) {
-        $ifconfig_out = shell_exec('/sbin/ifconfig ' . escapeshellarg($port) . ' 2>/dev/null');
-        if (!is_string($ifconfig_out)) {
-          continue;
+        foreach ($ports as $port) {
+            $ifconfig_out = shell_exec('/sbin/ifconfig ' . escapeshellarg($port) . ' 2>/dev/null');
+            if (!is_string($ifconfig_out)) {
+                continue;
+            }
+
+            if (preg_match('/\bcarp:\s+MASTER\b/m', $ifconfig_out)) {
+                $carp_master = true;
+                break;
+            }
         }
 
-        if (preg_match('/\bcarp:\s+MASTER\b/m', $ifconfig_out)) {
-          $carp_master = true;
-          break;
+        if (!$carp_master) {
+            log_msg(
+                "interface_ppps_configure() skipped for {$interface} " .
+                "(disconnectppps enabled, no parent interface is CARP MASTER)",
+                LOG_NOTICE
+            );
+            return;
         }
-      }
-
-      if (!$carp_master) {
-        log_msg(
-          "interface_ppps_configure() skipped for {$interface} " .
-          "(disconnectppps enabled, no parent interface is CARP MASTER)",
-          LOG_NOTICE
-        );
-        return;
-      }
     }
 
     /* precaution for post-start 'up' check */

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1008,6 +1008,44 @@ function interface_ppps_hardware($device)
     return $devices;
 }
 
+function interface_ppps_carp_master($ports)
+{
+    /*
+     * Whether CARP considers this node the one to run a PPP link on: null when
+     * CARP does not own the link, true when a parent device is MASTER and false
+     * when the link must not run here.  A VIP that is configured but not up yet
+     * counts as false, because interfaces are configured without any notion of a
+     * PPP link depending on the VIPs of its parent and being unable to tell is
+     * not a reason to start.
+     */
+    if (empty(config_read_array('hasync', false)['disconnectppps'])) {
+        return null;
+    }
+
+    $owned = false;
+
+    foreach ($ports as $port) {
+        foreach (legacy_interface_details($port)['carp'] ?? [] as $carp) {
+            if ($carp['status'] == 'MASTER') {
+                return true;
+            }
+            $owned = true;
+        }
+    }
+
+    if (!$owned) {
+        /* the parent interface may not be configured yet, so ask the configuration */
+        foreach (config_read_array('virtualip', 'vip', false) as $vip) {
+            if (($vip['mode'] ?? '') == 'carp' && in_array(get_real_interface($vip['interface']), $ports)) {
+                $owned = true;
+                break;
+            }
+        }
+    }
+
+    return $owned ? false : null;
+}
+
 function interface_ppps_reset($interface, $suspend, $ifcfg, $ppps)
 {
     if (!interface_ppps_capable($ifcfg, $ppps)) {
@@ -1026,7 +1064,7 @@ function interface_ppps_reset($interface, $suspend, $ifcfg, $ppps)
     }
 }
 
-function interface_ppps_configure($interface)
+function interface_ppps_configure($interface, $defer_to_carp = false)
 {
     global $config;
 
@@ -1133,6 +1171,26 @@ function interface_ppps_configure($interface)
                 log_msg("Unknown {$ppp['type']} configured as PPP interface.", LOG_ERR);
                 break;
         }
+    }
+
+    $carp_master = interface_ppps_carp_master($ports);
+
+    if ($carp_master === false) {
+        /* decide before mpd5 is set up at all so a link is never started to be stopped again */
+        log_msg("interface_ppps_configure() skipped for {$interface}, no parent device is CARP MASTER", LOG_NOTICE);
+        killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
+        return;
+    }
+
+    /*
+     * The interface configuration does not know the outcome of the election
+     * while booting, but the CARP event that follows it does.  Let the event
+     * own the link until then so it has a single starter instead of two racing
+     * ones and cannot be brought up twice.
+     */
+    if ($carp_master && $defer_to_carp && product::getInstance()->booting()) {
+        log_msg("interface_ppps_configure() deferred for {$interface} to the CARP event", LOG_NOTICE);
+        return;
     }
 
     // Construct the mpd.conf file
@@ -1365,6 +1423,16 @@ EOD;
         default:
             legacy_interface_mtu($ifcfg['if'], $mtus[0]);
             break;
+    }
+
+    /*
+     * CARP may have moved on while the link was coming up.  A teardown that
+     * arrived before mpd5 wrote its pid file could not stop it, so check the
+     * state once more now that there is a pid file to act on.
+     */
+    if (interface_ppps_carp_master($ports) === false) {
+        log_msg("interface_ppps_configure() stopping {$interface}, no parent device is CARP MASTER", LOG_NOTICE);
+        killbypid("/var/run/{$ppp['type']}_{$interface}.pid");
     }
 }
 
@@ -2484,7 +2552,7 @@ function interface_configure($verbose = false, $interface = 'wan', $reload = fal
     }
 
     /* since the connectivity can include IPv4 and/or IPv6 let the function decide */
-    interface_ppps_configure($interface);
+    interface_ppps_configure($interface, true);
 
     switch ($wancfg['ipaddr'] ?? 'none') {
         case 'dhcp':


### PR DESCRIPTION

**Important notices**

- [x] I have read the contributing guidelines
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 5 (via Claude Code)
- Extent of AI involvement: analysis of the ordering and startup races, drafting
  the patch and its comments, and a test harness for the CARP decision logic.
  Reviewed, tested on my HA pair and submitted by me.

---

**Describe the problem**

With `disconnectppps` enabled the PPP link should only run on the CARP MASTER.
Two things prevent that today:

1. `interfaces_configure()` orders interfaces by queue and then by description.
   Nothing in that order knows a PPP interface depends on the CARP VIPs of its
   parent, so depending on which side wins, either the BACKUP node starts PPP
   and keeps it, or it starts PPP and the CARP hook suspends it moments later
   -- the short window where both nodes hold a session that @fichtner raised.

2. During boot the link has two possible starters: `interfaces_configure()` and
   the CARP hook. On a node that becomes MASTER while still booting, both can
   fire, so the link is started twice or killed and redialled right after
   coming up.

The same gap applies outside boot: Save/Apply on a BACKUP node starts the link
there, and since `20-ppp` only fires on a state transition, nothing brings it
back down again.

**Describe the proposed solution**

One file, `src/etc/inc/interfaces.inc`, +70/-2.

- `interface_ppps_carp_master()` reports whether CARP controls the link and
  whether this node is MASTER. A VIP configured on the parent but not up yet
  counts as not MASTER, which makes the decision independent of interface
  order. It uses the resolved `$ports`, so a PPP link on top of an assigned
  interface works (see the existing XXX in `interface_ppps_hardware()`), and it
  requires a MASTER rather than the absence of a BACKUP, so a parent with
  several vhids is judged correctly.
- The decision is made before mpd5 is set up at all, so a link is never started
  only to be stopped again.
- While booting, a CARP-controlled link is left to the CARP hook, the only
  caller that knows the election is over. That gives it a single starter, so no
  locking is needed. `interface_ppps_configure()` gained an optional
  `$defer_to_carp` argument for this, passed from `interface_configure()`;
  existing callers are unaffected and `rc.syshook.d/carp/20-ppp` is untouched.
- After the link came up the state is checked once more, because a teardown
  arriving before mpd5 wrote its pid file could not have stopped it.

Behaviour without `disconnectppps` is unchanged: `interface_ppps_carp_master()`
returns null before touching ifconfig or the VIP configuration, and every
branch is gated on it.

**Testing**

Static: `php -l` clean. The CARP decision logic was extracted from the patched
file and run against stubbed config/ifconfig lookups -- 22 cases across three
suites covering HA off, HA on without CARP, MASTER/BACKUP/INIT, VIP configured
but not yet up, VIP on an unrelated interface, ipalias vs carp, missing `mode`
key, multiple vhids, MLPPP, serial modem device nodes, and my real topology.
All pass under E_ALL with no notices.

On hardware, an HA pair where the two nodes do not even share a parent device
for the link -- master is `ix0` (physical), backup is `vlan040` -- both on
vhid 2:

| Test | Result |
|------|--------|
| Reboot BACKUP | link stays down, gate logs the skip, mpd config not regenerated |
| Maintenance failover | new MASTER starts the link once, mpd5 start time matches the CARP event to the second |
| `configctl interface reconfigure wan` on MASTER | link restarts cleanly, address restored |
| Reboot demoted (maintenance) node | link stays down, live WAN on the peer completely undisturbed |
| Failback | both nodes transition in the same second, exactly one session |
| Reboot MASTER without maintenance | WAN moves to the peer and back, single start on each, never two sessions |
| Forced ordering: PPP interface configured before its parent | link stays down through the configuration fallback |
| Save/Apply WAN on BACKUP from the GUI | no session started, skip logged from `/interfaces.php` |

Every transition ended with exactly one mpd5 across the pair.

For the forced-ordering case I set the PPP interface's IPv6 type to None and
renamed the parent so it sorts after it. The skip is then logged *before* the
CARP event for the parent's VIP, so the decision came from the configuration
rather than from live CARP state -- the case that could not be decided before.
Reproduced on 26.7.1_1; master resolves VLAN devices differently since
137513cc25, so the same trick may not provoke that ordering there.

**Not covered by these tests**

- The deferral path needs a node that becomes MASTER *during* boot, which only
  happens when the peer is absent (cold start of a single node, or both nodes
  booting together after a power cut). Reasoning and unit tests only.

**Known limitation**

Teardown on the old MASTER and startup on the new one are driven by devd
independently on each node, so a brief window remains on failover. Split brain
gives two MASTERs and therefore two sessions by definition. Neither is
addressable from a single node.

