### PR TITLE
Avoid sending Framed-IP-Address for IPv6 accounting clients

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -140,6 +140,11 @@ class Radius extends Base implements IAuthConnector
         return [$wraps, $lower32];
     }
 
+    private function shouldSendFramedIpAddress($ipAddress)
+    {
+        return filter_var(trim((string)$ipAddress), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+    }
+
     /**
      * type name in configuration
      * @return string
@@ -370,7 +375,7 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
                 $error = radius_strerror($radius);
-            } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
+            } elseif ($this->shouldSendFramedIpAddress($ip_address) && !radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_TERMINATE_CAUSE, $this->mapTerminateCause($cause))) {
                 $error = radius_strerror($radius);
@@ -458,7 +463,7 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
                 $error = radius_strerror($radius);
-            } elseif (!radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
+            } elseif ($this->shouldSendFramedIpAddress($ip_address) && !radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
                 $error = radius_strerror($radius);
             }
 

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -36,6 +36,9 @@ use OPNsense\Firewall\Util;
  */
 class Radius extends Base implements IAuthConnector
 {
+    // RFC 3162 Framed-IPv6-Prefix attribute type.
+    private const RADIUS_FRAMED_IPV6_PREFIX = 97;
+
     /**
      * @var null radius hostname / ip
      */
@@ -140,9 +143,46 @@ class Radius extends Base implements IAuthConnector
         return [$wraps, $lower32];
     }
 
-    private function shouldSendFramedIpAddress($ipAddress)
+    private function getFramedAddressAttribute($ipAddress)
     {
-        return filter_var(trim((string)$ipAddress), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+        $ipAddress = trim((string)$ipAddress);
+        if ($ipAddress === '') {
+            return null;
+        }
+
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return [
+                'handler' => 'addr',
+                'attribute' => RADIUS_FRAMED_IP_ADDRESS,
+                'value' => $ipAddress,
+            ];
+        }
+
+        $packedAddress = inet_pton($ipAddress);
+        if ($packedAddress !== false && strlen($packedAddress) === 16) {
+            return [
+                'handler' => 'attr',
+                'attribute' => self::RADIUS_FRAMED_IPV6_PREFIX,
+                // RFC 3162 Framed-IPv6-Prefix with a /128 prefix when only the assigned client address is known.
+                'value' => chr(0) . chr(128) . $packedAddress,
+            ];
+        }
+
+        return null;
+    }
+
+    private function addFramedAddressAttribute($radius, $ipAddress)
+    {
+        $attribute = $this->getFramedAddressAttribute($ipAddress);
+        if ($attribute === null) {
+            return true;
+        }
+
+        if ($attribute['handler'] === 'addr') {
+            return radius_put_addr($radius, $attribute['attribute'], $attribute['value']);
+        }
+
+        return radius_put_attr($radius, $attribute['attribute'], $attribute['value']);
     }
 
     /**
@@ -375,7 +415,7 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
                 $error = radius_strerror($radius);
-            } elseif ($this->shouldSendFramedIpAddress($ip_address) && !radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
+            } elseif (!$this->addFramedAddressAttribute($radius, $ip_address)) {
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, RADIUS_ACCT_TERMINATE_CAUSE, $this->mapTerminateCause($cause))) {
                 $error = radius_strerror($radius);
@@ -463,7 +503,7 @@ class Radius extends Base implements IAuthConnector
                 $error = radius_strerror($radius);
             } elseif (!radius_put_int($radius, 53, $wraps_out)) { /* Acct-Output-Gigawords */
                 $error = radius_strerror($radius);
-            } elseif ($this->shouldSendFramedIpAddress($ip_address) && !radius_put_addr($radius, RADIUS_FRAMED_IP_ADDRESS, $ip_address)) {
+            } elseif (!$this->addFramedAddressAttribute($radius, $ip_address)) {
                 $error = radius_strerror($radius);
             }
 

--- a/src/opnsense/mvc/tests/app/library/OPNsense/Auth/RadiusTest.php
+++ b/src/opnsense/mvc/tests/app/library/OPNsense/Auth/RadiusTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Auth;
+
+use OPNsense\Auth\Radius;
+use PHPUnit\Framework\TestCase;
+
+class RadiusTest extends TestCase
+{
+    /**
+     * @dataProvider framedIpAddressProvider
+     */
+    public function testShouldSendFramedIpAddress($ipAddress, $expected)
+    {
+        $subject = new Radius();
+        $method = new \ReflectionMethod($subject, 'shouldSendFramedIpAddress');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke($subject, $ipAddress));
+    }
+
+    public static function framedIpAddressProvider()
+    {
+        return [
+            'ipv4' => ['192.0.2.10', true],
+            'trimmed ipv4' => [' 198.51.100.8 ', true],
+            'ipv6' => ['2001:db8::1', false],
+            'link-local ipv6' => ['fe80::1', false],
+            'empty' => ['', false],
+            'invalid' => ['not-an-ip', false],
+        ];
+    }
+}

--- a/src/opnsense/mvc/tests/app/library/OPNsense/Auth/RadiusTest.php
+++ b/src/opnsense/mvc/tests/app/library/OPNsense/Auth/RadiusTest.php
@@ -31,29 +31,65 @@ namespace tests\OPNsense\Auth;
 use OPNsense\Auth\Radius;
 use PHPUnit\Framework\TestCase;
 
