### PR TITLE
kea: add FQDN override flags for server-side PTR updates

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -101,6 +101,28 @@ class KeaDdns extends BaseModel
                             $reverse_domains[$rev_zone] = $reverse_domain;
                         }
                     }
+                } elseif (!empty($subnet_cidr) && str_contains($subnet_cidr, ':')) {
+                    /* IPv6: derive ip6.arpa zone from subnet prefix.
+                     * Use /48 boundary for the reverse zone since that is the
+                     * standard delegation size for ULA and most ISP allocations.
+                     * Multiple /64 subnets under the same /48 share one reverse zone. */
+                    $parts = explode('/', $subnet_cidr);
+                    $expanded = @inet_pton($parts[0]);
+                    if ($expanded !== false) {
+                        $hex = bin2hex($expanded);
+                        /* Use /48 (12 nibbles) as the reverse zone boundary */
+                        $nibbles = 12;
+                        $prefix_nibbles = substr($hex, 0, $nibbles);
+                        $rev_zone = implode('.', array_reverse(str_split($prefix_nibbles))) . '.ip6.arpa.';
+                        if (!isset($reverse_domains[$rev_zone])) {
+                            $reverse_domain = ['name' => $rev_zone, 'dns-servers' => []];
+                            if ($keyname) {
+                                $reverse_domain['key-name'] = $keyname;
+                            }
+                            $reverse_domain['dns-servers'][] = $server_entry;
+                            $reverse_domains[$rev_zone] = $reverse_domain;
+                        }
+                    }
                 }
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -39,6 +39,7 @@ class KeaDdns extends BaseModel
             return;
         }
         $domains = [];
