### PR TITLE
Update ACL.xml

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Diagnostics/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Diagnostics/ACL/ACL.xml
@@ -31,6 +31,17 @@
             <pattern>api/diagnostics/interface/get_routes*</pattern>
         </patterns>
     </page-diagnostics-routingtables>
+    <page-diagnostics-showstates>
+        <name>Diagnostics: Show States</name>
+        <patterns>
+             <pattern>ui/diagnostics/firewall/states*</pattern>
+             <pattern>api/diagnostics/firewall/queryStates*</pattern>
+             <pattern>api/diagnostics/firewall/delState*</pattern>
+             <pattern>api/diagnostics/firewall/killStates*</pattern>
+             <pattern>api/diagnostics/firewall/flush_sources*</pattern>
+             <pattern>api/diagnostics/firewall/flush_states*</pattern>
+        </patterns>
+    </page-diagnostics-showstates>
     <page-diagnostics-system-activity>
         <name>Diagnostics: System Activity</name>
         <patterns>


### PR DESCRIPTION
Fixes #9961

**Disclaimer:**
First of all, I would like to note that I am not a programmer, just a user. I found a bug and after some digging around I fixed it myself so I just wanted to share it with others. Also, I've never really used github for anything serious before so I hope I am creating this pull request correctly. 

I really enjoy using OPNsense at home so I hope I can help even just a little bit.

**Issue description**
Update ACL.xml file to fix a bug where giving a user privilege of "Diagnostics: Show States" does nothing. See #9961

**Testing**
I've tested this updated file by editing it manually on my home instance of OPNSense, rebooting it, and then doing these API calls with `curl` command. After this change, I am able to call them using a user account that only have one privilege assigned: "Diagnostics: Show States" 