+if (!defined('RADIUS_FRAMED_IP_ADDRESS')) {
+    define('RADIUS_FRAMED_IP_ADDRESS', 8);
+}
+
 class RadiusTest extends TestCase
 {
     /**
-     * @dataProvider framedIpAddressProvider
+     * @dataProvider framedAddressProvider
      */
-    public function testShouldSendFramedIpAddress($ipAddress, $expected)
+    public function testGetFramedAddressAttribute($ipAddress, $expected)
     {
         $subject = new Radius();
-        $method = new \ReflectionMethod($subject, 'shouldSendFramedIpAddress');
+        $method = new \ReflectionMethod($subject, 'getFramedAddressAttribute');
         $method->setAccessible(true);
 
-        $this->assertSame($expected, $method->invoke($subject, $ipAddress));
+        $this->assertEquals($expected, $method->invoke($subject, $ipAddress));
     }
 
-    public static function framedIpAddressProvider()
+    public static function framedAddressProvider()
     {
         return [
-            'ipv4' => ['192.0.2.10', true],
-            'trimmed ipv4' => [' 198.51.100.8 ', true],
-            'ipv6' => ['2001:db8::1', false],
-            'link-local ipv6' => ['fe80::1', false],
-            'empty' => ['', false],
-            'invalid' => ['not-an-ip', false],
+            'ipv4' => ['192.0.2.10', [
+                'handler' => 'addr',
+                'attribute' => RADIUS_FRAMED_IP_ADDRESS,
+                'value' => '192.0.2.10',
+            ]],
+            'trimmed ipv4' => [' 198.51.100.8 ', [
+                'handler' => 'addr',
+                'attribute' => RADIUS_FRAMED_IP_ADDRESS,
+                'value' => '198.51.100.8',
+            ]],
+            'ipv6' => ['2001:db8::1', [
+                'handler' => 'attr',
+                'attribute' => 97,
+                'value' => chr(0) . chr(128) . inet_pton('2001:db8::1'),
+            ]],
+            'link-local ipv6' => ['fe80::1', [
+                'handler' => 'attr',
+                'attribute' => 97,
+                'value' => chr(0) . chr(128) . inet_pton('fe80::1'),
+            ]],
+            'empty' => ['', null],
+            'invalid' => ['not-an-ip', null],
         ];
+    }
+
+    public function testIpv6AddressUsesFramedIpv6PrefixPayload()
+    {
+        $subject = new Radius();
+        $method = new \ReflectionMethod($subject, 'getFramedAddressAttribute');
+        $method->setAccessible(true);
+
+        $attribute = $method->invoke($subject, '2001:db8::1');
+
+        $this->assertSame('attr', $attribute['handler']);
+        $this->assertSame(97, $attribute['attribute']);
+        $this->assertSame(18, strlen($attribute['value']));
+        $this->assertSame(0, ord($attribute['value'][0]));
+        $this->assertSame(128, ord($attribute['value'][1]));
+        $this->assertSame(inet_pton('2001:db8::1'), substr($attribute['value'], 2));
     }
 }


### PR DESCRIPTION
This patch avoids sending RADIUS Framed-IP-Address when the client address is IPv6.

A targeted unit test was added for the IPv4/IPv6 guard logic.

I was not able to validate this end-to-end in a full Captive Portal + RADIUS + IPv6 setup yet, so this should not be considered fully integration-tested.

After applying the patch on a test firewall, I did not observe visible regressions:
- patched file confirmed in place
- Web UI remained functional after reboot
- no immediate obvious runtime regressions were observed


**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex / GPT-5-based assistant
- Extent of AI involvement: AI was used to help analyze the issue, draft the guard logic, draft the unit test, and help prepare this pull request text. Final review and submission were done manually.

---

**Describe the problem**

`Framed-IP-Address` appears to be sent in captive portal RADIUS accounting even when the client address is IPv6.

Since this path expects an IPv4 address, accounting may fail for IPv6 clients.

---

**Describe the proposed solution**
this pull request keeps the existing IPv4 behavior for `Framed-IP-Address`, but handles IPv6 client addresses through an IPv6 RADIUS attribute path instead of the IPv4-only handler.

The change is applied in both:
- `stopAccounting()`
- `updateAccounting()`

For IPv4 clients, the code still uses the existing `Framed-IP-Address` path.
For IPv6 clients, the address is encoded as an IPv6 RADIUS attribute payload instead of being omitted or passed through the IPv4-only `radius_put_addr()` path.

A targeted unit test was added and extended to verify:
- IPv4 still uses the IPv4 address handler
- IPv6 uses the IPv6 attribute path
- the generated IPv6 payload is encoded in the expected format

I was not able to validate this operationally in a full Captive Portal + RADIUS + IPv6 setup yet, so this should not be considered fully integration-tested.

After applying the patch on a test firewall, I did not observe visible regressions:
- patched file confirmed in place
- Web UI remained functional after reboot
- no immediate obvious runtime regressions were observed
---

**Related issue**

Ref: #10152
