### PR TITLE
mvc: Remove UIModelGrid imports in IDS, Monit, Syslog SettingsController, unused

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/Api/SettingsController.php
@@ -32,7 +32,6 @@ use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Backend;
 use OPNsense\Core\Config;
 use OPNsense\Core\SanitizeFilter;
-use OPNsense\Base\UIModelGrid;
 
 /**
  * Class SettingsController Handles settings related API actions for the IDS module

--- a/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Monit/Api/SettingsController.php
@@ -32,7 +32,6 @@ namespace OPNsense\Monit\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Config;
-use OPNsense\Base\UIModelGrid;
 
 /**
  * Class SettingsController

--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/Api/SettingsController.php
@@ -31,7 +31,6 @@ namespace OPNsense\Syslog\Api;
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Backend;
 use OPNsense\Core\Config;
-use OPNsense\Base\UIModelGrid;
 
 /**
  * Class SettingsController Handles settings related API actions for the Syslog module


### PR DESCRIPTION
Removes the last artifacts of direct UIModelGrid imports, looks like it's unused in those controllers and just a leftover.

There are more use statements that are probably leftover, maybe a linter could catch them?

For: https://github.com/opnsense/core/issues/9797