### PR TITLE
Finish GHSA-jpm7-f59c-mp54 remediation

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -471,26 +471,6 @@ class LDAP extends Base implements IAuthConnector
     }
 
     /**
-     * unused
-     * @return array mixed named list of authentication properties
-     */
-    public function getLastAuthProperties()
-    {
-        return $this->lastAuthProperties;
-    }
-
-    /**
-     * authenticate user against ldap server without Base's timer
-     * @param string $username username to authenticate
-     * @param string $password user password
-     * @return bool authentication status
-     */
-    public function authenticate($username, $password)
-    {
-        return $this->_authenticate($username, $password);
-    }
-
-    /**
      * authenticate user against ldap server, implementation as described in Base class
      * @param string $username username to authenticate
      * @param string $password user password

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -471,6 +471,15 @@ class LDAP extends Base implements IAuthConnector
     }
 
     /**
+     * unused
+     * @return array mixed named list of authentication properties
+     */
+    public function getLastAuthProperties()
+    {
+        return $this->lastAuthProperties;
+    }
+
+    /**
      * authenticate user against ldap server, implementation as described in Base class
      * @param string $username username to authenticate
      * @param string $password user password


### PR DESCRIPTION
During the publishing of [GHSA-jpm7-f59c-mp54](https://github.com/opnsense/core/security/advisories/GHSA-jpm7-f59c-mp54), the temporary private fork from GitHub was not used. This change was lost from the changeset that I provided. This should help to finish closing that issue out entirely.
