### PR TITLE
fix(ntpd): remove stale /dev/pps0 symlink when PPS is disabled

### DIFF
--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -212,9 +212,15 @@ function ntpd_configure_do($verbose = false)
     }
     $ntpcfg .= "\n";
 
+    /* Clean up PPS symlink if PPS is disabled or port is not set */
+    if (empty($config['ntpd']['pps']['port'])) {
+        @unlink('/dev/pps0');
+    }
+
     /* Add PPS configuration */
     if (
         !empty($config['ntpd']['pps'])
+		&& !empty($config['ntpd']['pps']['port'])
         && file_exists('/dev/' . $config['ntpd']['pps']['port'])
         && ntpd_configure_pps($config['ntpd']['pps']['port'])
     ) {


### PR DESCRIPTION
When PPS serial port is set to none, the /dev/pps0 symlink created by ntpd_configure_pps() persists and causes file_exists() to return true, resulting in PPS lines being written to ntpd.conf even when PPS is disabled. This causes ntpd to crash on startup with: refclock_atom: /dev/pps0: Is a directory

Fix: explicitly remove the symlink when port is empty, and add port emptiness check to guard the PPS config block.

Fixes #2219
Fixes #9968
Fixes #9970