### PR TITLE
Services: Kea DHCPv6: add reservations-out-of-pool per subnet

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -300,6 +300,9 @@ class KeaDhcpv6 extends BaseModel
                 }
                 $record['option-data'][] = $entry;
             }
+            if (!$subnet->reservations_out_of_pool->isEmpty()) {
+                $record['reservations-out-of-pool'] = true;
+            }
             /* DDNS per subnet settings */
             if ($ddns_enabled) {
                 if (!$subnet->ddns_qualifying_suffix->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -201,6 +201,7 @@
                 <ddns_override_no_update type="BooleanField"/>
                 <ddns_override_client_update type="BooleanField"/>
                 <ddns_update_on_renew type="BooleanField"/>
+                <reservations_out_of_pool type="BooleanField"/>
                 <description type="DescriptionField"/>
             </subnet6>
         </subnets>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 4.6
- Extent of AI involvement: Implementation assistance

---

**Describe the problem**

Kea DHCPv6 subnets that define reservations with addresses below the dynamic pool range (e.g. reserved `fd00::52` with pool starting at `fd00::1000:0`) do not honour those reservations. Kea's default behaviour (`reservations-out-of-pool: false`) requires reserved addresses to be within the pool range; without the flag set, clients with out-of-pool reservations are classified as `KNOWN` but allocation fails with `ALLOC_ENGINE_V6_ALLOC_FAIL_NO_POOLS` and they fall back to a dynamic address.

---

**Describe the proposed solution**

Adds a `reservations_out_of_pool` BooleanField to the `subnet6` model node (analogous to the existing `ddns_override_no_update` / `ddns_update_on_renew` flags) and emits `"reservations-out-of-pool": true` in the generated Kea configuration when the field is set.

Changes:
- `KeaDhcpv6.xml`: add `<reservations_out_of_pool type="BooleanField"/>` to the `subnet6` node
- `KeaDhcpv6.php`: emit `reservations-out-of-pool` in `getConfigSubnets()` when the field is set

---

**Related issue**

N/A