### PR TITLE
Services: Kea DHCPv4/6: Add decline_probation_period and set lower default to mitigate faulty client implementations to consume the whole pool

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
@@ -49,6 +49,14 @@
         <help>The valid life time of the leases given out by the server in seconds.</help>
     </field>
     <field>
+        <id>dhcpv4.general.decline_probation_period</id>
+        <label>Decline Probation Period</label>
+        <type>text</type>
+        <hint>600</hint>
+        <advanced>true</advanced>
+        <help>Defines how long an address that has been detected as duplicate via DHCPDECLINE will be prevented to be given out to other clients.</help>
+    </field>
+    <field>
         <id>dhcpv4.general.fwrules</id>
         <label>Firewall rules</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
@@ -49,6 +49,14 @@
         <help>The valid life time of the leases given out by the server in seconds.</help>
     </field>
     <field>
+        <id>dhcpv6.general.decline_probation_period</id>
+        <label>Decline Probation Period</label>
+        <type>text</type>
+        <hint>600</hint>
+        <advanced>true</advanced>
+        <help>Defines how long an address that has been detected as duplicate via DHCPDECLINE will be prevented to be given out to other clients.</help>
+    </field>
+    <field>
         <id>dhcpv6.general.mac_sources</id>
         <label>MAC sources</label>
         <type>select_multiple</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -320,6 +320,8 @@ class KeaDhcpv4 extends BaseModel
         $cnf = [
             'Dhcp4' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
+                'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
+                                            $this->general->service_sockets_max_retries->asInt() : 600,
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     'dhcp-socket-type' => $this->general->dhcp_socket_type->getValue(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -321,7 +321,7 @@ class KeaDhcpv4 extends BaseModel
             'Dhcp4' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
                 'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
-                                            $this->general->service_sockets_max_retries->asInt() : 600,
+                                            $this->general->decline_probation_period->asInt() : 600,
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     'dhcp-socket-type' => $this->general->dhcp_socket_type->getValue(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -320,8 +320,8 @@ class KeaDhcpv4 extends BaseModel
         $cnf = [
             'Dhcp4' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
-                'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
-                                            $this->general->decline_probation_period->asInt() : 600,
+                'decline-probation-period' => $this->general->decline_probation_period->isSet() ?
+                                              $this->general->decline_probation_period->asInt() : 600,
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     'dhcp-socket-type' => $this->general->dhcp_socket_type->getValue(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -18,6 +18,9 @@
                 <Default>4000</Default>
                 <Required>Y</Required>
             </valid_lifetime>
+            <decline_probation_period type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </decline_probation_period>
             <fwrules type="BooleanField">
                 <Required>Y</Required>
                 <Default>1</Default>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -354,7 +354,7 @@ class KeaDhcpv6 extends BaseModel
             'Dhcp6' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
                 'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
-                                            $this->general->service_sockets_max_retries->asInt() : 600,
+                                            $this->general->decline_probation_period->asInt() : 600,
                 'mac-sources' => $this->general->mac_sources->getValues(),
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -353,6 +353,8 @@ class KeaDhcpv6 extends BaseModel
         $cnf = [
             'Dhcp6' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
+                'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
+                                            $this->general->service_sockets_max_retries->asInt() : 600,
                 'mac-sources' => $this->general->mac_sources->getValues(),
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -353,8 +353,8 @@ class KeaDhcpv6 extends BaseModel
         $cnf = [
             'Dhcp6' => [
                 'valid-lifetime' => $this->general->valid_lifetime->asInt(),
-                'decline-probation-period' => !$this->general->decline_probation_period->isEmpty() ?
-                                            $this->general->decline_probation_period->asInt() : 600,
+                'decline-probation-period' => $this->general->decline_probation_period->isSet() ?
+                                              $this->general->decline_probation_period->asInt() : 600,
                 'mac-sources' => $this->general->mac_sources->getValues(),
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -18,6 +18,9 @@
                 <Default>4000</Default>
                 <Required>Y</Required>
             </valid_lifetime>
+            <decline_probation_period type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </decline_probation_period>
             <mac_sources type="OptionField">
                 <Default>ipv6-link-local</Default>
                 <Required>Y</Required>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

A faulty client implementation can cycle through all available leases in a pool, all declined addresses will be reserved for 24 hours with the current defaults.

---

**Describe the proposed solution**

Add:
https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#duplicate-addresses-dhcpdecline-support
https://kea.readthedocs.io/en/latest/arm/dhcp6-srv.html#duplicate-addresses-dhcpdecline-support

Set a lower default to 10 minutes. In very large networks this might need to be increased, but for default /24 networks this seems to be a good default.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10285
Fixes: https://forum.opnsense.org/index.php?topic=51324.45
