### PR TITLE
firewall: make getRealInterface() a static utility function #10251

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -674,4 +674,51 @@ class Util
         /* return a convenient one-entry array to iterate over for our callers */
         return [$lockout_if => $lockout_ports];
     }
+
+    /**
+     * return the device name present in the system for the specific configuration,
+     * almost the same as get_real_interface() in backend code with the exception
+     * that the interface names will not be passed through as device names on failures
+     * @param string $interface name of the interface
+     * @param string $family type: inet/inet6/both
+     * @return null|string|array target device name or null, on both array with all known
+     */
+    public static function getRealInterface(string $interface, string $family = 'inet')
+    {
+        $cfg = Config::getInstance()->object();
+
+        if (!isset($cfg->interfaces->{$interface})) {
+            /* name invalid so return nothing */
+            return $family != 'both' ? null : [];
+        }
+
+        $devices = []; /* store both: 0 => IPv4, 1 = > IPv6 (if different) */
+
+        $devices[0] = (string)$cfg->interfaces->{$interface}->if;
+
+        switch ((string)$cfg->interfaces->{$interface}->ipaddrv6 ?? 'none') {
+            case '6rd':
+            case '6to4':
+                $devices[1] = "{$interface}_stf";
+                break;
+            default:
+                break;
+        }
+
+        switch ($family) {
+            case 'inet6':
+                /* select special IPv6 interface if it exists */
+                $devices = $devices[1] ?? $devices[0];
+                break;
+            case 'both':
+                /* pass array as is */
+                break;
+            case 'inet':
+            default:
+                $devices = $devices[0];
+                break;
+        }
+
+        return $devices;
+    }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -109,16 +109,13 @@ class KeaDhcpv4 extends BaseModel
                 !$this->general->interfaces->isEmpty();
     }
 
-    /**
-     *
-     */
     private function getConfigPhysicalInterfaces()
     {
         $result = [];
-        $cfg = Config::getInstance()->object();
-        foreach ($this->general->interfaces->getValues() as $if) {
-            if (isset($cfg->interfaces->$if) && !empty($cfg->interfaces->$if->if)) {
-                $result[] = (string)$cfg->interfaces->$if->if;
+        foreach ($this->general->interfaces->getValues() as $interface) {
+            $device = Util::getRealInterface($interface, 'inet');
+            if (!empty($device)) {
+                $result[] = $device;
             }
         }
         return $result;

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -135,16 +135,13 @@ class KeaDhcpv6 extends BaseModel
                 !$this->general->interfaces->isEmpty();
     }
 
-    /**
-     *
-     */
     private function getConfigPhysicalInterfaces()
     {
         $result = [];
-        $cfg = Config::getInstance()->object();
-        foreach ($this->general->interfaces->getValues() as $if) {
-            if (isset($cfg->interfaces->$if) && !empty($cfg->interfaces->$if->if)) {
-                $result[] = (string)$cfg->interfaces->$if->if;
+        foreach ($this->general->interfaces->getValues() as $interface) {
+            $device = Util::getRealInterface($interface, 'inet6');
+            if (!empty($device)) {
+                $result[] = $device;
             }
         }
         return $result;
@@ -161,7 +158,6 @@ class KeaDhcpv6 extends BaseModel
 
     private function getConfigSubnets($ddns_enabled = false)
     {
-        $cfg = Config::getInstance()->object();
         $result = [];
         $subnet_id = 1;
         foreach ($this->subnets->subnet6->iterateItems() as $subnet_uuid => $subnet) {
@@ -173,9 +169,9 @@ class KeaDhcpv6 extends BaseModel
                 'pd-pools' => [],
                 'reservations' => []
             ];
-            $if = $subnet->interface->getValue();
-            if (isset($cfg->interfaces->$if) && !empty($cfg->interfaces->$if->if)) {
-                $record['interface'] = (string)$cfg->interfaces->$if->if;
+            $device = Util::getRealInterface($subnet->interface->getValue(), 'inet6');
+            if (!empty($device)) {
+                $record['interface'] = $device;
             }
             if (!$subnet->{'pd-allocator'}->isEmpty()) {
                 $record['pd-allocator'] = $subnet->{'pd-allocator'}->getValue();

--- a/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Routing/Gateways.php
@@ -275,37 +275,6 @@ class Gateways extends BaseModel
     }
 
     /**
-     * return the device name present in the system for the specific configuration
-     * @param string $ifname name of the interface
-     * @param array $definedIntf configuration of interface
-     * @param string $ipproto inet/inet6 type
-     * @return string $device target device name
-     */
-    private function getRealInterface($definedIntf, $ifname, $ipproto = 'inet')
-    {
-        if (empty($definedIntf[$ifname])) {
-            /* name already resolved or invalid */
-            return $ifname;
-        }
-
-        $ifcfg = $definedIntf[$ifname];
-        $device = $ifcfg['if'];
-
-        if ($ipproto == 'inet6') {
-            switch ($ifcfg['ipaddrv6'] ?? 'none') {
-                case '6rd':
-                case '6to4':
-                    $device = "{$ifname}_stf";
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        return $device;
-    }
-
-    /**
      * return the type of the interface, for backwards compatibility
      * @param string $ipproto inet/inet6 type
      * @param array $ifcfg
@@ -395,7 +364,7 @@ class Gateways extends BaseModel
                     );
                 }
                 $reservednames[] = $gw_arr['name'];
-                $gw_arr['if'] = $this->getRealInterface($definedIntf, $gw_arr['interface'], $gw_arr['ipprotocol']);
+                $gw_arr['if'] = Util::getRealInterface($gw_arr['interface'], $gw_arr['ipprotocol']);
                 $gw_arr['attribute'] = $i++;
                 if (Util::isIpAddress($gw_arr['gateway'])) {
                     if (empty($gw_arr['monitor_disable']) && empty($gw_arr['monitor'])) {
@@ -421,7 +390,7 @@ class Gateways extends BaseModel
                 foreach (["inet", "inet6"] as $ipproto) {
                     // filename suffix and interface type as defined in the interface
                     $descr = !empty($ifcfg['descr']) ? $ifcfg['descr'] : $ifname;
-                    $device = $this->getRealInterface($definedIntf, $ifname, $ipproto);
+                    $device = Util::getRealInterface($ifname, $ipproto);
                     $ctype = self::convertType($ipproto, $ifcfg);
                     $ctype = $ctype != null ? $ctype : "GW";
                     // default configuration, when not set in gateway_item


### PR DESCRIPTION
Align implementation with get_real_interface() except that we shall not give a fallback of $device = $interface since we want better integrity in MVC code (and don't deal with devices in configuration data there).

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

See #10251

---

**Describe the proposed solution**

Change function to Util class

---

**Related issue**

N/A
