### PR TITLE
dnsmasq: Ignore DHCP names for 'wpad' to fix CERT Vulnerability VU#598349

### DIFF
--- a/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
+++ b/src/opnsense/service/templates/OPNsense/Dnsmasq/dnsmasq.conf
@@ -362,3 +362,8 @@ tag:{{ tag }},
 {% if dnsmasq.no_ident == '1' %}
 no-ident
 {% endif %}
+
+# If a DHCP client claims that its name is "wpad", ignore that.
+# This fixes a security hole. see CERT Vulnerability VU#598349
+dhcp-name-match=set:wpad-ignore,wpad
+dhcp-ignore-names=tag:wpad-ignore


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

```
Fetching dnsmasq.pkg: ... done
Verifying signature with trusted certificate pkg.opnsense.org.20260120... done
dnsmasq-2.92_2,1: already unlocked
Installing dnsmasq-2.92.r2,1...
package dnsmasq is already installed, forced install
Extracting dnsmasq-2.92.r2,1: 100%

Message from dnsmasq-2.92.r2,1:
--

To enable dnsmasq, edit /usr/local/etc/dnsmasq.conf and
set dnsmasq_enable="YES" in /etc/rc.conf[.local]
Further options and actions are documented inside
/usr/local/etc/rc.d/dnsmasq
NOTE: when using dnssec, inaccurate system clocks
can cause DNS resolution to fail
because DNSSEC signatures may then not validate.
SECURITY RECOMMENDATION

~~~~~~~~~~~~~~~~~~~~~~~

It is recommended to enable the wpad-related options
at the end of the configuration file (you may need to
copy them from the example file to yours) to fix
CERT Vulnerability VU#598349.
```

---

**Describe the proposed solution**

Use recommended settings from dnsmasq.conf.sample at the end of our template.

---

**Related issue**

None
