### PR TITLE
Services: Kea: Add DDNS conflict resolution option

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -298,4 +298,14 @@
         </grid_view>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>subnet4.ddns_conflict_resolution_mode</id>
+        <label>Conflict resolution mode</label>
+        <type>dropdown</type>
+        <help>Conflict resolution behavior used by Kea if a DNS entry already exists. Any value other than check-with-dhcid disables overwrite safeguards.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet6.xml
@@ -199,4 +199,14 @@
         </grid_view>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>subnet6.ddns_conflict_resolution_mode</id>
+        <label>Conflict resolution mode</label>
+        <type>dropdown</type>
+        <help>Conflict resolution behavior used by Kea if a DNS entry already exists. Any value other than check-with-dhcid disables overwrite safeguards.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -268,6 +268,9 @@ class KeaDhcpv4 extends BaseModel
                 $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
                 $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
                 $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
+                if (!$subnet->ddns_conflict_resolution_mode->isEmpty()) {
+                    $record['ddns-conflict-resolution-mode'] = $subnet->ddns_conflict_resolution_mode->getValue();
+                }
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -219,6 +219,15 @@
                 <ddns_override_no_update type="BooleanField"/>
                 <ddns_override_client_update type="BooleanField"/>
                 <ddns_update_on_renew type="BooleanField"/>
+                <ddns_conflict_resolution_mode type="OptionField">
+                    <Default>check-with-dhcid</Default>
+                    <OptionValues>
+                        <check-with-dhcid>check-with-dhcid</check-with-dhcid>
+                        <no-check-with-dhcid>no-check-with-dhcid</no-check-with-dhcid>
+                        <check-exists-with-dhcid>check-exists-with-dhcid</check-exists-with-dhcid>
+                        <no-check-without-dhcid>no-check-without-dhcid</no-check-without-dhcid>
+                    </OptionValues>
+                </ddns_conflict_resolution_mode>
                 <description type="DescriptionField"/>
             </subnet4>
         </subnets>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -309,6 +309,9 @@ class KeaDhcpv6 extends BaseModel
                 $record['ddns-override-no-update'] = !$subnet->ddns_override_no_update->isEmpty();
                 $record['ddns-override-client-update'] = !$subnet->ddns_override_client_update->isEmpty();
                 $record['ddns-update-on-renew'] = !$subnet->ddns_update_on_renew->isEmpty();
+                if (!$subnet->ddns_conflict_resolution_mode->isEmpty()) {
+                    $record['ddns-conflict-resolution-mode'] = $subnet->ddns_conflict_resolution_mode->getValue();
+                }
             }
             $result[] = $record;
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -201,6 +201,15 @@
                 <ddns_override_no_update type="BooleanField"/>
                 <ddns_override_client_update type="BooleanField"/>
                 <ddns_update_on_renew type="BooleanField"/>
+                <ddns_conflict_resolution_mode type="OptionField">
+                    <Default>check-with-dhcid</Default>
+                    <OptionValues>
+                        <check-with-dhcid>check-with-dhcid</check-with-dhcid>
+                        <no-check-with-dhcid>no-check-with-dhcid</no-check-with-dhcid>
+                        <check-exists-with-dhcid>check-exists-with-dhcid</check-exists-with-dhcid>
+                        <no-check-without-dhcid>no-check-without-dhcid</no-check-without-dhcid>
+                    </OptionValues>
+                </ddns_conflict_resolution_mode>
                 <description type="DescriptionField"/>
             </subnet6>
         </subnets>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] An issue already exists and it is linked below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

The default DDNS conflict resolution mode in Kea (`check-with-dhcid`) prevents the use of DDNS with both DHCPv4 and DHCPv6 at the same time. Since Kea uses the DHCID record to protect DNS entries, only an A or an AAAA record can be created, but not both.

---

**Describe the proposed solution**

Expose the `ddns-conflict-resolution-mode` option for both the DHCPv4 (see [here](https://kea.readthedocs.io/en/stable/arm/dhcp4-srv.html#ddns-for-dhcpv4)) and DHCPv6 (see [here](https://kea.readthedocs.io/en/stable/arm/dhcp6-srv.html#ddns-for-dhcpv6)) configurations. This option offers 3 other conflict resolution modes: `no-check-with-dhcid`, `check-exists-with-dhcid` and `no-check-without-dhcid`. `check-exists-with-dhcid` is probably the best choice is most cases, but others might be appropriate too.

The Kea documentation has the following warning:

> Setting `ddns-conflict-resolution-mode` to any value other than `check-with-dhcid` disables the overwrite safeguards that the rules of conflict resolution (from [RFC 4703](https://tools.ietf.org/html/rfc4703)) are intended to prevent.

This PR therefore keeps `check-with-dhcid` as  the default value. However, the [OPNsense documentation for Dynamic DNS](https://docs.opnsense.org/manual/kea.html#dynamic-dns-rfc2136) should probably suggest the use of  `check-exists-with-dhcid` in dual-stack configuration.s

---

**Related issue**

Fixes #10212