### PR TITLE
openvpn: check group membership from current config

### DIFF
--- a/src/opnsense/scripts/openvpn/user_pass_verify.php
+++ b/src/opnsense/scripts/openvpn/user_pass_verify.php
@@ -53,6 +53,44 @@ function parse_auth_properties($props)
 }
 
 /**
+ * Check local group membership using the current configuration state
+ * @param string $username username to find
+ * @param string $groupname group name to test
+ * @return bool user is a member of the requested group
+ */
+function user_in_local_group($username, $groupname)
+{
+    $cnf = OPNsense\Core\Config::getInstance()->object();
+    $uid = null;
+
+    if (isset($cnf->system->user)) {
+        foreach ($cnf->system->user as $user) {
+            if ((string)$user->name == $username) {
+                $uid = (string)$user->uid;
+                break;
+            }
+        }
+    }
+
+    if ($uid === null || !isset($cnf->system->group)) {
+        return false;
+    }
+
+    foreach ($cnf->system->group as $group) {
+        if ((string)$group->name == $groupname) {
+            foreach ($group->member as $member) {
+                if (in_array($uid, explode(',', (string)$member))) {
+                    return true;
+                }
+            }
+            break;
+        }
+    }
+
+    return false;
+}
+
+/**
  * perform authentication
  * @param string $common_name certificate common name for this connection
  * @param string $serverid server identifier
@@ -128,7 +166,7 @@ function do_auth($common_name, $serverid, $method, $auth_file)
             }
 
             if ($authenticator->authenticate($username, $password)) {
-                if (!empty($a_server['local_group']) && !in_array($a_server['local_group'], getUserGroups($username))) {
+                if (!empty($a_server['local_group']) && !user_in_local_group($username, $a_server['local_group'])) {
                     return "OpenVPN '$serverid' requires the local group {$a_server['local_group']}. " .
                         "Denying authentication for user {$username}";
                 }


### PR DESCRIPTION
LDAP authentication can update local group membership during a successful OpenVPN login. The local group constraint used the legacy getUserGroups() helper, which reads the global config state loaded before authentication.

Check membership against the current config object instead so group constraints can see memberships synchronized by the authenticator in the same login flow.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [ x ] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ x ] I opened an issue first for non-trivial changes and linked it below.
- [ x ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- ChatGPT 5.5:
- I was aware of the issue; the AI then wrote the entire patch and the Pull Request and the Issue text (my english is quite bad) :)

---

**Describe the problem**

OpenVPN user authentication can synchronize LDAP group membership during a successful login. The local group constraint currently checks membership through the legacy `getUserGroups()` helper, which reads the global config state loaded before authentication.

As a result, group membership synchronized by the authenticator during the same login flow may not be visible until a second login attempt.

Fixes: #10255

---

**Describe the proposed solution**

Check OpenVPN local group membership against the current OPNsense config object after authentication succeeds. This lets the group constraint see memberships synchronized by LDAP/RADIUS-style authenticators in the same login flow, without changing the authentication order or the existing CSO/provisioning logic.

---

**Testing**

- `php -l src/opnsense/scripts/openvpn/user_pass_verify.php`
- `git diff --check -- src/opnsense/scripts/openvpn/user_pass_verify.php`
- `bmake lint`

`bmake lint` completed successfully with:

```text
Checked 2567 files in 5.9 seconds
No syntax error found