+        $reverse_domains = [];
         $keys = [];
         foreach ([(new KeaDhcpv4())->subnets->subnet4, (new KeaDhcpv6())->subnets->subnet6] as $subnets) {
             foreach ($subnets->iterateItems() as $subnet) {
@@ -69,6 +70,38 @@ class KeaDdns extends BaseModel
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $domains[$forward_zone]['dns-servers'][] = $server_entry;
                 }
+
+                /* Build reverse-ddns domains from the subnet's CIDR */
+                $subnet_cidr = (string)$subnet->subnet;
+                if (!empty($subnet_cidr) && str_contains($subnet_cidr, '.')) {
+                    /* IPv4: derive in-addr.arpa zone(s) from subnet */
+                    $parts = explode('/', $subnet_cidr);
+                    $octets = explode('.', $parts[0]);
+                    $mask = isset($parts[1]) ? intval($parts[1]) : 24;
+                    $rev_zones = [];
+                    if ($mask >= 24) {
+                        $rev_zones[] = sprintf('%s.%s.%s.in-addr.arpa.', $octets[2], $octets[1], $octets[0]);
+                    } elseif ($mask >= 16) {
+                        /* For /16-/23 subnets, enumerate each /24 reverse zone */
+                        $base = intval($octets[2]);
+                        $count = 1 << (24 - $mask);
+                        for ($i = 0; $i < $count; $i++) {
+                            $rev_zones[] = sprintf('%d.%s.%s.in-addr.arpa.', $base + $i, $octets[1], $octets[0]);
+                        }
+                    } else {
+                        $rev_zones[] = sprintf('%s.in-addr.arpa.', $octets[0]);
+                    }
+                    foreach ($rev_zones as $rev_zone) {
+                        if (!isset($reverse_domains[$rev_zone])) {
+                            $reverse_domain = ['name' => $rev_zone, 'dns-servers' => []];
+                            if ($keyname) {
+                                $reverse_domain['key-name'] = $keyname;
+                            }
+                            $reverse_domain['dns-servers'][] = $server_entry;
+                            $reverse_domains[$rev_zone] = $reverse_domain;
+                        }
+                    }
+                }
             }
         }
         $cnf = [
@@ -78,6 +111,9 @@ class KeaDdns extends BaseModel
                 'tsig-keys' => array_values($keys),
                 'forward-ddns' => [
                     'ddns-domains' => array_values($domains)
+                ],
+                'reverse-ddns' => [
+                    'ddns-domains' => array_values($reverse_domains)
                 ],
                 'loggers' => [[
                     'name' => 'kea-dhcp-ddns',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -39,7 +39,6 @@ class KeaDdns extends BaseModel
             return;
         }
         $domains = [];
-        $reverse_domains = [];
         $keys = [];
         foreach ([(new KeaDhcpv4())->subnets->subnet4, (new KeaDhcpv6())->subnets->subnet6] as $subnets) {
             foreach ($subnets->iterateItems() as $subnet) {
@@ -70,60 +69,6 @@ class KeaDdns extends BaseModel
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $domains[$forward_zone]['dns-servers'][] = $server_entry;
                 }
-
-                /* Build reverse-ddns domains from the subnet's CIDR */
-                $subnet_cidr = (string)$subnet->subnet;
-                if (!empty($subnet_cidr) && str_contains($subnet_cidr, '.')) {
-                    /* IPv4: derive in-addr.arpa zone(s) from subnet */
-                    $parts = explode('/', $subnet_cidr);
-                    $octets = explode('.', $parts[0]);
-                    $mask = isset($parts[1]) ? intval($parts[1]) : 24;
-                    $rev_zones = [];
-                    if ($mask >= 24) {
-                        $rev_zones[] = sprintf('%s.%s.%s.in-addr.arpa.', $octets[2], $octets[1], $octets[0]);
-                    } elseif ($mask >= 16) {
-                        /* For /16-/23 subnets, enumerate each /24 reverse zone */
-                        $base = intval($octets[2]);
-                        $count = 1 << (24 - $mask);
-                        for ($i = 0; $i < $count; $i++) {
-                            $rev_zones[] = sprintf('%d.%s.%s.in-addr.arpa.', $base + $i, $octets[1], $octets[0]);
-                        }
-                    } else {
-                        $rev_zones[] = sprintf('%s.in-addr.arpa.', $octets[0]);
-                    }
-                    foreach ($rev_zones as $rev_zone) {
-                        if (!isset($reverse_domains[$rev_zone])) {
-                            $reverse_domain = ['name' => $rev_zone, 'dns-servers' => []];
-                            if ($keyname) {
-                                $reverse_domain['key-name'] = $keyname;
-                            }
-                            $reverse_domain['dns-servers'][] = $server_entry;
-                            $reverse_domains[$rev_zone] = $reverse_domain;
-                        }
-                    }
-                } elseif (!empty($subnet_cidr) && str_contains($subnet_cidr, ':')) {
-                    /* IPv6: derive ip6.arpa zone from subnet prefix.
-                     * Use /48 boundary for the reverse zone since that is the
-                     * standard delegation size for ULA and most ISP allocations.
-                     * Multiple /64 subnets under the same /48 share one reverse zone. */
-                    $parts = explode('/', $subnet_cidr);
-                    $expanded = @inet_pton($parts[0]);
-                    if ($expanded !== false) {
-                        $hex = bin2hex($expanded);
-                        /* Use /48 (12 nibbles) as the reverse zone boundary */
-                        $nibbles = 12;
-                        $prefix_nibbles = substr($hex, 0, $nibbles);
-                        $rev_zone = implode('.', array_reverse(str_split($prefix_nibbles))) . '.ip6.arpa.';
-                        if (!isset($reverse_domains[$rev_zone])) {
-                            $reverse_domain = ['name' => $rev_zone, 'dns-servers' => []];
-                            if ($keyname) {
-                                $reverse_domain['key-name'] = $keyname;
-                            }
-                            $reverse_domain['dns-servers'][] = $server_entry;
-                            $reverse_domains[$rev_zone] = $reverse_domain;
-                        }
-                    }
-                }
             }
         }
         $cnf = [
@@ -133,9 +78,6 @@ class KeaDdns extends BaseModel
                 'tsig-keys' => array_values($keys),
                 'forward-ddns' => [
                     'ddns-domains' => array_values($domains)
-                ],
-                'reverse-ddns' => [
-                    'ddns-domains' => array_values($reverse_domains)
                 ],
                 'loggers' => [[
                     'name' => 'kea-dhcp-ddns',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -362,6 +362,14 @@ class KeaDhcpv4 extends BaseModel
                 'server-ip' => $ddns->general->server_ip->getValue(),
                 'server-port' => $ddns->general->server_port->asInt(),
             ];
+            /* Override client FQDN flags to ensure the server performs both
+             * forward and reverse DNS updates, regardless of client preferences.
+             * Without these, many clients (macOS, Windows) set the N or S flags
+             * in the FQDN option to skip reverse updates, leaving PTR records
+             * empty. See RFC 4702 sections 3.1-3.2. */
+            $cnf['Dhcp4']['ddns-override-no-update'] = true;
+            $cnf['Dhcp4']['ddns-override-client-update'] = true;
+            $cnf['Dhcp4']['ddns-update-on-renew'] = true;
         }
         File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
     }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -383,6 +383,9 @@ class KeaDhcpv6 extends BaseModel
                 'server-ip' => $ddns->general->server_ip->getValue(),
                 'server-port' => $ddns->general->server_port->asInt(),
             ];
