### PR TITLE
firewall: fix regression in 8554581eac so alias content summary is shown

### DIFF
--- a/src/etc/inc/legacy_bindings.inc
+++ b/src/etc/inc/legacy_bindings.inc
@@ -175,7 +175,7 @@ function legacy_move_config_list_items($source, $id, $items)
  */
 function get_alias_description($name)
 {
-    return OPNsense\Firewall\Util::aliasDescription($name);
+    return OPNsense\Firewall\Util::aliasSummary($name);
 }
 
 /* XXX deprecated */

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
@@ -115,12 +115,15 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
                     'description' => ''
                 ];
             }
+            /* create alias object for summary */
+            Util::attachAliasObject(new Alias(true));
             foreach (Alias::getCachedData()['aliases']['alias'] ?? [] as $alias) {
                 $this->networks[$alias['name']] = [
+                    'summary' => Util::aliasSummary($alias['name']),
+                    'description' => $alias['description'],
                     'value' => $alias['name'],
                     '%value' => $alias['name'],
                     'isAlias' => true,
-                    'description' => $alias['description'],
                 ];
             }
         }

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -43,9 +43,9 @@ class Util
     private static $aliasObject = null;
 
     /**
-     * @var null|array cached alias descriptions
+     * @var null|array cached alias content
      */
-    private static $aliasDescriptions = [];
+    private static $aliasSummaries = [];
 
     /**
      * @var array cached getservbyname results
@@ -266,20 +266,20 @@ class Util
     }
 
     /**
-     * return alias descriptions
+     * return alias summary (description and content as found)
      * @param string $name name
      * @return string
      */
-    public static function aliasDescription($name)
+    public static function aliasSummary($name)
     {
-        if (empty(self::$aliasDescriptions)) {
+        if (empty(self::$aliasSummaries)) {
             // read all aliases at once, and cache descriptions.
             foreach ((new Alias(true))->aliasIterator() as $alias) {
-                if (empty(self::$aliasDescriptions[$alias['name']])) {
+                if (empty(self::$aliasSummaries[$alias['name']])) {
                     if (!empty($alias['description'])) {
-                        self::$aliasDescriptions[$alias['name']] = '<strong>' . $alias['description'] . '</strong><br/>';
+                        self::$aliasSummaries[$alias['name']] = '<strong>' . $alias['description'] . '</strong><br/>';
                     } else {
-                        self::$aliasDescriptions[$alias['name']] = "";
+                        self::$aliasSummaries[$alias['name']] = '';
                     }
 
                     if (!empty($alias['content'])) {
@@ -288,16 +288,13 @@ class Util
                         if (count($alias['content']) > 10) {
                             $tmp[] = '[...]';
                         }
-                        self::$aliasDescriptions[$alias['name']] .= implode("<br/>", $tmp);
+                        self::$aliasSummaries[$alias['name']] .= implode('<br/>', $tmp);
                     }
                 }
             }
         }
-        if (!empty(self::$aliasDescriptions[$name])) {
-            return self::$aliasDescriptions[$name];
-        } else {
-            return null;
-        }
+
+        return self::$aliasSummaries[$name] ?? null;
     }
 
     /**

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -503,7 +503,7 @@
                         // Return all icons
                         return result;
                     },
-                    // Show Edit alias icon, alias description and integrate "not" functionality
+                    // Show Edit alias icon, alias info and integrate "not" functionality
                     alias: function(column, row) {
                         if (row.isGroup) {
                             return "";
@@ -525,7 +525,7 @@
 
                         const renderedItems = aliasMetadataList.map(aliasInfo => {
                             if (aliasInfo.isAlias) {
-                                const tooltipHtml = aliasInfo.description || aliasInfo.value || "";
+                                const tooltipHtml = aliasInfo.summary || aliasInfo.description || aliasInfo.value || "";
                                 return `
                                     <span data-toggle="tooltip" data-html="true" title="${tooltipHtml}">${aliasInfo.value}&nbsp;</span>
                                     <a href="/ui/firewall/alias/index/${encodeURIComponent(aliasInfo.value)}"

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -312,7 +312,7 @@
 
                         const renderedItems = aliasMetadataList.map(aliasInfo => {
                             if (aliasInfo.isAlias) {
-                                const tooltipHtml = aliasInfo.description || aliasInfo.value || "";
+                                const tooltipHtml = aliasInfo.summary || aliasInfo.description || aliasInfo.value || "";
                                 return `
                                     <span data-toggle="tooltip" data-html="true" title="${tooltipHtml}">${aliasInfo.value}&nbsp;</span>
                                     <a href="/ui/firewall/alias/index/${encodeURIComponent(aliasInfo.value)}"


### PR DESCRIPTION
The "description" is a summary so change the underlying code accordingly to avoid future misinterpretations.