### PR TITLE
Kea: add explicit reverse DDNS zones

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -197,6 +197,15 @@
         </grid_view>
     </field>
     <field>
+        <id>subnet4.ddns_reverse_zone</id>
+        <label>DNS reverse zone</label>
+        <type>text</type>
+        <help>Full reverse DNS zone receiving PTR updates (e.g. "200.10.10.in-addr.arpa.").</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>subnet4.ddns_qualifying_suffix</id>
         <label>DNS qualifying suffix</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -98,6 +98,15 @@
         </grid_view>
     </field>
     <field>
+        <id>subnet6.ddns_reverse_zone</id>
+        <label>DNS reverse zone</label>
+        <type>text</type>
+        <help>Full reverse DNS zone receiving PTR updates (e.g. "8.b.d.0.1.0.0.2.ip6.arpa.").</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>subnet6.ddns_qualifying_suffix</id>
         <label>DNS qualifying suffix</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -33,25 +33,6 @@ use OPNsense\Core\File;
 
 class KeaDdns extends BaseModel
 {
-    private function addDdnsDomain(&$domains, $name, $server, $keyname)
-    {
-        if (!isset($domains[$name])) {
-            $domains[$name] = ['name' => $name];
-            if ($keyname) {
-                $domains[$name]['key-name'] = $keyname;
-            }
-            $domains[$name]['dns-servers'] = [];
-        }
-
-        $server_entry = [
-            'ip-address' => $server,
-            'port' => 53,
-        ];
-        if (!in_array($server_entry, $domains[$name]['dns-servers'], true)) {
-            $domains[$name]['dns-servers'][] = $server_entry;
-        }
-    }
-
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp-ddns.conf')
     {
         if ($this->general->enabled->isEmpty()) {
@@ -75,11 +56,36 @@ class KeaDdns extends BaseModel
                         'secret' => $subnet->ddns_domain_key_secret->getValue(),
                     ];
                 }
-                $this->addDdnsDomain($forward_domains, $forward_zone, $server, $keyname);
-
+                if (!isset($forward_domains[$forward_zone])) {
+                    $forward_domains[$forward_zone] = ['name' => $forward_zone];
+                    if ($keyname) {
+                        $forward_domains[$forward_zone]['key-name'] = $keyname;
+                    }
+                    $forward_domains[$forward_zone]['dns-servers'] = [];
+                }
+                $server_entry = [
+                    'ip-address' => $server,
+                    'port' => 53,
+                ];
+                if (!in_array($server_entry, $forward_domains[$forward_zone]['dns-servers'], true)) {
+                    $forward_domains[$forward_zone]['dns-servers'][] = $server_entry;
+                }
                 $reverse_zone = $subnet->ddns_reverse_zone->getValue();
                 if (!empty($reverse_zone)) {
-                    $this->addDdnsDomain($reverse_domains, $reverse_zone, $server, $keyname);
+                    if (!isset($reverse_domains[$reverse_zone])) {
+                        $reverse_domains[$reverse_zone] = ['name' => $reverse_zone];
+                        if ($keyname) {
+                            $reverse_domains[$reverse_zone]['key-name'] = $keyname;
+                        }
+                        $reverse_domains[$reverse_zone]['dns-servers'] = [];
+                    }
+                    $server_entry = [
+                        'ip-address' => $server,
+                        'port' => 53,
+                    ];
+                    if (!in_array($server_entry, $reverse_domains[$reverse_zone]['dns-servers'], true)) {
+                        $reverse_domains[$reverse_zone]['dns-servers'][] = $server_entry;
+                    }
                 }
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -38,7 +38,7 @@ class KeaDdns extends BaseModel
         if ($this->general->enabled->isEmpty()) {
             return;
         }
-        $forward_domains = [];
+        $domains = [];
         $reverse_domains = [];
         $keys = [];
         foreach ([(new KeaDhcpv4())->subnets->subnet4, (new KeaDhcpv6())->subnets->subnet6] as $subnets) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -95,7 +95,7 @@ class KeaDdns extends BaseModel
                 'port' => $this->general->server_port->asInt(),
                 'tsig-keys' => array_values($keys),
                 'forward-ddns' => [
-                    'ddns-domains' => array_values($forward_domains)
+                    'ddns-domains' => array_values($domains)
                 ],
                 'reverse-ddns' => [
                     'ddns-domains' => array_values($reverse_domains)

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -33,12 +33,67 @@ use OPNsense\Core\File;
 
 class KeaDdns extends BaseModel
 {
+    private function addDdnsDomain(&$domains, $name, $server, $keyname)
+    {
+        if (!isset($domains[$name])) {
+            $domains[$name] = ['name' => $name];
+            if ($keyname) {
+                $domains[$name]['key-name'] = $keyname;
+            }
+            $domains[$name]['dns-servers'] = [];
+        }
+
+        $server_entry = [
+            'ip-address' => $server,
+            'port' => 53,
+        ];
+        if (!in_array($server_entry, $domains[$name]['dns-servers'], true)) {
+            $domains[$name]['dns-servers'][] = $server_entry;
+        }
+    }
+
+    private function getReverseZoneForSubnet($subnet)
+    {
+        if (empty($subnet) || strpos($subnet, '/') === false) {
+            return null;
+        }
+
+        [$address, $prefix_length] = explode('/', $subnet, 2);
+        if (!is_numeric($prefix_length)) {
+            return null;
+        }
+
+        $prefix_length = (int)$prefix_length;
+        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            if ($prefix_length < 8 || $prefix_length > 32 || $prefix_length % 8 !== 0) {
+                return null;
+            }
+            $octets = explode('.', $address);
+            return implode('.', array_reverse(array_slice($octets, 0, $prefix_length / 8))) . '.in-addr.arpa.';
+        }
+
+        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            if ($prefix_length < 4 || $prefix_length > 128 || $prefix_length % 4 !== 0) {
+                return null;
+            }
+            $packed = inet_pton($address);
+            if ($packed === false) {
+                return null;
+            }
+            $nibbles = str_split(substr(bin2hex($packed), 0, $prefix_length / 4));
+            return implode('.', array_reverse($nibbles)) . '.ip6.arpa.';
+        }
+
+        return null;
+    }
+
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp-ddns.conf')
     {
         if ($this->general->enabled->isEmpty()) {
             return;
         }
-        $domains = [];
+        $forward_domains = [];
+        $reverse_domains = [];
         $keys = [];
         foreach ([(new KeaDhcpv4())->subnets->subnet4, (new KeaDhcpv6())->subnets->subnet6] as $subnets) {
             foreach ($subnets->iterateItems() as $subnet) {
@@ -55,19 +110,11 @@ class KeaDdns extends BaseModel
                         'secret' => $subnet->ddns_domain_key_secret->getValue(),
                     ];
                 }
-                if (!isset($domains[$forward_zone])) {
-                    $domains[$forward_zone] = ['name' => $forward_zone];
-                    if ($keyname) {
-                        $domains[$forward_zone]['key-name'] = $keyname;
-                    }
-                    $domains[$forward_zone]['dns-servers'] = [];
-                }
-                $server_entry = [
-                    'ip-address' => $server,
-                    'port' => 53,
-                ];
-                if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
-                    $domains[$forward_zone]['dns-servers'][] = $server_entry;
+                $this->addDdnsDomain($forward_domains, $forward_zone, $server, $keyname);
+
+                $reverse_zone = $this->getReverseZoneForSubnet($subnet->subnet->getValue());
+                if ($reverse_zone !== null) {
+                    $this->addDdnsDomain($reverse_domains, $reverse_zone, $server, $keyname);
                 }
             }
         }
