### PR TITLE
lint: Add linter that finds unused imports in php classes

### DIFF
--- a/Mk/lint.mk
+++ b/Mk/lint.mk
@@ -111,6 +111,9 @@ lint-acl:
 lint-class:
 	@${COREREFDIR}/Scripts/class-filename.sh ${COREREFDIR}
 
+lint-import:
+	@${COREREFDIR}/Scripts/class-import.sh ${COREREFDIR}
+
 SCRIPTDIRS!=	if [ -d ${.CURDIR}/src/opnsense/scripts ]; then find ${.CURDIR}/src/opnsense/scripts -type d -depth 1; fi
 
 lint-exec:
@@ -154,4 +157,4 @@ lint-plist:
 	@rm ${WRKDIR}/plist.*
 .endif
 
-lint: lint-plist lint-desc lint-shell lint-xml lint-model lint-acl lint-class lint-exec lint-php
+lint: lint-plist lint-desc lint-shell lint-xml lint-model lint-acl lint-class lint-import lint-exec lint-php

--- a/Scripts/class-import.sh
+++ b/Scripts/class-import.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Copyright (c) 2026 Deciso B.V. 
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+RET=0
+
+cd "${1}" || exit ${RET}
+
+if [ ! -d src ]; then
+	exit ${RET}
+fi
+
+for FILE in $(find src -name "*.php"); do
+	for LINE in $(grep '^use ' ${FILE} || true); do
+		IMPORT=$(echo "${LINE}" | sed 's/^use //; s/;//')
+		CLASS=${IMPORT##*\\}
+
+		COUNT=$(grep -w "${CLASS}" ${FILE} | wc -l)
+
+		if [ "${COUNT}" -le 1 ]; then
+			echo "${FILE}: warning: stale import use ${IMPORT}"
+		fi
+	done
+done
+
+exit ${RET}


### PR DESCRIPTION
Idea when thinking about this: https://github.com/opnsense/core/pull/10052

Example output:

root@opn-dev-02:/src/git/core # make lint-import
```
src/www/firewall_rule_lookup.php: warning: stale import use OPNsense\Firewall\Filter
src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php: warning: stale import use OPNsense\Firewall\Util
src/opnsense/mvc/script/run_validations.php: warning: stale import use OPNsense\Core\Config
src/opnsense/mvc/app/library/OPNsense/Base/UIModelGrid.php: warning: stale import use OPNsense\Core\Type
src/opnsense/mvc/app/library/OPNsense/Auth/LDAPTOTP.php: warning: stale import use OPNsense\Core\Config
src/opnsense/mvc/app/library/OPNsense/Auth/Voucher.php: warning: stale import use OPNsense\Core\Config
...
```