### PR TITLE
Services: Kea: DDNS: Add subnet specific qualifying suffix and prevent updates if no server is set

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -191,7 +191,16 @@
         <id>subnet4.ddns_forward_zone</id>
         <label>DNS forward zone</label>
         <type>text</type>
-        <help>DNS zone where DHCP clients should be registered (e.g. home.arpa).</help>
+        <help>DNS zone where DHCP clients should be registered (e.g. "home.arpa.").</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>subnet4.ddns_qualifying_suffix</id>
+        <label>DNS qualifying suffix</label>
+        <type>text</type>
+        <help>If a DHCP client only sends a hostname in option 81, append this suffix to create an FQDN (e.g. "home.arpa.").</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -92,7 +92,16 @@
         <id>subnet6.ddns_forward_zone</id>
         <label>DNS forward zone</label>
         <type>text</type>
-        <help>DNS zone where DHCP clients should be registered (e.g. home.arpa).</help>
+        <help>DNS zone where DHCP clients should be registered (e.g. "home.arpa.").</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>subnet6.ddns_qualifying_suffix</id>
+        <label>DNS qualifying suffix</label>
+        <type>text</type>
+        <help>If a DHCP client only sends a hostname in option 81, append this suffix to create an FQDN (e.g. "home.arpa.").</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -161,7 +161,7 @@ class KeaDhcpv4 extends BaseModel
         return $result;
     }
 
-    private function getConfigSubnets()
+    private function getConfigSubnets($ddns_enabled = false)
     {
         $result = [];
         $subnet_id = 1;
@@ -238,6 +238,13 @@ class KeaDhcpv4 extends BaseModel
                 }
                 $record['option-data'][] = $entry;
             }
+            /* DDNS per subnet settings */
+            if ($ddns_enabled) {
+                if (!$subnet->ddns_qualifying_suffix->isEmpty()) {
+                    $record['ddns-qualifying-suffix'] = $subnet->ddns_qualifying_suffix->getValue();
+                }
+                $record['ddns-send-updates'] = !$subnet->ddns_dns_server->isEmpty();
+            }
             $result[] = $record;
         }
         return $result;
@@ -273,6 +280,8 @@ class KeaDhcpv4 extends BaseModel
 
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp4.conf')
     {
+        $ddns = new KeaDdns();
+        $ddns_enabled = !$ddns->general->enabled->isEmpty();
         $cnf = [
             'Dhcp4' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
@@ -299,7 +308,7 @@ class KeaDhcpv4 extends BaseModel
                         'severity' => 'INFO',
                     ]
                 ],
-                'subnet4' => $this->getConfigSubnets(),
+                'subnet4' => $this->getConfigSubnets($ddns_enabled),
             ]
         ];
         $client_classes = $this->getConfigClientClasses();
@@ -347,8 +356,7 @@ class KeaDhcpv4 extends BaseModel
                 $cnf['Dhcp4']['hooks-libraries'][] = $record;
             }
         }
-        $ddns = new KeaDdns();
-        if (!$ddns->general->enabled->isEmpty()) {
+        if ($ddns_enabled) {
             $cnf['Dhcp4']['dhcp-ddns'] = [
                 'enable-updates' => true,
                 'server-ip' => $ddns->general->server_ip->getValue(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -157,6 +157,7 @@
                         </check001>
                     </Constraints>
                 </ddns_forward_zone>
+                <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>
                     <Constraints>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -160,7 +160,7 @@ class KeaDhcpv6 extends BaseModel
         return $hostname;
     }
 
-    private function getConfigSubnets()
+    private function getConfigSubnets($ddns_enabled = false)
     {
         $cfg = Config::getInstance()->object();
         $result = [];
@@ -270,6 +270,13 @@ class KeaDhcpv6 extends BaseModel
                 }
                 $record['option-data'][] = $entry;
             }
+            /* DDNS per subnet settings */
+            if ($ddns_enabled) {
+                if (!$subnet->ddns_qualifying_suffix->isEmpty()) {
+                    $record['ddns-qualifying-suffix'] = $subnet->ddns_qualifying_suffix->getValue();
+                }
+                $record['ddns-send-updates'] = !$subnet->ddns_dns_server->isEmpty();
+            }
             $result[] = $record;
         }
         return $result;
@@ -305,6 +312,8 @@ class KeaDhcpv6 extends BaseModel
 
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp6.conf')
     {
+        $ddns = new KeaDdns();
+        $ddns_enabled = !$ddns->general->enabled->isEmpty();
         $cnf = [
             'Dhcp6' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
@@ -330,7 +339,7 @@ class KeaDhcpv6 extends BaseModel
                         'severity' => 'INFO',
                     ]
                 ],
-                'subnet6' => $this->getConfigSubnets(),
+                'subnet6' => $this->getConfigSubnets($ddns_enabled),
             ]
         ];
         $client_classes = $this->getConfigClientClasses();
@@ -378,8 +387,7 @@ class KeaDhcpv6 extends BaseModel
                 $cnf['Dhcp6']['hooks-libraries'][] = $record;
             }
         }
-        $ddns = new KeaDdns();
-        if (!$ddns->general->enabled->isEmpty()) {
+        if ($ddns_enabled) {
             $cnf['Dhcp6']['dhcp-ddns'] = [
                 'enable-updates' => true,
                 'server-ip' => $ddns->general->server_ip->getValue(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -126,6 +126,7 @@
                         </check001>
                     </Constraints>
                 </ddns_forward_zone>
+                <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>
                     <Constraints>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/10030

Adds two parameters that can be set subnet specific, only appends them when ddns is enabled globally.

Example from the docs:

https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#ddns-for-dhcpv4

```ddns-send-updates```
```ddns-qualifying-suffix```

```Kea 2.7.6 added support for these parameters to the pool level.```

Support "to" the pool level must mean they are valid in the context of the subnet as well. My generated config shows no errors, but better let users test this.