### PR TITLE
Kea: DHCPv4/v6: DDNS dns server port can now be specified, default will remain 53

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -204,6 +204,7 @@
         <grid_view>
             <visible>false</visible>
         </grid_view>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>subnet4.ddns_qualifying_suffix</id>
@@ -216,12 +217,23 @@
     </field>
     <field>
         <id>subnet4.ddns_dns_server</id>
-        <label>DNS server</label>
+        <label>DNS server address</label>
         <type>text</type>
         <help>Authoritative DNS server receiving dynamic updates.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
+    </field>
+    <field>
+        <id>subnet4.ddns_dns_port</id>
+        <label>DNS server port</label>
+        <type>text</type>
+        <help>Port of the authoritative DNS server receiving dynamic updates. Leave empty to use default.</help>
+        <hint>53</hint>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>subnet4.ddns_domain_key_name</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -105,6 +105,7 @@
         <grid_view>
             <visible>false</visible>
         </grid_view>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>subnet6.ddns_qualifying_suffix</id>
@@ -117,12 +118,23 @@
     </field>
     <field>
         <id>subnet6.ddns_dns_server</id>
-        <label>DNS server</label>
+        <label>DNS server address</label>
         <type>text</type>
         <help>Authoritative DNS server receiving dynamic updates.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
+    </field>
+    <field>
+        <id>subnet6.ddns_dns_port</id>
+        <label>DNS server port</label>
+        <type>text</type>
+        <help>Port of the authoritative DNS server receiving dynamic updates. Leave empty to use default.</help>
+        <hint>53</hint>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>subnet6.ddns_domain_key_name</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -48,6 +48,7 @@ class KeaDdns extends BaseModel
                 }
                 $forward_zone = $subnet->ddns_forward_zone->getValue();
                 $server = $subnet->ddns_dns_server->getValue();
+                $port = !$subnet->ddns_dns_port->isEmpty() ? $subnet->ddns_dns_port->asInt() : 53;
                 $keyname = $subnet->ddns_domain_key_name->getValue();
                 if ($keyname && !isset($keys[$keyname])) {
                     $keys[$keyname] = [
@@ -65,7 +66,7 @@ class KeaDdns extends BaseModel
                 }
                 $server_entry = [
                     'ip-address' => $server,
-                    'port' => 53,
+                    'port' => $port,
                 ];
                 if (!in_array($server_entry, $domains[$forward_zone]['dns-servers'], true)) {
                     $domains[$forward_zone]['dns-servers'][] = $server_entry;
@@ -81,7 +82,7 @@ class KeaDdns extends BaseModel
                     }
                     $server_entry = [
                         'ip-address' => $server,
-                        'port' => 53,
+                        'port' => $port,
                     ];
                     if (!in_array($server_entry, $reverse_domains[$reverse_zone]['dns-servers'], true)) {
                         $reverse_domains[$reverse_zone]['dns-servers'][] = $server_entry;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -174,6 +174,7 @@
                         </check001>
                     </Constraints>
                 </ddns_dns_server>
+                <ddns_dns_port type="PortField"/>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>
                         <check001>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -143,6 +143,7 @@
                         </check001>
                     </Constraints>
                 </ddns_dns_server>
+                <ddns_dns_port type="PortField"/>
                 <ddns_domain_key_name type="TextField">
                     <Constraints>
                         <check001>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Dns server port was hardcoded to 53 in the DDNS configuration because it fits 90% of usecases, now a new usecase emerged (using os-bind on opnsense localhost on port 53053).

---

**Describe the proposed solution**

DDNS dns server port can now be specified, default will remain 53.
No model default because it's optional, no constraint because empty has a default in the config generator.

---

**Related issue**

Fixes: https://github.com/opnsense/core/pull/10117
Fixes: https://github.com/opnsense/core/issues/10116
