### PR TITLE
Services: Kea DHCPv4/6: Add user-context object to config to emit description

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -176,9 +176,9 @@ class KeaDhcpv4 extends BaseModel
                 'reservations' => []
             ];
             /* add description and other custom keys - not parsed by KEA */
-            $record['user-context'] = new \stdClass();
+            $record['user-context'] = ['uuid' => $subnet->getAttribute('uuid')];
             if (!$subnet->description->isEmpty()) {
-                $record['user-context']->description = $subnet->description->getValue();
+                $record['user-context']['description'] = $subnet->description->getValue();
             }
             /* add pools */
             foreach ($subnet->pools->getValues() as $pool) {
@@ -214,9 +214,9 @@ class KeaDhcpv4 extends BaseModel
                         'always-send' => !$option->force->isEmpty(),
                     ];
                     /* add description and other custom keys - not parsed by KEA */
-                    $entry['user-context'] = new \stdClass();
+                    $entry['user-context'] = ['uuid' => $option->getAttribute('uuid')];
                     if (!$option->description->isEmpty()) {
-                        $entry['user-context']->description = $option->description->getValue();
+                        $entry['user-context']['description'] = $option->description->getValue();
                     }
                     /* only conditionally send the option when a client option matches */
                     if (!$option->match_code->isEmpty()) {
@@ -229,9 +229,9 @@ class KeaDhcpv4 extends BaseModel
                 }
 
                 /* add description and other custom keys - not parsed by KEA */
-                $res['user-context'] = new \stdClass();
+                $res['user-context'] = ['uuid' => $reservation->getAttribute('uuid')];
                 if (!$reservation->description->isEmpty()) {
-                    $res['user-context']->description = $reservation->description->getValue();
+                    $res['user-context']['description'] = $reservation->description->getValue();
                 }
 
                 $record['reservations'][] = $res;
@@ -249,9 +249,9 @@ class KeaDhcpv4 extends BaseModel
                     'always-send' => !$option->force->isEmpty(),
                 ];
                 /* add description and other custom keys - not parsed by KEA */
-                $entry['user-context'] = new \stdClass();
+                $entry['user-context'] = ['uuid' => $option->getAttribute('uuid')];
                 if (!$option->description->isEmpty()) {
-                    $entry['user-context']->description = $option->description->getValue();
+                    $entry['user-context']['description'] = $option->description->getValue();
                 }
                 /* only conditionally send the option when a client option matches */
                 if (!$option->match_code->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -175,6 +175,11 @@ class KeaDhcpv4 extends BaseModel
                 'pools' => [],
                 'reservations' => []
             ];
+            /* add description and other custom keys - not parsed by KEA */
+            $record['user-context'] = new \stdClass();
+            if (!$subnet->description->isEmpty()) {
+                $record['user-context']->description = $subnet->description->getValue();
+            }
             /* add pools */
             foreach ($subnet->pools->getValues() as $pool) {
                 $record['pools'][] = ['pool' => $pool];
@@ -208,6 +213,11 @@ class KeaDhcpv4 extends BaseModel
                         'data' => $option->data->encodeValue(),
                         'always-send' => !$option->force->isEmpty(),
                     ];
+                    /* add description and other custom keys - not parsed by KEA */
+                    $entry['user-context'] = new \stdClass();
+                    if (!$option->description->isEmpty()) {
+                        $entry['user-context']->description = $option->description->getValue();
+                    }
                     /* only conditionally send the option when a client option matches */
                     if (!$option->match_code->isEmpty()) {
                         $entry['client-classes'] = [$uuid];
@@ -216,6 +226,12 @@ class KeaDhcpv4 extends BaseModel
                 }
                 if (!empty($optdata)) {
                     $res['option-data'] = $optdata;
+                }
+
+                /* add description and other custom keys - not parsed by KEA */
+                $res['user-context'] = new \stdClass();
+                if (!$reservation->description->isEmpty()) {
+                    $res['user-context']->description = $reservation->description->getValue();
                 }
 
                 $record['reservations'][] = $res;
@@ -232,6 +248,11 @@ class KeaDhcpv4 extends BaseModel
                     'data' => $option->data->encodeValue(),
                     'always-send' => !$option->force->isEmpty(),
                 ];
