### PR TITLE
Services: Kea DHCPv6: Add prefix to reservations to allow for static PD allocations based on DUID/MAC

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
@@ -12,6 +12,12 @@
         <help>IP address to offer to the client</help>
     </field>
     <field>
+        <id>reservation.prefix</id>
+        <label>Prefix</label>
+        <type>text</type>
+        <help>Prefix to offer to the client. This is relevant for reserving a prefix delegation, for a simple IP address reservation this is not used.</help>
+    </field>
+    <field>
         <id>reservation.duid</id>
         <label>DUID</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -474,6 +474,38 @@ class Util
     }
 
     /**
+     * Returns whether a given IPv6 prefix is contained in another IPv6 prefix.
+     *
+     * Examples:
+     * - fd10::/64 is contained in fd10::/56
+     * - fd10:0:0:1::/64 is not contained in fd10::/56
+     *
+     * @param string $childPrefix IPv6 prefix to test
+     * @param string $parentPrefix containing IPv6 prefix
+     * @return bool true when childPrefix is contained in parentPrefix
+     */
+    public static function isIPv6PrefixInPrefix(string $childPrefix, string $parentPrefix): bool
+    {
+        if (!self::isSubnetStrict($childPrefix) || !self::isSubnetStrict($parentPrefix)) {
+            return false;
+        }
+
+        list($childAddress, $childBits) = explode('/', $childPrefix);
+        list($parentAddress, $parentBits) = explode('/', $parentPrefix);
+
+        if (!self::isIpv6Address($childAddress) || !self::isIpv6Address($parentAddress)) {
+            return false;
+        }
+
+        // Ensure direction is valid
+        if ((int)$childBits < (int)$parentBits) {
+            return false;
+        }
+
+        return self::isIPInCIDR($childAddress, $parentPrefix);
+    }
+
+    /**
      * convert ipv4 cidr to netmask e.g. 24 --> 255.255.255.0
      * @param int $bits ipv4 bits
      * @return string netmask

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -225,10 +225,10 @@ class KeaDhcpv6 extends BaseModel
                     }
                 }
                 if (!$reservation->ip_address->isEmpty()) {
-                    $res['ip-addresses'] = explode(',', $reservation->ip_address->getValue());
+                    $res['ip-addresses'] = $reservation->ip_address->getValues();
                 }
                 if (!$reservation->prefix->isEmpty()) {
-                    $res['prefixes'] = explode(',', $reservation->prefix->getValue());
+                    $res['prefixes'] = $reservation->prefix->getValues();
                 }
                 if (!$reservation->domain_search->isEmpty()) {
                     $res['option-data'][] = [

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -54,8 +54,14 @@ class KeaDhcpv6 extends BaseModel
             if ($subnet_node) {
                 $subnet = $subnet_node->subnet->getValue();
             }
-            if (!Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
+            if (!Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet) && !$reservation->ip_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Address not in specified subnet"), $key . ".ip_address"));
+            }
+            if (!Util::isIPv6PrefixInPrefix($reservation->prefix->getValue(), $subnet) && !$reservation->prefix->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("Prefix not in specified subnet"), $key . ".prefix"));
+            }
+            if ($reservation->ip_address->isEmpty() && $reservation->prefix->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("Either an IP address or a Prefix should be specified."), $key . ".ip_address"));
             }
             if (!$reservation->duid->isEmpty() && !$reservation->hw_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Either a DUID or an Ether address should be specified, but not both"), $key . ".duid"));
@@ -218,7 +224,12 @@ class KeaDhcpv6 extends BaseModel
                         $res[str_replace('_', '-', $key)] = $reservation->$key->getValue();
                     }
                 }
-                $res['ip-addresses'] = explode(',', $reservation->ip_address->getValue());
+                if (!$reservation->ip_address->isEmpty()) {
+                    $res['ip-addresses'] = explode(',', $reservation->ip_address->getValue());
+                }
+                if (!$reservation->prefix->isEmpty()) {
+                    $res['prefixes'] = explode(',', $reservation->prefix->getValue());
+                }
                 if (!$reservation->domain_search->isEmpty()) {
                     $res['option-data'][] = [
                         'name' => 'domain-search',

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -219,6 +219,17 @@
                         </check001>
                     </Constraints>
                 </ip_address>
+                <prefix type="NetworkField">
+                    <AddressFamily>ipv6</AddressFamily>
+                    <NetMaskRequired>Y</NetMaskRequired>
+                    <ValidationMessage>The prefix length must be in CIDR format (e.g., fd80::/64).</ValidationMessage>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Duplicate entry exists.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
+                </prefix>
                 <duid type="TextField">
                     <Mask>/^(?:[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2})+)$/</Mask>
                     <ValidationMessage>Value must be a colon-separated hexadecimal sequence (e.g., 01:02:f3).</ValidationMessage>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
@@ -177,6 +177,7 @@
                     $('#{{ formGridReservation["edit_dialog_id"] }}').one('opnsense_bootgrid_mapped', () => {
                         if (params.has('hostname')) $('#reservation\\.hostname').val(params.get('hostname'));
                         if (params.has('ip_address')) $('#reservation\\.ip_address').val(params.get('ip_address'));
+                        if (params.has('prefix')) $('#reservation\\.prefix').val(params.get('prefix'));
                         if (params.has('duid')) $('#reservation\\.duid').val(params.get('duid'));
                         if (params.has('hw_address')) $('#reservation\\.hw_address').val(params.get('hw_address'));
                         history.replaceState(null, null, window.location.pathname + '#reservations');

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -101,9 +101,14 @@
                             searchValue = row.hwaddr || '';
                         }
 
+                        const address = row.address || '';
+                        const prefixLen = parseInt(row.prefix_len, 10);
+                        const isPrefix = prefixLen !== 128;
+
                         const searchUrl = `${baseUrl}&search=${encodeURIComponent(searchValue)}`;
                         const addUrlParams = {
-                            ip_address: row.address || '',
+                            ip_address: isPrefix ? '' : address,
+                            prefix: isPrefix ? `${address}/${prefixLen}` : '',
                             duid: row.duid || '',
                             hw_address: row.hwaddr || '',
                             hostname: row.hostname || ''
@@ -171,6 +176,7 @@
             <tr>
                 <th data-column-id="if_descr" data-type="string">{{ lang._('Interface') }}</th>
                 <th data-column-id="address" data-identifier="true" data-type="string" data-formatter="overflowformatter">{{ lang._('IP Address') }}</th>
+                <th data-column-id="prefix_len" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Length') }}</th>
                 <th data-column-id="duid" data-type="string" data-width="9em">{{ lang._('DUID') }}</th>
                 <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="valid_lifetime" data-type="integer">{{ lang._('Lifetime') }}</th>

--- a/src/opnsense/scripts/kea/get_kea_leases.py
+++ b/src/opnsense/scripts/kea/get_kea_leases.py
@@ -83,6 +83,7 @@ if __name__ == '__main__':
 
         records.append({
             "address": address,
+            "prefix_len": lease.get("prefix-len", 128),
             "hwaddr": lease.get("hw-address", ""),
             "duid": lease.get("duid", ""),
             "valid_lifetime": lease.get("valid-lft", 0),


### PR DESCRIPTION
…

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.4
- Extent of AI involvement: Help with the new Util function ``isIPv6PrefixInPrefix()``

---

**Describe the problem**

Reservations could only reserve addresses, not prefixes.

---

**Describe the proposed solution**

Adds prefixes to reservations as per KEA documentation.
https://kb.isc.org/docs/what-are-host-reservations-how-to-use-them

Allows to reserve a PD allocated prefix to a MAC address or DUID so upstream client/router always gets the same.
Fixes that prefix length was not shown in lease view.
Lease reservation button has some new magic to detect prefixes, to prefill correct field.

---

**Related issue**

https://github.com/opnsense/core/issues/10202
