### PR TITLE
unbound: reload templates during service reconfigure

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Unbound/Api/ServiceController.php
@@ -30,6 +30,7 @@
 namespace OPNsense\Unbound\Api;
 
 use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Base\UserException;
 use OPNsense\Core\Backend;
 
 class ServiceController extends ApiMutableServiceControllerBase
@@ -52,6 +53,21 @@ class ServiceController extends ApiMutableServiceControllerBase
         $response = $backend->configdRun(static::$internalServiceName . ' dnsbl');
 
         return ['status' => $response];
+    }
+
+    public function reconfigureAction()
+    {
+        if ($this->request->isPost() && $this->serviceEnabled()) {
+            $result = trim((new Backend())->configdpRun('template reload', ['OPNsense/Unbound/*']));
+            if ($result !== 'OK') {
+                throw new UserException(sprintf(
+                    gettext('Template generation failed for internal service "%s". See backend log for details.'),
+                    static::$internalServiceName
+                ), gettext('Configuration exception'));
+            }
+        }
+
+        return parent::reconfigureAction();
     }
 
     /**


### PR DESCRIPTION
## Summary
- reload Unbound templates explicitly during `ServiceController::reconfigureAction()` when the resolver is enabled
- keep the `#8888` stop/disable behavior intact instead of re-enabling the generic `$internalServiceTemplate` path
- avoid stale generated runtime files after Apply when saved Unbound settings have changed

## Testing
- inspected the Unbound apply flow from GUI to `/api/unbound/service/reconfigure`
- confirmed that `ServiceController` no longer uses `$internalServiceTemplate` after `9e8039f7`
- verified the patch is limited to the Unbound reconfigure path on `stable/26.1`

## Notes
This change is intended to address cases where the saved Unbound configuration is updated successfully, but generated runtime files such as `dot.conf` or `private_domains.conf` remain stale after Apply.

Closes #10144.