### PR TITLE
Services: Kea DHCP: Kea DHCPv4 - add subnet allocator field

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -12,6 +12,13 @@
         <help>You may enter a description here for your reference (not parsed).</help>
     </field>
     <field>
+        <id>subnet4.allocator</id>
+        <label>Allocator</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Select allocator method to use when offering leases to clients.</help>
+    </field>
+    <field>
         <id>subnet4.pools</id>
         <label>Pools</label>
         <type>textbox</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -17,6 +17,9 @@
         <type>dropdown</type>
         <advanced>true</advanced>
         <help>Select allocator method to use when offering leases to clients.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>subnet4.pools</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -181,6 +181,10 @@ class KeaDhcpv4 extends BaseModel
             if ($subnet->valid_lifetime->isSet()) {
                 $record['valid-lifetime'] = $subnet->valid_lifetime->asInt();
             }
+            /* add allocator if selected */
+            if (!$subnet->allocator->isEmpty()) {
+                $record['allocator'] = $subnet->allocator->getValue();
+            }
             /* add description and other custom keys - not parsed by KEA */
             $record['user-context'] = ['uuid' => $subnet->getAttribute('uuid')];
             if (!$subnet->description->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -161,7 +161,7 @@
                   <OptionValues>
                     <iterative>iterative</iterative>
                     <random>random</random>
-                    <flq>Free Lease Queue Allocator</flq>
+                    <flq>Free Lease Queue</flq>
                   </OptionValues>
                 </allocator>
                 <pools type=".\KeaPoolsField"/>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -161,7 +161,7 @@
                   <OptionValues>
                     <iterative>iterative</iterative>
                     <random>random</random>
-                    <flq>flq</flq>
+                    <flq>Free Lease Queue Allocator</flq>
                   </OptionValues>
                 </allocator>
                 <pools type=".\KeaPoolsField"/>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -159,7 +159,7 @@
                 <allocator type="OptionField">
                   <BlankDesc>Default</BlankDesc>
                   <OptionValues>
-                    <iterative>iterative</iterative>
+                    <iterative>Iterative</iterative>
                     <random>Random</random>
                     <flq>Free Lease Queue</flq>
                   </OptionValues>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -156,6 +156,14 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </match-client-id>
+                <allocator type="OptionField">
+                  <BlankDesc>Default</BlankDesc>
+                  <OptionValues>
+                    <iterative>iterative</iterative>
+                    <random>random</random>
+                    <flq>flq</flq>
+                  </OptionValues>
+                </allocator>
                 <pools type=".\KeaPoolsField"/>
                 <ddns_forward_zone type="HostnameField">
                     <IpAllowed>N</IpAllowed>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -160,7 +160,7 @@
                   <BlankDesc>Default</BlankDesc>
                   <OptionValues>
                     <iterative>iterative</iterative>
-                    <random>random</random>
+                    <random>Random</random>
                     <flq>Free Lease Queue</flq>
                   </OptionValues>
                 </allocator>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.7
- Extent of AI involvement: Searching for specific sections to work on, testing validation

---

**Describe the problem**

Needed the dhcpv4 per-subnet "allocator:" variable. Specifically it can be non-existant (default), "random", "iterative", "flq". Although it can be scoped to the entire subnet and overridden specifically per subnet, I chose not to implement the subnet scope (to match the missing scope in dhcpv6).

---

**Describe the proposed solution**

Exposes the per-subnet `allocator` field on DHCPv4 for parity with DHCPv6.
Adds `iterative`, `random`, `flq` (FLQ is DHCPv4-only in Kea ≥ 2.5.0).
Blank default; existing subnets unchanged.

---

**Related issue**
This closes #10322  

---
**Test plan**
- [x] Edit a subnet -> "Allocator" dropdown shows `(default)`, `iterative`, `random`, `flq`.
- [x] Set `random`, save, restart kea-dhcp4 -> /usr/local/etc/kea/kea-dhcp4.conf returns `"random"` on that subnet, key absent elsewhere.
- [x] HA pair w/ Kea sync enabled: set `random` on primary, save -> secondary's `/conf/config.xml` and rendered kea dhcp4.conf both show `random` on the matching `<subnet4>`
- [x] Repeat with `flq` to confirm round-trip.
- [x] Repeat with `default` to confirm the removal of the "allocator:" option