### PR TITLE
Added NAS-IP-Address attribute to radius access server calls

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -172,8 +172,8 @@ class Radius extends Base implements IAuthConnector
             'radius_acct_port' => 'acctPort',
             'radius_protocol' => 'protocol',
             'radius_stationid' => 'calledStationId',
-	    'radius_nasipaddress' => 'nasIpAddress',
-	    'radius_nasporttype' => 'nasPortType',
+            'radius_nasipaddress' => 'nasIpAddress',
+            'radius_nasporttype' => 'nasPortType',
             'refid' => 'nasIdentifier'
         );
 

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -70,6 +70,11 @@ class Radius extends Base implements IAuthConnector
     private $callingStationId = null;
 
     /**
+     * @var string ip addess to use for NAS-IP-Address attribute
+     */
+    private $nasIpAddress = null;
+
+    /**
      * @var int timeout to use
      */
     private $timeout = 10;
@@ -108,6 +113,8 @@ class Radius extends Base implements IAuthConnector
      * @var array list of groups to add by default
      */
     private $syncDefaultGroups = [];
+
+    private $nasPortType = RADIUS_ETHERNET;
 
     private function mapTerminateCause($cause)
     {
@@ -165,6 +172,8 @@ class Radius extends Base implements IAuthConnector
             'radius_acct_port' => 'acctPort',
             'radius_protocol' => 'protocol',
             'radius_stationid' => 'calledStationId',
+	    'radius_nasipaddress' => 'nasIpAddress',
+	    'radius_nasporttype' => 'nasPortType',
             'refid' => 'nasIdentifier'
         );
 
