### PR TITLE
Services: Kea DHCPv4/v6: DDNS add ddns-override-no-update, ddns-override-client-update and ddns-update-on-renew per subnet

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -262,4 +262,40 @@
             <visible>false</visible>
         </grid_view>
     </field>
+    <field>
+        <id>subnet4.ddns_override_no_update</id>
+        <label>Override no update</label>
+        <type>checkbox</type>
+        <help>Ignores the client's wishes for no DDNS updates to be performed.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>subnet4.ddns_override_client_update</id>
+        <label>Override client update</label>
+        <type>checkbox</type>
+        <help>Ignores the client's delegation requests. Causes Kea to perform Dynamic DNS updates even though the client indicated its intention to perform the updates itself.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>subnet4.ddns_update_on_renew</id>
+        <label>Update on renew</label>
+        <type>checkbox</type>
+        <help>Instructs the server to always update the DNS information when a lease is renewed, even if its DNS information has not changed. This allows Kea to self-heal if it was previously unable to add DNS entries or they were somehow lost by the DNS server. May impact performance, especially for servers with numerous clients that renew often.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -163,4 +163,40 @@
             <visible>false</visible>
         </grid_view>
     </field>
+    <field>
+        <id>subnet6.ddns_override_no_update</id>
+        <label>Override no update</label>
+        <type>checkbox</type>
+        <help>Ignores the client's wishes for no DDNS updates to be performed.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>subnet6.ddns_override_client_update</id>
+        <label>Override client update</label>
+        <type>checkbox</type>
+        <help>Ignores the client's delegation requests. Causes Kea to perform Dynamic DNS updates even though the client indicated its intention to perform the updates itself.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>subnet6.ddns_update_on_renew</id>
+        <label>Update on renew</label>
+        <type>checkbox</type>
+        <help>Instructs the server to always update the DNS information when a lease is renewed, even if its DNS information has not changed. This allows Kea to self-heal if it was previously unable to add DNS entries or they were somehow lost by the DNS server. May impact performance, especially for servers with numerous clients that renew often.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -244,6 +244,9 @@ class KeaDhcpv4 extends BaseModel
                     $record['ddns-qualifying-suffix'] = $subnet->ddns_qualifying_suffix->getValue();
                 }
                 $record['ddns-send-updates'] = !$subnet->ddns_dns_server->isEmpty();
+                $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
+                $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
+                $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -216,6 +216,9 @@
                         </check001>
                     </Constraints>
                 </ddns_domain_key_algorithm>
+                <ddns_override_no_update type="BooleanField"/>
+                <ddns_override_client_update type="BooleanField"/>
+                <ddns_update_on_renew type="BooleanField"/>
                 <description type="DescriptionField"/>
             </subnet4>
         </subnets>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -269,6 +269,9 @@ class KeaDhcpv6 extends BaseModel
                     $record['ddns-qualifying-suffix'] = $subnet->ddns_qualifying_suffix->getValue();
                 }
                 $record['ddns-send-updates'] = !$subnet->ddns_dns_server->isEmpty();
+                $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
+                $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
+                $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -185,6 +185,9 @@
                         </check001>
                     </Constraints>
                 </ddns_domain_key_algorithm>
+                <ddns_override_no_update type="BooleanField"/>
+                <ddns_override_client_update type="BooleanField"/>
+                <ddns_update_on_renew type="BooleanField"/>
                 <description type="DescriptionField"/>
             </subnet6>
         </subnets>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/pull/10132

These can all be defined per subnet, so better put them there.
