### PR TITLE
allow pool definitions with same format used in KeaDhcpv4

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -79,7 +79,7 @@ class KeaDhcpv6 extends BaseModel
                 if (Util::isSubnet($pool)) {
                     $range = Util::cidrToRange($pool);
                 } else {
-                    $range = explode('-', $pool);
+                    $range = array_map('trim', explode('-', $pool));
                 }
                 foreach (!empty($range) ? $range : [] as $addr) {
                     if (!Util::isIPInCIDR($addr, $subnet->subnet->getValue())) {


### PR DESCRIPTION
Kea DHCPv4 allows Pool defintions both as "$ip_start-$ip_end" as well as "$ip_start - $ip_end" (help text suggests the second one)
Kea DHCPv6 only accepts "$ip-$ip" as the help text correctly suggests, but if coming from DHCPv4 the pool is likely to be defined with spaces, which leads to the confusing message "Pool $pool not in specified subnet".

This trims off spaces when checking for pool/subnet match, so both input formats are accepted.
The kea-dhcp6.conf file accepts both formats, although the Kea documentation also has the different input formats between v4 and v6.
It does explicitely state that both formats are accepted in both DHCPv4 and DHCPv6 documentation:
"White space in pool definitions is ignored, so spaces before and after the hyphen are optional. They can be used to improve readability."