### PR TITLE
ids: add DNS, flow, stats EVE output types and community-id toggle

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IDS/forms/generalSettings.xml
@@ -180,4 +180,46 @@
         <help>Custom TLS fields to include in eve-log for TLS. (Overrides extended if non-empty).</help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>ids.general.eveLog.dns.enable</id>
+        <label>Enable eve DNS logging</label>
+        <type>checkbox</type>
+        <help>Send DNS transaction metadata to eve-log.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.dns.query</id>
+        <label>Eve DNS log queries</label>
+        <type>checkbox</type>
+        <help>Log DNS query messages.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.dns.answer</id>
+        <label>Eve DNS log answers</label>
+        <type>checkbox</type>
+        <help>Log DNS answer messages.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.flow.enable</id>
+        <label>Enable eve flow logging</label>
+        <type>checkbox</type>
+        <help>Send flow metadata to eve-log. Logs network flow records when connections end, including duration, byte counts, and protocol information.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.stats.enable</id>
+        <label>Enable eve stats logging</label>
+        <type>checkbox</type>
+        <help>Send Suricata engine statistics to eve-log. Includes capture counters, decoder stats, and memory usage for performance monitoring.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>ids.general.eveLog.communityId</id>
+        <label>Enable Community ID</label>
+        <type>checkbox</type>
+        <help>Add a Community ID flow hash to eve-log events, enabling cross-tool correlation between Suricata, Zeek, and other network security tools.</help>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/IDS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/IDS</mount>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <description>Intrusion detection</description>
     <items>
         <rules>
@@ -306,6 +306,36 @@
                         <Multiple>Y</Multiple>
                     </custom>
                 </tls>
+                <dns>
+                    <enable type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </enable>
+                    <query type="BooleanField">
+                        <Default>1</Default>
+                        <Required>Y</Required>
+                    </query>
+                    <answer type="BooleanField">
+                        <Default>1</Default>
+                        <Required>Y</Required>
+                    </answer>
+                </dns>
+                <flow>
+                    <enable type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </enable>
+                </flow>
+                <stats>
+                    <enable type="BooleanField">
+                        <Default>0</Default>
+                        <Required>Y</Required>
+                    </enable>
+                </stats>
+                <communityId type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </communityId>
             </eveLog>
         </general>
     </items>

--- a/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_1_3.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IDS/Migrations/M1_1_3.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\IDS\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_1_3 extends BaseModelMigration
+{
+    /**
+     * Migrate to 1.1.3: adds DNS, flow, stats EVE output types and community-id toggle.
+     * New fields have sensible defaults in the model, so no data migration is needed.
+     */
+    public function run($model)
+    {
+        parent::run($model);
+    }
+}

--- a/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
+++ b/src/opnsense/service/templates/OPNsense/IDS/suricata.yaml
@@ -44,7 +44,7 @@ outputs:
       filetype: regular
       filename: eve.json
       pcap-file: false
-      community-id: false
+      community-id: {{ 'true' if not helpers.empty('OPNsense.IDS.general.eveLog.communityId') else 'false' }}
       community-id-seed: 0
 
       types:
@@ -81,6 +81,21 @@ outputs:
             flows: start
 
         - ssh
+
+{%      if not helpers.empty('OPNsense.IDS.general.eveLog.dns.enable') %}
+        - dns:
+            query: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.dns.query') else 'yes' }}
+            answer: {{ 'no' if helpers.empty('OPNsense.IDS.general.eveLog.dns.answer') else 'yes' }}
+{%      endif %}
+{%      if not helpers.empty('OPNsense.IDS.general.eveLog.flow.enable') %}
+        - flow
+{%      endif %}
+{%      if not helpers.empty('OPNsense.IDS.general.eveLog.stats.enable') %}
+        - stats:
+            totals: yes
+            threads: no
+            deltas: no
+{%      endif %}
 
 {% if not helpers.empty('OPNsense.IDS.general.syslog_eve') %}
   - eve-log:


### PR DESCRIPTION
## Summary

Extends the EVE log configuration with additional output types, following the pattern established for HTTP and TLS in #7775.

**New configurable EVE output types** (all disabled by default, under Advanced):

- **DNS** — logs DNS transactions with optional query/answer sub-toggles
- **Flow** — logs network flow records (duration, byte counts, protocol)
- **Stats** — logs Suricata engine statistics (capture counters, decoder stats, memory usage)

**Community ID** — makes the `community-id` field configurable via the GUI (was hardcoded to `false`). [Community ID](https://github.com/corelight/community-id-spec) is a standardised flow hash that enables cross-tool correlation between Suricata, Zeek, and other network security tools.

## Changes

| File | Change |
|------|--------|
| `IDS.xml` | Add `dns`, `flow`, `stats`, `communityId` fields under `eveLog`; bump version 1.1.2 → 1.1.3 |
| `suricata.yaml` | Add conditional Jinja2 blocks for new EVE types; make `community-id` configurable |
| `generalSettings.xml` | Add 6 new form fields under Advanced toggle |
| `M1_1_3.php` | No-op migration — new fields use model defaults |

## Motivation

SIEM integrations (Wazuh, Elastic, Splunk) benefit from richer EVE output beyond alerts. DNS logging enables threat hunting (tunneling, DGA detection), flow records provide network visibility, and stats enable performance monitoring. Community ID is increasingly expected by correlation tools.

The existing `custom.yaml` escape hatch cannot be used for this because Suricata's YAML merge fully overrides the `outputs` key rather than merging lists, so any `custom.yaml` approach would lose the default alert/anomaly/drop/ssh types.

This was originally raised in #2038 (2018, closed as timeout). PR #7775 solved it for HTTP and TLS — this PR extends the same pattern to the remaining commonly-requested types.

## Testing

- Verified template renders correct YAML with all combinations of toggles enabled/disabled
- Confirmed new model fields are accessible via the API (`/api/ids/settings/get`)
- Confirmed migration runs cleanly on upgrade from 1.1.2