### PR TITLE
Captive portal: fix bracketed IPv6 literal in redirurl regex

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
+++ b/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
@@ -92,7 +92,7 @@ $HTTP["host"] !~ "(.*{{ cp_zone_item.redirect_host_match }}.*)" {
 
 $SERVER["socket"] == "[::]:{{ cp_zone_item.zoneid|int + 8000 }}" {
 	$HTTP["host"] !~ "(.*{{cp_zone_item.redirect_host_match}}.*)" {
-		$HTTP["host"] =~ "([^:/]+)" {
+		$HTTP["host"] =~ "(\[[^\]]+\]|[^:/]+)" {
 			url.redirect = ( "^(.*)$" => "{{cp_zone_item.redirect_host}}?redirurl=%1$1")
 		}
     }
@@ -111,7 +111,7 @@ $SERVER["socket"] == ":{{ cp_zone_item.zoneid|int + 9000 }}" {
 	ssl.engine = "disable"
 }
 $SERVER["socket"] == "[::]:{{ cp_zone_item.zoneid|int + 9000 }}" {
-	$HTTP["host"] =~ "([^:/]+)" {
+	$HTTP["host"] =~ "(\[[^\]]+\]|[^:/]+)" {
 		url.redirect = ( "^(.*)$" => "{{ cp_zone_item.redirect_host }}?redirurl=%1$1")
 	}
 	ssl.engine = "disable"


### PR DESCRIPTION
### Summary

Follow-up to <https://github.com/opnsense/core/pull/9745> (Captive portal: IPv6 support). The host-match regex fix from #9973 was not included when #9745 merged.

When a client reaches the captive portal via a raw IPv6 address, the `Host` header contains a bracketed literal (e.g. `[2606:4700:4700::1111]`). The regex `([^:/]+)` stops at the first colon, so the redirect URL becomes `[2601/` instead of `[2606:4700:4700::1111]/`.

This PR updates the regex to `(\[[^\]]+\]|[^:/]+)` so full bracketed IPv6 literals are matched first, with the original pattern still used for IPv4 and hostnames.

## Testing

### Lab overview
 
| Host | Interfaces | Role |
|------|------------|------|
| opnsense-dev | WAN: `3d06:bad:b01:200::11/128`<br/>LAN: `3d06:bad:b01:210::1/64` | Firewall under test. Captive portal enabled. |
| ubuntu-test-client | LAN: `3d06:bad:b01:210::902/64` | IPv6-only client behind opnsense-dev. |
 

| Case | Upstream result | This PR |
|------|-----------------|---------|
| Bracketed IPv6 literal preserved in `redirurl` | Fails. `redirurl=[2606/` | `redirurl=[2606:4700:4700::1111]/` |
 

Missed in: 369630dbd35c (Captive portal: IPv6 support, #9745)
See also: #9973
