### PR TITLE
Kea: allow configuring DDNS target port per subnet

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -215,6 +215,15 @@
         </grid_view>
     </field>
     <field>
+        <id>subnet4.ddns_dns_server_port</id>
+        <label>DNS server port</label>
+        <type>text</type>
+        <help>Port on the authoritative DNS server receiving dynamic updates.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>subnet4.ddns_domain_key_name</id>
         <label>TSIG key name</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -116,6 +116,15 @@
         </grid_view>
     </field>
     <field>
+        <id>subnet6.ddns_dns_server_port</id>
+        <label>DNS server port</label>
+        <type>text</type>
+        <help>Port on the authoritative DNS server receiving dynamic updates.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>subnet6.ddns_domain_key_name</id>
         <label>TSIG key name</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -47,6 +47,7 @@ class KeaDdns extends BaseModel
                 }
                 $forward_zone = $subnet->ddns_forward_zone->getValue();
                 $server = $subnet->ddns_dns_server->getValue();
+                $server_port = $subnet->ddns_dns_server_port->isEmpty() ? 53 : $subnet->ddns_dns_server_port->asInt();
                 $keyname = $subnet->ddns_domain_key_name->getValue();
                 if ($keyname && !isset($keys[$keyname])) {
                     $keys[$keyname] = [
@@ -64,7 +65,7 @@ class KeaDdns extends BaseModel
                 }
                 $server_entry = [
                     'ip-address' => $server,
-                    'port' => 53,
+                    'port' => $server_port,
                 ];
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $domains[$forward_zone]['dns-servers'][] = $server_entry;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -63,7 +63,7 @@ class KeaDdns extends BaseModel
                 }
                 $server_entry = [
                     'ip-address' => $subnet->ddns_dns_server->getValue(),
-                    'port' => $server_port,
+                    'port' => $subnet->ddns_dns_server_port->asInt(),
                 ];
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $domains[$forward_zone]['dns-servers'][] = $server_entry;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -62,7 +62,7 @@ class KeaDdns extends BaseModel
                     $domains[$forward_zone]['dns-servers'] = [];
                 }
                 $server_entry = [
-                    'ip-address' => $server,
+                    'ip-address' => $subnet->ddns_dns_server->getValue(),
                     'port' => $server_port,
                 ];
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -46,8 +46,6 @@ class KeaDdns extends BaseModel
                     continue;
                 }
                 $forward_zone = $subnet->ddns_forward_zone->getValue();
-                $server = $subnet->ddns_dns_server->getValue();
-                $server_port = $subnet->ddns_dns_server_port->isEmpty() ? 53 : $subnet->ddns_dns_server_port->asInt();
                 $keyname = $subnet->ddns_domain_key_name->getValue();
                 if ($keyname && !isset($keys[$keyname])) {
                     $keys[$keyname] = [

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -171,6 +171,9 @@
                         </check001>
                     </Constraints>
                 </ddns_dns_server>
+                <ddns_dns_server_port type="PortField">
+                    <Default>53</Default>
+                </ddns_dns_server_port>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>
                         <check001>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -173,6 +173,7 @@
                 </ddns_dns_server>
                 <ddns_dns_server_port type="PortField">
                     <Default>53</Default>
+                    <Required>Y</Required>
                 </ddns_dns_server_port>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -140,6 +140,9 @@
                         </check001>
                     </Constraints>
                 </ddns_dns_server>
+                <ddns_dns_server_port type="PortField">
+                    <Default>53</Default>
+                </ddns_dns_server_port>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>
                         <check001>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -142,6 +142,7 @@
                 </ddns_dns_server>
                 <ddns_dns_server_port type="PortField">
                     <Default>53</Default>
+                    <Required>Y</Required>
                 </ddns_dns_server_port>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp6</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>Kea DHCPv6 configuration</description>
     <items>
         <general>


### PR DESCRIPTION
## What
Add a configurable DDNS target port to Kea DHCPv4 and DHCPv6 subnets.

## Why
The current DDNS generator always writes `dns-servers[].port` as `53`, even though the authoritative DNS server may intentionally listen on a different port. This makes otherwise valid local resolver/authoritative split setups impossible to express in the GUI.

## How
- add a `ddns_dns_server_port` model field for DHCPv4 and DHCPv6 subnets
- expose the field in the subnet dialogs
- use the configured port in `KeaDdns::generateConfig()`
- keep the default at `53` for backward compatibility

## Notes
This keeps the existing behavior unchanged for current installations and only extends the generated `kea-dhcp-ddns.conf` when a non-default port is configured.

Ref: opnsense/core#10116