### PR TITLE
dnsmasq: Prevent * from being collected as client_id to prevent it being matched as static reservation

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
@@ -79,7 +79,8 @@ class LeasesController extends ApiControllerBase
         ];
 
         foreach ((new Dnsmasq())->hosts->iterateItems() as $host) {
-            if (!$host->client_id->isEmpty()) {
+            // Exclude '*' and other non-unique matches
+            if (!$host->client_id->isEmpty() && strpos($host->client_id->getValue(), ':') !== false) {
                 $reservedKeys['client_id'][strtolower($host->client_id->getValue())] = true;
             }
 

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
@@ -99,7 +99,7 @@
                         // No guessing here based on IP protocol, client_id and hwaddr can both be valid for IPv4 leases
                         const addUrlParams = {
                             ip: row.address || '',
-                            ...(row.client_id ? { client_id: row.client_id } : {}),
+                            ...(row.client_id && row.client_id.includes(':') ? { client_id: row.client_id } : {}),
                             ...(row.hwaddr ? { hwaddr: row.hwaddr } : {}),
                             ...(row.hostname && !row.hostname.includes('*')
                                 ? { host: row.hostname }


### PR DESCRIPTION
Fixes: https://github.com/opnsense/core/issues/10054

Reference: https://www.reddit.com/r/opnsense/comments/1s5g0cb/dnsmasq_dhcp_lease_type/