### PR TITLE
Captive Portal: adjust redirection for modern portal support

### DIFF
--- a/src/etc/inc/plugins.inc.d/captiveportal.inc
+++ b/src/etc/inc/plugins.inc.d/captiveportal.inc
@@ -156,44 +156,6 @@ function captiveportal_firewall($fw)
                         ]
                     );
 
-                    // Restrict authenticated clients to proxy only (IPv4)
-                    $fw->registerForwardRule(
-                        2,
-                        [
-                            'interface' => $intf,
-                            'nordr' => false,
-                            'ipprotocol' => 'inet',
-                            'protocol' => 'tcp',
-                            'from' => "<__captiveportal_zone_{$zoneid}>",
-                            'to' => '(self)',
-                            'to_port' => $to_port,
-                            'target' => '127.0.0.1',
-                            'localport' => $rdr_port,
-                            'natreflection' => 'disable',
-                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
-                            '#ref' => "ui/captiveportal#edit={$uuid}"
-                        ]
-                    );
-
-                    // Restrict authenticated clients to proxy only (IPv6)
-                    $fw->registerForwardRule(
-                        2,
-                        [
-                            'interface' => $intf,
-                            'nordr' => false,
-                            'ipprotocol' => 'inet6',
-                            'protocol' => 'tcp',
-                            'from' => "<__captiveportal_zone_{$zoneid}>",
-                            'to' => '(self)',
-                            'to_port' => $to_port,
-                            'target' => $intf . 'ip',
-                            'localport' => $rdr_port,
-                            'natreflection' => 'disable',
-                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
-                            '#ref' => "ui/captiveportal#edit={$uuid}"
-                        ]
-                    );
-
                     $fw->registerFilterRule(
                         2,
                         [

--- a/src/etc/inc/plugins.inc.d/captiveportal.inc
+++ b/src/etc/inc/plugins.inc.d/captiveportal.inc
@@ -107,51 +107,92 @@ function captiveportal_firewall($fw)
                     ]
                 );
 
