### PR TITLE
configurable radius max retries and cascade-on-timeout suppression

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -97,6 +97,11 @@ class Radius extends Base implements IAuthConnector
     private $lastAuthProperties = [];
 
     /**
+     * @var string|null outcome of the last authenticate() call (accept|reject|timeout|error)
+     */
+    private $lastResult = null;
+
+    /**
      * @var boolean when set, synchronize groups defined in memberOf attribute to local database
      */
     private $syncMemberOf = false;
@@ -174,6 +179,7 @@ class Radius extends Base implements IAuthConnector
             'radius_secret' => 'sharedSecret',
             'radius_stationid' => 'calledStationId',
             'radius_timeout' => 'timeout',
+            'radius_max_retries' => 'maxRetries',
             'refid' => 'nasIdentifier',
         ];
 
@@ -243,6 +249,15 @@ class Radius extends Base implements IAuthConnector
     public function getLastAuthProperties()
     {
         return $this->lastAuthProperties;
+    }
+
+    /**
+     * outcome of the last authenticate() call
+     * @return string|null one of accept, reject, timeout, error, or null
+     */
+    public function getLastResult()
+    {
+        return $this->lastResult;
     }
 
     /**
@@ -512,6 +527,7 @@ class Radius extends Base implements IAuthConnector
     public function authenticate($username, $password)
     {
         $this->lastAuthProperties = [];// reset auth properties
+        $this->lastResult = null;
         $radius = radius_auth_open();
 
         $error = null;
@@ -592,6 +608,7 @@ class Radius extends Base implements IAuthConnector
                     break;
                 default:
                     syslog(LOG_ERR, 'Unsupported protocol ' . $this->protocol);
+                    $this->lastResult = 'error';
                     return false;
             }
         }
@@ -601,10 +618,12 @@ class Radius extends Base implements IAuthConnector
 
         // log errors and perform actual authentication request
         if ($error != null) {
+            $this->lastResult = 'error';
             syslog(LOG_ERR, 'RadiusError: ' . $error);
         } else {
             $request = radius_send_request($radius);
             if (!$request) {
+                $this->lastResult = 'timeout';
                 syslog(LOG_ERR, 'RadiusError: ' . radius_strerror($radius));
             } else {
                 switch ($request) {
@@ -652,13 +671,16 @@ class Radius extends Base implements IAuthConnector
                                 $this->syncDefaultGroups
                             );
                         }
+                        $this->lastResult = 'accept';
                         return true;
                         break;
                     case RADIUS_ACCESS_REJECT:
+                        $this->lastResult = 'reject';
                         return false;
                         break;
                     default:
                         // unexpected result, log
+                        $this->lastResult = 'error';
                         syslog(LOG_ERR, 'Radius unexpected response:' . $request);
                 }
             }

--- a/src/opnsense/scripts/openvpn/user_pass_verify.php
+++ b/src/opnsense/scripts/openvpn/user_pass_verify.php
@@ -156,6 +156,18 @@ function do_auth($common_name, $serverid, $method, $auth_file)
                 }
                 return true;
             }
+            // only cascade on a decisive answer; an upstream that didn't
+            // respond may dedup the next request and suppress new MFA prompts
+            if (
+                method_exists($authenticator, 'getLastResult')
+                && $authenticator->getLastResult() === 'timeout'
+            ) {
+                syslog(
+                    LOG_WARNING,
+                    "auth source '{$authName}' did not respond for user '{$username}', not cascading"
+                );
+                break;
+            }
         }
     }
     return "user '{$username}' could not authenticate.";

--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -99,6 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $pconfig['radius_acct_port'] = $a_server[$id]['radius_acct_port'] ?? '';
             $pconfig['radius_secret'] = $a_server[$id]['radius_secret'] ?? '';
             $pconfig['radius_timeout'] = $a_server[$id]['radius_timeout'] ?? '';
+            $pconfig['radius_max_retries'] = $a_server[$id]['radius_max_retries'] ?? '';
             $pconfig['radius_stationid'] = $a_server[$id]['radius_stationid'] ?? '';
 
             if (!empty($pconfig['radius_auth_port']) &&
@@ -217,6 +218,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       if (($pconfig['type'] == "radius") && isset($pconfig['radius_timeout']) && !empty($pconfig['radius_timeout']) && (!is_numeric($pconfig['radius_timeout']) || (is_numeric($pconfig['radius_timeout']) && ($pconfig['radius_timeout'] <= 0)))) {
           $input_errors[] = gettext("RADIUS Timeout value must be numeric and positive.");
       }
+      if (($pconfig['type'] == "radius") && isset($pconfig['radius_max_retries']) && !empty($pconfig['radius_max_retries']) && (!is_numeric($pconfig['radius_max_retries']) || (is_numeric($pconfig['radius_max_retries']) && ($pconfig['radius_max_retries'] <= 0)))) {
+          $input_errors[] = gettext("RADIUS Max Retries value must be numeric and positive.");
+      }
       if (empty($pconfig['name'])) {
           $input_errors[] = gettext('A server name must be provided.');
       } elseif (strpos($pconfig['name'], ',') !== false) {
@@ -276,6 +280,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                   $server['radius_timeout'] = $pconfig['radius_timeout'];
               } else {
                   $server['radius_timeout'] = 5;
+              }
+
+              if (!empty($pconfig['radius_max_retries'])) {
+                  $server['radius_max_retries'] = $pconfig['radius_max_retries'];
+              } else {
+                  unset($server['radius_max_retries']);
               }
 
               if (!empty($pconfig['radius_stationid'])) {
@@ -368,6 +378,7 @@ $all_authfields = [
     'radius_secret',
     'radius_srvcs',
     'radius_timeout',
+    'radius_max_retries',
     'radius_stationid',
     'sync_create_local_users',
     'sync_memberof',
@@ -861,6 +872,17 @@ endif; ?>
                       <br /><?= gettext("This value controls how long, in seconds, that the RADIUS server may take to respond to an authentication request.") ?>
                       <br /><?= gettext("If left blank, the default value is 5 seconds.") ?>
                       <br /><br /><?= gettext("NOTE: If you are using an interactive two-factor authentication system, increase this timeout to account for how long it will take the user to receive and enter a token.") ?>
+                    </div>
+                  </td>
+                </tr>
+                <tr class="auth_radius auth_options hidden">
+                  <td><a id="help_for_radius_max_retries" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Max Retries");?></td>
+                  <td>
+                    <input name="radius_max_retries" type="text" id="radius_max_retries" size="20" value="<?=$pconfig['radius_max_retries'];?>"/>
+                    <div class="hidden" data-for="help_for_radius_max_retries">
+                      <br /><?= gettext("Maximum number of request attempts to send to the RADIUS server before giving up.") ?>
+                      <br /><?= gettext("If left blank, the default value is 3.") ?>
+                      <br /><br /><?= gettext("NOTE: If you are using an interactive two-factor authentication system, raise this value (and/or Authentication Timeout) to extend the approval window the user has to acknowledge the prompt.") ?>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.7
- Extent of AI involvement: Code review, test. Also all changes were tested before submitting by me.

---

**Describe the problem**

OpenVPN authentication via RADIUS to an interactive-2FA backend (e.g. NPS with the NPS Extension for Microsoft Entra MFA) is unreliable due to a hardcoded retry count and an unconditional authmode-cascade on timeout. See #10270  for the full reproduction.

---

**Describe the proposed solution**

1. Configurable `radius_max_retries`. Plumb the existing libradius `max_tries` parameter through `OPNsense\Auth\Radius::setProperties()` and add a UI field next to "Authentication Timeout" under System → Access → Servers. The class default of 3 is preserved when the field is empty, so existing installs are unchanged. Users with interactive 2FA backends can raise it (e.g. 20) to extend the per-attempt approval window without touching any other knob.
2. Suppress authmode cascade on RADIUS timeout. Record the outcome of each `authenticate()` call on the `Radius` class as one of `accept`, `reject`, `timeout`, or `error`, exposed via a new `getLastResult()` method. In `user_pass_verify.php`, after a failed authenticate(), `break` out of the authmode foreach if the previous source returned `timeout`. Explicit Access-Reject still cascades, preserving multi-source flows such as a Local-then-RADIUS fall-through, or routing users that exist in NPS2 but not NPS1.

The cascade-suppression check uses `method_exists()` against the authenticator, so non-Radius authenticators behaviour is unchanged.

Validation against the live setup described in the issue: with `radius_max_retries=20`, an end-to-end MFA approval that previously failed at ~9 seconds now succeeds at any point within the configured budget; with the cascade-suppression in place a no-tap negative test produces 20 retransmits to the primary NPS, zero traffic to the secondary, and a single-line `auth source '...' did not respond ... skipping remaining auth sources` warning in syslog.

Compared to the log in the related Issue, only sends request to the IP of one NPS Server. Still timeouts after reaching `radius_max_retries=20` 
```
14:49:47.641163 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:49:50.673553 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:49:53.827342 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:49:56.935630 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:00.068626 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:03.088720 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:06.127568 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:09.310343 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:12.498892 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:15.671278 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:18.731801 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:21.791243 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:24.815799 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:27.849564 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:30.913266 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:34.001625 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:37.100363 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:40.107626 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:43.128629 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:50:46.208645 IP 10.20.30.12.64201 > 10.20.30.31.1812: RADIUS, Access-Request (1), id: 0x7f length: 120
14:51:29.350378 IP 10.20.30.31.1812 > 10.20.30.12.64201: RADIUS, Access-Reject (3), id: 0x7f length: 38
```
---

**Related issue**

#10270 
