### PR TITLE
IPsec: Adding legacy dhgroups and hash algorithms to proposals.

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -129,11 +129,15 @@ class IPsecProposalField extends BaseListField
             ],
             gettext('Commonly used, but insecure cipher suites') => [
                 'aes256-sha1-modp2048' => 'aes256-sha1-modp2048 [DH14]',
+                'aes192-sha1-modp2048' => 'aes192-sha1-modp2048 [DH14]',
                 'aes128-sha1-modp2048' => 'aes128-sha1-modp2048 [DH14]',
                 'aes256-sha1-modp4096' => 'aes256-sha1-modp4096 [DH16]',
                 'aes256-sha1-ecp521' => 'aes256-sha1-ecp521 [DH21, NIST EC]',
                 'aes256-sha256-modp1024' => 'aes256-sha256-modp1024 [DH2]',
                 'aes256-sha512-modp1024' => 'aes256-sha512-modp1024 [DH2]',
+                'aes256-sha256-modp1536' => 'aes256-sha256-modp1536 [DH5]',
+                'aes128-sha256-modp1536' => 'aes128-sha256-modp1536 [DH5]',
+                'aes256gcm16-sha256-modp1536' => 'aes256gcm16-sha256-modp1536 [DH5]',
                 'aes256-sha1' => 'aes256-sha1',
                 'aes256-sha256' => 'aes256-sha256',
                 'null' => gettext('null (testing only, no encryption and no integrity checking!)')


### PR DESCRIPTION
Hello,

this adds the dhgroups modp768, modp1024, modp1536 and the SHA1 Hash Algorithm to the Proposals. These can be necessary for compatibility.

Thanks.