@@ -507,12 +516,14 @@ class Radius extends Base implements IAuthConnector
             $error = radius_strerror($radius);
         } elseif (!radius_put_int($radius, RADIUS_NAS_PORT, 0)) {
             $error = radius_strerror($radius);
-        } elseif (!radius_put_int($radius, RADIUS_NAS_PORT_TYPE, RADIUS_ETHERNET)) {
+        } elseif (!radius_put_int($radius, RADIUS_NAS_PORT_TYPE, $this->nasPortType)) {
             $error = radius_strerror($radius);
         } elseif (!empty($this->calledStationId) && !radius_put_string($radius, RADIUS_CALLED_STATION_ID, $this->calledStationId)) {
             $error = radius_strerror($radius);
         } elseif (!empty($this->callingStationId) && !radius_put_string($radius, RADIUS_CALLING_STATION_ID, $this->callingStationId)) {
             $error = radius_strerror($radius);
+        } elseif (!empty($this->nasIpAddress) && !radius_put_addr($radius, RADIUS_NAS_IP_ADDRESS, $this->nasIpAddress)) {
+            $error = radius_stderror($radius);
         } else {
             // Implement extra protocols in this section.
             switch ($this->protocol) {

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -27,6 +27,7 @@
  */
 
 namespace OPNsense\Auth;
+require_once("interfaces.inc");
 
 /**
  * Class Radius connector
@@ -114,8 +115,6 @@ class Radius extends Base implements IAuthConnector
      */
     private $syncDefaultGroups = [];
 
-    private $nasPortType = RADIUS_ETHERNET;
-
     private function mapTerminateCause($cause)
     {
         switch ($cause) {
@@ -173,7 +172,6 @@ class Radius extends Base implements IAuthConnector
             'radius_protocol' => 'protocol',
             'radius_stationid' => 'calledStationId',
             'radius_nasipaddress' => 'nasIpAddress',
-            'radius_nasporttype' => 'nasPortType',
             'refid' => 'nasIdentifier'
         );
 
@@ -215,6 +213,31 @@ class Radius extends Base implements IAuthConnector
         $options['radius_protocol']['validate'] = function ($value) {
             if (!in_array($value, ['PAP', 'MSCHAPv2'])) {
                 return [gettext('Invalid protocol specified')];
+            } else {
+                return [];
+            }
+        };
+
+        $options['radius_nasipaddress'] = [];
+        $options['radius_nasipaddress']['name'] = gettext('NAS IP address');
+        $options['radius_nasipaddress']['type'] = 'dropdown';
+        $options['radius_nasipaddress']['default'] = '';
+        $options['radius_nasipaddress']['options'] = [null => ''];
+        $interfaces = get_configured_interface_with_descr();
+
+        // Create options list using interface IPs
+        foreach($interfaces as $if => $descr) {
+            $ip = get_interface_ip($if);
+            $options['radius_nasipaddress']['options'] += [$ip => "$descr - $ip"];
+        }
+
+        $options['radius_nasipaddress']['validate'] = function ($value) {
+            $interfaces = get_configured_interface_with_descr();
+            $ips = [];
+            foreach($interfaces as $if => $descr)
+                $ips[] = get_interface_ip($if);
+            if(!empty($value) && !in_array($value, $ips)) {
+                return [gettext('Invalid address specified')];
             } else {
                 return [];
             }
@@ -510,13 +533,11 @@ class Radius extends Base implements IAuthConnector
             $error = radius_strerror($radius);
         } elseif (!radius_put_int($radius, RADIUS_SERVICE_TYPE, RADIUS_LOGIN)) {
             $error = radius_strerror($radius);
-        } elseif (!radius_put_int($radius, RADIUS_FRAMED_PROTOCOL, RADIUS_ETHERNET)) {
-            $error = radius_strerror($radius);
         } elseif (!radius_put_string($radius, RADIUS_NAS_IDENTIFIER, $this->nasIdentifier)) {
             $error = radius_strerror($radius);
         } elseif (!radius_put_int($radius, RADIUS_NAS_PORT, 0)) {
             $error = radius_strerror($radius);
-        } elseif (!radius_put_int($radius, RADIUS_NAS_PORT_TYPE, $this->nasPortType)) {
+        } elseif (!radius_put_int($radius, RADIUS_NAS_PORT_TYPE, RADIUS_VIRTUAL)) {
             $error = radius_strerror($radius);
         } elseif (!empty($this->calledStationId) && !radius_put_string($radius, RADIUS_CALLED_STATION_ID, $this->calledStationId)) {
             $error = radius_strerror($radius);

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -100,6 +100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig['radius_secret'] = $a_server[$id]['radius_secret'] ?? '';
             $pconfig['radius_timeout'] = $a_server[$id]['radius_timeout'] ?? '';
             $pconfig['radius_stationid'] = $a_server[$id]['radius_stationid'] ?? '';
+            $pconfig['radius_nasipaddress'] = $a_server[$id]['radius_nasipaddress'] ?? '';
 
             if (!empty($pconfig['radius_auth_port']) &&
                 !empty($pconfig['radius_acct_port'])) {
@@ -284,6 +285,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                   unset($server['radius_stationid']);
               }
 
+              if (!empty($pconfig['radius_nasipaddress'])) {
+                  $server['radius_nasipaddress'] = $pconfig['radius_nasipaddress'];
+              } else {
+		      unset($server['radius_nasipaddress']);
+              }
+
               if ($pconfig['radius_srvcs'] == "both") {
                   $server['radius_auth_port'] = $pconfig['radius_auth_port'];
                   $server['radius_acct_port'] = $pconfig['radius_acct_port'];
@@ -296,7 +303,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
               $server['sync_memberof'] = !empty($pconfig['sync_memberof']);
               $server['sync_memberof_groups'] = !empty($pconfig['sync_memberof_groups']) ? implode(",", $pconfig['sync_memberof_groups']) : [];
               $server['sync_default_groups'] = !empty($pconfig['sync_default_groups']) ? implode(",", $pconfig['sync_default_groups']) : [];
-              $server['sync_create_local_users'] = !empty($pconfig['sync_create_local_users']);
+	      $server['sync_create_local_users'] = !empty($pconfig['sync_create_local_users']);
+	      $server['radius_nasporttype'] = RADIUS_VIRTUAL;
           } elseif ($server['type'] == 'local') {
               foreach (['password_policy_duration', 'enable_password_policy_constraints',
                   'password_policy_complexity', 'password_policy_compliance',
@@ -369,6 +377,8 @@ $all_authfields = [
     'radius_srvcs',
     'radius_timeout',
     'radius_stationid',
+    'radius_nasipaddress',
+    'radius_nasporttype',
     'sync_create_local_users',
     'sync_memberof',
     'ldap_attr_memberof',
@@ -872,6 +882,15 @@ endif; ?>
                       <br /><?= gettext("This value serves as a unique identifier for this NAS. This value typically contains a MAC address, optionally appended with a known SSID or FQDN, separated by a \":\".") ?>
                       <br /><?= gettext("The MAC address can be any uniquely associated with this machine, but typically the MAC address facing the RADIUS server is used.") ?>
                       <br /><?= gettext("For example: 00:1A:2B:3C:4F:5E:opnsense.localdomain") ?>
+                    </div>
+                  </td>
+                </tr>
+                <tr class="auth_radius auth_options hidden">
+                  <td><a id="help_for_radius_nasipaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NAS IP Address");?></td>
+                  <td>
+                    <input name="radius_nasipaddress" type="text" id="radius_nasipaddress" size="20" value="<?=$pconfig['radius_nasipaddress'];?>"/>
+                    <div class="hidden" data-for="help_for_radius_nasipaddress">
+                      <br /><?= gettext("Enter the IP to use for the 'NAS-IP-Address' attribute during RADIUS Access-Requests.") ?>
                     </div>
                   </td>
                 </tr>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -100,7 +100,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig['radius_secret'] = $a_server[$id]['radius_secret'] ?? '';
             $pconfig['radius_timeout'] = $a_server[$id]['radius_timeout'] ?? '';
             $pconfig['radius_stationid'] = $a_server[$id]['radius_stationid'] ?? '';
-            $pconfig['radius_nasipaddress'] = $a_server[$id]['radius_nasipaddress'] ?? '';
 
             if (!empty($pconfig['radius_auth_port']) &&
                 !empty($pconfig['radius_acct_port'])) {
@@ -285,12 +284,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                   unset($server['radius_stationid']);
               }
 
-              if (!empty($pconfig['radius_nasipaddress'])) {
-                  $server['radius_nasipaddress'] = $pconfig['radius_nasipaddress'];
-              } else {
-                  unset($server['radius_nasipaddress']);
-              }
-
               if ($pconfig['radius_srvcs'] == "both") {
                   $server['radius_auth_port'] = $pconfig['radius_auth_port'];
                   $server['radius_acct_port'] = $pconfig['radius_acct_port'];
@@ -304,7 +297,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
               $server['sync_memberof_groups'] = !empty($pconfig['sync_memberof_groups']) ? implode(",", $pconfig['sync_memberof_groups']) : [];
               $server['sync_default_groups'] = !empty($pconfig['sync_default_groups']) ? implode(",", $pconfig['sync_default_groups']) : [];
               $server['sync_create_local_users'] = !empty($pconfig['sync_create_local_users']);
-              $server['radius_nasporttype'] = RADIUS_VIRTUAL;
           } elseif ($server['type'] == 'local') {
               foreach (['password_policy_duration', 'enable_password_policy_constraints',
                   'password_policy_complexity', 'password_policy_compliance',
@@ -377,8 +369,6 @@ $all_authfields = [
     'radius_srvcs',
     'radius_timeout',
     'radius_stationid',
-    'radius_nasipaddress',
-    'radius_nasporttype',
     'sync_create_local_users',
     'sync_memberof',
     'ldap_attr_memberof',
@@ -882,15 +872,6 @@ endif; ?>
                       <br /><?= gettext("This value serves as a unique identifier for this NAS. This value typically contains a MAC address, optionally appended with a known SSID or FQDN, separated by a \":\".") ?>
                       <br /><?= gettext("The MAC address can be any uniquely associated with this machine, but typically the MAC address facing the RADIUS server is used.") ?>
                       <br /><?= gettext("For example: 00:1A:2B:3C:4F:5E:opnsense.localdomain") ?>
-                    </div>
-                  </td>
-                </tr>
-                <tr class="auth_radius auth_options hidden">
-                  <td><a id="help_for_radius_nasipaddress" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("NAS IP Address");?></td>
-                  <td>
-                    <input name="radius_nasipaddress" type="text" id="radius_nasipaddress" size="20" value="<?=$pconfig['radius_nasipaddress'];?>"/>
-                    <div class="hidden" data-for="help_for_radius_nasipaddress">
-                      <br /><?= gettext("Enter the IP to use for the 'NAS-IP-Address' attribute during RADIUS Access-Requests.") ?>
                     </div>
                   </td>
                 </tr>

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -288,7 +288,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
               if (!empty($pconfig['radius_nasipaddress'])) {
                   $server['radius_nasipaddress'] = $pconfig['radius_nasipaddress'];
               } else {
-		      unset($server['radius_nasipaddress']);
+                  unset($server['radius_nasipaddress']);
               }
 
               if ($pconfig['radius_srvcs'] == "both") {
@@ -303,8 +303,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
               $server['sync_memberof'] = !empty($pconfig['sync_memberof']);
               $server['sync_memberof_groups'] = !empty($pconfig['sync_memberof_groups']) ? implode(",", $pconfig['sync_memberof_groups']) : [];
               $server['sync_default_groups'] = !empty($pconfig['sync_default_groups']) ? implode(",", $pconfig['sync_default_groups']) : [];
-	      $server['sync_create_local_users'] = !empty($pconfig['sync_create_local_users']);
-	      $server['radius_nasporttype'] = RADIUS_VIRTUAL;
+              $server['sync_create_local_users'] = !empty($pconfig['sync_create_local_users']);
+              $server['radius_nasporttype'] = RADIUS_VIRTUAL;
           } elseif ($server['type'] == 'local') {
               foreach (['password_policy_duration', 'enable_password_policy_constraints',
                   'password_policy_complexity', 'password_policy_compliance',


### PR DESCRIPTION
Added NAS-IP-Address attribute to radius access server calls
Changed NAS-Port-Type to virtual for radius access server calls

No open issues I could find regarding this, but I needed NAS-IP-Address to be set for Microsoft NPS to work. I also found that the NAS-Port-Type was hard coded to RADIUS_ETHERNET which didn't work with NPS either. I changed it to be hard coded RADIUS_VIRTUAL for access servers and kept the default of RADIUS_ETHERNET for everything else.