### PR TITLE
firewall: clarify redirect target port help text

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogDNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogDNatRule.xml
@@ -189,7 +189,7 @@
         <label>Redirect Target Port</label>
         <type>text</type>
         <style>port_selector</style>
-        <help>The port on the internal host to forward traffic to. Use "any" to preserve the destination port or port range. For port ranges, enter the first target port; the remaining ports are calculated automatically.</help>
+        <help>The port on the internal host to forward traffic to. For port ranges, enter the first target port; the remaining ports are calculated automatically. Use "any" to preserve the given destination port or port range.</help>
         <grid_view>
             <formatter>alias</formatter>
             <sequence>95</sequence>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogDNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogDNatRule.xml
@@ -189,7 +189,7 @@
         <label>Redirect Target Port</label>
         <type>text</type>
         <style>port_selector</style>
-        <help>The port on the internal host to forward traffic to.</help>
+        <help>The port on the internal host to forward traffic to. Use "any" to preserve the destination port or port range. For port ranges, enter the first target port; the remaining ports are calculated automatically.</help>
         <grid_view>
             <formatter>alias</formatter>
             <sequence>95</sequence>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [ X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

A clear and concise description of the problem this pull request addresses.

The help text for the DNAT Redirect Port Target is currently "The port on the internal host to forward traffic to." It does not explain what to do with port ranges or how "any" works.

---

**Describe the proposed solution**

Explain what this pull request changes and why.

Update the help text to "The port on the internal host to forward traffic to. Use "any" to preserve the destination port or port range. For port ranges, enter the first target port; the remaining ports are calculated automatically."

---

**Related issue**

If this pull request relates to an issue, link it here.
