### PR TITLE
Services: Kea DHCPv6: kea_prefix_watcher: Plug socket into dynamic pd route installation script

### DIFF
--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -173,7 +173,7 @@ function kea_configure_do($verbose = false)
             $keaDdns->generateConfig();
         }
         (new \OPNsense\Kea\KeaCtrlAgent())->generateConfig();
-        if ($keaDhcpv6->isEnabled() && $keaDhcpv6->hasPdPools()) {
+        if ($keaDhcpv6->isEnabled() && $keaDhcpv6->pd_pools->pd_pool->count() > 0) {
             mwexecfb(
                 '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py',
                 [],

--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -175,8 +175,7 @@ function kea_configure_do($verbose = false)
         (new \OPNsense\Kea\KeaCtrlAgent())->generateConfig();
         if ($keaDhcpv6->isEnabled() && $keaDhcpv6->hasPdPools()) {
             mwexecfb(
-                '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py --interval %s',
-                ['10'],
+                '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py',
                 [
                     'pidfile' => '/var/run/kea_prefix_watcher.pid',
                     'logfile' => '/var/log/kea/kea_prefix_watcher.log',

--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -173,10 +173,10 @@ function kea_configure_do($verbose = false)
             $keaDdns->generateConfig();
         }
         (new \OPNsense\Kea\KeaCtrlAgent())->generateConfig();
-        if ($keaDhcpv6->isEnabled()) {
+        if ($keaDhcpv6->isEnabled() && $keaDhcpv6->hasPdPools()) {
             mwexecfb(
                 '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py %s',
-                ['/var/db/kea/kea-leases6.csv'],
+                ['10'],
                 [
                     'pidfile' => '/var/run/kea_prefix_watcher.pid',
                     'logfile' => '/var/log/kea/kea_prefix_watcher.log',

--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -175,7 +175,7 @@ function kea_configure_do($verbose = false)
         (new \OPNsense\Kea\KeaCtrlAgent())->generateConfig();
         if ($keaDhcpv6->isEnabled() && $keaDhcpv6->hasPdPools()) {
             mwexecfb(
-                '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py %s',
+                '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py --interval %s',
                 ['10'],
                 [
                     'pidfile' => '/var/run/kea_prefix_watcher.pid',

--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -176,6 +176,7 @@ function kea_configure_do($verbose = false)
         if ($keaDhcpv6->isEnabled() && $keaDhcpv6->hasPdPools()) {
             mwexecfb(
                 '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py',
+                [],
                 [
                     'pidfile' => '/var/run/kea_prefix_watcher.pid',
                     'logfile' => '/var/log/kea/kea_prefix_watcher.log',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -119,15 +119,6 @@ class KeaDhcpv6 extends BaseModel
     }
 
     /**
-     * only start the kea_prefix_watcher if pd pools are actually configured
-     * @return bool
-     */
-    public function hasPdPools()
-    {
-        return $this->pd_pools->pd_pool->count() > 0;
-    }
-
-    /**
      * should filter rules be enabled
      * @return bool
      */

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -124,10 +124,7 @@ class KeaDhcpv6 extends BaseModel
      */
     public function hasPdPools()
     {
-        foreach ($this->pd_pools->pd_pool->iterateItems() as $_) {
-            return true;  // found one
-        }
-        return false;
+        return $this->pd_pools->pd_pool->count() > 0;
     }
 
     /**

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -119,6 +119,18 @@ class KeaDhcpv6 extends BaseModel
     }
 
     /**
+     * only start the kea_prefix_watcher if pd pools are actually configured
+     * @return bool
+     */
+    public function hasPdPools()
+    {
+        foreach ($this->pd_pools->pd_pool->iterateItems() as $_) {
+            return true;  // found one
+        }
+        return false;
+    }
+
+    /**
      * should filter rules be enabled
      * @return bool
      */

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -28,6 +28,7 @@
 """
 import argparse
 import ipaddress
+import time
 import ujson
 import subprocess
 import syslog

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -29,7 +29,6 @@
 import argparse
 import ipaddress
 import ujson
-import time
 import subprocess
 import syslog
 
@@ -37,7 +36,7 @@ from lib.kea_ctrl import KeaCtrl
 
 
 def yield_lease_records(service='dhcp6', limit=256, poll_interval=10):
-    """ 
+    """
     Poll KEA lease pages and yield records from domain socket
     https://kea.readthedocs.io/en/latest/api.html#lease6-get-page
     Since amount of leases can be large, using get-page is recommended.
@@ -56,8 +55,7 @@ def yield_lease_records(service='dhcp6', limit=256, poll_interval=10):
                         "address": lease.get("ip-address", ""),
                         "prefix_len": lease.get("prefix-len", 128),
                         "hwaddr": lease.get("hw-address", ""),
-                        "valid_lifetime": lease.get("valid-lft", 0),
-                        "expire": lease.get("cltt", 0) + lease.get("valid-lft", 0)
+                        "state": lease.get("state", 0)  # State 0 means active
                     }
 
             last_addr = leases[-1].get("ip-address")
@@ -111,7 +109,7 @@ if __name__ == '__main__':
         # IA_PD: guaranteed via "type = IA_PD"
         prefix = "%(address)s/%(prefix_len)d" %  record
         if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \
-                and record.get('expire', 0) > time.time():
+                and record.get('state', 0) == 0:
             prefixes[prefix] = record
             ll_addr = hostwatch.get(record.get('hwaddr'))
             if not ll_addr:
@@ -122,7 +120,7 @@ if __name__ == '__main__':
                 continue
             # lazy drop
             subprocess.run(['/sbin/route', 'delete', '-inet6', prefix], capture_output=True)
-            if record.get('valid_lifetime', 0) > 0:
+            if record.get('state', 0) == 0:
                 # only add when still valid
                 if subprocess.run(['/sbin/route', 'add', '-inet6', prefix, ll_addr], capture_output=True).returncode:
                     syslog.syslog(syslog.LOG_ERR, "failed adding route %s -> %s" % (prefix, ll_addr))

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -1,6 +1,7 @@
 #!/usr/local/bin/python3
 
 """
+    Copyright (c) 2026 Deciso B.V.
     Copyright (c) 2025 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
@@ -26,49 +27,46 @@
     POSSIBILITY OF SUCH DAMAGE.
 """
 import argparse
-import csv
 import ipaddress
 import ujson
-import os
 import time
 import subprocess
 import syslog
-import sys
+
+from lib.kea_ctrl import KeaCtrl
 
 
-def yield_log_records(filename, poll_interval=5):
-    """ Simple log tailer, prepends known kea archive files and tails the active one indefinitely
+def yield_lease_records(service='dhcp6', limit=256, poll_interval=10):
+    """ 
+    Poll KEA lease pages and yield records from domain socket
+    https://kea.readthedocs.io/en/latest/api.html#lease6-get-page
+    Since amount of leases can be large, using get-page is recommended.
     """
-    # Lease processing after cleanup according to KEA
-    # https://github.com/isc-projects/kea/blob/ef1f878f5272d/src/lib/dhcpsrv/memfile_lease_mgr.h#L1039-L1051
-    if os.path.isfile('%s.completed' % filename):
-        filenames = ['%s.completed' % filename, filename]
-    else:
-        filenames = ['%s.2' % filename, '%s.1' % filename, filename]
-
-    for fn in (x for x in filenames if os.path.exists(x)):
-        fhandle = None
-        lstpos = None
-        header = {}
+    while True:
+        from_addr = "start"
         while True:
-            if lstpos is None or (os.path.isfile(fn) and os.fstat(fhandle.fileno()).st_ino != os.stat(fn).st_ino):
-                fhandle = open(fn, 'r') # open / rotate
-                lstpos = None
-            elif lstpos:
-                fhandle.seek(lstpos)
-            for idx, item in enumerate(csv.reader(fhandle, delimiter=',', quotechar='"')):
-                if idx == 0 and lstpos is None:
-                    header = item
-                elif len(item) == len(header):
-                    result_rec = {}
-                    for i, key in enumerate(header):
-                        result_rec[key] = int(item[i]) if item[i].isdigit() else item[i]
-                    yield result_rec
-            lstpos = fhandle.tell()
-            if fn != filename:
+            response = KeaCtrl.send_command('lease6-get-page', {"from": from_addr, "limit": limit}, service)
+            leases = response.get("arguments", {}).get("leases", [])
+            if not leases:
                 break
-            else:
-                time.sleep(poll_interval)
+
+            for lease in leases:
+                if lease.get("type") == "IA_PD":
+                    yield {
+                        "address": lease.get("ip-address", ""),
+                        "prefix_len": lease.get("prefix-len", 128),
+                        "hwaddr": lease.get("hw-address", ""),
+                        "valid_lifetime": lease.get("valid-lft", 0),
+                        "expire": lease.get("cltt", 0) + lease.get("valid-lft", 0)
+                    }
+
+            last_addr = leases[-1].get("ip-address")
+            if len(leases) < limit or not last_addr:
+                break
+            from_addr = last_addr
+
+        time.sleep(poll_interval)
+
 
 class Hostwatch:
     """
@@ -101,40 +99,32 @@ class Hostwatch:
             return self._def_local_db[mac]
 
 
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('filename',
-                        help='filename to watch (including .1,.2, .completed)',
-                        default='/var/db/kea/kea-leases6.csv'
-    )
+    parser.add_argument('--interval', help='poll interval in seconds', default=10, type=int)
     inputargs = parser.parse_args()
     prefixes = {}
     syslog.openlog('kea-dhcp6', facility=syslog.LOG_LOCAL4)
     syslog.syslog(syslog.LOG_NOTICE, "startup kea prefix watcher")
-    if not os.path.isfile(inputargs.filename):
-        syslog.syslog(syslog.LOG_ERR, "lease file does not exist: %s" % inputargs.filename)
-        sys.exit(1)
     hostwatch = Hostwatch()
-    for record in yield_log_records(inputargs.filename):
-        # IA_PD: type 2, prefix_len <= 64 - the delegated prefix
-        if record.get('lease_type', 0) == 2 and record.get('prefix_len', 128) <= 64:
-            prefix = "%(address)s/%(prefix_len)d" %  record
-            if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \
-                    and record.get('expire', 0) > time.time():
-                prefixes[prefix] = record
-                ll_addr = hostwatch.get(record.get('hwaddr'))
-                if not ll_addr:
-                    syslog.syslog(
-                        syslog.LOG_WARNING,
-                        "no LLA found for %s, skipping route %s" % (record.get('hwaddr'), prefix)
-                    )
-                    continue
-                # lazy drop
-                subprocess.run(['/sbin/route', 'delete', '-inet6', prefix], capture_output=True)
-                if record.get('valid_lifetime', 0) > 0:
-                    # only add when still valid
-                    if subprocess.run(['/sbin/route', 'add', '-inet6', prefix, ll_addr], capture_output=True).returncode:
-                        syslog.syslog(syslog.LOG_ERR, "failed adding route %s -> %s" % (prefix, ll_addr))
-                    else:
-                        syslog.syslog(syslog.LOG_NOTICE, "add route %s -> %s" % (prefix, ll_addr))
+    for record in yield_lease_records(poll_interval=inputargs.interval):
+        # IA_PD: guaranteed via "type = IA_PD"
+        prefix = "%(address)s/%(prefix_len)d" %  record
+        if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \
+                and record.get('expire', 0) > time.time():
+            prefixes[prefix] = record
+            ll_addr = hostwatch.get(record.get('hwaddr'))
+            if not ll_addr:
+                syslog.syslog(
+                    syslog.LOG_WARNING,
+                    "no LLA found for %s, skipping route %s" % (record.get('hwaddr'), prefix)
+                )
+                continue
+            # lazy drop
+            subprocess.run(['/sbin/route', 'delete', '-inet6', prefix], capture_output=True)
+            if record.get('valid_lifetime', 0) > 0:
+                # only add when still valid
+                if subprocess.run(['/sbin/route', 'add', '-inet6', prefix, ll_addr], capture_output=True).returncode:
+                    syslog.syslog(syslog.LOG_ERR, "failed adding route %s -> %s" % (prefix, ll_addr))
+                else:
+                    syslog.syslog(syslog.LOG_NOTICE, "add route %s -> %s" % (prefix, ll_addr))

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -105,7 +105,8 @@ if __name__ == '__main__':
     for record in yield_lease_records():
         # IA_PD: guaranteed via "type = IA_PD"
         prefix = "%(address)s/%(prefix_len)d" %  record
-        if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')):
+        if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \
+                and record.get('state', 0) == 0:
             prefixes[prefix] = record
             ll_addr = hostwatch.get(record.get('hwaddr'))
             if not ll_addr:

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -26,7 +26,6 @@
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 """
-import argparse
 import ipaddress
 import time
 import ujson
@@ -99,14 +98,11 @@ class Hostwatch:
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--interval', help='poll interval in seconds', default=10, type=int)
-    inputargs = parser.parse_args()
     prefixes = {}
     syslog.openlog('kea-dhcp6', facility=syslog.LOG_LOCAL4)
     syslog.syslog(syslog.LOG_NOTICE, "startup kea prefix watcher")
     hostwatch = Hostwatch()
-    for record in yield_lease_records(poll_interval=inputargs.interval):
+    for record in yield_lease_records():
         # IA_PD: guaranteed via "type = IA_PD"
         prefix = "%(address)s/%(prefix_len)d" %  record
         if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -55,7 +55,7 @@ def yield_lease_records(service='dhcp6', limit=256, poll_interval=10):
                         "address": lease.get("ip-address", ""),
                         "prefix_len": lease.get("prefix-len", 128),
                         "hwaddr": lease.get("hw-address", ""),
-                        "state": lease.get("state", 0)  # State 0 means active
+                        "state": lease.get("state", 0)
                     }
 
             last_addr = leases[-1].get("ip-address")
@@ -105,8 +105,7 @@ if __name__ == '__main__':
     for record in yield_lease_records():
         # IA_PD: guaranteed via "type = IA_PD"
         prefix = "%(address)s/%(prefix_len)d" %  record
-        if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')) \
-                and record.get('state', 0) == 0:
+        if (prefix not in prefixes or prefixes[prefix].get('hwaddr') != record.get('hwaddr')):
             prefixes[prefix] = record
             ll_addr = hostwatch.get(record.get('hwaddr'))
             if not ll_addr:
@@ -117,6 +116,8 @@ if __name__ == '__main__':
                 continue
             # lazy drop
             subprocess.run(['/sbin/route', 'delete', '-inet6', prefix], capture_output=True)
+            # https://kea.readthedocs.io/en/latest/arm/hooks.html#the-lease4-get-by-lease6-get-by-commands
+            # state names (default (or assigned) (0), declined (1), expired-reclaimed (2), released (3), and registered (4))
             if record.get('state', 0) == 0:
                 # only add when still valid
                 if subprocess.run(['/sbin/route', 'add', '-inet6', prefix, ll_addr], capture_output=True).returncode:


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.4
- Extent of AI involvement: Crawled the KEA API docs, some back and forth brainstorming about polling vs. event based approach, evaluated some different socket outputs

---

**Describe the problem**

Problem is described in issue.

---

**Describe the proposed solution**

Use KeaCtrl python lib for kea_prefix_watcher to switch to polling the socket instead of streaming the csv lease files.

The running configuration has structured output, and we stay in memory without needing to read and parse any files.

The tradeoff is that we always have to poll the full set of leases, yet by using lease6-get-page which is especially made for efficient bulk operations, this should be rather cheap.

The main benefit is we always work with structured json data, can filter for ID_PD better, and reprocess the full truth on every poll interval to ensure the whole setup is self-healing

This also fixes that the script cannot start if no lease files exist (since they are irrelevant now)

For structured output check:
https://github.com/opnsense/core/issues/10181#issuecomment-4302537723

---

**Related issue**

https://github.com/opnsense/core/issues/10181