@@ -77,7 +124,10 @@ class KeaDdns extends BaseModel
                 'port' => $this->general->server_port->asInt(),
                 'tsig-keys' => array_values($keys),
                 'forward-ddns' => [
-                    'ddns-domains' => array_values($domains)
+                    'ddns-domains' => array_values($forward_domains)
+                ],
+                'reverse-ddns' => [
+                    'ddns-domains' => array_values($reverse_domains)
                 ],
                 'loggers' => [[
                     'name' => 'kea-dhcp-ddns',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -61,7 +61,7 @@ class KeaDdns extends BaseModel
                     if ($keyname) {
                         $domains[$forward_zone]['key-name'] = $keyname;
                     }
-                    $forward_domains[$forward_zone]['dns-servers'] = [];
+                    $domains[$forward_zone]['dns-servers'] = [];
                 }
                 $server_entry = [
                     'ip-address' => $server,

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -52,41 +52,6 @@ class KeaDdns extends BaseModel
         }
     }
 
-    private function getReverseZoneForSubnet($subnet)
-    {
-        if (empty($subnet) || strpos($subnet, '/') === false) {
-            return null;
-        }
-
-        [$address, $prefix_length] = explode('/', $subnet, 2);
-        if (!is_numeric($prefix_length)) {
-            return null;
-        }
-
-        $prefix_length = (int)$prefix_length;
-        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
-            if ($prefix_length < 8 || $prefix_length > 32 || $prefix_length % 8 !== 0) {
-                return null;
-            }
-            $octets = explode('.', $address);
-            return implode('.', array_reverse(array_slice($octets, 0, $prefix_length / 8))) . '.in-addr.arpa.';
-        }
-
-        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
-            if ($prefix_length < 4 || $prefix_length > 128 || $prefix_length % 4 !== 0) {
-                return null;
-            }
-            $packed = inet_pton($address);
-            if ($packed === false) {
-                return null;
-            }
-            $nibbles = str_split(substr(bin2hex($packed), 0, $prefix_length / 4));
-            return implode('.', array_reverse($nibbles)) . '.ip6.arpa.';
-        }
-
-        return null;
-    }
-
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp-ddns.conf')
     {
         if ($this->general->enabled->isEmpty()) {
@@ -112,8 +77,8 @@ class KeaDdns extends BaseModel
                 }
                 $this->addDdnsDomain($forward_domains, $forward_zone, $server, $keyname);
 
-                $reverse_zone = $this->getReverseZoneForSubnet($subnet->subnet->getValue());
-                if ($reverse_zone !== null) {
+                $reverse_zone = $subnet->ddns_reverse_zone->getValue();
+                if (!empty($reverse_zone)) {
                     $this->addDdnsDomain($reverse_domains, $reverse_zone, $server, $keyname);
                 }
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -68,7 +68,7 @@ class KeaDdns extends BaseModel
                     'port' => 53,
                 ];
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
-                    $forward_domains[$forward_zone]['dns-servers'][] = $server_entry;
+                    $domains[$forward_zone]['dns-servers'][] = $server_entry;
                 }
                 $reverse_zone = $subnet->ddns_reverse_zone->getValue();
                 if (!empty($reverse_zone)) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -56,7 +56,7 @@ class KeaDdns extends BaseModel
                         'secret' => $subnet->ddns_domain_key_secret->getValue(),
                     ];
                 }
