### PR TITLE
Firewall: Rules [new]: Fix automatically generated rules metadata being accidentally overwritten later

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -171,6 +171,9 @@ class FilterController extends FilterBaseController
                 $label = gettext('Automatically generated rules');
                 $record['categories'] = $label;  // Grouping key for tree view
                 $record['category_colors'] = [['name'  => $label]];  // Category formatter metadata
+            } else {
+                /* frontend can format categories with colors */
+                $record['category_colors'] = $this->getCategoryColors($r_categories);
             }
 
             /* frontend can format aliases with an alias icon */
@@ -179,9 +182,6 @@ class FilterController extends FilterBaseController
                     $record["alias_meta_{$field}"] = $this->getNetworks($record[$field]);
                 }
             }
-
-            /* frontend can format categories with colors */
-            $record['category_colors'] = $this->getCategoryColors($r_categories);
             return true;
         };
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -182,6 +182,7 @@ class FilterController extends FilterBaseController
                     $record["alias_meta_{$field}"] = $this->getNetworks($record[$field]);
                 }
             }
+
             return true;
         };
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes empty category for automatically generated rules.