### PR TITLE
Don't select invalid gateway as active one

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
@@ -33,6 +33,7 @@ use OPNsense\Core\Config;
 use OPNsense\Firewall\Util;
 use OPNsense\Interface\Autoconf;
 use OPNsense\Base\Messages\Message;
+use OPNsense\Core\Backend;
 
 class Gateways extends BaseModel
 {
@@ -366,6 +367,8 @@ class Gateways extends BaseModel
             $gatewaySeq = 1;
             $i = 0; // sequence used in legacy edit form (item in the list)
             $reservednames = array();
+            $cfg = Config::getInstance()->object();
+            $ifconfig = json_decode((new Backend())->configdRun('interface list ifconfig'), true);
 
             // add loopback, lowest priority
             $this->cached_gateways[$this->newKey(255)] = [
@@ -398,6 +401,38 @@ class Gateways extends BaseModel
                 $gw_arr['if'] = $this->getRealInterface($definedIntf, $gw_arr['interface'], $gw_arr['ipprotocol']);
                 $gw_arr['attribute'] = $i++;
                 if (Util::isIpAddress($gw_arr['gateway'])) {
+
+                    // Check if gateway IP address is outside interface netmask.
+                    // If so, mark it disabled.
+
+                    $proto = $gw_arr['ipprotocol'] === 'inet' ? 'ipaddr' : 'ipaddrv6';
+                    $ip = (string)$cfg->interfaces->{$gw_arr['interface']}->{$proto};
+                    $include = (!empty($ip) && Util::isIpAddress($ip));
+                    $far = $gw_arr['fargw'];
+                    if ($far == 0 && $include && array_key_exists($gw_arr['if'], $ifconfig)) {
+
+                        $ipproto = $gw_arr['ipprotocol'] === 'inet' ? 'ipv4' : 'ipv6';
+                        $subnets = [];
+
+                        foreach ($ifconfig[$gw_arr['if']][$ipproto] as $ip) {
+                            if (!empty($ip['ipaddr']) && !empty($ip['subnetbits'])) {
+                                $subnets[] = $ip['ipaddr'] . '/' . $ip['subnetbits'];
+                            }
+                        }
+
+                        $match = false;
+                        foreach ($subnets as $subnet) {
+                            if (Util::isIPInCIDR($gw_arr['gateway'], $subnet)) {
+                                $match = true;
+                                break;
+                            }
+                        }
+
+                        if (empty($subnets) || !$match) {
+                            $gw_arr['disabled'] = 1;
+                        }
+                    }
+
                     if (empty($gw_arr['monitor_disable']) && empty($gw_arr['monitor'])) {
                         $gw_arr['monitor'] = $gw_arr['gateway'];
                     }


### PR DESCRIPTION
OPNsense GUI displays nicely that a gateway has invalid settings when it's IP address is outside interfaces address range (checked agains netmask). However, the backend logic does not work similarly. If multiple upstream gateways have been configured
and the topmost one (having highest priority) is not valid, system still tries to use it which renders a valid gateway configuration having lower priority useless.

Added code (with my *very* limited PHP skills) to Gateways.php to perform similar check as done in SettingsController.php already. It marks gateway as disabled if it's address falls outside of interfaces netmask and it has not been marked as a far gateway.

My use case for this scenario is a HA pair in datacenter where master and backup nodes have different upstream gateway address. This allows me to configure upstream gateways in master (with master's gateway as priority 10 and backup's gateway as priority 11). When configuration is synced to backup, this change detects that priority 10 gateway is not valid, causing system to select next gateway - which is the correct one for backup node.

As said, I'm not very skilled with PHP, so I'm not sure if this code is usable as-is. But I hope that the idea is.

This is tested on 25.7.11.