### PR TITLE
menu: add Favorites section

### DIFF
--- a/plist
+++ b/plist
@@ -654,6 +654,7 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/UpdateOnlyTextField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/UrlField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/VirtualIPField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuFavorites.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuInitException.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuItem.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -1043,6 +1044,7 @@
 /usr/local/opnsense/mvc/app/views/layout_partials/base_dialog.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_dialog_processing.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_form.volt
+/usr/local/opnsense/mvc/app/views/layout_partials/base_menu_favorites.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_tabs_content.volt
 /usr/local/opnsense/mvc/app/views/layout_partials/base_tabs_header.volt
@@ -2163,6 +2165,7 @@
 /usr/local/opnsense/www/css/nv.d3.css
 /usr/local/opnsense/www/css/opnsense-bootgrid-layout.css
 /usr/local/opnsense/www/css/opnsense-bootgrid.css
+/usr/local/opnsense/www/css/opnsense-favorites.css
 /usr/local/opnsense/www/css/tabulator.min.css
 /usr/local/opnsense/www/css/tokenize2.css
 /usr/local/opnsense/www/fonts/FontAwesome.otf
@@ -2204,6 +2207,7 @@
 /usr/local/opnsense/www/js/opnsense.js
 /usr/local/opnsense/www/js/opnsense_bootgrid.js
 /usr/local/opnsense/www/js/opnsense_health.js
+/usr/local/opnsense/www/js/opnsense_menu_favorites.js
 /usr/local/opnsense/www/js/opnsense_status.js
 /usr/local/opnsense/www/js/opnsense_theme.js
 /usr/local/opnsense/www/js/opnsense_ui.js

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -99,6 +99,7 @@ class ControllerBase extends ControllerRoot
             '/css/tabulator.min.css',
             '/css/opnsense-bootgrid.css',
             '/css/opnsense-bootgrid-layout.css',
+            '/css/opnsense-favorites.css',
             // Font awesome
             '/ui/assets/fontawesome/css/all.min.css',
             '/ui/assets/fontawesome/css/v4-shims.min.css',
@@ -370,9 +371,12 @@ class ControllerBase extends ControllerRoot
         $this->view->setVar('langcode', str_replace('_', '-', $this->langcode));
 
         $rewrite_uri = explode("?", $_SERVER["REQUEST_URI"])[0];
-        $this->view->menuSystem = $menu->getItems($rewrite_uri);
+        $this->view->menuSystem = $menu->getItems($rewrite_uri, $_SESSION['Username'] ?? '');
         /* XXX generating breadcrumbs requires getItems() call */
         $this->view->menuBreadcrumbs = $menu->getBreadcrumbs();
