### PR TITLE
Services: Kea DHCPv4/v6: Add missing isEnabled() for 61055b93

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -33,6 +33,11 @@ use OPNsense\Core\File;
 
 class KeaDdns extends BaseModel
 {
+    public function isEnabled()
+    {
+        return $this->general->enabled->isEqual('1');
+    }
+
     public function generateConfig($target = '/usr/local/etc/kea/kea-dhcp-ddns.conf')
     {
         if ($this->general->enabled->isEmpty()) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Small oversight in 61055b93