### PR TITLE
Services: Kea DHCPv4/v6: Improve lease delete command for IPv6 so it can actually delete IA_NA and IA_PD leases

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -137,7 +137,7 @@ abstract class LeasesController extends ApiControllerBase
 
         $result = json_decode((new Backend())->configdpRun('kea delete lease', [$ip, $type]), true);
 
-        if (empty($result) || !is_array($result)) {
+        if (!is_array($result) || empty($result)) {
             throw new UserException(gettext('Invalid backend response'));
         }
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -132,24 +132,17 @@ abstract class LeasesController extends ApiControllerBase
         $type = $this->request->getPost('type');
 
         if (empty($ip)) {
-            return ['status' => 'error', 'message' => gettext('Missing lease IP parameter (e.g., fe80::1)')];
+            return ['status' => 'error', 'message' => gettext('Missing lease IP parameter')];
         }
 
-        if (empty($type)) {
-            return ['status' => 'error', 'message' => gettext('Missing lease type parameter (e.g., IA_NA)')];
-        }
+        $result = json_decode((new Backend())->configdpRun('kea delete lease', [$ip, $type]), true);
 
-        $results = json_decode((new Backend())->configdpRun('kea delete lease', [$ip, $type]), true);
-
-        if (!is_array($results) || empty($results)) {
+        if (empty($result) || !is_array($result)) {
             throw new UserException(gettext('Invalid backend response'));
         }
 
-        if (!empty($results['failed'])) {
-            throw new UserException(sprintf(
-                gettext('Failed to delete lease(s): %s'),
-                implode(', ', $results['failed'])
-            ));
+        if (!empty($result['failed'])) {
+            throw new UserException($result['failed'][0]);
         }
 
         return ['status' => 'ok'];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -122,7 +122,7 @@ abstract class LeasesController extends ApiControllerBase
         return $response;
     }
 
-    public function delLeaseAction($ips = null)
+    public function delLeaseAction($ips = null, $type = null)
     {
         if (!$this->request->isPost()) {
             return ['status' => 'error', 'message' => gettext('Invalid request method')];
@@ -130,7 +130,7 @@ abstract class LeasesController extends ApiControllerBase
             return ['status' => 'error', 'message' => gettext('Missing lease IP parameter')];
         }
 
-        $results = json_decode((new Backend())->configdpRun("kea delete lease " . $ips), true);
+        $results = json_decode((new Backend())->configdpRun('kea delete lease', [$ips, $type]), true);
 
         if (!is_array($results) || empty($results)) {
             throw new UserException(gettext('Invalid backend response'));

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -122,15 +122,24 @@ abstract class LeasesController extends ApiControllerBase
         return $response;
     }
 
-    public function delLeaseAction($ips = null, $type = null)
+    public function delLeaseAction()
     {
         if (!$this->request->isPost()) {
             return ['status' => 'error', 'message' => gettext('Invalid request method')];
-        } elseif (empty($ips)) {
-            return ['status' => 'error', 'message' => gettext('Missing lease IP parameter')];
         }
 
-        $results = json_decode((new Backend())->configdpRun('kea delete lease', [$ips, $type]), true);
+        $ip = $this->request->getPost('ip');
+        $type = $this->request->getPost('type');
+
+        if (empty($ip)) {
+            return ['status' => 'error', 'message' => gettext('Missing lease IP parameter (e.g., fe80::1)')];
+        }
+
+        if (empty($type)) {
+            return ['status' => 'error', 'message' => gettext('Missing lease type parameter (e.g., IA_NA)')];
+        }
+
+        $results = json_decode((new Backend())->configdpRun('kea delete lease', [$ip, $type]), true);
 
         if (!is_array($results) || empty($results)) {
             throw new UserException(gettext('Invalid backend response'));

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -129,7 +129,7 @@ abstract class LeasesController extends ApiControllerBase
         }
 
         $ip = $this->request->getPost('ip');
-        $type = $this->request->getPost('type');
+        $type = $this->request->getPost('type') ?: null;
 
         if (empty($ip)) {
             return ['status' => 'error', 'message' => gettext('Missing lease IP parameter')];

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
@@ -125,7 +125,6 @@
 
                         const deleteBtn = $(`
                             <button type="button" class="btn btn-xs btn-default command-delete bootgrid-tooltip"
-                                data-row-id="${row.address}"
                                 title="{{ lang._('Delete Lease') }}">
                                 <span class="fa fa-fw fa-trash-o"></span>
                             </button>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
@@ -134,7 +134,50 @@
                         return $('<div class="btn-group"></div>').append(reservationBtn).append(deleteBtn)[0];
                     },
                 }
-            }
+            },
+            commands: {
+                "delete": {
+                    method: function (event, cell) {
+                        const row = cell.getData();
+                        stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", () => {
+                            ajaxCall('/api/kea/leases6/del_lease/', {
+                                    ip: row.address,
+                                },
+                                function () {
+                                    $("#grid-leases").bootgrid("reload");
+                                },
+                                null,
+                                'POST'
+                            );
+                        });
+                    }
+                },
+                "delete-selected": {
+                    method: function () {
+                        const grid = $("#grid-leases");
+                        stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", function () {
+                            const selected = grid.bootgrid("getSelectedRows");
+                            const currentRows = grid.bootgrid("getCurrentRows");
+                            const calls = selected.map(id => {
+                                const row = currentRows.find(r => r.address === id);
+                                if (!row) return;
+
+                                return ajaxCall('/api/kea/leases6/del_lease/', {
+                                        ip: row.address,
+                                    },
+                                    null,
+                                    null,
+                                    'POST'
+                                );
+                            });
+
+                            $.when.apply($, calls).done(function () {
+                                grid.bootgrid("reload");
+                            });
+                        });
+                    }
+                },
+            },
         });
 
         $("#interface-selection-wrapper").detach().insertAfter('#grid-leases-header .search');

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
@@ -139,9 +139,7 @@
                     method: function (event, cell) {
                         const row = cell.getData();
                         stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", () => {
-                            ajaxCall('/api/kea/leases6/del_lease/', {
-                                    ip: row.address,
-                                },
+                            ajaxCall('/api/kea/leases4/del_lease/', {ip: row.address},
                                 function () {
                                     $("#grid-leases").bootgrid("reload");
                                 },
@@ -160,16 +158,8 @@
                             const calls = selected.map(id => {
                                 const row = currentRows.find(r => r.address === id);
                                 if (!row) return;
-
-                                return ajaxCall('/api/kea/leases6/del_lease/', {
-                                        ip: row.address,
-                                    },
-                                    null,
-                                    null,
-                                    'POST'
-                                );
+                                return ajaxCall('/api/kea/leases4/del_lease/', {ip: row.address}, null, null, 'POST');
                             });
-
                             $.when.apply($, calls).done(function () {
                                 grid.bootgrid("reload");
                             });

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -153,10 +153,7 @@
                     method: function (event, cell) {
                         const row = cell.getData();
                         stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", () => {
-                            ajaxCall('/api/kea/leases6/del_lease/', {
-                                    ip: row.address,
-                                    type: row.type,
-                                },
+                            ajaxCall('/api/kea/leases6/del_lease/', {ip: row.address, type: row.type},
                                 function () {
                                     $("#grid-leases").bootgrid("reload");
                                 },
@@ -175,17 +172,8 @@
                             const calls = selected.map(id => {
                                 const row = currentRows.find(r => r.address === id);
                                 if (!row) return;
-
-                                return ajaxCall('/api/kea/leases6/del_lease/', {
-                                        ip: row.address,
-                                        type: row.type,
-                                    },
-                                    null,
-                                    null,
-                                    'POST'
-                                );
+                                return ajaxCall('/api/kea/leases6/del_lease/', {ip: row.address, type: row.type}, null, null, 'POST');
                             });
-
                             $.when.apply($, calls).done(function () {
                                 grid.bootgrid("reload");
                             });

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -139,8 +139,6 @@
 
                         const deleteBtn = $(`
                             <button type="button" class="btn btn-xs btn-default command-delete bootgrid-tooltip"
-                                data-row-id="${row.address}"
-                                data-type="${row.type || ''}"
                                 title="{{ lang._('Delete Lease') }}">
                                 <span class="fa fa-fw fa-trash-o"></span>
                             </button>
@@ -148,6 +146,51 @@
                         return $('<div class="btn-group"></div>').append(reservationBtn).append(deleteBtn)[0];
                     },
                 }
+            },
+            commands: {
+                "delete": {
+                    method: function (event, cell) {
+                        const row = cell.getData();
+                        stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", () => {
+                            ajaxCall('/api/kea/leases6/del_lease/', {
+                                    ip: row.address,
+                                    type: row.type,
+                                },
+                                function () {
+                                    $("#grid-leases").bootgrid("reload");
+                                },
+                                null,
+                                'POST'
+                            );
+                        });
+                    }
+                },
+                "delete-selected": {
+                    method: function () {
+                        const grid = $("#grid-leases");
+                        stdDialogRemoveItem("{{ lang._('Remove selected item(s)?') }}", function () {
+                            const selected = grid.bootgrid("getSelectedRows");
+                            const currentRows = grid.bootgrid("getCurrentRows");
+                            const calls = selected.map(id => {
+                                const row = currentRows.find(r => r.address === id);
+                                if (!row) return;
+
+                                return ajaxCall('/api/kea/leases6/del_lease/', {
+                                        ip: row.address,
+                                        type: row.type,
+                                    },
+                                    null,
+                                    null,
+                                    'POST'
+                                );
+                            });
+
+                            $.when.apply($, calls).done(function () {
+                                grid.bootgrid("reload");
+                            });
+                        });
+                    }
+                },
             }
         });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -177,6 +177,7 @@
                 <th data-column-id="if_descr" data-type="string">{{ lang._('Interface') }}</th>
                 <th data-column-id="address" data-identifier="true" data-type="string" data-formatter="overflowformatter">{{ lang._('IP Address') }}</th>
                 <th data-column-id="prefix_len" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Length') }}</th>
