### PR TITLE
Gateways.xml: allow load balance weights from 1 to 10 for more flexibility

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Routing/forms/dialogEditGateway.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Routing/forms/dialogEditGateway.xml
@@ -143,7 +143,7 @@
         <label>Weight</label>
         <advanced>true</advanced>
         <type>text</type>
-        <help>Weight for this gateway when used in a gateway group. Specificed as an integer number between 1 and 5. Default equals 1.</help>
+        <help>Weight for this gateway when used in a gateway group. Specificed as an integer number between 1 and 10. Default equals 1.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.xml
@@ -69,7 +69,7 @@
                 <Default>1</Default>
                 <Required>Y</Required>
                 <MinimumValue>1</MinimumValue>
-                <MaximumValue>5</MaximumValue>
+                <MaximumValue>10</MaximumValue>
             </weight>
             <latencylow type="IntegerField">
                 <MinimumValue>1</MinimumValue>


### PR DESCRIPTION
fixes #10147

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

There is an odd restriction on Gateway weights as integers from 1 to 5, when PFSense allows 1 to 30.

I ran into the issue when configuring a 10 GbE - 1 GbE active-active mullti-WAN failover pair.

Meanwhile, PFSense has a good explanation of why more flexibility should be offered here:

https://docs.netgate.com/pfsense/en/latest/multiwan/strategies.html#unequal-cost-load-balancing

---

**Describe the proposed solution**

This PR relaxes the MVC restriction on values one can place in the weight field.

---

**Related issue**

https://github.com/opnsense/core/issues/10147