### PR TITLE
Services: Kea DHCPv4/v6: Remove depend constraint of ddns_reverse_zone

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -160,15 +160,6 @@
                 </ddns_forward_zone>
                 <ddns_reverse_zone type="HostnameField">
                     <IpAllowed>N</IpAllowed>
-                    <Constraints>
-                        <check001>
-                            <ValidationMessage>Reverse zone requires a DNS server.</ValidationMessage>
-                            <type>DependConstraint</type>
-                            <addFields>
-                                <field1>ddns_dns_server</field1>
-                            </addFields>
-                        </check001>
-                    </Constraints>
                 </ddns_reverse_zone>
                 <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -129,15 +129,6 @@
                 </ddns_forward_zone>
                 <ddns_reverse_zone type="HostnameField">
                     <IpAllowed>N</IpAllowed>
-                    <Constraints>
-                        <check001>
-                            <ValidationMessage>Reverse zone requires a DNS server.</ValidationMessage>
-                            <type>DependConstraint</type>
-                            <addFields>
-                                <field1>ddns_dns_server</field1>
-                            </addFields>
-                        </check001>
-                    </Constraints>
                 </ddns_reverse_zone>
                 <ddns_qualifying_suffix type="HostnameField"/>
                 <ddns_dns_server type="NetworkField">


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Since ddns_forward_zone already depends on ddns_ddns_server, and the config generator bails if either of these are empty we do not need to protect ddns_reverse_zone in any specific way right now.
Bailout happens here: https://github.com/opnsense/core/blob/293e645d89edb53c7f3fd2388740f28f5ec50346/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php#L46

Cleanup: https://github.com/opnsense/core/commit/db41dfce2e67be3f6d3fd676ba5a47e7ef182d66

It's a good idea to keep it this way, only populating a reverse zone is very uncommon, and ISC also tethered it to the forward zone being there.

---

**Describe the proposed solution**

---

**Related issue**
