### PR TITLE
Services: Kea DHCPv4/6: Enable internalModelSafeDelete due to model relation field usage

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv4Controller.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv4Controller.php
@@ -36,6 +36,7 @@ class Dhcpv4Controller extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'dhcpv4';
     protected static $internalModelClass = 'OPNsense\Kea\KeaDhcpv4';
+    protected static $internalModelUseSafeDelete = true;
 
     /**
      * @inheritdoc

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv6Controller.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/Dhcpv6Controller.php
@@ -36,6 +36,7 @@ class Dhcpv6Controller extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'dhcpv6';
     protected static $internalModelClass = 'OPNsense\Kea\KeaDhcpv6';
+    protected static $internalModelUseSafeDelete = true;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Lots of model relation fields, delete leave orphans behind.

---

**Describe the proposed solution**

internalModelSafeDelete prevents deletes if related children of an item are found

---

**Related issue**

None
