### PR TITLE
Auth/LDAP: restore timing normalization on failed logins

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/LDAP.php
@@ -479,17 +479,6 @@ class LDAP extends Base implements IAuthConnector
     }
 
     /**
-     * authenticate user against ldap server without Base's timer
-     * @param string $username username to authenticate
-     * @param string $password user password
-     * @return bool authentication status
-     */
-    public function authenticate($username, $password)
-    {
-        return $this->_authenticate($username, $password);
-    }
-
-    /**
      * authenticate user against ldap server, implementation as described in Base class
      * @param string $username username to authenticate
      * @param string $password user password


### PR DESCRIPTION
The LDAP class overrides Base::authenticate() and calls _authenticate() directly, bypassing the constant-time timing normalization that Base provides on failed logins. This allows distinguishing "user not found" (fast) from "wrong password" (slow LDAP bind round-trip) via response timing, enabling remote user enumeration through the login form, Captive Portal, or OpenVPN authentication endpoints.

This is related to GHSA-f683-wg4m-rhf2.

Remove the override so LDAP/LDAPTOTP inherit Base's 2-second timing floor on failures, consistent with Local and LocalTOTP.