### PR TITLE
Firewall: Aliases: Add target to getAliasSource()

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Alias.php
@@ -133,6 +133,7 @@ class Alias extends BaseModel
         $sources[] = [['OPNsense', 'Firewall', 'Filter', 'snatrules', 'rule'], ['source_port']];
         $sources[] = [['OPNsense', 'Firewall', 'Filter', 'snatrules', 'rule'], ['destination_net']];
         $sources[] = [['OPNsense', 'Firewall', 'Filter', 'snatrules', 'rule'], ['destination_port']];
+        $sources[] = [['OPNsense', 'Firewall', 'Filter', 'snatrules', 'rule'], ['target']];
 
         return $sources;
     }


### PR DESCRIPTION
A config path in getAliasSource() was missing, which caused alias names that were used as Translate source IP in SNAT rules to not be tracked and updated whenever they were changed. By adding a config path to OPNsense/Firewall/Filter/snatrules/rule/target, alias names are now automatically updated in SNAT rules after renaming them.

Fixes: #9926 