### PR TITLE
ui: SimpleActionButton tab exclusion

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Unbound/dnsbl.volt
@@ -27,24 +27,13 @@
 
 <script>
    $(document).ready(function() {
-        let gridLoaded = false;
-        $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-            if (e.target.id === 'blocklists_tab') {
-                $('#reconfigureAct').closest('.content-box').show();
-                if (!gridLoaded) {
-                    $("#{{formGridDnsbl['table_id']}}").UIBootgrid({
-                        search:'/api/unbound/settings/searchDnsbl/',
-                        get:'/api/unbound/settings/getDnsbl/',
-                        set:'/api/unbound/settings/setDnsbl/',
-                        add:'/api/unbound/settings/addDnsbl/',
-                        del:'/api/unbound/settings/delDnsbl/',
-                        toggle:'/api/unbound/settings/toggleDnsbl/',
-                    });
-                    gridLoaded = true;
-                }
-            } else {
-                $('#reconfigureAct').closest('.content-box').hide();
-            }
+        $("#{{formGridDnsbl['table_id']}}").UIBootgrid({
+            search:'/api/unbound/settings/searchDnsbl/',
+            get:'/api/unbound/settings/getDnsbl/',
+            set:'/api/unbound/settings/setDnsbl/',
+            add:'/api/unbound/settings/addDnsbl/',
+            del:'/api/unbound/settings/delDnsbl/',
+            toggle:'/api/unbound/settings/toggleDnsbl/',
         });
 
         if (window.location.hash != "") {
@@ -126,5 +115,5 @@
     </div>
 </div>
 
-{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/dnsbl', 'data_change_message_content': 'After changing settings, please remember to apply in order to update the blocklists.'}) }}
+{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/unbound/service/dnsbl', 'data_exclude_scope': 'blocklist_tester_tab', 'data_change_message_content': 'After changing settings, please remember to apply in order to update the blocklists.'}) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogDnsbl,'id':formGridDnsbl['edit_dialog_id'],'label':lang._('Edit Blocklist')])}}

--- a/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_apply_button.volt
@@ -10,6 +10,9 @@
 {% if data_grid_reload is defined %}
             data-grid-reload="{{ data_grid_reload }}"
 {% endif %}
+{% if data_exclude_scope is defined %}
+            data-exclude-scope="{{ data_exclude_scope }}"
+{% endif %}
             type="button">
         </button>
         <div id="change_message_base_form" style="display: none">

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -627,7 +627,7 @@ stdDialogRemoveItem.defaults = {
  *      data-label="Apply text"
  *      data-icon="fa fa-icon"
  *      data-service-widget="service" (optional service widget to signal)
- *      data-exclude-scope="tab id" (optional tab id to hide action button in)
+ *      data-exclude-scope="tab id" (optional comma-separated tab ids to hide action button in)
  *      data-error-title="My error message"
  */
 $.fn.SimpleActionButton = function (params) {
@@ -659,7 +659,7 @@ $.fn.SimpleActionButton = function (params) {
 
         if (this_button && this_button.data('exclude-scope')) {
             $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-                if (e.target.id === this_button.data('exclude-scope')) {
+                if ((this_button.data('exclude-scope') ?? '').split(',').map(s => s.trim()).includes(e.target.id)) {
                     this_button.closest('.page-content-main').hide();
                 } else {
                     this_button.closest('.page-content-main').show();

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -657,9 +657,10 @@ $.fn.SimpleActionButton = function (params) {
             $('#change_message_base_form').show().parent('.alert').addClass('alert-info').removeClass('content-box');
         });
 
-        if (this_button && this_button.data('exclude-scope')) {
+        const excludeScope = this_button?.data('exclude-scope');
+        if (excludeScope) {
             $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-                if ((this_button.data('exclude-scope') ?? '').split(',').map(s => s.trim()).includes(e.target.id)) {
+                if (excludeScope.split(',').map(s => s.trim()).includes(e.target.id)) {
                     this_button.closest('.page-content-main').hide();
                 } else {
                     this_button.closest('.page-content-main').show();

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -664,7 +664,7 @@ $.fn.SimpleActionButton = function (params) {
                 } else {
                     this_button.closest('.page-content-main').show();
                 }
-            })
+            });
         }
 
         this_button.on('click', function () {

--- a/src/opnsense/www/js/opnsense_ui.js
+++ b/src/opnsense/www/js/opnsense_ui.js
@@ -627,6 +627,7 @@ stdDialogRemoveItem.defaults = {
  *      data-label="Apply text"
  *      data-icon="fa fa-icon"
  *      data-service-widget="service" (optional service widget to signal)
+ *      data-exclude-scope="tab id" (optional tab id to hide action button in)
  *      data-error-title="My error message"
  */
 $.fn.SimpleActionButton = function (params) {
@@ -655,6 +656,16 @@ $.fn.SimpleActionButton = function (params) {
         $(document).on("settings-changed", function () {
             $('#change_message_base_form').show().parent('.alert').addClass('alert-info').removeClass('content-box');
         });
+
+        if (this_button && this_button.data('exclude-scope')) {
+            $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+                if (e.target.id === this_button.data('exclude-scope')) {
+                    this_button.closest('.page-content-main').hide();
+                } else {
+                    this_button.closest('.page-content-main').show();
+                }
+            })
+        }
 
         this_button.on('click', function () {
             const icon = this_button.find('.reload_progress');


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The unified apply button needs to be targeted manually te remove it in certain spots, at least for tabs this should be controllable on the apply button itself.

---

**Describe the proposed solution**

Add an exclusion scope for tabs.

---

**Related issue**

This is a result of the inconsistencies spotted in what https://github.com/opnsense/core/pull/10283 already attempted to fix
