### PR TITLE
OpenVPN: set KeepAlive default settings

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml
@@ -353,9 +353,11 @@
                     <MinimumValue>1</MinimumValue>
                 </maxclients>
                 <keepalive_interval type="IntegerField">
+                    <Default>10</Default>
                     <MinimumValue>0</MinimumValue>
                 </keepalive_interval>
                 <keepalive_timeout type="IntegerField">
+                    <Default>60</Default>
                     <MinimumValue>0</MinimumValue>
                 </keepalive_timeout>
                 <reneg-sec type="IntegerField">


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:
I used ChatGPT (model 5.4) to find the relevant files; this text and the code (just two XML lines) are 100% hand-written.

---

**Describe the problem**

I came across issue #8106 (periodic OpenVPN client disconnections) while trying to migrate a server instance away from "Legacy" OpenVPN.

As indicated, this is solved by setting a couple of KeepAlive options.

In the Legacy version this was set automatically:

https://github.com/opnsense/core/blob/72a8f6b6f17c3bbf8967d39e6e63e4cc0ef480d7/src/etc/inc/plugins.inc.d/openvpn.inc#L550

And in the new version these are not set:

https://github.com/opnsense/core/blob/72a8f6b6f17c3bbf8967d39e6e63e4cc0ef480d7/src/opnsense/mvc/app/models/OPNsense/OpenVPN/OpenVPN.xml#L355-L360

As a result the corresponding `keepalive interval timeout` line is missing from the generated config file.
Keeping this new default behavior is highly inconvenient, especially when these options are hidden behind "Advanced mode".

---

**Describe the proposed solution**

This restores the previous default values in the new interface, which fixes the underlying issue by default.

---

**Related issue**

If this pull request relates to an issue, link it here: #8106