+                /* add description and other custom keys - not parsed by KEA */
+                $entry['user-context'] = new \stdClass();
+                if (!$option->description->isEmpty()) {
+                    $entry['user-context']->description = $option->description->getValue();
+                }
                 /* only conditionally send the option when a client option matches */
                 if (!$option->match_code->isEmpty()) {
                     $entry['client-classes'] = [$uuid];

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -183,6 +183,11 @@ class KeaDhcpv6 extends BaseModel
             if (!$subnet->allocator->isEmpty()) {
                 $record['allocator'] = $subnet->allocator->getValue();
             }
+            /* add description and other custom keys - not parsed by KEA */
+            $record['user-context'] = new \stdClass();
+            if (!$subnet->description->isEmpty()) {
+                $record['user-context']->description = $subnet->description->getValue();
+            }
             /* standard option-data elements */
             foreach ($subnet->option_data->iterateItems() as $key => $value) {
                 $target_fieldname = str_replace('_', '-', $key);
@@ -207,11 +212,17 @@ class KeaDhcpv6 extends BaseModel
                 if ($pdpool->subnet != $subnet_uuid) {
                     continue;
                 }
-                $record['pd-pools'][] = [
+                $entry = [
                     'prefix' => $pdpool->prefix->getValue(),
                     'prefix-len' => $pdpool->prefix_len->asInt(),
                     'delegated-len' => $pdpool->delegated_len->asInt()
                 ];
+                /* add description and other custom keys - not parsed by KEA */
+                $entry['user-context'] = new \stdClass();
+                if (!$pdpool->description->isEmpty()) {
+                    $entry['user-context']->description = $pdpool->description->getValue();
+                }
+                $record['pd-pools'][] = $entry;
             }
             /* static reservations */
             foreach ($this->reservations->reservation->iterateItems() as $key => $reservation) {
@@ -248,11 +259,21 @@ class KeaDhcpv6 extends BaseModel
                         'data' => $option->data->encodeValue(),
                         'always-send' => !$option->force->isEmpty(),
                     ];
+                    /* add description and other custom keys - not parsed by KEA */
+                    $entry['user-context'] = new \stdClass();
+                    if (!$option->description->isEmpty()) {
+                        $entry['user-context']->description = $option->description->getValue();
+                    }
                     /* only conditionally send the option when a client option matches */
                     if (!$option->match_code->isEmpty()) {
                         $entry['client-classes'] = [$uuid];
                     }
                     $res['option-data'][] = $entry;
+                }
+                /* add description and other custom keys - not parsed by KEA */
+                $res['user-context'] = new \stdClass();
+                if (!$reservation->description->isEmpty()) {
+                    $res['user-context']->description = $reservation->description->getValue();
                 }
                 $record['reservations'][] = $res;
             }
@@ -268,6 +289,11 @@ class KeaDhcpv6 extends BaseModel
                     'data' => $option->data->encodeValue(),
                     'always-send' => !$option->force->isEmpty(),
                 ];
+                /* add description and other custom keys - not parsed by KEA */
+                $entry['user-context'] = new \stdClass();
+                if (!$option->description->isEmpty()) {
+                    $entry['user-context']->description = $option->description->getValue();
+                }
                 /* only conditionally send the option when a client option matches */
                 if (!$option->match_code->isEmpty()) {
                     $entry['client-classes'] = [$uuid];

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -184,9 +184,9 @@ class KeaDhcpv6 extends BaseModel
                 $record['allocator'] = $subnet->allocator->getValue();
             }
             /* add description and other custom keys - not parsed by KEA */
-            $record['user-context'] = new \stdClass();
+            $record['user-context'] = ['uuid' => $subnet->getAttribute('uuid')];
             if (!$subnet->description->isEmpty()) {
-                $record['user-context']->description = $subnet->description->getValue();
+                $record['user-context']['description'] = $subnet->description->getValue();
             }
             /* standard option-data elements */
             foreach ($subnet->option_data->iterateItems() as $key => $value) {
@@ -218,9 +218,9 @@ class KeaDhcpv6 extends BaseModel
                     'delegated-len' => $pdpool->delegated_len->asInt()
                 ];
                 /* add description and other custom keys - not parsed by KEA */
-                $entry['user-context'] = new \stdClass();
+                $entry['user-context'] = ['uuid' => $pdpool->getAttribute('uuid')];
                 if (!$pdpool->description->isEmpty()) {
-                    $entry['user-context']->description = $pdpool->description->getValue();
+                    $entry['user-context']['description'] = $pdpool->description->getValue();
                 }
                 $record['pd-pools'][] = $entry;
             }
@@ -260,9 +260,9 @@ class KeaDhcpv6 extends BaseModel
                         'always-send' => !$option->force->isEmpty(),
                     ];
                     /* add description and other custom keys - not parsed by KEA */
-                    $entry['user-context'] = new \stdClass();
+                    $entry['user-context'] = ['uuid' => $option->getAttribute('uuid')];
                     if (!$option->description->isEmpty()) {
-                        $entry['user-context']->description = $option->description->getValue();
+                        $entry['user-context']['description'] = $option->description->getValue();
                     }
                     /* only conditionally send the option when a client option matches */
                     if (!$option->match_code->isEmpty()) {
@@ -271,9 +271,9 @@ class KeaDhcpv6 extends BaseModel
                     $res['option-data'][] = $entry;
                 }
                 /* add description and other custom keys - not parsed by KEA */
-                $res['user-context'] = new \stdClass();
+                $res['user-context'] = ['uuid' => $reservation->getAttribute('uuid')];
                 if (!$reservation->description->isEmpty()) {
-                    $res['user-context']->description = $reservation->description->getValue();
+                    $res['user-context']['description'] = $reservation->description->getValue();
                 }
                 $record['reservations'][] = $res;
             }
@@ -290,9 +290,9 @@ class KeaDhcpv6 extends BaseModel
                     'always-send' => !$option->force->isEmpty(),
                 ];
                 /* add description and other custom keys - not parsed by KEA */
-                $entry['user-context'] = new \stdClass();
+                $entry['user-context'] = ['uuid' => $option->getAttribute('uuid')];
                 if (!$option->description->isEmpty()) {
-                    $entry['user-context']->description = $option->description->getValue();
+                    $entry['user-context']['description'] = $option->description->getValue();
                 }
                 /* only conditionally send the option when a client option matches */
                 if (!$option->match_code->isEmpty()) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

This emits the description into the user-context space which is an object that can be freely used without being parsed by KEA directly.

https://kea.readthedocs.io/en/stable/arm/config.html#comments-and-user-context

I know this looks like prime content for a helper, but I would refrain of that from now, since there will be differences when we use the user-context for keys used by our own automation, especially for IPv6-PD.

A requirement for this roadmap item: https://github.com/opnsense/core/issues/9941
