### PR TITLE
Services: Kea DHCPv4/v6: add ddns-conflict-resolution-mode per subnet

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -298,4 +298,14 @@
         </grid_view>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>subnet4.ddns_conflict_resolution_mode</id>
+        <label>Conflict resolution mode</label>
+        <type>dropdown</type>
+        <help>Controls how Kea handles DNS name conflicts when DHCID records are present. Use "no-check-with-dhcid" in dual-stack deployments where the same hostname is registered by both DHCPv4 (DHCID type 01) and DHCPv6 (DHCID type 02): without this setting, the type mismatch triggers conflict resolution and removes the existing record. When empty, Kea defaults to "check-with-dhcid".</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -199,4 +199,14 @@
         </grid_view>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>subnet6.ddns_conflict_resolution_mode</id>
+        <label>Conflict resolution mode</label>
+        <type>dropdown</type>
+        <help>Controls how Kea handles DNS name conflicts when DHCID records are present. Use "no-check-with-dhcid" in dual-stack deployments where the same hostname is registered by both DHCPv4 (DHCID type 01) and DHCPv6 (DHCID type 02): without this setting, the type mismatch triggers conflict resolution and removes the existing record. When empty, Kea defaults to "check-with-dhcid".</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -268,6 +268,9 @@ class KeaDhcpv4 extends BaseModel
                 $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
                 $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
                 $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
+                if (!$subnet->ddns_conflict_resolution_mode->isEmpty()) {
+                    $record['ddns-conflict-resolution-mode'] = $subnet->ddns_conflict_resolution_mode->getValue();
+                }
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -219,6 +219,14 @@
                 <ddns_override_no_update type="BooleanField"/>
                 <ddns_override_client_update type="BooleanField"/>
                 <ddns_update_on_renew type="BooleanField"/>
+                <ddns_conflict_resolution_mode type="OptionField">
+                    <OptionValues>
+                        <check-with-dhcid>check-with-dhcid</check-with-dhcid>
+                        <no-check-with-dhcid>no-check-with-dhcid</no-check-with-dhcid>
+                        <no-check-without-dhcid>no-check-without-dhcid</no-check-without-dhcid>
+                        <check-exists-with-dhcid>check-exists-with-dhcid</check-exists-with-dhcid>
+                    </OptionValues>
+                </ddns_conflict_resolution_mode>
                 <description type="DescriptionField"/>
             </subnet4>
         </subnets>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -309,6 +309,9 @@ class KeaDhcpv6 extends BaseModel
                 $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
                 $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
                 $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
+                if (!$subnet->ddns_conflict_resolution_mode->isEmpty()) {
+                    $record['ddns-conflict-resolution-mode'] = $subnet->ddns_conflict_resolution_mode->getValue();
+                }
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -201,6 +201,14 @@
                 <ddns_override_no_update type="BooleanField"/>
                 <ddns_override_client_update type="BooleanField"/>
                 <ddns_update_on_renew type="BooleanField"/>
+                <ddns_conflict_resolution_mode type="OptionField">
+                    <OptionValues>
+                        <check-with-dhcid>check-with-dhcid</check-with-dhcid>
+                        <no-check-with-dhcid>no-check-with-dhcid</no-check-with-dhcid>
+                        <no-check-without-dhcid>no-check-without-dhcid</no-check-without-dhcid>
+                        <check-exists-with-dhcid>check-exists-with-dhcid</check-exists-with-dhcid>
+                    </OptionValues>
+                </ddns_conflict_resolution_mode>
                 <description type="DescriptionField"/>
             </subnet6>
         </subnets>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 4.6 (Anthropic)
- Extent of AI involvement: AI assisted with initial implementation; all changes reviewed, tested, and verified on live OPNsense 26.1.7 infrastructure before submission.

---

**Describe the problem**

In dual-stack deployments where the same hostname is registered by both DHCPv4 and DHCPv6 leases, Kea DDNS (D2) performs conflict resolution that silently removes the existing DNS record.

The root cause is a DHCID type mismatch: IPv4 DHCID uses type 01 (client identifier / MAC), while IPv6 DHCID uses type 02 (DUID). When D2 processes a AAAA registration for a hostname that already has an A record with a type-01 DHCID, it detects a conflict, removes the A record, and registers the AAAA with a type-02 DHCID. The reverse occurs on the next IPv4 renewal.

Kea's `ddns-conflict-resolution-mode: no-check-with-dhcid` setting disables this ownership check and allows both A and AAAA records to coexist. There is currently no way to set this option through the OPNsense GUI or API.

Related: follows #10188 which added `ddns-override-no-update`, `ddns-override-client-update`, and `ddns-update-on-renew` per subnet.

**Describe the proposed solution**

Add `ddns-conflict-resolution-mode` as an optional per-subnet dropdown for both DHCPv4 and DHCPv6 subnets. When left empty (the default), the key is omitted from the generated config and Kea uses its built-in default (`check-with-dhcid`). When set, the selected value is written to the subnet block.

The four valid Kea values are exposed as options:
- `check-with-dhcid` — default Kea behavior; use DHCID ownership checks
- `no-check-with-dhcid` — skip ownership checks; recommended for dual-stack (same FQDN for IPv4 + IPv6)
- `no-check-without-dhcid` — skip checks and do not create DHCID records
- `check-exists-with-dhcid` — update only if a DHCID already exists

**Files changed**

- `KeaDhcpv4.xml` / `KeaDhcpv6.xml` — add `ddns_conflict_resolution_mode` OptionField to subnet model
- `KeaDhcpv4.php` / `KeaDhcpv6.php` — emit `ddns-conflict-resolution-mode` in subnet config when field is non-empty
- `dialogSubnet4.xml` / `dialogSubnet6.xml` — add dropdown under Advanced DDNS settings

**Testing**

Tested on OPNsense 26.1.7_1 with Kea 2.x:
1. Verified that leaving the field empty produces no `ddns-conflict-resolution-mode` key in the generated config (Kea default preserved)
2. Verified that setting `no-check-with-dhcid` produces the correct key in all three IPv4 subnets and all three IPv6 subnets
3. Verified that A and AAAA records coexist for the same hostname after both DHCPv4 and DHCPv6 DDNS updates complete
4. Confirmed PTR records (both IPv4 and IPv6) are registered correctly alongside the forward records