### PR TITLE
fix: forced password change bypass

### DIFF
--- a/src/www/system_usermanager_passwordmg.php
+++ b/src/www/system_usermanager_passwordmg.php
@@ -102,6 +102,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 $authenticator = (new OPNsense\Auth\AuthenticationFactory())->get('Local Database');
                 $input_errors = $authenticator->checkPolicy($username, $pconfig['passwordfld0'], $pconfig['passwordfld1']);
             }
+        } elseif (!empty($_SESSION['user_shouldChangePassword'])) {
+            $input_errors[] = gettext('Your password does not match the selected security policies. Please provide a new one.');
         }
 
         if (count($input_errors) == 0) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

**Describe the problem**

The current implementation lets the user press save without changing the password and bypass the forced password change.