+                <th data-column-id="type" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Type') }}</th>
                 <th data-column-id="duid" data-type="string" data-width="9em">{{ lang._('DUID') }}</th>
                 <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="valid_lifetime" data-type="integer">{{ lang._('Lifetime') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -103,7 +103,7 @@
 
                         const address = row.address || '';
                         const prefixLen = parseInt(row.prefix_len, 10);
-                        const isPrefix = prefixLen !== 128;
+                        const isPrefix = row.type === 'IA_PD';
 
                         const searchUrl = `${baseUrl}&search=${encodeURIComponent(searchValue)}`;
                         const addUrlParams = {
@@ -140,11 +140,11 @@
                         const deleteBtn = $(`
                             <button type="button" class="btn btn-xs btn-default command-delete bootgrid-tooltip"
                                 data-row-id="${row.address}"
+                                data-type="${row.type || ''}"
                                 title="{{ lang._('Delete Lease') }}">
                                 <span class="fa fa-fw fa-trash-o"></span>
                             </button>
                         `);
-
                         return $('<div class="btn-group"></div>').append(reservationBtn).append(deleteBtn)[0];
                     },
                 }

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -143,6 +143,7 @@
                                 <span class="fa fa-fw fa-trash-o"></span>
                             </button>
                         `);
+
                         return $('<div class="btn-group"></div>').append(reservationBtn).append(deleteBtn)[0];
                     },
                 }
@@ -191,7 +192,7 @@
                         });
                     }
                 },
-            }
+            },
         });
 
         $("#interface-selection-wrapper").detach().insertAfter('#grid-leases-header .search');

--- a/src/opnsense/scripts/kea/del_kea_leases.py
+++ b/src/opnsense/scripts/kea/del_kea_leases.py
@@ -33,8 +33,8 @@ from lib.kea_ctrl import KeaCtrl
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", required=True, help="IP address to delete")
-    parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (e.g. IA_NA, IA_PD)", default=None)
+    parser.add_argument("--ip", required=True, help="IP address to delete (192.168.1.1 or fe80::1)")
+    parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (IA_NA or IA_PD)", default=None)
 
     args = parser.parse_args()
     ip = args.ip.strip()

--- a/src/opnsense/scripts/kea/del_kea_leases.py
+++ b/src/opnsense/scripts/kea/del_kea_leases.py
@@ -33,8 +33,8 @@ from lib.kea_ctrl import KeaCtrl
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("ip", help="IP address(es) to delete, comma separated")
-    parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (e.g. IA_PD for prefix delegation)", default=None)
+    parser.add_argument("--ip", required=True, help="IP address(es) to delete, comma separated")
+    parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (e.g. IA_NA, IA_PD)", default=None)
 
     args = parser.parse_args()
     ips = [ip.strip() for ip in args.ip.split(',') if ip.strip()]

--- a/src/opnsense/scripts/kea/del_kea_leases.py
+++ b/src/opnsense/scripts/kea/del_kea_leases.py
@@ -34,7 +34,11 @@ from lib.kea_ctrl import KeaCtrl
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("ip", help="IP address(es) to delete, comma separated")
-    ips = [ip.strip() for ip in parser.parse_args().ip.split(',') if ip.strip()]
+    parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (e.g. IA_PD for prefix delegation)", default=None)
+
+    args = parser.parse_args()
+    ips = [ip.strip() for ip in args.ip.split(',') if ip.strip()]
+    lease_type = args.lease_type.upper() if args.lease_type else None
 
     results = {
         "failed": [],
@@ -46,9 +50,15 @@ if __name__ == '__main__':
         cmd = "lease6-del" if is_v6 else "lease4-del"
         service = "dhcp6" if is_v6 else "dhcp4"
 
-        result = KeaCtrl.send_command(cmd, {"ip-address": ip}, service)
+        payload = {"ip-address": ip}
+
+        if is_v6 and lease_type:
+            payload["type"] = lease_type
+
+        result = KeaCtrl.send_command(cmd, payload, service)
+
         if result.get("result", 1) > 0:
-            results["failed"].append(f"{ip}: {result.get("text", "unknown error")}")
+            results["failed"].append(f"{ip}: {result.get('text', 'unknown error')}")
         else:
             results["removed"].append(ip)
 

--- a/src/opnsense/scripts/kea/del_kea_leases.py
+++ b/src/opnsense/scripts/kea/del_kea_leases.py
@@ -33,33 +33,25 @@ from lib.kea_ctrl import KeaCtrl
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", required=True, help="IP address(es) to delete, comma separated")
+    parser.add_argument("--ip", required=True, help="IP address to delete")
     parser.add_argument("--type", dest="lease_type", help="Lease type of IPv6 lease (e.g. IA_NA, IA_PD)", default=None)
 
     args = parser.parse_args()
-    ips = [ip.strip() for ip in args.ip.split(',') if ip.strip()]
+    ip = args.ip.strip()
     lease_type = args.lease_type.upper() if args.lease_type else None
 
-    results = {
-        "failed": [],
-        "removed": []
-    }
+    is_v6 = ":" in ip
+    cmd = "lease6-del" if is_v6 else "lease4-del"
+    service = "dhcp6" if is_v6 else "dhcp4"
 
-    for ip in ips:
-        is_v6 = ":" in ip
-        cmd = "lease6-del" if is_v6 else "lease4-del"
-        service = "dhcp6" if is_v6 else "dhcp4"
+    payload = {"ip-address": ip}
 
-        payload = {"ip-address": ip}
+    if is_v6 and lease_type:
+        payload["type"] = lease_type
 
-        if is_v6 and lease_type:
-            payload["type"] = lease_type
+    result = KeaCtrl.send_command(cmd, payload, service)
 
-        result = KeaCtrl.send_command(cmd, payload, service)
-
-        if result.get("result", 1) > 0:
-            results["failed"].append(f"{ip}: {result.get('text', 'unknown error')}")
-        else:
-            results["removed"].append(ip)
-
-    print(ujson.dumps(results))
+    if result.get("result", 1) > 0:
+        print(ujson.dumps({"failed": [f"{ip}: {result.get('text', 'unknown error')}"], "removed": []}))
+    else:
+        print(ujson.dumps({"failed": [], "removed": [ip]}))

--- a/src/opnsense/scripts/kea/get_kea_leases.py
+++ b/src/opnsense/scripts/kea/get_kea_leases.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
         records.append({
             "address": address,
             "prefix_len": lease.get("prefix-len", 128),
+            "type": lease.get("type", ""),
             "hwaddr": lease.get("hw-address", ""),
             "duid": lease.get("duid", ""),
             "valid_lifetime": lease.get("valid-lft", 0),

--- a/src/opnsense/service/conf/actions.d/actions_kea.conf
+++ b/src/opnsense/service/conf/actions.d/actions_kea.conf
@@ -49,6 +49,6 @@ message:list kea inet dhcp leases
 
 [delete.lease]
 command:/usr/local/opnsense/scripts/kea/del_kea_leases.py
-parameters:%s %s
+parameters:--ip %s --type %s
 type:script_output
 message:delete kea dhcp lease

--- a/src/opnsense/service/conf/actions.d/actions_kea.conf
+++ b/src/opnsense/service/conf/actions.d/actions_kea.conf
@@ -49,6 +49,6 @@ message:list kea inet dhcp leases
 
 [delete.lease]
 command:/usr/local/opnsense/scripts/kea/del_kea_leases.py
-parameters:--ip %s --type %s
+parameters:--ip=%s --type=%s
 type:script_output
 message:delete kea dhcp lease

--- a/src/opnsense/service/conf/actions.d/actions_kea.conf
+++ b/src/opnsense/service/conf/actions.d/actions_kea.conf
@@ -49,6 +49,6 @@ message:list kea inet dhcp leases
 
 [delete.lease]
 command:/usr/local/opnsense/scripts/kea/del_kea_leases.py
-parameters:%s
+parameters:%s %s
 type:script_output
 message:delete kea dhcp lease


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

This was a rabbithole, but there was no other way to fix this than to spawn all those overrides for the commands and the additional parameter for the lease type.

---

**Describe the proposed solution**

Pass lease type for IPv6 so IA_NA and IA_PD leases are correctly deleted.

---

**Related issue**
https://github.com/opnsense/core/issues/10224

