### PR TITLE
Services: Kea: DHCPv4/v6: Use SetConstraint for match_data to allow 0 as valid value

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -389,7 +389,7 @@
                     <Constraints>
                         <check001>
                             <ValidationMessage>Match option and match data must either both be set or left empty.</ValidationMessage>
-                            <type>DependConstraint</type>
+                            <type>SetConstraint</type>
                             <addFields>
                                 <field1>match_code</field1>
                             </addFields>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -337,7 +337,7 @@
                     <Constraints>
                         <check001>
                             <ValidationMessage>Match option and match data must either both be set or left empty.</ValidationMessage>
-                            <type>DependConstraint</type>
+                            <type>SetConstraint</type>
                             <addFields>
                                 <field1>match_code</field1>
                             </addFields>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/10029