### PR TITLE
Firewall: DNat: Display effective port when local-port is omitted

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -297,6 +297,15 @@
                         if (row.isGroup) {
                             return "";
                         }
+
+                        if (column.id === "local-port") {
+                            const localPort = row["local-port"] || "";
+                            const destinationPort = row["destination.port"] || "";
+                            const isOmitted = !localPort || localPort === "any";
+                            // Display "*" in case localPort and destinationPort are both omitted
+                            return (isOmitted ? destinationPort : localPort) || "*";
+                        }
+
                         const value = row[column.id] || "";
                         // DNAT uses network, SNAT and ONAT uses net
                         const isNegated = (row[column.id.replace(/network|net/, 'not')] == 1) ? "! " : "";

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -403,23 +403,16 @@
                             return "";
                         }
 
-                        if (column.id === "local-port") {
-                            const localPort = row["local-port"] || "";
-                            const destinationPort = row["destination.port"] || "";
-                            const isOmitted = !localPort || localPort === "any";
-                            // Display "*" in case localPort and destinationPort are both omitted
-                            return (isOmitted ? destinationPort : localPort) || "*";
-                        }
-
                         const value = row[column.id] || "";
                         // DNAT uses network, SNAT and ONAT uses net
                         const isNegated = (row[column.id.replace(/network|net/, 'not')] == 1) ? "! " : "";
 
                         if (typeof value !== 'string') {
                             return '';
-                        }
-
-                        if (!value || value === "any") {
+                        } else if (column.id === "local-port") {
+                            // DNAT: mirror destination port into local-port for better visibility
+                            return (!row["local-port"] ? row["destination.port"] : row["local-port"]) || "*";
+                        } else if (!value || value === "any") {
                             return isNegated + '*';
                         }
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -402,6 +402,15 @@
                         if (row.isGroup) {
                             return "";
                         }
+
+                        if (column.id === "local-port") {
+                            const localPort = row["local-port"] || "";
+                            const destinationPort = row["destination.port"] || "";
+                            const isOmitted = !localPort || localPort === "any";
+                            // Display "*" in case localPort and destinationPort are both omitted
+                            return (isOmitted ? destinationPort : localPort) || "*";
+                        }
+
                         const value = row[column.id] || "";
                         // DNAT uses network, SNAT and ONAT uses net
                         const isNegated = (row[column.id.replace(/network|net/, 'not')] == 1) ? "! " : "";


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

Currently when selecting any/skipping local-port field, it's unclear which port is effective.

---

**Describe the proposed solution**

Display the selected destination port in the local-port field. Local-port will only display "*" if both destination port and local-port are omitted.

---

**Related issue**
Closes: #9677 