### PR TITLE
openvpn: add ADAPTER_DOMAIN_SUFFIX support to Instances module

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/forms/dialogInstance.xml
@@ -645,6 +645,20 @@ Set to 0 to disable, remember to change your client as well.
         </grid_view>
     </field>
     <field>
+        <id>instance.adapter_domain_suffix</id>
+        <label>Adapter Domain Suffix</label>
+        <type>select_multiple</type>
+        <style>tokenize role role_server</style>
+        <allownew>true</allownew>
+        <help>
+            Push ADAPTER_DOMAIN_SUFFIX to clients. Sets the connection-specific DNS suffix on the VPN adapter,
+            required for reliable DNS short name resolution on Windows clients using the DCO (Data Channel Offload) driver.
+        </help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>instance.tun_mtu</id>
         <label>TUN device MTU</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.php
@@ -701,6 +701,11 @@ class OpenVPN extends BaseModel
                             $options['push'][] = "\"dhcp-option NTP {$opt}\"";
                         }
                     }
+                    if (!$node->adapter_domain_suffix->isEmpty()) {
+                        foreach (explode(',', (string)$node->adapter_domain_suffix) as $opt) {
+                            $options['push'][] = "\"dhcp-option ADAPTER_DOMAIN_SUFFIX {$opt}\"";
+                        }
+                    }
                     if (!$node->push_inactive->isEmpty()) {
                         $options['push'][] = "\"inactive {$node->push_inactive}\"";
                     }

--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -407,6 +407,9 @@
                     <NetMaskAllowed>N</NetMaskAllowed>
                     <AsList>Y</AsList>
                 </ntp_servers>
+                <adapter_domain_suffix type="HostnameField">
+                    <AsList>Y</AsList>
+                </adapter_domain_suffix>
                 <tun_mtu type="IntegerField">
                     <MinimumValue>60</MinimumValue>
                     <MaximumValue>65535</MaximumValue>


### PR DESCRIPTION
## What does this PR do?

Adds an "Adapter Domain Suffix" field to the OpenVPN Instances server configuration. When set, the server pushes `dhcp-option ADAPTER_DOMAIN_SUFFIX <domain>` to clients.

## Why is this needed?

Windows clients using OpenVPN with DCO (Data Channel Offload) cannot resolve DNS short names (e.g. `server`) because the DCO driver does not support DHCP-based domain search list configuration. The only reliable workaround is pushing `ADAPTER_DOMAIN_SUFFIX`, which sets the connection-specific DNS suffix via wmic on the Windows client.

This has been an open upstream issue for 3+ years ([OpenVPN/openvpn#326](https://github.com/OpenVPN/openvpn/issues/326)) with no fix in sight. The DCO maintainer has explicitly declined to add DHCP support to the driver.

The legacy OpenVPN Server module allowed Custom Options as a workaround. The Instances module (which replaces it) does not, leaving administrators with no GUI-based solution.

## Changes

- **Model** (`OpenVPN.xml`): Added `adapter_domain_suffix` field of type `HostnameField` with list support
- **Config generator** (`OpenVPN.php`): Emit `push "dhcp-option ADAPTER_DOMAIN_SUFFIX <domain>"` for each configured value
- **Form** (`dialogInstance.xml`): Added tokenized multi-select field in the DNS options section, visible only for server instances

## How to test

1. Configure an OpenVPN server instance with the new "Adapter Domain Suffix" field set to `example.local`
2. Connect a Windows client with OpenVPN Connect (DCO enabled)
3. Run `ipconfig /all` – verify "Connection-specific DNS Suffix" shows `example.local` on the DCO adapter
4. Run `ping server` – verify it resolves to `server.example.local`

## Related issues

- Partially addresses https://github.com/opnsense/core/issues/7316
- Partially addresses https://github.com/opnsense/core/issues/6758
- Upstream: https://github.com/OpenVPN/openvpn/issues/326, https://github.com/OpenVPN/openvpn/issues/306