### PR TITLE
mvc: BaseField: add count()

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
@@ -345,6 +345,7 @@ abstract class BaseField
      */
     public function count(): int
     {
+        /* XXX could use count($this->getValues()) if we fix BaseField's version to reject empty */
         return $this->isContainer() ? iterator_count($this->iterateItems()) : 1;
     }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/BaseField.php
@@ -340,6 +340,15 @@ abstract class BaseField
     }
 
     /**
+     * count the number of (non virtual) child nodes or 1 for the current node
+     * @return int count
+     */
+    public function count(): int
+    {
+        return $this->isContainer() ? iterator_count($this->iterateItems()) : 1;
+    }
+
+    /**
      * iterate all nodes recursively.
      * @return Generator
      */

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/AutoNumberFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/AutoNumberFieldTest.php
@@ -1,31 +1,29 @@
 <?php
 
-/**
- *    Copyright (C) 2016 Deciso B.V.
+/*
+ * Copyright (C) 2016 Deciso B.V.
+ * All rights reserved.
  *
- *    All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *    Redistribution and use in source and binary forms, with or without
- *    modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- *    1. Redistributions of source code must retain the above copyright notice,
- *       this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
- *    2. Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *
- *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *    POSSIBILITY OF SUCH DAMAGE.
- *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 namespace tests\OPNsense\Base\FieldTypes;
@@ -61,6 +59,7 @@ class AutoNumberFieldTest extends Field_Framework_TestCase
         $fieldTopLevel->addChildNode("items", $fieldContainer);
         $itemContainer = new ArrayField($fieldContainer->__reference . ".item", "item");
         $fieldContainer->addChildNode("item", $itemContainer);
+        $this->assertEquals(0, $itemContainer->count());
         for ($i = 1; $i <= 10; $i++) {
             $item = new ContainerField($itemContainer->__reference . "." . $i, "item");
             $tmp = new AutoNumberField($item->__reference . ".id", "id");
@@ -71,6 +70,7 @@ class AutoNumberFieldTest extends Field_Framework_TestCase
             } else {
                 $tmp->applyDefault();
             }
+            $this->assertEquals($i, $itemContainer->count());
         }
 
         // validate if all items contain the expected sequence number

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
@@ -1,31 +1,29 @@
 <?php
 
-/**
- *    Copyright (C) 2016 Deciso B.V.
+/*
+ * Copyright (C) 2016 Deciso B.V.
+ * All rights reserved.
  *
- *    All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *    Redistribution and use in source and binary forms, with or without
- *    modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- *    1. Redistributions of source code must retain the above copyright notice,
- *       this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
- *    2. Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *
- *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *    POSSIBILITY OF SUCH DAMAGE.
- *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 namespace tests\OPNsense\Base\FieldTypes;
@@ -126,6 +124,7 @@ class TextFieldTest extends Field_Framework_TestCase
         $this->assertEquals(1, count($field->getValues()));
         $this->assertEquals($value, $field->getValues()[0]);
         $this->assertEmpty($this->validate($field));
+        $this->assertEquals(1, $field->count());
     }
 
     /**


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

@Monviech was using `iterateItems()` to see if any configuration exists for the field and a helper for this task appears to make sense.

---

**Describe the proposed solution**

Count similar to iterateItems, but only count to 1 if the field does not have child nodes.

---

**Related issue**

#10197
