### PR TITLE
Firewall: NAT: One-to-One NAT: add missing log statement

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/DNatRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/DNatRule.php
@@ -38,6 +38,7 @@ class DNatRule extends Rule
         'nat' => array(
             'disabled' => 'parseIsComment',
             'type' => 'parsePlain',
+            'log' => 'parseBool,log',
             'interface' => 'parseInterface',
             'from' => 'parsePlain,from ',
             'to' => 'parsePlain,to ',


### PR DESCRIPTION
Seems binat isn't logged at all, even though enabled (https://github.com/opnsense/ports/blob/master/opnsense/filterlog/files/filterlog.c#L61-L62). In `DNatRule` there is also `nat_rdr` and `nat_refl` types to consider, but these options generate a lot of rules, so intentionally skip logging here (up for discussion).