### PR TITLE
ui: use space in apply box for the apply reminder

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
@@ -1,8 +1,7 @@
-<section class="page-content-main" style="padding: 15px 0 0">
+<section class="page-content-main">
     <div class="content-box grid-bottom-reserve">
-        <div class="col-md-12">
-            <br/>
-            <button class="btn btn-primary" id="{{ button_id|default('reconfigureAct') }}"
+        <div class="col-md-12 __mt __mb" style="display: flex; align-items: center;">
+            <button class="btn btn-primary __mr" id="{{ button_id|default('reconfigureAct') }}"
                     data-endpoint="{{ data_endpoint }}"
                     data-label="{{ lang._(data_label|default('Apply')) }}"
                     data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
@@ -12,13 +11,13 @@
 {% if data_grid_reload is defined %}
                     data-grid-reload="{{ data_grid_reload }}"
 {% endif %}
+                    data-message-id="{{ message_id|default('change_message_base_form') }}"
                     type="button">
             </button>
-            <br/><br/>
+            <div id="{{ message_id|default('change_message_base_form') }}" class="text-danger" style="display: none">
+                <i class="fa fa-fw fa-exclamation-triangle"></i>
+                {{ lang._(data_change_message_content | default('After changing settings, please remember to apply them.')) }}
+            </div>
         </div>
     </div>
 </section>
-
-<div id="{{ message_id|default('change_message_base_form') }}" class="alert alert-info" style="display: none" role="alert">
-    {{ lang._(data_change_message_content | default('After changing settings, please remember to apply them.')) }}
-</div>

--- a/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
@@ -1,23 +1,20 @@
-<section class="page-content-main">
-    <div class="content-box grid-bottom-reserve">
-        <div class="col-md-12 __mt __mb" style="display: flex; align-items: center;">
-            <button class="btn btn-primary __mr" id="{{ button_id|default('reconfigureAct') }}"
-                    data-endpoint="{{ data_endpoint }}"
-                    data-label="{{ lang._(data_label|default('Apply')) }}"
-                    data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
+<section class="page-content-main grid-bottom-reserve">
+    <div class="alert content-box" style="display: flex; align-items: center; margin-bottom: 0;">
+        <button class="btn btn-primary __mr" id="{{ button_id|default('reconfigureAct') }}"
+            data-endpoint="{{ data_endpoint }}"
+            data-label="{{ lang._(data_label|default('Apply')) }}"
+            data-error-title="{{ lang._(data_error_title|default('Error reconfiguring service.')) }}"
 {% if data_service_widget is defined %}
-                    data-service-widget="{{ data_service_widget }}"
+            data-service-widget="{{ data_service_widget }}"
 {% endif %}
 {% if data_grid_reload is defined %}
-                    data-grid-reload="{{ data_grid_reload }}"
+            data-grid-reload="{{ data_grid_reload }}"
 {% endif %}
-                    data-message-id="{{ message_id|default('change_message_base_form') }}"
-                    type="button">
-            </button>
-            <div id="{{ message_id|default('change_message_base_form') }}" class="text-danger" style="display: none">
-                <i class="fa fa-fw fa-exclamation-triangle"></i>
-                {{ lang._(data_change_message_content | default('After changing settings, please remember to apply them.')) }}
-            </div>
+            data-message-id="{{ message_id|default('change_message_base_form') }}"
+            type="button">
+        </button>
+        <div id="{{ message_id|default('change_message_base_form') }}" style="display: none">
+            {{ lang._(data_change_message_content | default('After changing settings, please remember to apply them.')) }}
         </div>
     </div>
 </section>

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -2056,25 +2056,7 @@ class UIBootgrid {
     showSaveAlert(event) {
         let editAlert = this.$compatElement.attr('data-editAlert');
         if (editAlert !== undefined) {
-            const $el = $("#" + editAlert);
-            const rect = $(".page-content-head").first()[0].getBoundingClientRect();
-            const top = $('.navbar').first().outerHeight() + 5;
-            const centerX = rect.left + (rect.width / 2);
-
-            $el.css({
-                position: "fixed",
-                top: top + "px",
-                left: centerX + "px",
-                right: "auto",
-                zIndex: 9999,
-                transform: "translateX(-50%)"
-            });
-
-            $el.slideDown(1000, function () {
-                setTimeout(function () {
-                    $el.not(":animated").slideUp(2000);
-                }, 2000);
-            });
+            $("#" + editAlert).show();
         }
     }
 

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -2056,7 +2056,7 @@ class UIBootgrid {
     showSaveAlert(event) {
         let editAlert = this.$compatElement.attr('data-editAlert');
         if (editAlert !== undefined) {
-            $("#" + editAlert).show();
+            $("#" + editAlert).show().parent('.alert').addClass('alert-info').removeClass('content-box');
         }
     }
 

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -685,6 +685,7 @@ $.fn.SimpleActionButton = function (params) {
                     } else {
                         setIcon(icon, 'fa fa-spinner fa-pulse', 'fa fa-check');
                         $("#" + this_button.data('message-id')).hide();
+                        this_button.parent('.alert').addClass('content-box').removeClass('alert-info');
 
                         // XXX instead of infamous check mark we could show a success or even failure message
                         hideCheckTimeout = setTimeout(function () {

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -687,7 +687,6 @@ $.fn.SimpleActionButton = function (params) {
                         $("#" + this_button.data('message-id')).hide();
                         this_button.parent('.alert').addClass('content-box').removeClass('alert-info');
 
-                        // XXX instead of infamous check mark we could show a success or even failure message
                         hideCheckTimeout = setTimeout(function () {
                             setIcon(icon, 'fa fa-check', '');
                         }, 4000);

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -684,7 +684,9 @@ $.fn.SimpleActionButton = function (params) {
                         setIcon(icon, 'fa fa-check fa-spinner fa-pulse', 'fa fa-spinner fa-pulse');
                     } else {
                         setIcon(icon, 'fa fa-spinner fa-pulse', 'fa fa-check');
+                        $("#" + this_button.data('message-id')).hide();
 
+                        // XXX instead of infamous check mark we could show a success or even failure message
                         hideCheckTimeout = setTimeout(function () {
                             setIcon(icon, 'fa fa-check', '');
                         }, 4000);


### PR DESCRIPTION
We could extend this a bit if we want to go this way. It's the best way to use existing space and move the message to where it matters most -- the apply button itself.

I'm not entirely sure about coloring.  We could instead make the whole box change color similar to what alerts are doing.

wide:

<img width="768" height="418" alt="Screenshot 2026-04-08 at 12 15 35" src="https://github.com/user-attachments/assets/9a972fa9-faaf-4ef4-9d28-455d780a5843" />

squashed:

<img width="474" height="337" alt="Screenshot 2026-04-08 at 12 15 43" src="https://github.com/user-attachments/assets/aee9102c-c183-45c5-8541-14692fbf95dc" />

Based on discussions with @Monviech and more recently @swhite2 since the alert box moved for related reasons.
