### PR TITLE
Services: Kea DHCPv6: infer IPv6 lease type in delete script via lease lookup so IA_NA and IA_PD can be deleted

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -130,7 +130,7 @@ abstract class LeasesController extends ApiControllerBase
             return ['status' => 'error', 'message' => gettext('Missing lease IP parameter')];
         }
 
-        $results = json_decode((new Backend())->configdpRun("kea delete lease " . $ips), true);
+        $results = json_decode((new Backend())->configdpRun('kea delete lease', [$ips]), true);
 
         if (!is_array($results) || empty($results)) {
             throw new UserException(gettext('Invalid backend response'));

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -103,7 +103,7 @@
 
                         const address = row.address || '';
                         const prefixLen = parseInt(row.prefix_len, 10);
-                        const isPrefix = prefixLen !== 128;
+                        const isPrefix = row.type === 'IA_PD';
 
                         const searchUrl = `${baseUrl}&search=${encodeURIComponent(searchValue)}`;
                         const addUrlParams = {
@@ -177,6 +177,7 @@
                 <th data-column-id="if_descr" data-type="string">{{ lang._('Interface') }}</th>
                 <th data-column-id="address" data-identifier="true" data-type="string" data-formatter="overflowformatter">{{ lang._('IP Address') }}</th>
                 <th data-column-id="prefix_len" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Length') }}</th>
+                <th data-column-id="type" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Type') }}</th>
                 <th data-column-id="duid" data-type="string" data-width="9em">{{ lang._('DUID') }}</th>
                 <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="valid_lifetime" data-type="integer">{{ lang._('Lifetime') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -178,8 +178,8 @@
                 <th data-column-id="address" data-identifier="true" data-type="string" data-formatter="overflowformatter">{{ lang._('IP Address') }}</th>
                 <th data-column-id="prefix_len" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Length') }}</th>
                 <th data-column-id="type" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Type') }}</th>
-                <th data-column-id="duid" data-type="string" data-width="9em">{{ lang._('DUID') }}</th>
-                <th data-column-id="iaid" data-type="string" data-width="9em">{{ lang._('IAID') }}</th>
+                <th data-column-id="duid" data-type="string" data-width="18em">{{ lang._('DUID') }}</th>
+                <th data-column-id="iaid" data-type="string" data-width="4em">{{ lang._('IAID') }}</th>
                 <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="valid_lifetime" data-type="integer">{{ lang._('Lifetime') }}</th>
                 <th data-column-id="expire" data-type="string" data-formatter="timestamp">{{ lang._('Expire') }}</th>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -179,6 +179,7 @@
                 <th data-column-id="prefix_len" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Length') }}</th>
                 <th data-column-id="type" data-identifier="true" data-type="string" data-width="4em">{{ lang._('Type') }}</th>
                 <th data-column-id="duid" data-type="string" data-width="9em">{{ lang._('DUID') }}</th>
+                <th data-column-id="iaid" data-type="string" data-width="9em">{{ lang._('IAID') }}</th>
                 <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="valid_lifetime" data-type="integer">{{ lang._('Lifetime') }}</th>
                 <th data-column-id="expire" data-type="string" data-formatter="timestamp">{{ lang._('Expire') }}</th>

--- a/src/opnsense/scripts/kea/del_kea_leases.py
+++ b/src/opnsense/scripts/kea/del_kea_leases.py
@@ -31,6 +31,18 @@ import ujson
 
 from lib.kea_ctrl import KeaCtrl
 
+
+def get_ipv6_lease_types():
+    lease_map = {}
+    leases = KeaCtrl.send_command('lease6-get-all', None, 'dhcp6').get("arguments", {}).get("leases", [])
+    for lease in leases:
+        addr = lease.get("ip-address")
+        lease_type = lease.get("type")
+        lease_map.setdefault(addr, set()).add(lease_type)
+
+    return lease_map
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("ip", help="IP address(es) to delete, comma separated")
@@ -41,15 +53,27 @@ if __name__ == '__main__':
         "removed": []
     }
 
+    has_v6 = any(":" in ip for ip in ips)
+    lease_map = get_ipv6_lease_types() if has_v6 else {}
+
     for ip in ips:
         is_v6 = ":" in ip
         cmd = "lease6-del" if is_v6 else "lease4-del"
         service = "dhcp6" if is_v6 else "dhcp4"
 
-        result = KeaCtrl.send_command(cmd, {"ip-address": ip}, service)
-        if result.get("result", 1) > 0:
-            results["failed"].append(f"{ip}: {result.get("text", "unknown error")}")
-        else:
-            results["removed"].append(ip)
+        types = lease_map.get(ip, {None}) if is_v6 else {None}
+
+        # This is a pragmatic assumption since collisions between IA_NA and IA_PD
+        # on the same base address can be considered negligible
+        for lease_type in types:
+            payload = {"ip-address": ip}
+            if is_v6 and lease_type:
+                payload["type"] = lease_type
+
+            result = KeaCtrl.send_command(cmd, payload, service)
+            if result.get("result", 1) > 0:
+                results["failed"].append(f"{ip}: {result.get('text', 'unknown error')}")
+            else:
+                results["removed"].append(ip)
 
     print(ujson.dumps(results))

--- a/src/opnsense/scripts/kea/get_kea_leases.py
+++ b/src/opnsense/scripts/kea/get_kea_leases.py
@@ -84,8 +84,10 @@ if __name__ == '__main__':
         records.append({
             "address": address,
             "prefix_len": lease.get("prefix-len", 128),
+            "type": lease.get("type", ""),
             "hwaddr": lease.get("hw-address", ""),
             "duid": lease.get("duid", ""),
+            "iaid": lease.get("iaid", ""),
             "valid_lifetime": lease.get("valid-lft", 0),
             "expire": lease.get("cltt", 0) + lease.get("valid-lft", 0),
             "hostname": lease.get("hostname", ""),


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Initial PR found here, this one supersedes it: https://github.com/opnsense/core/pull/10227

---

**Describe the proposed solution**

This avoids propagating lease type handling through controller and UI layers while fixing unreliable deletion of IA_PD leases.

The approach is pragmatic: in the extremely unlikely case that IA_NA and IA_PD share the same base address, multiple leases may be deleted. This tradeoff is considered acceptable given the low impact and recoverable nature of DHCP leases.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10224
