### PR TITLE
Add cmd timeout, error detection and syslog logging to wireguard re-r…

### DIFF
--- a/src/opnsense/scripts/wireguard/reresolve-dns.py
+++ b/src/opnsense/scripts/wireguard/reresolve-dns.py
@@ -1,31 +1,30 @@
 #!/usr/local/bin/python3
 
 """
-Copyright (c) 2023-2026 Ad Schellevis <ad@opnsense.org>
-All rights reserved.
+    Copyright (c) 2023-2026 Ad Schellevis <ad@opnsense.org>
+    All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
- this list of conditions and the following disclaimer.
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
 """
-
 # Python implementation to re-resolve dns entries, for reference see:
 # https://github.com/WireGuard/wireguard-tools/tree/master/contrib/reresolve-dns
 

--- a/src/opnsense/scripts/wireguard/reresolve-dns.py
+++ b/src/opnsense/scripts/wireguard/reresolve-dns.py
@@ -1,75 +1,183 @@
 #!/usr/local/bin/python3
 
 """
-    Copyright (c) 2023 Ad Schellevis <ad@opnsense.org>
-    All rights reserved.
+Copyright (c) 2023-2026 Ad Schellevis <ad@opnsense.org>
+All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 """
+
 # Python implementation to re-resolve dns entries, for reference see:
 # https://github.com/WireGuard/wireguard-tools/tree/master/contrib/reresolve-dns
+
+from typing import Tuple, Union, List, Optional
+import sys
 import glob
 import os
 import time
 import subprocess
+import syslog
 
 
+class Syslogger:
+    """
+    Abstract for syslog to keep the same syntax as logger
+    """
 
