### PR TITLE
Services: Kea DHCPv4/6: Some cleanup regarding isEmpty usage when 0 is allowed in IntegerFields, and ensure no IntegerField accepts negative values

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -178,7 +178,7 @@ class KeaDhcpv4 extends BaseModel
                 'reservations' => []
             ];
             /* add valid-lifetime at this level if given */
-            if (!$subnet->valid_lifetime->isEmpty()) {
+            if ($subnet->valid_lifetime->isSet()) {
                 $record['valid-lifetime'] = $subnet->valid_lifetime->asInt();
             }
             /* add description and other custom keys - not parsed by KEA */
@@ -324,9 +324,9 @@ class KeaDhcpv4 extends BaseModel
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     'dhcp-socket-type' => $this->general->dhcp_socket_type->getValue(),
                     /* socket retries are on a per-interface basis, failing to open one won't affect others */
-                    'service-sockets-max-retries' => !$this->general->service_sockets_max_retries->isEmpty() ?
+                    'service-sockets-max-retries' => $this->general->service_sockets_max_retries->isSet() ?
                                                      $this->general->service_sockets_max_retries->asInt() : 5,
-                    'service-sockets-retry-wait-time' => !$this->general->service_sockets_retry_wait_time->isEmpty() ?
+                    'service-sockets-retry-wait-time' => $this->general->service_sockets_retry_wait_time->isSet() ?
                                                          $this->general->service_sockets_retry_wait_time->asInt() : 5000,
                 ],
                 'lease-database' => [

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -12,9 +12,14 @@
             <interfaces type="InterfaceField">
                 <Multiple>Y</Multiple>
             </interfaces>
-            <service_sockets_max_retries type="IntegerField"/>
-            <service_sockets_retry_wait_time type="IntegerField"/>
+            <service_sockets_max_retries type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </service_sockets_max_retries>
+            <service_sockets_retry_wait_time type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </service_sockets_retry_wait_time>
             <valid_lifetime type="IntegerField">
+                <MinimumValue>0</MinimumValue>
                 <Default>4000</Default>
                 <Required>Y</Required>
             </valid_lifetime>
@@ -79,7 +84,9 @@
                         </check001>
                     </Constraints>
                 </subnet>
-                <valid_lifetime type="IntegerField"/>
+                <valid_lifetime type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                </valid_lifetime>
                 <next_server type="NetworkField">
                     <NetMaskAllowed>N</NetMaskAllowed>
                     <AddressFamily>ipv4</AddressFamily>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -170,7 +170,7 @@ class KeaDhcpv6 extends BaseModel
                 'reservations' => []
             ];
             /* add valid-lifetime at this level if given */
-            if (!$subnet->valid_lifetime->isEmpty()) {
+            if ($subnet->valid_lifetime->isSet()) {
                 $record['valid-lifetime'] = $subnet->valid_lifetime->asInt();
             }
             $device = Util::getRealInterface($subnet->interface->getValue(), 'inet6');
@@ -357,9 +357,9 @@ class KeaDhcpv6 extends BaseModel
                 'interfaces-config' => [
                     'interfaces' => $this->getConfigPhysicalInterfaces(),
                     /* socket retries are on a per-interface basis, failing to open one won't affect others */
-                    'service-sockets-max-retries' => !$this->general->service_sockets_max_retries->isEmpty() ?
+                    'service-sockets-max-retries' => $this->general->service_sockets_max_retries->isSet() ?
                                                      $this->general->service_sockets_max_retries->asInt() : 5,
-                    'service-sockets-retry-wait-time' => !$this->general->service_sockets_retry_wait_time->isEmpty() ?
+                    'service-sockets-retry-wait-time' => $this->general->service_sockets_retry_wait_time->isSet() ?
                                                          $this->general->service_sockets_retry_wait_time->asInt() : 5000,
                 ],
                 'lease-database' => [

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -12,9 +12,14 @@
             <interfaces type="InterfaceField">
                 <Multiple>Y</Multiple>
             </interfaces>
-            <service_sockets_max_retries type="IntegerField"/>
-            <service_sockets_retry_wait_time type="IntegerField"/>
+            <service_sockets_max_retries type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </service_sockets_max_retries>
+            <service_sockets_retry_wait_time type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </service_sockets_retry_wait_time>
             <valid_lifetime type="IntegerField">
+                <MinimumValue>0</MinimumValue>
                 <Default>4000</Default>
                 <Required>Y</Required>
             </valid_lifetime>
@@ -84,7 +89,9 @@
                         </check001>
                     </Constraints>
                 </subnet>
-                <valid_lifetime type="IntegerField"/>
+                <valid_lifetime type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                </valid_lifetime>
                 <allocator type="OptionField">
                     <BlankDesc>Default</BlankDesc>
                     <OptionValues>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Some cleanup regarding isEmpty usage when 0 is allowed in IntegerFields, and ensure no IntegerField accepts negative values.