+            $cnf['Dhcp6']['ddns-override-no-update'] = true;
+            $cnf['Dhcp6']['ddns-override-client-update'] = true;
+            $cnf['Dhcp6']['ddns-update-on-renew'] = true;
         }
         File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
     }


### PR DESCRIPTION
## Summary

- **KeaDhcpv4.php**: Add `ddns-override-no-update`, `ddns-override-client-update`, and `ddns-update-on-renew` to the DHCPv4 config when DDNS is enabled.
- **KeaDhcpv6.php**: Apply the same three flags to the DHCPv6 config generator (previously missing entirely).

## Problem

When DDNS is enabled via the Kea DHCP GUI, PTR (reverse) records are often not created. Many DHCP clients (macOS, Windows, iOS) set FQDN option flags (`N=1` or `S=0`) instructing the server not to perform reverse updates. Without `ddns-override-no-update` and `ddns-override-client-update`, Kea respects these flags and skips PTR creation entirely.

This affects both DHCPv4 and DHCPv6. On the IPv6 side the problem is more severe: no AAAA or PTR records are registered for any dynamic DHCPv6 lease, even when `fqdn_fwd=1` is set on the lease, because the three override flags were absent from `KeaDhcpv6.php::generateConfig()` entirely.

## Solution

When DDNS is enabled, add three global settings to both `kea-dhcp4.conf` and `kea-dhcp6.conf`:

- `ddns-override-no-update: true` — override client N flag (RFC 4702 §3.1)
- `ddns-override-client-update: true` — override client S flag (RFC 4702 §3.2)
- `ddns-update-on-renew: true` — re-send DDNS updates on lease renewal

These flags are already supported by the upstream Kea model fields (`ddns_override_no_update`, etc.) — this change wires them into both config generators so they take effect when DDNS is active.

Note: this PR does not add automatic reverse zone derivation. Reverse zone names are inherently site-specific; the correct approach is for operators to configure them explicitly via the existing forward zone fields once #10123 or equivalent reverse zone UI support lands.

## Test plan

- [x] Configure DDNS on a DHCPv4 subnet with BIND9 as the DNS server
- [x] Verify `kea-dhcp4.conf` contains all three override flags
- [x] Verify `kea-dhcp6.conf` contains all three override flags
- [x] Force a DHCP renewal from a macOS client: `sudo ipconfig set en0 DHCP`
- [x] Verify forward lookup works: `dig @localhost <hostname>.<domain> A`
- [x] Verify forward lookup works: `dig @localhost <hostname>.<domain> AAAA`
- [x] Verify reverse lookup works: `dig @localhost -x <ipv4>`
- [x] Verify reverse lookup works: `dig @localhost -x <ipv6>`
- [x] Verify configs survive `configctl kea restart`

Tested on OPNsense 26.1.6 with Kea 3.0.2 and BIND 9.20.

Fixes #7768
Fixes #9359