-sp = subprocess.run(['/usr/bin/wg', 'show', 'all', 'latest-handshakes'], capture_output=True, text=True)
-ts_now = time.time()
-handshakes = {}
-for line in sp.stdout.split('\n'):
-    parts = line.split()
-    if len(parts) == 3 and parts[2].isdigit():
-        handshakes["%s-%s" % (parts[0], parts[1])] = ts_now - int(parts[2])
+    def __init__(self):
+        syslog.openlog(facility=syslog.LOG_SYSLOG)
+        self._logger = syslog.syslog
+
+    def debug(self, msg):
+        self._logger(syslog.LOG_DEBUG, msg)
+
+    def info(self, msg):
+        self._logger(syslog.LOG_INFO, msg)
+
+    def warning(self, msg):
+        self._logger(syslog.LOG_WARNING, msg)
+
+    def error(self, msg):
+        self._logger(syslog.LOG_ERR, msg)
+
+    def critical(self, msg):
+        self._logger(syslog.LOG_CRIT, msg)
 
 
-for filename in glob.glob('/usr/local/etc/wireguard/*.conf'):
-    this_peer = {}
-    ifname = os.path.basename(filename).split('.')[0]
-    with open(filename, 'r') as fhandle:
-        for line in fhandle:
-            if line.startswith('[Peer]'):
-                this_peer = {'ifname': ifname}
-            elif line.startswith('PublicKey'):
-                this_peer['PublicKey'] = line.split('=', 1)[1].strip()
-            elif line.startswith('Endpoint'):
-                this_peer['Endpoint'] = line.split('=', 1)[1].strip()
+def runner(cmd: Union[List[str], str]) -> Tuple[bool, str]:
+    try:
+        logger.debug("Running command: {}".format(cmd))
+        child = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
+        )
+        stdout, stderr = child.communicate(timeout=60)
+        child.wait(timeout=60)
+        if child.returncode == 0:
+            return True, stdout
+        logger.error(
+            "Command {} failed with exit code {}:\n{}".format(
+                cmd, child.returncode, stderr
+            )
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.error("Command {} took too long: {}".format(cmd, exc))
+    except subprocess.SubprocessError as exc:
+        logger.error("Command {} failed: {}".format(cmd, exc))
+    return False, None
 
-            if 'Endpoint' in this_peer and 'PublicKey' in this_peer:
-                peer_key = "%(ifname)s-%(PublicKey)s" % this_peer
-                if handshakes.get(peer_key, 999) > 135:
-                    # skip if there has been a handshake recently
-                    subprocess.run(
-                        [
-                            '/usr/bin/wg',
-                            'set',
-                            ifname,
-                            'peer',
-                            this_peer['PublicKey'],
-                            'endpoint',
-                            this_peer['Endpoint']
-                        ],
-                        capture_output=True,
-                        text=True
-                    )
-                this_peer = {}
+
+def get_handshakes() -> dict:
+    logger.debug("Getting handshakes")
+    # wg show all latest-handshakes produces one line per peer in for of
+    # iface pubkey epoch-of-last-handshake
+
+    handshakes = {}
+    ts_now = time.time()
+
+    result, content = runner(["/usr/bin/wg", "show", "all", "latest-handshakes"])
+    if not result:
+        return handshakes
+
+    for line in content.split("\n"):
+        parts = line.split()
+        if len(parts) == 3 and parts[2].isdigit():
+            elapsed_time = ts_now - int(parts[2])
+            handshakes["%s-%s" % (parts[0], parts[1])] = elapsed_time
+            logger.info(
+                "Last handshake for interface {} was {:.2f} seconds ago".format(
+                    parts[0], elapsed_time
+                )
+            )
+    return handshakes
+
+
+def check_recent_handshakes(
+    threshold: int, conf_file_path: str, failure_command: Optional[str] = None
+) -> bool:
+    successful_run = True
+    handshakes = get_handshakes()
+    globs = glob.glob(conf_file_path.rstrip("/") + "/*.conf")
+    if not globs:
+        logger.warning(
+            "It seems that there are no config file candidates in {}".format(
+                conf_file_path
+            )
+        )
+        return False
+    for filename in globs:
+        this_peer = {}
+        ifname = os.path.basename(filename).split(".")[0]
+        logger.info("Checking handshake threshold for interface {}".format(ifname))
+        with open(filename, "r", encoding="utf-8") as fhandle:
+            for line in fhandle:
+                if line.startswith("[Peer]"):
+                    this_peer = {"ifname": ifname}
+                elif line.lower().startswith("publickey"):
+                    this_peer["PublicKey"] = line.split("=", 1)[1].strip()
+                elif line.lower().startswith("endpoint"):
+                    this_peer["Endpoint"] = line.split("=", 1)[1].strip()
+
+                if "Endpoint" in this_peer and "PublicKey" in this_peer:
+                    peer_key = "%(ifname)s-%(PublicKey)s" % this_peer
+                    if handshakes.get(peer_key, 999) > threshold:
+                        logger.info(
+                            "Trying to reset connection to peer {}".format(
+                                this_peer["Endpoint"]
+                            )
+                        )
+                        # skip if there has been a handshake recently
+                        result, output = runner(
+                            [
+                                "/usr/bin/wg",
+                                "set",
+                                ifname,
+                                "peer",
+                                this_peer["PublicKey"],
+                                "endpoint",
+                                this_peer["Endpoint"],
+                            ],
+                        )
+                        if not result:
+                            logger.error(
+                                "Failed to reset peer {} on interface {}: {}".format(
+                                    this_peer["Endpoint"], ifname, output
+                                )
+                            )
+                            successful_run = False
+                    this_peer = {}
+    return successful_run
+
+
+if __name__ == "__main__":
+    threshold = 135
+    configdir = "/usr/local/etc/wireguard"
+
+    logger = Syslogger()
+
+    logger.debug(
+        "Running wireguard watchdog with a threshold of {} seconds".format(threshold)
+    )
+    try:
+        (sys.exit(0) if check_recent_handshakes(threshold, configdir) else sys.exit(1))
+    except Exception as exc:
+        logger.critical("Failed to run: {}".format(exc))
+        sys.exit(1)


### PR DESCRIPTION
Refactor DNS re-resolution script to improve logging and command execution, make it generally more reliable, add proper exit code, and make it portable for use in other projects (tested in OPNSense 26.1 and RHEL9 so far)

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below (not applicable)
- [ ] AI tools were used to create at least part of the code submitted herewith.

**Describe the problem**

I'm currently investigating issues with wireguard where after a WAN drop, wireguard never reconnects (handshake becomes stale) unless I restart the service on local or remote OPNsense side.

**Describe the proposed solution**

This PR adds stderr capture to the commands, adds a timeout in case a subprocess command gets stuck, and adds generic  (rotated) logging for optional debugging purposes, catches all possible errors and logs them.
It is a first step into diagonsis of what actually happens with wireguard not reconnecting.

@AdSchellevis Please let me know if I'm out of line with this.
~~I would also like to add an optional "restart service" action when handshake is stale and updating resolved FQDN don't fix the issue, but that's too broad for a diagnostic right now.~~