### PR TITLE
Services: Kea DHCPv6: Always start the prefix watcher when DHCPv6 is enabled.

### DIFF
--- a/src/etc/inc/plugins.inc.d/kea.inc
+++ b/src/etc/inc/plugins.inc.d/kea.inc
@@ -173,7 +173,7 @@ function kea_configure_do($verbose = false)
             $keaDdns->generateConfig();
         }
         (new \OPNsense\Kea\KeaCtrlAgent())->generateConfig();
-        if ($keaDhcpv6->isEnabled() && $keaDhcpv6->pd_pools->pd_pool->count() > 0) {
+        if ($keaDhcpv6->isEnabled()) {
             mwexecfb(
                 '/usr/local/opnsense/scripts/kea/kea_prefix_watcher.py',
                 [],


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

A reservation with a prefix but without a configured pd_pool is also valid, it's more pragmatic to allow it than doing some complex validation gymnastics to prevent it.

---

**Describe the proposed solution**

Always start the prefix watcher.

Doing a proper validation here would require a new model relation field, which would require more code than just allowing this valid usecase.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10326