### PR TITLE
Services: Kea: DHCPv4: Remove option auto-conversion of string to binary

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogOption4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogOption4.xml
@@ -9,7 +9,7 @@
         <id>option.encoding</id>
         <label>Encoding</label>
         <type>dropdown</type>
-        <help>Choose between auto-converting string data to binary, or providing hexadecimal data yourself. For encapsulated and other complex options, constructing your own binary payload can be a requirement.</help>
+        <help>Choose the encoding type. "Hex" supports all encapsulated and structured options generically via payload in uppercase hexadecimal byte pairs.</help>
     </field>
     <field>
         <id>option.data</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/FieldTypes/KeaOptionDataField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/FieldTypes/KeaOptionDataField.php
@@ -52,12 +52,6 @@ class KeaOptionDataField extends BaseField
                         }
                     }
 
-                    if ($encoding === "string") {
-                        if (preg_match('/[\'"]/', $data)) {
-                            $messages[] = gettext("String value must not contain quotes.");
-                        }
-                    }
-
                     return $messages;
                 }
             ]);

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -202,16 +202,10 @@ class KeaDhcpv4 extends BaseModel
                     if ($option === null) {
                         continue;
                     }
-                    // Kea autoconverts strings to binary when providing 'data' => "'data to convert'"
-                    $data = $option->data->getValue();
-                    if ($option->encoding->isEqual('string')) {
-                        $data = "'{$data}'";
-                    }
-
                     $optdata[] = [
                         'code' => $option->code->asInt(),
                         'csv-format' => false,
-                        'data' => $data,
+                        'data' => $option->data->getValue(),
                         'always-send' => !$option->force->isEmpty(),
                     ];
                 }
@@ -227,20 +221,12 @@ class KeaDhcpv4 extends BaseModel
                 if ($option === null) {
                     continue;
                 }
-
-                // Kea autoconverts strings to binary when providing 'data' => "'data to convert'"
-                $data = $option->data->getValue();
-                if ($option->encoding->isEqual('string')) {
-                    $data = "'{$data}'";
-                }
-
                 $entry = [
                     'code' => $option->code->asInt(),
                     'csv-format' => false,
-                    'data' => $data,
+                    'data' => $option->data->getValue(),
                     'always-send' => !$option->force->isEmpty(),
                 ];
-
                 $record['option-data'][] = $entry;
             }
             $result[] = $record;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -324,7 +324,6 @@
                     <Default>hex</Default>
                     <OptionValues>
                         <hex>hex</hex>
-                        <string>string</string>
                     </OptionValues>
                 </encoding>
                 <data type=".\KeaOptionDataField">


### PR DESCRIPTION
Cleanup previous: https://github.com/opnsense/core/commit/8350fcb73b9dd44e8b1e00d2ea03ced71e0f71ac

It's not as it seems, it only supports flat options and is very picky. It will create wrong expectations, rather than what hexadecimal byte pairs do - which are really generic.

I was lucky when I evaluated it by picking the 1 or 2 options it actually worked with, but it fails for most others, unlike hex.

Better not go into there right away, it will attract the wrong user reactions.