### PR TITLE
interfaces: do not drop VIP alias on no-op API edit

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VipSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VipSettingsController.php
@@ -120,14 +120,23 @@ class VipSettingsController extends ApiMutableModelControllerBase
         Config::getInstance()->lock();
         $node = $this->getModel()->getNodeByReference('vip.' . $uuid);
         $validations = [];
-        $post_subnet = '';
-        $post_interface = '';
+        $post_subnet = null;
+        $post_interface = null;
         if (isset($_POST['vip'])) {
-            $post_subnet = !empty($_POST['vip']['network']) ? explode('/', $_POST['vip']['network'])[0] : '';
-            $post_interface = !empty($_POST['vip']['interface']) ? $_POST['vip']['interface'] : '';
+            if (!empty($_POST['vip']['network'])) {
+                $post_subnet = explode('/', $_POST['vip']['network'])[0];
+            } elseif (isset($_POST['vip']['subnet'])) {
+                $post_subnet = $_POST['vip']['subnet'];
+            }
+            if (isset($_POST['vip']['interface'])) {
+                $post_interface = $_POST['vip']['interface'];
+            }
         }
 
-        if ($node != null && $post_subnet != (string)$node->subnet) {
+        $subnet_changed = $post_subnet !== null && $post_subnet != (string)$node?->subnet;
+        $interface_changed = $post_interface !== null && $post_interface != (string)$node?->interface;
+
+        if ($node != null && $subnet_changed) {
             $validations = $this->getModel()->whereUsed((string)$node->subnet);
             if (!empty($validations)) {
                 // XXX a bit unpractical, but we can not validate previous values from the model so
@@ -140,7 +149,7 @@ class VipSettingsController extends ApiMutableModelControllerBase
                 ];
             }
         }
-        if ($node != null && ($post_subnet != (string)$node->subnet || $post_interface != (string)$node->interface)) {
+        if ($node != null && ($subnet_changed || $interface_changed)) {
             $addr = (string)$node->subnet;
             if (Util::isLinkLocal($addr)) {
                 $addr .= "@{$node->interface}";

--- a/src/opnsense/scripts/interfaces/reconfigure_vips.php
+++ b/src/opnsense/scripts/interfaces/reconfigure_vips.php
@@ -78,6 +78,8 @@ foreach (glob("/tmp/delete_vip_*.todo") as $filename) {
         }
         if (isset($addresses[$address])) {
             legacy_interface_deladdress($addresses[$address]['if'], $address, is_ipaddrv6($address) ? 6 : 4);
+            // keep snapshot in sync so the re-add loop below sees the address as missing
+            unset($addresses[$address]);
         } else {
             // not found, likely proxy arp
             $proxyarp = true;


### PR DESCRIPTION
- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.6
- Extent of AI involvement: debugging, code generation, testing

---

**Describe the problem**

When editing a Virtual IP Alias via the API to modify only the description without altering the IP or subnet, the IP is silently dropped from the interface. In the WebGUI, the IP appears to still exist. Clicking "Apply" in the WebGUI is required to restore the IP to the interface.
This issue only occurs when the client POSTs subnet and subnet_bits as separate fields instead of using the combined network field.

---

**Describe the proposed solution**

`VipSettingsController::setItemAction` now only flags an address for deletion when the subnet or interface really changed. Before, any API edit that didn't use the combined `network` field looked like a subnet change, so a delete was scheduled on every call, even description-only edits.

`reconfigure_vips.php` now removes deleted addresses from its in-memory list right after deleting them. The re-add loop uses that list to decide whether an alias is already bound. Without the update, a freshly-deleted address still looked bound, so it was never re-added.

---

**Related issue**

This pull request fixes #10301