-                // forward to localhost if not authenticated (IPv4)
-                $fw->registerForwardRule(
-                    2,
-                    [
-                        'interface' => $intf,
-                        'nordr' => false,
-                        'ipprotocol' => 'inet',
-                        'protocol' => 'tcp',
-                        'from' => "<__captiveportal_zone_{$zoneid}>",
-                        'from_not' => true,
-                        'to' => "<__captiveportal_zone_{$zoneid}>",
-                        'to_not' => true,
-                        'to_port' => '80',
-                        'target' => '127.0.0.1',
-                        'localport' => (9000 + (int)$zoneid),
-                        'natreflection' => 'disable',
-                        'descr' => "Redirect to Captive Portal (zone {$zoneid})",
-                        '#ref' => "ui/captiveportal#edit={$uuid}"
-                    ]
-                );
-
-                // forward to localhost if not authenticated (IPv6)
-                $fw->registerForwardRule(
-                    2,
-                    [
-                        'interface' => $intf,
-                        'nordr' => false,
-                        'ipprotocol' => 'inet6',
-                        'protocol' => 'tcp',
-                        'from' => "<__captiveportal_zone_{$zoneid}>",
-                        'from_not' => true,
-                        'to' => "<__captiveportal_zone_{$zoneid}>",
-                        'to_not' => true,
-                        'to_port' => '80',
-                        'target' => $intf . 'ip',
-                        'localport' => (9000 + (int)$zoneid),
-                        'natreflection' => 'disable',
-                        'descr' => "Redirect to Captive Portal (zone {$zoneid})",
-                        '#ref' => "ui/captiveportal#edit={$uuid}"
-                    ]
-                );
-
                 foreach (['80', '443'] as $to_port) {
                     $rdr_port = $to_port === '443' ? (8000 + (int)$zoneid) : (9000 + (int)$zoneid);
+                    $to = $to_port === '443' ? "(self)" : "<__captiveportal_zone_{$zoneid}>";
+                    $to_not = $to_port === '443' ? false : true;
                     $proto = $to_port === '443' ? 'HTTPS' : 'HTTP';
+
+                    // forward HTTP(S) to localhost if not authenticated (IPv4)
+                    // Only match HTTPS headed to (self) to facilitate RFC 8908
+                    $fw->registerForwardRule(
+                        2,
+                        [
+                            'interface' => $intf,
+                            'nordr' => false,
+                            'ipprotocol' => 'inet',
+                            'protocol' => 'tcp',
+                            'from' => "<__captiveportal_zone_{$zoneid}>",
+                            'from_not' => true,
+                            'to' => $to,
+                            'to_not' => $to_not,
+                            'to_port' => $to_port,
+                            'target' => '127.0.0.1',
+                            'localport' => $rdr_port,
+                            'natreflection' => 'disable',
+                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
+                            '#ref' => "ui/captiveportal#edit={$uuid}"
+                        ]
+                    );
+
+                    // forward to localhost if not authenticated (IPv6)
+                    $fw->registerForwardRule(
+                        2,
+                        [
+                            'interface' => $intf,
+                            'nordr' => false,
+                            'ipprotocol' => 'inet6',
+                            'protocol' => 'tcp',
+                            'from' => "<__captiveportal_zone_{$zoneid}>",
+                            'from_not' => true,
+                            'to' => $to,
+                            'to_not' => $to_not,
+                            'to_port' => $to_port,
+                            'target' => $intf . 'ip',
+                            'localport' => $rdr_port,
+                            'natreflection' => 'disable',
+                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
+                            '#ref' => "ui/captiveportal#edit={$uuid}"
+                        ]
+                    );
+
+                    // Restrict authenticated clients to proxy only (IPv4)
+                    $fw->registerForwardRule(
+                        2,
+                        [
+                            'interface' => $intf,
+                            'nordr' => false,
+                            'ipprotocol' => 'inet',
+                            'protocol' => 'tcp',
+                            'from' => "<__captiveportal_zone_{$zoneid}>",
+                            'to' => '(self)',
+                            'to_port' => $to_port,
+                            'target' => '127.0.0.1',
+                            'localport' => $rdr_port,
+                            'natreflection' => 'disable',
+                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
+                            '#ref' => "ui/captiveportal#edit={$uuid}"
+                        ]
+                    );
+
+                    // Restrict authenticated clients to proxy only (IPv6)
+                    $fw->registerForwardRule(
+                        2,
+                        [
+                            'interface' => $intf,
+                            'nordr' => false,
+                            'ipprotocol' => 'inet6',
+                            'protocol' => 'tcp',
+                            'from' => "<__captiveportal_zone_{$zoneid}>",
+                            'to' => '(self)',
+                            'to_port' => $to_port,
+                            'target' => $intf . 'ip',
+                            'localport' => $rdr_port,
+                            'natreflection' => 'disable',
+                            'descr' => "Redirect to Captive Portal (zone {$zoneid})",
+                            '#ref' => "ui/captiveportal#edit={$uuid}"
+                        ]
+                    );
 
                     $fw->registerFilterRule(
                         2,

--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
@@ -162,47 +162,50 @@ class AccessController extends ApiControllerBase
             $this->request->isGet() &&
             $this->request->getHeader("accept") == "application/captive+json"
         ) {
-            $result = [];
             $zoneId = $this->request->getHeader("zoneid");
-            $clientSession = $this->clientSession($zoneId);
-            $captive = $clientSession["clientState"] != "AUTHORIZED";
             $host = $this->request->getHeader('X-Forwarded-Host');
 
-            $zone = (new \OPNsense\CaptivePortal\CaptivePortal())->getByZoneId($zoneId);
+            // if zoneid or host headers missing, we are not proxied
+            if ($zoneId !== '' && $host !== '') {
+                $result = [];
+                $clientSession = $this->clientSession($zoneId);
+                $captive = $clientSession["clientState"] != "AUTHORIZED";
+                $zone = (new \OPNsense\CaptivePortal\CaptivePortal())->getByZoneId($zoneId);
 
-            if ($zone != null && !empty($clientSession['startTime'])) {
-                $startTime = (int)$clientSession['startTime'];
-                $secondsPassed = time() - $startTime;
-                $remainingTimes = [];
+                if ($zone != null && !empty($clientSession['startTime'])) {
+                    $startTime = (int)$clientSession['startTime'];
+                    $secondsPassed = time() - $startTime;
+                    $remainingTimes = [];
 
-                if (!$zone->hardtimeout->isEmpty()) {
-                    $timeout = $zone->hardtimeout->asInt() * 60;
-                    if ($secondsPassed < $timeout) {
-                        $remainingTimes[] = $timeout - $secondsPassed;
+                    if (!$zone->hardtimeout->isEmpty()) {
+                        $timeout = $zone->hardtimeout->asInt() * 60;
+                        if ($secondsPassed < $timeout) {
+                            $remainingTimes[] = $timeout - $secondsPassed;
+                        }
+                    }
+
+                    if (!empty($clientSession['acc_session_timeout'])) {
+                        $timeout = (int)$clientSession['acc_session_timeout'];
+                        if ($secondsPassed < $timeout) {
+                            $remainingTimes[] = $timeout - $secondsPassed;
+                        }
+                    }
+
+                    if (!empty($remainingTimes)) {
+                        $result['seconds-remaining'] = min($remainingTimes);
                     }
                 }
 
-                if (!empty($clientSession['acc_session_timeout'])) {
-                    $timeout = (int)$clientSession['acc_session_timeout'];
-                    if ($secondsPassed < $timeout) {
-                        $remainingTimes[] = $timeout - $secondsPassed;
-                    }
-                }
+                $this->response->setRawHeader("Cache-Control: private");
+                $this->response->setContentType("application/captive+json");
 
-                if (!empty($remainingTimes)) {
-                    $result['seconds-remaining'] = min($remainingTimes);
-                }
+                $result["captive"] = $captive;
+                $result["user-portal-url"] = "https://{$host}/index.html";
+
+                $this->response->setContent($result);
+
+                return;
             }
-
-            $this->response->setRawHeader("Cache-Control: private");
-            $this->response->setContentType("application/captive+json");
-
-            $result["captive"] = $captive;
-            $result["user-portal-url"] = "https://{$host}/index.html";
-
-            $this->response->setContent($result);
-
-            return;
         }
 
         $this->response->setStatusCode(400);

--- a/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
+++ b/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
@@ -85,7 +85,7 @@ server.port              = {{ cp_zone_item.zoneid|int + 8000  }}
 url.redirect-code        = 302
 
 $HTTP["host"] !~ "(.*{{ cp_zone_item.redirect_host_match }}.*)" {
-    $HTTP["url"] !~ "^/api/captiveportal/access/api$" {
+    $HTTP["url"] !~ "^/api/captiveportal/access" {
         $HTTP["host"] =~ "([^:/]+)" {
             url.redirect = ( "^(.*)$" => "{{ cp_zone_item.redirect_host }}?redirurl=%1$1")
         }
@@ -93,7 +93,7 @@ $HTTP["host"] !~ "(.*{{ cp_zone_item.redirect_host_match }}.*)" {
 }
 
 $SERVER["socket"] == "[::]:{{ cp_zone_item.zoneid|int + 8000 }}" {
-    $HTTP["url"] !~ "^/api/captiveportal/access/api$" {
+    $HTTP["url"] !~ "^/api/captiveportal/access" {
         $HTTP["host"] !~ "(.*{{cp_zone_item.redirect_host_match}}.*)" {
             $HTTP["host"] =~ "(\[[^\]]+\]|[^:/]+)" {
                 url.redirect = ( "^(.*)$" => "{{cp_zone_item.redirect_host}}?redirurl=%1$1")

--- a/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
+++ b/src/opnsense/service/templates/OPNsense/Captiveportal/lighttpd-zone.conf
@@ -85,16 +85,20 @@ server.port              = {{ cp_zone_item.zoneid|int + 8000  }}
 url.redirect-code        = 302
 
 $HTTP["host"] !~ "(.*{{ cp_zone_item.redirect_host_match }}.*)" {
-	$HTTP["host"] =~ "([^:/]+)" {
-		url.redirect = ( "^(.*)$" => "{{ cp_zone_item.redirect_host }}?redirurl=%1$1")
-	}
+    $HTTP["url"] !~ "^/api/captiveportal/access/api$" {
+        $HTTP["host"] =~ "([^:/]+)" {
+            url.redirect = ( "^(.*)$" => "{{ cp_zone_item.redirect_host }}?redirurl=%1$1")
+        }
+    }
 }
 
 $SERVER["socket"] == "[::]:{{ cp_zone_item.zoneid|int + 8000 }}" {
-	$HTTP["host"] !~ "(.*{{cp_zone_item.redirect_host_match}}.*)" {
-		$HTTP["host"] =~ "(\[[^\]]+\]|[^:/]+)" {
-			url.redirect = ( "^(.*)$" => "{{cp_zone_item.redirect_host}}?redirurl=%1$1")
-		}
+    $HTTP["url"] !~ "^/api/captiveportal/access/api$" {
+        $HTTP["host"] !~ "(.*{{cp_zone_item.redirect_host_match}}.*)" {
+            $HTTP["host"] =~ "(\[[^\]]+\]|[^:/]+)" {
+                url.redirect = ( "^(.*)$" => "{{cp_zone_item.redirect_host}}?redirurl=%1$1")
+            }
+        }
     }
     {% if cp_zone_item.certificate|default("") != "" %}
     ssl.engine = "enable"


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Currently, the pf rules managing portal access force redirection for unauthenticated clients. There are however two issues related to the modern portal support documented here: https://docs.opnsense.org/manual/captiveportal.html#modern-portal-support, and only specifically when the administrator has set `https://<firewall_fqdn>/api/captiveportal/access/api`.

1. Clients connecting to `https://<firewall_fqdn>/api/captiveportal/access/api` will set the `Host` header to <firewall_fqdn>. If this doesn't contain `8000 + zoneid` as a manual header, the redirect rule still applies and the client gets a portal login page instead of a response to the `api` endpoint. This can be solved by exluding the redirect match in the lighttpd config:

```
$HTTP["url"] !~ "^/api/captiveportal/access/api$"
```

Which means that redirection for requests going to `/api/captiveportal/access/api` *exactly* must always be skipped, so that the request can be properly proxied as configured further down in the lighttpd configuration.

2. Once a client becomes authenticated, no HTTP(S) requests to the firewall are redirected anymore, meaning the client cannot access `/api/captiveportal/access/api`, as it's now sent to the normal OPNsense WebGUI. It will receive a response, but the endpoint cannot determine `zoneid`, nor `host`, since the request wasn't proxied. This response is therefore invalid.

---

**Describe the proposed solution**

Possible solutions:

1. Restricting all authenticated clients to the proxy as well, which is what this PR proposes (but only for discussion purposes). This means no client in a portal network can access the normal GUI anymore.
2. Create a special clause in the OPNsense WebGUI, redirecting requests to `/api/captiveportal/access/api` to localhost.
3. Do nothing and instead document that administrators should always specify the `8000 + zoneid` port. This has the drawback that it could break existing setups, though it is unlikely this would have worked *after* authentication to begin with.

---

**Related issue**

If this pull request relates to an issue, link it here.
