### PR TITLE
kea: kea_prefix_watcher guard when no link-local address exists for a route that should be installed

### DIFF
--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -124,6 +124,12 @@ if __name__ == '__main__':
                     and record.get('expire', 0) > time.time():
                 prefixes[prefix] = record
                 ll_addr = hostwatch.get(record.get('hwaddr'))
+                if not ll_addr:
+                    syslog.syslog(
+                        syslog.LOG_WARNING,
+                        "no LLA found for %s, skipping route %s" % (record.get('hwaddr'), prefix)
+                    )
+                    continue
                 # lazy drop
                 subprocess.run(['/sbin/route', 'delete', '-inet6', prefix], capture_output=True)
                 if record.get('valid_lifetime', 0) > 0:


### PR DESCRIPTION
Ran into this while testing stuff:

```
File "/usr/local/lib/python3.13/subprocess.py", line 554, in run
~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
if subprocess.run(['/sbin/route', 'add', '-inet6', prefix, ll_addr], capture_output=True).returncode:
File "/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py", line 131, in <module>
Traceback (most recent call last):
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

The script blows up here
```
ll_addr=hostwatch.get(record.get('hwaddr'))
```

Happens if there are old entries in the lease file and the ndp table or hostwatch do not have any LLA stored for this entry. They should be skipped.