### PR TITLE
mvc: HostnameField: show string that failed validation by default

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/HostnameField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/HostnameField.php
@@ -119,7 +119,7 @@ class HostnameField extends BaseSetField
      */
     protected function defaultValidationMessage()
     {
-        return gettext('Please specify a valid IP address or hostname.');
+        return gettext('[%s] is not a valid IP address or hostname.');
     }
 
     /**
@@ -137,6 +137,7 @@ class HostnameField extends BaseSetField
                 $response = [];
 
                 foreach ($sender->iterateInput($data) as $value) {
+                    $orig = $value;
                     // set filter options
                     $filterOptDomain = $sender->internalIsDNSName ? 0 : FILTER_FLAG_HOSTNAME;
                     $val_is_ip = filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) !== false;
@@ -159,7 +160,7 @@ class HostnameField extends BaseSetField
 
                     if (!$result) {
                         // append validation message
-                        $response[] = $sender->getValidationMessage();
+                        $response[] = $sender->getValidationMessage($orig);
                         break;
                     }
                 }


### PR DESCRIPTION
Noticed during https://github.com/opnsense/core/pull/9954 where `AsList` was a requirement.

https://github.com/opnsense/core/commit/47bc962ade added the structure for this, but we can't do this generically in `BaseSetField` as we don't know what to validate there.

We can also optionally limit this to when `AsList` is set, hence the PR.