-                if (!isset($forward_domains[$forward_zone])) {
+                if (!isset($domains[$forward_zone])) {
                     $forward_domains[$forward_zone] = ['name' => $forward_zone];
                     if ($keyname) {
                         $forward_domains[$forward_zone]['key-name'] = $keyname;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -57,7 +57,7 @@ class KeaDdns extends BaseModel
                     ];
                 }
                 if (!isset($domains[$forward_zone])) {
-                    $forward_domains[$forward_zone] = ['name' => $forward_zone];
+                    $domains[$forward_zone] = ['name' => $forward_zone];
                     if ($keyname) {
                         $domains[$forward_zone]['key-name'] = $keyname;
                     }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -67,7 +67,7 @@ class KeaDdns extends BaseModel
                     'ip-address' => $server,
                     'port' => 53,
                 ];
-                if (!in_array($server_entry, $forward_domains[$forward_zone]['dns-servers'], true)) {
+                if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $forward_domains[$forward_zone]['dns-servers'][] = $server_entry;
                 }
                 $reverse_zone = $subnet->ddns_reverse_zone->getValue();

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -59,7 +59,7 @@ class KeaDdns extends BaseModel
                 if (!isset($domains[$forward_zone])) {
                     $forward_domains[$forward_zone] = ['name' => $forward_zone];
                     if ($keyname) {
-                        $forward_domains[$forward_zone]['key-name'] = $keyname;
+                        $domains[$forward_zone]['key-name'] = $keyname;
                     }
                     $forward_domains[$forward_zone]['dns-servers'] = [];
                 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -158,6 +158,18 @@
                         </check001>
                     </Constraints>
                 </ddns_forward_zone>
+                <ddns_reverse_zone type="HostnameField">
+                    <IpAllowed>N</IpAllowed>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Reverse zone requires a DNS server.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>ddns_dns_server</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
+                </ddns_reverse_zone>
                 <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -127,6 +127,18 @@
                         </check001>
                     </Constraints>
                 </ddns_forward_zone>
+                <ddns_reverse_zone type="HostnameField">
+                    <IpAllowed>N</IpAllowed>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Reverse zone requires a DNS server.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>ddns_dns_server</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
+                </ddns_reverse_zone>
                 <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>


### PR DESCRIPTION
## Summary

Add an explicit `DNS reverse zone` field to Kea subnets and generate `reverse-ddns.ddns-domains` from that configured value.

Ref: #10122

## Why

The original proposal derived reverse zones automatically from configured subnets.

Based on maintainer feedback, this was changed to avoid implicit reverse-zone inference because the authoritative DNS reverse zone size and delegation boundaries cannot be assumed safely.

## What this changes

- keeps the existing forward DDNS generation unchanged
- adds a `DNS reverse zone` field to Kea DHCPv4 and DHCPv6 subnet dialogs
- generates `reverse-ddns.ddns-domains` only from explicitly configured reverse zones
- reuses the same DNS target and TSIG key configuration already used for forward DDNS

## Validation

Tested on my live OPNsense box on 2026-04-11:

- PHP syntax check for the installed `KeaDdns.php`
- XML validation for the updated model and form files
- applied explicit `ddns_reverse_zone` values to the active Kea subnet config
- regenerated Kea config via `kea_configure_do(true)`
- verified `/usr/local/etc/kea/kea-dhcp-ddns.conf` now contains the explicit reverse zones and still points to the configured DDNS target `127.0.0.1:53530`
- verified `kea-dhcp4` and `kea-dhcp-ddns` remain active after reload

Note: the live box also carries a separate local DDNS target port patch that is not part of this PR, because BIND in this setup listens on port `53530`.
