### PR TITLE
Services: Kea DHCPv4/6: When serializing the config to json, use JSON_UNESCAPED_UNICODE

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaCtrlAgent.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaCtrlAgent.php
@@ -68,6 +68,6 @@ class KeaCtrlAgent extends BaseModel
             ]
         ];
 
-        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
+        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT, JSON_UNESCAPED_UNICODE), 0600);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDdns.php
@@ -116,6 +116,6 @@ class KeaDdns extends BaseModel
             ]
         ];
 
-        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
+        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT, JSON_UNESCAPED_UNICODE), 0600);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -400,6 +400,6 @@ class KeaDhcpv4 extends BaseModel
                 'server-port' => $ddns->general->server_port->asInt(),
             ];
         }
-        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
+        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 0600);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -433,6 +433,6 @@ class KeaDhcpv6 extends BaseModel
                 'server-port' => $ddns->general->server_port->asInt(),
             ];
         }
-        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT), 0600);
+        File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 0600);
     }
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

KEA uses an input validation that checks the configuration for escaped unicode characters starting with 00, these are considered valid Any other escaped unicode character will refuse the whole config to be loaded.

Ref: https://github.com/isc-projects/kea/blob/476ff110e90b3412fcd1d089b276e86709df5c7f/src/lib/cc/data.cc#L471-L484

---

**Describe the proposed solution**

Using JSON_UNESCAPED_UNICODE will print these characters without escaping.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10296
