### PR TITLE
auth/user: Added option to API to set the user password as a hash

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/UserController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/UserController.php
@@ -98,7 +98,11 @@ class UserController extends ApiMutableModelControllerBase
             } else {
                 $password = $node->password->getValue();
             }
-            $hash = $this->getModel()->generatePasswordHash($password);
+            if (empty((string)$node->scrambled_password) && !empty((string)$node->hashed_password)) {
+                $hash = $password;
+            } else {
+                $hash = $this->getModel()->generatePasswordHash($password);
+            }
             if ($hash !== false && strpos($hash, '$') === 0) {
                 $node->password = $hash;
                 $node->pwd_changed_at = microtime(true);

--- a/src/opnsense/mvc/app/models/OPNsense/Auth/User.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Auth/User.php
@@ -149,6 +149,9 @@ class User extends BaseModel
             if ($node->password->isEmpty() && $node->scrambled_password->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("A password is required"), $key . ".password"));
             }
+            if (!$node->scrambled_password->isEmpty() && !$node->hashed_password->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("scrambled_password and hashed_password can not be set at the same time"), $key . ".hashed_password"));
+            }
             /* XXX: validate reserved users? (/etc/passwd)*/
         }
         return $messages;

--- a/src/opnsense/mvc/app/models/OPNsense/Auth/User.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Auth/User.xml
@@ -30,6 +30,7 @@
                 <BlankDesc>Default (none for all but root)</BlankDesc>
             </shell>
             <password type="UpdateOnlyTextField"/>
+            <hashed_password type="BooleanField" volatile="true"/>
             <scrambled_password type="BooleanField" volatile="true"/>
             <!-- password policy constraints store last pwd change timestamp -->
             <pwd_changed_at type="TextField"/>


### PR DESCRIPTION
This adds a boolean option hashed_password to the API. When set to true, it means that the password is already hashed, and therefore doesnt need to be hashed anymore.

This is useful for automatically importing users.

I hope this can be merged like this. Thanks.