### PR TITLE
Services: Kea DHCPv6: Allow customizing mac_sources and change default to ipv6-link-local

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
@@ -52,8 +52,7 @@
         <id>dhcpv6.general.mac_sources</id>
         <label>MAC sources</label>
         <type>select_multiple</type>
-        <advanced>true</advanced>
-        <help>The DHCPv6 protocol does not provide any completely reliable way to retrieve hardware addresses of clients. To mitigate that issue, a number of mechanisms are available. Each of these mechanisms works in certain cases, but may not in others. Whether the mechanism works in a particular deployment is somewhat dependent on the network topology and the technologies used. Please note that this influences PD route installation, since the source MAC address of the client is required to target the link-local route.</help>
+        <help>The DHCPv6 protocol does not provide any completely reliable way to retrieve hardware addresses of clients. To mitigate that issue, a number of mechanisms are available. Each of these mechanisms works in certain cases, but may not in others. Whether the mechanism works in a particular deployment is somewhat dependent on the network topology and the technologies used. Please note that this influences PD route installation, since the source MAC address of the client is required to target the link-local route. It also influences MAC based reservations.</help>
     </field>
     <field>
         <id>dhcpv6.general.fwrules</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
@@ -49,6 +49,13 @@
         <help>The valid life time of the leases given out by the server in seconds.</help>
     </field>
     <field>
+        <id>dhcpv6.general.mac_sources</id>
+        <label>MAC sources</label>
+        <type>select_multiple</type>
+        <advanced>true</advanced>
+        <help>The DHCPv6 protocol does not provide any completely reliable way to retrieve hardware addresses of clients. To mitigate that issue, a number of mechanisms are available. Each of these mechanisms works in certain cases, but may not in others. Whether the mechanism works in a particular deployment is somewhat dependent on the network topology and the technologies used. Please note that this influences PD route installation, since the source MAC address of the client is required to target the link-local route.</help>
+    </field>
+    <field>
         <id>dhcpv6.general.fwrules</id>
         <label>Firewall rules</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -324,6 +324,7 @@ class KeaDhcpv6 extends BaseModel
         $cnf = [
             'Dhcp6' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
+                'mac-sources' => $this->general->mac_sources->getValues(),
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     /* socket retries are on a per-interface basis, failing to open one won't affect others */

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp6</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>Kea DHCPv6 configuration</description>
     <items>
         <general>
@@ -18,6 +18,19 @@
                 <Default>4000</Default>
                 <Required>Y</Required>
             </valid_lifetime>
+            <mac_sources type="OptionField">
+                <Default>ipv6-link-local</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <duid>duid</duid>
+                    <ipv6-link-local>ipv6-link-local</ipv6-link-local>
+                    <client-link-addr-option>client-link-addr-option</client-link-addr-option>
+                    <remote-id>remote-id</remote-id>
+                    <docsis-cmts>docsis-cmts</docsis-cmts>
+                    <docsis-modem>docsis-modem</docsis-modem>
+                </OptionValues>
+                <Multiple>Y</Multiple>
+            </mac_sources>
             <fwrules type="BooleanField">
                 <Required>Y</Required>
                 <Default>1</Default>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Check issue.

---

**Describe the proposed solution**

Allow customizing mac_sources and change default to ipv6-link-local since it seems to align best with the expectations of our setup, especially taking PD route installation via kea_prefix_watcher.py into account.

Per default KEA would derive MAC addresses of clients from the DUID (using a precedence of methods via "any", but duid always comes first), but these do not take multiple interfaces into account. This means, the route target could be the wrong MAC address. The new default ipv6-link-local takes the EUI-64 assumption of the link-local address, this seems to be better suited as our default.

Two methods have been skipped since they are not implemented by KEA upstream, raw and subscriber-id.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10217
