### PR TITLE
Services: Kea DHCPv6: Missed DUID during lease collection

### DIFF
--- a/src/opnsense/scripts/kea/get_kea_leases.py
+++ b/src/opnsense/scripts/kea/get_kea_leases.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
         records.append({
             "address": address,
             "hwaddr": lease.get("hw-address", ""),
+            "duid": lease.get("duid", ""),
             "valid_lifetime": lease.get("valid-lft", 0),
             "expire": lease.get("cltt", 0) + lease.get("valid-lft", 0),
             "hostname": lease.get("hostname", ""),


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

When change to socket was made, DUID was forgotten to be collected. Relevant for IPv6 leases.