### PR TITLE
ntp: fix acl

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Ntpd/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Ntpd/ACL/ACL.xml
@@ -6,22 +6,22 @@
         </patterns>
     </page-services-ntpd>
     <page-services-ntp-gps>
-        <name>Status: NTP GPS</name>
+        <name>Services: NTP GPS</name>
         <patterns>
-            <pattern>status_ntpd_gps.php*</pattern>
+            <pattern>services_ntpd_gps.php*</pattern>
         </patterns>
     </page-services-ntp-gps>
     <page-status-ntp>
         <name>Status: NTP</name>
         <patterns>
-            <pattern>/ui/ntpd/status/*</pattern>
-            <pattern>/api/ntpd/service/status</pattern>
+            <pattern>ui/ntpd/status/*</pattern>
+            <pattern>api/ntpd/service/status</pattern>
         </patterns>
     </page-status-ntp>
     <page-services-ntp-pps>
-        <name>Status: NTP PPS</name>
+        <name>Services: NTP PPS</name>
         <patterns>
-            <pattern>status_ntpd_pps.php*</pattern>
+            <pattern>services_ntpd_pps.php*</pattern>
         </patterns>
     </page-services-ntp-pps>
     <page-status-systemlogs-ntpd>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

**Describe the problem**

- The NTP acl has the GPS and PPS pages as status pages even though they are services.
- The MVC status page had a leading /.

Both of these issues make these pages inaccessible to anyone but full admins.

---