+        $this->view->menuHasFavorites = $menu->hasUserFavorites();
+        $this->view->menuSelectedUrl = $menu->getSelectedPageUrl();
+        $this->view->menuSelectedIsFavorite = $menu->getSelectedPageIsFavorite();
 
         // set theme in ui_theme template var, let template handle its defaults (if there is no theme).
         if (

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -372,6 +372,7 @@ class ControllerBase extends ControllerRoot
 
         $rewrite_uri = explode("?", $_SERVER["REQUEST_URI"])[0];
         $this->view->menuSystem = $menu->getItems($rewrite_uri, $_SESSION['Username'] ?? '');
+        /* XXX generating breadcrumbs requires getItems() call */
         $this->view->menuBreadcrumbs = $menu->getBreadcrumbs();
         $this->view->menuHasFavorites = $menu->hasUserFavorites();
         $this->view->menuSelectedUrl = $menu->getSelectedPageUrl();

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -99,6 +99,7 @@ class ControllerBase extends ControllerRoot
             '/css/tabulator.min.css',
             '/css/opnsense-bootgrid.css',
             '/css/opnsense-bootgrid-layout.css',
+            '/css/opnsense-favorites.css',
             // Font awesome
             '/ui/assets/fontawesome/css/all.min.css',
             '/ui/assets/fontawesome/css/v4-shims.min.css',
@@ -370,9 +371,11 @@ class ControllerBase extends ControllerRoot
         $this->view->setVar('langcode', str_replace('_', '-', $this->langcode));
 
         $rewrite_uri = explode("?", $_SERVER["REQUEST_URI"])[0];
-        $this->view->menuSystem = $menu->getItems($rewrite_uri);
-        /* XXX generating breadcrumbs requires getItems() call */
+        $this->view->menuSystem = $menu->getItems($rewrite_uri, $_SESSION['Username'] ?? '');
         $this->view->menuBreadcrumbs = $menu->getBreadcrumbs();
+        $this->view->menuHasFavorites = $menu->hasUserFavorites();
+        $this->view->menuSelectedUrl = $menu->getSelectedPageUrl();
+        $this->view->menuSelectedIsFavorite = $menu->getSelectedPageIsFavorite();
 
         // set theme in ui_theme template var, let template handle its defaults (if there is no theme).
         if (

--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/MenuController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/MenuController.php
@@ -110,7 +110,6 @@ class MenuController extends ApiControllerBase
         return $menu_items;
     }
 
-
     /**
      * flatten menu structure, only returning visible entries
      * @param $menu_items array containing stdClass objects
@@ -188,5 +187,52 @@ class MenuController extends ApiControllerBase
         $items = array();
         $this->extractMenuLeaves($menu_items, $items);
         return $items;
+    }
+
+    /**
+     * set/unset a menu item as favorite
+     * @return array
+     */
+    public function setFavoriteAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+
+        $menuUrl = $this->request->getPost('menuUrl', null, null);
+        $isFavorite = $this->request->getPost('isFavorite', null, null);
+
+        if ($menuUrl === null || $isFavorite === null) {
+            return ['result' => 'failed'];
+        }
+
+        // validate that the submitted URL corresponds to a real menu item
+        $menu = new Menu\MenuSystem();
+        if (!$menu->isValidMenuUrl($menuUrl)) {
+            return ['result' => 'failed'];
+        }
+
+        // verify the user has ACL access to this page
+        $username = $this->getUserName();
+        $acl = new \OPNsense\Core\ACL();
+        if (!$acl->isPageAccessible($username, $menuUrl)) {
+            return ['result' => 'failed'];
+        }
+
+        $favorites = Menu\MenuFavorites::get($username);
+
+        if ($isFavorite === 'true') {
+            if (!in_array($menuUrl, $favorites)) {
+                $favorites[] = $menuUrl;
+            }
+        } else {
+            $favorites = array_values(array_diff($favorites, [$menuUrl]));
+        }
+
+        if (!Menu\MenuFavorites::save($username, $favorites)) {
+            return ['result' => 'failed'];
+        }
+
+        return ['result' => 'saved'];
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuFavorites.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuFavorites.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Greelan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Base\Menu;
+
+use OPNsense\Core\Config;
+
+/**
+ * Class MenuFavorites
+ * @package OPNsense\Base\Menu
+ *
+ * Shared helper for reading and writing per-user menu favorites.
+ * Favorites are stored as a JSON array of URL strings in the
+ * <menu_favorites> element of each <user> node in config.xml.
+ */
+class MenuFavorites
+{
+    /**
+     * get favorites for a username
+     * @param string $username username to look up
+     * @return array list of favorite menu URLs (empty array if none)
+     */
+    public static function get($username)
+    {
+        if (empty($username)) {
+            return [];
+        }
+
+        try {
+            $cfg = Config::getInstance();
+            foreach ($cfg->object()->system->user as $node) {
+                if ($username === (string)$node->name && !empty($node->menu_favorites)) {
+                    $favorites = json_decode((string)$node->menu_favorites, true);
+                    return is_array($favorites) ? $favorites : [];
+                }
+            }
+        } catch (\Exception $e) {
+            return [];
+        }
+
+        return [];
+    }
+
+    /**
+     * save favorites for a username
+     * @param string $username username to save for
+     * @param array $favorites list of menu URLs to save
+     * @return bool true on success
+     */
+    public static function save($username, $favorites)
+    {
+        if (empty($username)) {
+            return false;
+        }
+
+        try {
+            $cfg = Config::getInstance();
+            foreach ($cfg->object()->system->user as $node) {
+                if ($username === (string)$node->name) {
+                    $node->menu_favorites = json_encode(array_values($favorites));
+                    $cfg->save();
+                    return true;
+                }
+            }
+            return false;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuItem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuItem.php
@@ -95,6 +95,12 @@ class MenuItem
     private $selected = false;
 
     /**
+     * is this item in the user's favorites
+     * @var bool
+     */
+    private $isFavorite = false;
+
+    /**
      * class method getters
      * @var array
      */
@@ -303,6 +309,34 @@ class MenuItem
     public function getSelected()
     {
         return $this->selected;
+    }
+
+    /**
+     * setter for isFavorite field
+     * @param $value
+     */
+    public function setIsFavorite($value)
+    {
+        $this->isFavorite = (bool)$value;
+    }
+
+    /**
+     * getter for isFavorite field
+     * @return bool is this item a favorite
+     */
+    public function getIsFavorite()
+    {
+        return $this->isFavorite;
+    }
+
+    /**
+     * return raw MenuItem children (not converted to stdClass)
+     * NOTE: uses fetch* prefix to avoid auto-exposure in stdClass via get* reflection
+     * @return MenuItem[]
+     */
+    public function fetchChildrenItems()
+    {
+        return $this->children;
     }
 
     /**

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -489,7 +489,8 @@ class MenuSystem
 
     /**
      * return the currently selected page's breadcrumbs
-     * also captures the selected page's URL and favorite status
+     * NOTE: must be called after getItems(); also populates state for
+     *       getSelectedPageUrl() and getSelectedPageIsFavorite()
      * @return array
      */
     public function getBreadcrumbs()
@@ -527,6 +528,7 @@ class MenuSystem
     }
 
     /**
+     * NOTE: must be called after getBreadcrumbs()
      * @return string URL of the selected page, or empty string
      */
     public function getSelectedPageUrl()
@@ -535,6 +537,7 @@ class MenuSystem
     }
 
     /**
+     * NOTE: must be called after getBreadcrumbs()
      * @return bool whether the selected page is in the user's favorites
      */
     public function getSelectedPageIsFavorite()

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -54,6 +54,21 @@ class MenuSystem
     private $menuCacheTTL = 3600;
 
     /**
+     * @var bool whether the last getItems() call found any active favorites
+     */
+    private $hasFavorites = false;
+
+    /**
+     * @var string URL of the currently selected page (set by getBreadcrumbs)
+     */
+    private $selectedPageUrl = '';
+
+    /**
+     * @var bool whether the selected page is a favorite (set by getBreadcrumbs)
+     */
+    private $selectedPageIsFavorite = false;
+
+    /**
      * add menu structure to root
      * @param string $filename menu xml filename
      * @return \SimpleXMLElement
@@ -402,35 +417,105 @@ class MenuSystem
     /**
      * return full menu system including selected items
      * @param string $url current location
+     * @param string $username current username (used to load favorites)
      * @return array
      */
-    public function getItems($url)
+    public function getItems($url, $username = '')
     {
         $this->root->toggleSelected($url);
-        $menu = $this->root->getChildren();
+        $this->hasFavorites = false;
+        if ($username !== '') {
+            $favorites = MenuFavorites::get($username);
+            if (!empty($favorites)) {
+                $validUrls = [];
+                $this->populateFavorites($this->root, array_flip($favorites), $validUrls);
+                $this->hasFavorites = !empty($validUrls);
+                /* prune favorites that no longer correspond to a menu item */
+                if (count($validUrls) !== count($favorites)) {
+                    MenuFavorites::save($username, $validUrls);
+                }
+            }
+        }
+        return $this->root->getChildren();
+    }
 
-        return $menu;
+    /**
+     * check if the last getItems() call found any active favorites
+     * NOTE: must be called after getItems()
+     * @return bool
+     */
+    public function hasUserFavorites()
+    {
+        return $this->hasFavorites;
+    }
+
+    /**
+     * check if a URL corresponds to an existing menu item
+     * @param string $url URL to check
+     * @param MenuItem|null $node starting node (defaults to root, used for recursion)
+     * @return bool
+     */
+    public function isValidMenuUrl($url, $node = null)
+    {
+        $node = $node ?? $this->root;
+        if ($node->getUrl() === $url) {
+            return true;
+        }
+        foreach ($node->fetchChildrenItems() as $child) {
+            if ($this->isValidMenuUrl($url, $child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * recursively populate favorite status on menu items
+     * @param MenuItem $menuItem menu item to process
+     * @param array $userFavorites map of favorite menu URLs (keyed by URL)
+     * @param array &$validUrls collects URLs that matched a menu item
+     */
+    private function populateFavorites($menuItem, $userFavorites, &$validUrls)
+    {
+        if (isset($userFavorites[$menuItem->getUrl()])) {
+            $menuItem->setIsFavorite(true);
+            $validUrls[] = $menuItem->getUrl();
+        }
+
+        foreach ($menuItem->fetchChildrenItems() as $child) {
+            $this->populateFavorites($child, $userFavorites, $validUrls);
+        }
     }
 
     /**
      * return the currently selected page's breadcrumbs
+     * NOTE: must be called after getItems(); also populates state for
+     *       getSelectedPageUrl() and getSelectedPageIsFavorite()
      * @return array
      */
     public function getBreadcrumbs()
     {
         $nodes = $this->root->getChildren();
         $breadcrumbs = [];
+        $this->selectedPageUrl = '';
+        $this->selectedPageIsFavorite = false;
 
         while ($nodes != null) {
             $next = null;
             foreach ($nodes as $node) {
                 if ($node->Selected) {
-                    /* ignore client-side anchor in breadcrumb */
+                    /* client-side anchor: capture for the favorite star but skip breadcrumb */
                     if (!empty($node->Url) && strpos($node->Url, '#') !== false) {
+                        $this->selectedPageUrl = $node->Url;
+                        $this->selectedPageIsFavorite = (bool)$node->IsFavorite;
                         $next = null;
                         break;
                     }
                     $breadcrumbs[] = ['name' => $node->VisibleName];
+                    if (!empty($node->Url)) {
+                        $this->selectedPageUrl = $node->Url;
+                        $this->selectedPageIsFavorite = (bool)$node->IsFavorite;
+                    }
                     /* only go as far as the first reachable URL */
                     $next = empty($node->Url) ? $node->Children : null;
                     break;
@@ -440,5 +525,23 @@ class MenuSystem
         }
 
         return $breadcrumbs;
+    }
+
+    /**
+     * NOTE: must be called after getBreadcrumbs()
+     * @return string URL of the selected page, or empty string
+     */
+    public function getSelectedPageUrl()
+    {
+        return $this->selectedPageUrl;
+    }
+
+    /**
+     * NOTE: must be called after getBreadcrumbs()
+     * @return bool whether the selected page is in the user's favorites
+     */
+    public function getSelectedPageIsFavorite()
+    {
+        return $this->selectedPageIsFavorite;
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -59,22 +59,12 @@ class MenuSystem
     private $hasFavorites = false;
 
     /**
-     * @var bool whether resolveSelectedPage() has already run
-     */
-    private $selectedPageResolved = false;
-
-    /**
-     * @var array breadcrumbs for the currently selected page
-     */
-    private $breadcrumbs = [];
-
-    /**
-     * @var string URL of the currently selected page
+     * @var string URL of the currently selected page (set by getBreadcrumbs)
      */
     private $selectedPageUrl = '';
 
     /**
-     * @var bool whether the selected page is a favorite
+     * @var bool whether the selected page is a favorite (set by getBreadcrumbs)
      */
     private $selectedPageIsFavorite = false;
 
@@ -498,21 +488,16 @@ class MenuSystem
     }
 
     /**
-     * resolve the currently selected page's breadcrumbs, URL, and favorite status
-     * runs at most once per request; subsequent calls are no-ops
+     * return the currently selected page's breadcrumbs
+     * also captures the selected page's URL and favorite status
+     * @return array
      */
-    private function resolveSelectedPage()
+    public function getBreadcrumbs()
     {
-        if ($this->selectedPageResolved) {
-            return;
-        }
-
-        $this->selectedPageResolved = true;
-        $this->breadcrumbs = [];
+        $nodes = $this->root->getChildren();
+        $breadcrumbs = [];
         $this->selectedPageUrl = '';
         $this->selectedPageIsFavorite = false;
-
-        $nodes = $this->root->getChildren();
 
         while ($nodes != null) {
             $next = null;
@@ -525,7 +510,7 @@ class MenuSystem
                         $next = null;
                         break;
                     }
-                    $this->breadcrumbs[] = ['name' => $node->VisibleName];
+                    $breadcrumbs[] = ['name' => $node->VisibleName];
                     if (!empty($node->Url)) {
                         $this->selectedPageUrl = $node->Url;
                         $this->selectedPageIsFavorite = (bool)$node->IsFavorite;
@@ -537,16 +522,8 @@ class MenuSystem
             }
             $nodes = $next;
         }
-    }
 
-    /**
-     * return the currently selected page's breadcrumbs
-     * @return array
-     */
-    public function getBreadcrumbs()
-    {
-        $this->resolveSelectedPage();
-        return $this->breadcrumbs;
+        return $breadcrumbs;
     }
 
     /**
@@ -554,7 +531,6 @@ class MenuSystem
      */
     public function getSelectedPageUrl()
     {
-        $this->resolveSelectedPage();
         return $this->selectedPageUrl;
     }
 
@@ -563,7 +539,6 @@ class MenuSystem
      */
     public function getSelectedPageIsFavorite()
     {
-        $this->resolveSelectedPage();
         return $this->selectedPageIsFavorite;
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/Menu/MenuSystem.php
@@ -54,6 +54,31 @@ class MenuSystem
     private $menuCacheTTL = 3600;
 
     /**
+     * @var bool whether the last getItems() call found any active favorites
+     */
+    private $hasFavorites = false;
+
+    /**
+     * @var bool whether resolveSelectedPage() has already run
+     */
+    private $selectedPageResolved = false;
+
+    /**
+     * @var array breadcrumbs for the currently selected page
+     */
+    private $breadcrumbs = [];
+
+    /**
+     * @var string URL of the currently selected page
+     */
+    private $selectedPageUrl = '';
+
+    /**
+     * @var bool whether the selected page is a favorite
+     */
+    private $selectedPageIsFavorite = false;
+
+    /**
      * add menu structure to root
      * @param string $filename menu xml filename
      * @return \SimpleXMLElement
@@ -402,14 +427,116 @@ class MenuSystem
     /**
      * return full menu system including selected items
      * @param string $url current location
+     * @param string $username current username (used to load favorites)
      * @return array
      */
-    public function getItems($url)
+    public function getItems($url, $username = '')
     {
         $this->root->toggleSelected($url);
-        $menu = $this->root->getChildren();
+        $this->hasFavorites = false;
+        if ($username !== '') {
+            $favorites = MenuFavorites::get($username);
+            if (!empty($favorites)) {
+                $validUrls = [];
+                $this->populateFavorites($this->root, array_flip($favorites), $validUrls);
+                $this->hasFavorites = !empty($validUrls);
+                /* prune favorites that no longer correspond to a menu item */
+                if (count($validUrls) !== count($favorites)) {
+                    MenuFavorites::save($username, $validUrls);
+                }
+            }
+        }
+        return $this->root->getChildren();
+    }
 
-        return $menu;
+    /**
+     * check if the last getItems() call found any active favorites
+     * NOTE: must be called after getItems()
+     * @return bool
+     */
+    public function hasUserFavorites()
+    {
+        return $this->hasFavorites;
+    }
+
+    /**
+     * check if a URL corresponds to an existing menu item
+     * @param string $url URL to check
+     * @param MenuItem|null $node starting node (defaults to root, used for recursion)
+     * @return bool
+     */
+    public function isValidMenuUrl($url, $node = null)
+    {
+        $node = $node ?? $this->root;
+        if ($node->getUrl() === $url) {
+            return true;
+        }
+        foreach ($node->fetchChildrenItems() as $child) {
+            if ($this->isValidMenuUrl($url, $child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * recursively populate favorite status on menu items
+     * @param MenuItem $menuItem menu item to process
+     * @param array $userFavorites map of favorite menu URLs (keyed by URL)
+     * @param array &$validUrls collects URLs that matched a menu item
+     */
+    private function populateFavorites($menuItem, $userFavorites, &$validUrls)
+    {
+        if (isset($userFavorites[$menuItem->getUrl()])) {
+            $menuItem->setIsFavorite(true);
+            $validUrls[] = $menuItem->getUrl();
+        }
+
+        foreach ($menuItem->fetchChildrenItems() as $child) {
+            $this->populateFavorites($child, $userFavorites, $validUrls);
+        }
+    }
+
+    /**
+     * resolve the currently selected page's breadcrumbs, URL, and favorite status
+     * runs at most once per request; subsequent calls are no-ops
+     */
+    private function resolveSelectedPage()
+    {
+        if ($this->selectedPageResolved) {
+            return;
+        }
+
+        $this->selectedPageResolved = true;
+        $this->breadcrumbs = [];
+        $this->selectedPageUrl = '';
+        $this->selectedPageIsFavorite = false;
+
+        $nodes = $this->root->getChildren();
+
+        while ($nodes != null) {
+            $next = null;
+            foreach ($nodes as $node) {
+                if ($node->Selected) {
+                    /* client-side anchor: capture for the favorite star but skip breadcrumb */
+                    if (!empty($node->Url) && strpos($node->Url, '#') !== false) {
+                        $this->selectedPageUrl = $node->Url;
+                        $this->selectedPageIsFavorite = (bool)$node->IsFavorite;
+                        $next = null;
+                        break;
+                    }
+                    $this->breadcrumbs[] = ['name' => $node->VisibleName];
+                    if (!empty($node->Url)) {
+                        $this->selectedPageUrl = $node->Url;
+                        $this->selectedPageIsFavorite = (bool)$node->IsFavorite;
+                    }
+                    /* only go as far as the first reachable URL */
+                    $next = empty($node->Url) ? $node->Children : null;
+                    break;
+                }
+            }
+            $nodes = $next;
+        }
     }
 
     /**
@@ -418,27 +545,25 @@ class MenuSystem
      */
     public function getBreadcrumbs()
     {
-        $nodes = $this->root->getChildren();
-        $breadcrumbs = [];
+        $this->resolveSelectedPage();
+        return $this->breadcrumbs;
+    }
 
-        while ($nodes != null) {
-            $next = null;
-            foreach ($nodes as $node) {
-                if ($node->Selected) {
-                    /* ignore client-side anchor in breadcrumb */
-                    if (!empty($node->Url) && strpos($node->Url, '#') !== false) {
-                        $next = null;
-                        break;
-                    }
-                    $breadcrumbs[] = ['name' => $node->VisibleName];
-                    /* only go as far as the first reachable URL */
-                    $next = empty($node->Url) ? $node->Children : null;
-                    break;
-                }
-            }
-            $nodes = $next;
-        }
+    /**
+     * @return string URL of the selected page, or empty string
+     */
+    public function getSelectedPageUrl()
+    {
+        $this->resolveSelectedPage();
+        return $this->selectedPageUrl;
+    }
 
-        return $breadcrumbs;
+    /**
+     * @return bool whether the selected page is in the user's favorites
+     */
+    public function getSelectedPageIsFavorite()
+    {
+        $this->resolveSelectedPage();
+        return $this->selectedPageIsFavorite;
     }
 }

--- a/src/opnsense/mvc/app/views/layout_partials/base_menu_favorites.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_menu_favorites.volt
@@ -1,0 +1,49 @@
+{# Favorites section - only show if user has favorites #}
+<a href="#Favorites" id="favorites-header" class="list-group-item" data-toggle="collapse" data-parent="#mainmenu"{% if not menuHasFavorites %} style="display:none;"{% endif %}>
+    <span class="fas fa-star __iconspacer"></span><span style="word-break: keep-all">{{ lang._('Favorites') }}</span>
+</a>
+<div class="collapse" id="Favorites">
+    {% for topMenuItem in menuSystem %}
+        {% if topMenuItem.IsFavorite and topMenuItem.Url != '' %}
+            {% if topMenuItem.IsExternal == "Y" %}
+                <a href="{{ topMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="{{ topMenuItem.Url }}">
+                    {{ topMenuItem.VisibleName | striptags }}
+                </a>
+            {% elseif acl.isPageAccessible(session.get('Username'),topMenuItem.Url) %}
+                <a href="{{ topMenuItem.Url }}" class="list-group-item" data-menu-url="{{ topMenuItem.Url }}">
+                    {{ topMenuItem.VisibleName | striptags }}
+                </a>
+            {% endif %}
+        {% endif %}
+        {% if topMenuItem.Children|length >= 1 %}
+            {% for subMenuItem in topMenuItem.Children %}
+                {% if subMenuItem.IsFavorite and subMenuItem.Url != '' %}
+                    {% if subMenuItem.IsExternal == "Y" %}
+                        <a href="{{ subMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="{{ subMenuItem.Url }}">
+                            {{ topMenuItem.VisibleName | striptags }}: {{ subMenuItem.VisibleName | striptags }}
+                        </a>
+                    {% elseif acl.isPageAccessible(session.get('Username'),subMenuItem.Url) %}
+                        <a href="{{ subMenuItem.Url }}" class="list-group-item" data-menu-url="{{ subMenuItem.Url }}">
+                            {{ topMenuItem.VisibleName | striptags }}: {{ subMenuItem.VisibleName | striptags }}
+                        </a>
+                    {% endif %}
+                {% endif %}
+                {% if subMenuItem.Children|length >= 1 %}
+                    {% for subsubMenuItem in subMenuItem.Children %}
+                        {% if subsubMenuItem.IsFavorite and subsubMenuItem.Url != '' %}
+                            {% if subsubMenuItem.IsExternal == "Y" %}
+                                <a href="{{ subsubMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="{{ subsubMenuItem.Url }}">
+                                    {{ topMenuItem.VisibleName | striptags }}: {{ subMenuItem.VisibleName | striptags }}: {{ subsubMenuItem.VisibleName | striptags }}
+                                </a>
+                            {% elseif acl.isPageAccessible(session.get('Username'),subsubMenuItem.Url) %}
+                                <a href="{{ subsubMenuItem.Url }}" class="list-group-item" data-menu-url="{{ subsubMenuItem.Url }}">
+                                    {{ topMenuItem.VisibleName | striptags }}: {{ subMenuItem.VisibleName | striptags }}: {{ subsubMenuItem.VisibleName | striptags }}
+                                </a>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+</div>

--- a/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_menu_system.volt
@@ -3,6 +3,7 @@
         <nav class="page-side-nav">
             <div id="mainmenu" class="panel" style="border:0px">
                 <div class="panel list-group" style="border:0px">
+                    {{ partial("layout_partials/base_menu_favorites") }}
                     {% for topMenuItem in menuSystem %}
                         {% if topMenuItem.Children|length >= 1 %}
                             <a href="#{{ topMenuItem.Id }}" class="list-group-item {% if topMenuItem.Selected %}  active-menu-title {% endif  %}" data-toggle="collapse" data-parent="#mainmenu">
@@ -25,10 +26,10 @@
                                         </a>
                                         <div class="collapse {% if subMenuItem.Selected %} active-menu in {% endif  %}" id="{{ topMenuItem.Id }}_{{ subMenuItem.Id }}">
                                             {% for subsubMenuItem in subMenuItem.Children %} {% if subsubMenuItem.IsExternal == "Y" %}
-                                            <a href="{{ subsubMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ subsubMenuItem.VisibleName }}</a>
-                                            {% elseif acl.isPageAccessible(session.get('Username'),subsubMenuItem.Url) %}
-                                            <a href="{{ subsubMenuItem.Url }}" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ subsubMenuItem.VisibleName }}</a>
-                                            {% endif %} {% endfor %}
+                                                <a href="{{ subsubMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ subsubMenuItem.VisibleName }}</a>
+                                                {% elseif acl.isPageAccessible(session.get('Username'),subsubMenuItem.Url) %}
+                                                <a href="{{ subsubMenuItem.Url }}" class="list-group-item menu-level-3-item {% if subsubMenuItem.Selected %} active {% endif  %}">{{ subsubMenuItem.VisibleName }}</a>
+                                                {% endif %} {% endfor %}
                                         </div>
                                     {% elseif subMenuItem.IsExternal == "Y" %}
                                         <a href="{{ subMenuItem.Url }}" target="_blank" rel="noopener noreferrer" class="list-group-item {% if subMenuItem.Selected %} active {% endif  %}"

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -67,7 +67,7 @@
                 });
 
                 // hide empty menu items
-                $('#mainmenu > div > .collapse').each(function () {
+                $('#mainmenu > div > .collapse').not('#Favorites').each(function () {
                     // cleanup empty second level menu containers
                     $(this).find("div.collapse").each(function () {
                         if ($(this).children().length == 0) {
@@ -260,6 +260,9 @@
   <main class="page-content col-sm-9 col-sm-push-3 col-lg-10 col-lg-push-2">
       <!-- menu system -->
       {{ partial("layout_partials/base_menu_system") }}
+      <!-- menu favorites -->
+      <span id="favorites-config" data-add-text="{{ lang._('Add Favorite') }}" data-remove-text="{{ lang._('Remove Favorite') }}"></span>
+      <script src="{{ cache_safe('/ui/js/opnsense_menu_favorites.js') }}"></script>
       <div class="row">
         <!-- page header -->
         <header class="page-content-head">
@@ -267,6 +270,9 @@
             <ul class="list-inline">
               <li><h1>{{title | default("")}}</h1></li>
               <li class="btn-group-container" id="service_status_container"></li>
+{% if menuSelectedUrl is defined and menuSelectedUrl != '' %}
+              <li><i class="menu-favorite-star {% if menuSelectedIsFavorite %}fas fa-star{% else %}far fa-star{% endif %}" data-menu-url="{{ menuSelectedUrl }}" data-menu-label="{{ title | default('') }}" data-toggle="tooltip" data-placement="bottom" title="{% if menuSelectedIsFavorite %}{{ lang._('Remove Favorite') }}{% else %}{{ lang._('Add Favorite') }}{% endif %}"></i></li>
+{% endif %}
             </ul>
           </div>
         </header>

--- a/src/opnsense/www/css/opnsense-favorites.css
+++ b/src/opnsense/www/css/opnsense-favorites.css
@@ -1,0 +1,21 @@
+/*
+ * For universal layout adjustments that do not need theme compilation.
+ * No color or other variables allowed, only static layout changes.
+ */
+
+.menu-favorite-star {
+  cursor: pointer;
+}
+
+.page-content-head .menu-favorite-star {
+  font-size: 14px;
+}
+
+.page-content-head .list-inline {
+  display: flex;
+  align-items: center;
+}
+
+.page-content-head .list-inline > li:first-child {
+  flex: 1;
+}

--- a/src/opnsense/www/js/opnsense_menu_favorites.js
+++ b/src/opnsense/www/js/opnsense_menu_favorites.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Greelan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Menu favorites toggle handler.
+ *
+ * Expects the following DOM setup before this script runs:
+ *   - A container element with id="favorites-config" carrying:
+ *       data-add-text="..."   (translated "Add Favorite" string)
+ *       data-remove-text="..." (translated "Remove Favorite" string)
+ *   - A star icon with class="menu-favorite-star" in the page heading carrying:
+ *       data-menu-url="..."   (menu item URL)
+ *       data-menu-label="..." (display label for the favorites panel)
+ *   - A collapse panel with id="Favorites" for favorite entries
+ *   - A header link with id="favorites-header"
+ */
+$(document).ready(function () {
+    var $cfg = $('#favorites-config');
+    var addToFavText = $cfg.data('add-text') || 'Add Favorite';
+    var removeFromFavText = $cfg.data('remove-text') || 'Remove Favorite';
+
+    // build menu-order index from sidebar links: url -> DOM position
+    // new Favorites entries are inserted in the same order as the main menu
+    var menuOrderIndex = {};
+    $('#mainmenu a[href]').not('#Favorites a').each(function (i) {
+        var href = $(this).attr('href');
+        if (href && href.charAt(0) !== '#') {
+            menuOrderIndex[href] = i;
+        }
+    });
+
+    // Favorites: for same-page clicks, collapse Favorites and expand the correct menu section
+    // use event delegation so dynamically added entries also get this handler
+    $('#Favorites').on('click', '.list-group-item', function (e) {
+        if (this.pathname + this.search == window.location.pathname + window.location.search) {
+            e.preventDefault();
+            $('#Favorites').collapse('hide');
+            var activeItem = $('#mainmenu .list-group-item.active').not('#Favorites .list-group-item');
+            if (activeItem.length) {
+                activeItem.parents('.collapse').each(function () {
+                    $(this).collapse('show');
+                });
+                var navbar_center = ($(window).height() - $(".collapse.navbar-collapse").height()) / 2;
+                $('html,aside').scrollTop(activeItem.offset().top - navbar_center);
+            }
+        }
+    });
+
+    // handle hash-based tab pages (e.g. Firewall: Shaper with #pipes, #queues, #rules)
+    // the server always picks the first tab; update the star for the actual active tab
+    var $headingStar = $('header.page-content-head .menu-favorite-star');
+    if ($headingStar.length && $headingStar.data('menu-url') && String($headingStar.data('menu-url')).indexOf('#') !== -1) {
+        var baseLabel = $headingStar.data('menu-label'); // e.g. "Firewall: Shaper" (no tab suffix)
+
+        var updateStarForTab = function (hash) {
+            var fullUrl = window.location.pathname + hash;
+            var $sidebarLink = $('#mainmenu a[href="' + fullUrl + '"]').not('#Favorites a');
+            var tabName = $sidebarLink.length ? $sidebarLink.text().trim() : hash.replace('#', '');
+            var label = baseLabel + ': ' + tabName;
+            var $favEntry = $('#Favorites [data-menu-url="' + fullUrl + '"]');
+            var isFavorited = $favEntry.length > 0;
+
+            $headingStar.data('menu-url', fullUrl)
+                 .attr('data-menu-url', fullUrl)
+                 .data('menu-label', label)
+                 .attr('data-menu-label', label);
+
+            if (isFavorited) {
+                $headingStar.removeClass('far').addClass('fas')
+                     .attr('data-original-title', removeFromFavText).tooltip('fixTitle');
+            } else {
+                $headingStar.removeClass('fas').addClass('far')
+                     .attr('data-original-title', addToFavText).tooltip('fixTitle');
+            }
+        };
+
+        // set correct state on page load
+        var initialHash = window.location.hash || '#' + String($headingStar.data('menu-url')).split('#')[1];
+        updateStarForTab(initialHash);
+
+        // update when user switches tabs
+        $(document).on('shown.bs.tab', 'a[data-toggle="tab"]', function (e) {
+            var hash = $(e.target).attr('href');
+            if (hash && hash.charAt(0) === '#') {
+                updateStarForTab(hash);
+            }
+        });
+    }
+
+    // handle favorite star click in page heading
+    $headingStar.on('click', function (e) {
+        e.stopPropagation();
+
+        var $star = $(this);
+        var menuUrl = $star.data('menu-url');
+        var menuLabel = $star.data('menu-label') || '';
+        var isFavorite = $star.hasClass('fas');
+        var newFavoriteState = !isFavorite;
+
+        // pre-emptively update star icon and tooltip
+        $star
+            .toggleClass('fas far')
+            .attr('data-original-title', newFavoriteState ? removeFromFavText : addToFavText).tooltip('fixTitle');
+
+        var revertStar = function () {
+            $star
+                .toggleClass('fas far')
+                .attr('data-original-title', isFavorite ? removeFromFavText : addToFavText).tooltip('fixTitle');
+        };
+
+        $.ajax('/api/core/menu/setFavorite/', {
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                menuUrl: menuUrl,
+                isFavorite: newFavoriteState ? 'true' : 'false'
+            },
+            success: function (response) {
+                if (response.result === 'saved') {
+                    var $favPanel = $('#Favorites');
+                    var $favHeader = $('#favorites-header');
+                    if (newFavoriteState) {
+                        var $newEntry = $('<a>')
+                            .attr('href', menuUrl)
+                            .addClass('list-group-item')
+                            .attr('data-menu-url', menuUrl)
+                            .text(menuLabel);
+                        // insert at the correct menu-order position
+                        var newOrder = menuOrderIndex[menuUrl];
+                        var $insertBefore = null;
+                        $favPanel.children('[data-menu-url]').each(function () {
+                            if (menuOrderIndex[$(this).data('menu-url')] > newOrder) {
+                                $insertBefore = $(this);
+                                return false;
+                            }
+                        });
+                        if ($insertBefore) {
+                            $insertBefore.before($newEntry);
+                        } else {
+                            $favPanel.append($newEntry);
+                        }
+                        $favHeader.show();
+                    } else {
+                        $favPanel.find('[data-menu-url="' + menuUrl + '"]').remove();
+                        if ($favPanel.children().length === 0) {
+                            $favPanel.collapse('hide');
+                            $favHeader.hide();
+                        }
+                    }
+                } else {
+                    revertStar();
+                }
+            },
+            error: function () {
+                revertStar();
+            }
+        });
+    });
+});

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -86,6 +86,41 @@ $aclObj = new \OPNsense\Core\ACL();
                 <div id="mainmenu" class="panel" style="border:0px" >
                     <div class="panel list-group" style="border:0px">
 <?php
+// Favorites section
+?>
+                            <a href="#Favorites" id="favorites-header" class="list-group-item" data-toggle="collapse" data-parent="#mainmenu"<?= !$menuHasFavorites ? ' style="display:none;"' : '' ?>>
+                                <span class="fas fa-star __iconspacer"></span><span style="word-break: keep-all"><?= html_safe(gettext('Favorites')) ?></span>
+                            </a>
+                            <div class="collapse" id="Favorites">
+<?php foreach ($menuSystem as $_mfi): ?>
+<?php if ($_mfi->IsFavorite && $_mfi->Url != ''): ?>
+<?php   if ($_mfi->IsExternal == "Y"): ?>
+                                <a href="<?=$_mfi->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="<?=html_safe($_mfi->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?></a>
+<?php   elseif ($aclObj->isPageAccessible($_SESSION['Username'], $_mfi->Url)): ?>
+                                <a href="<?=$_mfi->Url;?>" class="list-group-item" data-menu-url="<?=html_safe($_mfi->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?></a>
+<?php   endif; ?>
+<?php endif; ?>
+<?php foreach ($_mfi->Children as $_mfs): ?>
+<?php   if ($_mfs->IsFavorite && $_mfs->Url != ''): ?>
+<?php     if ($_mfs->IsExternal == "Y"): ?>
+                                <a href="<?=$_mfs->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="<?=html_safe($_mfs->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?>: <?=html_safe(strip_tags($_mfs->VisibleName))?></a>
+<?php     elseif ($aclObj->isPageAccessible($_SESSION['Username'], $_mfs->Url)): ?>
+                                <a href="<?=$_mfs->Url;?>" class="list-group-item" data-menu-url="<?=html_safe($_mfs->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?>: <?=html_safe(strip_tags($_mfs->VisibleName))?></a>
+<?php     endif; ?>
+<?php   endif; ?>
+<?php   foreach ($_mfs->Children as $_mfss): ?>
+<?php     if ($_mfss->IsFavorite && $_mfss->Url != ''): ?>
+<?php       if ($_mfss->IsExternal == "Y"): ?>
+                                <a href="<?=$_mfss->Url;?>" target="_blank" rel="noopener noreferrer" class="list-group-item" data-menu-url="<?=html_safe($_mfss->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?>: <?=html_safe(strip_tags($_mfs->VisibleName))?>: <?=html_safe(strip_tags($_mfss->VisibleName))?></a>
+<?php       elseif ($aclObj->isPageAccessible($_SESSION['Username'], $_mfss->Url)): ?>
+                                <a href="<?=$_mfss->Url;?>" class="list-group-item" data-menu-url="<?=html_safe($_mfss->Url);?>"><?=html_safe(strip_tags($_mfi->VisibleName))?>: <?=html_safe(strip_tags($_mfs->VisibleName))?>: <?=html_safe(strip_tags($_mfss->VisibleName))?></a>
+<?php       endif; ?>
+<?php     endif; ?>
+<?php   endforeach; ?>
+<?php endforeach; ?>
+<?php endforeach; ?>
+                            </div>
+<?php
                           foreach($menuSystem as $topMenuItem): ?>
 <?php
                           if (count($topMenuItem->Children) >= 1): ?>
@@ -163,6 +198,8 @@ $aclObj = new \OPNsense\Core\ACL();
                         endforeach; ?>
                     </div>
                 </div>
+<span id="favorites-config" data-add-text="<?=html_safe(gettext('Add Favorite'))?>" data-remove-text="<?=html_safe(gettext('Remove Favorite'))?>"></span>
+<script src="<?= cache_safe('/ui/js/opnsense_menu_favorites.js') ?>"></script>
             </nav>
         </div>
     </aside>
@@ -195,6 +232,9 @@ $aclObj = new \OPNsense\Core\ACL();
               <?php endif; ?>
              </form>
           </li>
+<?php if (!empty($menuSelectedUrl)): ?>
+          <li><i class="menu-favorite-star <?= $menuSelectedIsFavorite ? 'fas fa-star' : 'far fa-star' ?>" data-menu-url="<?= html_safe($menuSelectedUrl) ?>" data-menu-label="<?= html_safe(gentitle($menuBreadcrumbs)) ?>" data-toggle="tooltip" data-placement="bottom" title="<?= html_safe($menuSelectedIsFavorite ? gettext('Remove Favorite') : gettext('Add Favorite')) ?>"></i></li>
+<?php endif; ?>
         </ul>
       </div>
     </header>

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -2,9 +2,11 @@
 
 // link menu system
 $menu = new OPNsense\Base\Menu\MenuSystem();
-/* XXX generating breadcrumbs requires getItems() call */
-$menuSystem = $menu->getItems($_SERVER['REQUEST_URI']);
+$menuSystem = $menu->getItems($_SERVER['REQUEST_URI'], $_SESSION['Username'] ?? '');
 $menuBreadcrumbs = $menu->getBreadcrumbs();
+$menuHasFavorites = $menu->hasUserFavorites();
+$menuSelectedUrl = $menu->getSelectedPageUrl();
+$menuSelectedIsFavorite = $menu->getSelectedPageIsFavorite();
 
 if (isset($extraBreadcrumb)) {
     $menuBreadcrumbs[] = array('name' => $extraBreadcrumb);
@@ -74,6 +76,9 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <!-- bootstrap dialog -->
     <link rel="stylesheet" type="text/css" href="<?= cache_safe(get_themed_filename("/css/bootstrap-dialog.css")) ?>">
 
+    <!-- Favorites layout -->
+    <link rel="stylesheet" type="text/css" href="<?= cache_safe(get_themed_filename("/css/opnsense-favorites.css")) ?>">
+
     <!-- Font awesome -->
     <link rel="stylesheet" type="text/css" href="<?= cache_safe("/ui/assets/fontawesome/css/all.min.css") ?>">
     <link rel="stylesheet" type="text/css" href="<?= cache_safe("/ui/assets/fontawesome/css/v4-shims.min.css") ?>">
@@ -117,7 +122,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
       $("input").not("[autocomplete]").attr("autocomplete","off");
 
       // hide empty menu items
-      $('#mainmenu > div > .collapse').each(function(){
+      $('#mainmenu > div > .collapse').not('#Favorites').each(function(){
         // cleanup empty second level menu containers
         $(this).find("div.collapse").each(function(){
           if ($(this).children().length == 0 ) {

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -2,6 +2,7 @@
 
 // link menu system
 $menu = new OPNsense\Base\Menu\MenuSystem();
+/* XXX generating breadcrumbs requires getItems() call */
 $menuSystem = $menu->getItems($_SERVER['REQUEST_URI'], $_SESSION['Username'] ?? '');
 $menuBreadcrumbs = $menu->getBreadcrumbs();
 $menuHasFavorites = $menu->hasUserFavorites();

--- a/src/www/head.inc
+++ b/src/www/head.inc
@@ -3,8 +3,11 @@
 // link menu system
 $menu = new OPNsense\Base\Menu\MenuSystem();
 /* XXX generating breadcrumbs requires getItems() call */
-$menuSystem = $menu->getItems($_SERVER['REQUEST_URI']);
+$menuSystem = $menu->getItems($_SERVER['REQUEST_URI'], $_SESSION['Username'] ?? '');
 $menuBreadcrumbs = $menu->getBreadcrumbs();
+$menuHasFavorites = $menu->hasUserFavorites();
+$menuSelectedUrl = $menu->getSelectedPageUrl();
+$menuSelectedIsFavorite = $menu->getSelectedPageIsFavorite();
 
 if (isset($extraBreadcrumb)) {
     $menuBreadcrumbs[] = array('name' => $extraBreadcrumb);
@@ -74,6 +77,9 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
     <!-- bootstrap dialog -->
     <link rel="stylesheet" type="text/css" href="<?= cache_safe(get_themed_filename("/css/bootstrap-dialog.css")) ?>">
 
+    <!-- Favorites layout -->
+    <link rel="stylesheet" type="text/css" href="<?= cache_safe(get_themed_filename("/css/opnsense-favorites.css")) ?>">
+
     <!-- Font awesome -->
     <link rel="stylesheet" type="text/css" href="<?= cache_safe("/ui/assets/fontawesome/css/all.min.css") ?>">
     <link rel="stylesheet" type="text/css" href="<?= cache_safe("/ui/assets/fontawesome/css/v4-shims.min.css") ?>">
@@ -117,7 +123,7 @@ $pagetitle .= html_safe(sprintf(' | %s.%s', $config['system']['hostname'], $conf
       $("input").not("[autocomplete]").attr("autocomplete","off");
 
       // hide empty menu items
-      $('#mainmenu > div > .collapse').each(function(){
+      $('#mainmenu > div > .collapse').not('#Favorites').each(function(){
         // cleanup empty second level menu containers
         $(this).find("div.collapse").each(function(){
           if ($(this).children().length == 0 ) {


### PR DESCRIPTION
Implements a Favorites section:

- The section only appears if the user has at least one favorite selected. If all favorites are removed, the Favorites section disappears
- Favorites are added/removed simply by clicking on a star icon at the right hand side of the page heading on leaf menu item pages (the star will always appear furthest right, for consistency of appearance, even if other buttons are in the heading). The star icon changes appearance if the item is in the Favorites list
- The Favorites list is stored per-user, and is subject to their permissions
- If a favorited menu item is removed (eg an interface is removed or a plugin uninstalled), the Favorites entry is also removed
- Favorites entries appear in the same order as the corresponding menu items
- The PR caters for both MVC and legacy pages

Some sample screenshots attached.

<img width="1511" height="87" alt="Screenshot 5" src="https://github.com/user-attachments/assets/e2aa6541-5edf-4698-a75d-305450e0bb4a" />
<img width="1511" height="87" alt="Screenshot 6" src="https://github.com/user-attachments/assets/00b854b8-2d85-4fff-8da6-2704d7f01ff1" />

Javascript / HTML is not my strong suit, so be kind xD