### PR TITLE
Captive Portal: reload ipfw on captive portal reconfigure

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/ServiceController.php
@@ -54,7 +54,6 @@ class ServiceController extends ApiMutableServiceControllerBase
             }
 
             $status = parent::reconfigureAction();
-
         }
 
         return $status;

--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/ServiceController.php
@@ -29,6 +29,7 @@
 namespace OPNsense\CaptivePortal\Api;
 
 use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Core\Backend;
 
 /**
  * Class ServiceController
@@ -39,6 +40,25 @@ class ServiceController extends ApiMutableServiceControllerBase
     protected static $internalServiceClass = '\OPNsense\CaptivePortal\CaptivePortal';
     protected static $internalServiceTemplate = 'OPNsense/Captiveportal';
     protected static $internalServiceName = 'captiveportal';
+
+    public function reconfigureAction()
+    {
+        $status = ['status' => 'failed'];
+
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $backend->configdRun('template reload OPNsense/IPFW');
+            $result = trim($backend->configdRun("ipfw reload"));
+            if ($result != "OK") {
+                return ["status" => "error reloading ipfw (" . $result . ")"];
+            }
+
+            $status = parent::reconfigureAction();
+
+        }
+
+        return $status;
+    }
 
     protected function serviceEnabled()
     {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

When having no shaper rules/pipes configured, reloading captive portal doesn't enable/start IPFW when configured through the GUI. If the device is rebooted afterwards or fully reconfigured, or if there are any pipes defines, this issues goes unnoticed. The only symptom is missing byte counters through IPFW.

Disabling the Captive portal also does not disable ipfw, a single reconfigure on the shaper fixes this.

---

**Describe the proposed solution**

Reload the IPFW template + reconfigure ipfw in the captive portal service controller

---

**Related issue**

If this pull request relates to an issue, link it here.

https://github.com/opnsense/core/issues/9902