### PR TITLE
radvd: allow disabling DNSSL per interface #10282

### DIFF
--- a/src/etc/inc/plugins.inc.d/radvd.inc
+++ b/src/etc/inc/plugins.inc.d/radvd.inc
@@ -340,7 +340,9 @@ function radvd_configure_do($verbose = false, $ignorelist = [])
                 $rdnss[] = $server;
             }
 
-            if (count($searchlist_tmp)) {
+            if (count($searchlist_tmp) == 1 && $searchlist_tmp[0] == '.') {
+                /* explicitly disabled */
+            } elseif (count($searchlist_tmp)) {
                 $dnssl = $searchlist_tmp;
             } elseif (!empty($config['system']['domain'])) {
                 $dnssl = [$config['system']['domain']];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Radvd/forms/dialogEntry.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Radvd/forms/dialogEntry.xml
@@ -192,7 +192,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help>The default is to use the domain name of this system as the DNSSL option. You may specify explicit domains here instead.</help>
+        <help>The default is to use the domain name of this system as the DNSSL option. You may specify explicit domains here instead. Use "." by itself to disable DNS search domains.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>

--- a/src/opnsense/mvc/app/models/OPNsense/Radvd/Radvd.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Radvd/Radvd.php
@@ -37,6 +37,12 @@ use OPNsense\Base\Messages\Message;
  */
 class Radvd extends BaseModel
 {
+    private function isValidSearchDomain(string $domain): bool
+    {
+        return filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false &&
+            filter_var($domain, FILTER_VALIDATE_IP) === false;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -83,6 +89,27 @@ class Radvd extends BaseModel
                             );
                             break;
                     }
+                }
+            }
+
+            $dnssl = $entry->DNSSL->getValues();
+            if (in_array('.', $dnssl, true) && count($dnssl) > 1) {
+                $messages->appendMessage(
+                    new Message(
+                        gettext('Use "." by itself to disable DNS search domains.'),
+                        $key . '.DNSSL'
+                    )
+                );
+            }
+            foreach ($dnssl as $domain) {
+                if ($domain !== '.' && !$this->isValidSearchDomain($domain)) {
+                    $messages->appendMessage(
+                        new Message(
+                            gettext('A DNS search domain must be a valid hostname.'),
+                            $key . '.DNSSL'
+                        )
+                    );
+                    break;
                 }
             }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Radvd/Radvd.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Radvd/Radvd.xml
@@ -60,11 +60,7 @@
                 <AddressFamily>ipv6</AddressFamily>
                 <AsList>Y</AsList>
             </RDNSS>
-            <DNSSL type="HostnameField">
-                <IsDNSName>Y</IsDNSName>
-                <IpAllowed>N</IpAllowed>
-                <AsList>Y</AsList>
-            </DNSSL>
+            <DNSSL type="CSVListField"/>
             <dns type="BooleanField">
                 <Required>Y</Required>
                 <Default>1</Default>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Models used: Opus 4.6 and GPT-5.5
- Extent of AI involvement: Prototyping and validation, not a single word on the Issue or PR text was touched by an LLM.

---

**Describe the problem**

The **DNS Search List (DNSSL)** can't be disabled without also disabling **Recursive DNS Servers (RDNSS)** which may lead to adverse effects with certain devices, I only observed weirdness with Android phones.

---

**Describe the proposed solution**

Entering `.` into the **DNS Search List (DNSSL)** field will omit the relevant section for that interface in radvd.conf entirely per https://github.com/opnsense/core/issues/10282#issuecomment-4414880741.

---

**Related issue**

#10282

---

I already tried the patch for a brief period in isolation, it works as expected. 