### PR TITLE
Services: Kea DHCPv6: Clean up allocator and pd-allocator terminology

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -98,16 +98,17 @@
                 <allocator type="OptionField">
                     <BlankDesc>Default</BlankDesc>
                     <OptionValues>
-                        <iterative>iterative</iterative>
-                        <random>random</random>
+                        <iterative>Iterative</iterative>
+                        <random>Random</random>
+                        <flq>Free Lease Queue</flq>
                     </OptionValues>
                 </allocator>
                 <pd-allocator type="OptionField">
                     <BlankDesc>Default</BlankDesc>
                     <OptionValues>
-                        <iterative>iterative</iterative>
-                        <random>random</random>
-                        <flq>Free Lease Queue Allocator</flq>
+                        <iterative>Iterative</iterative>
+                        <random>Random</random>
+                        <flq>Free Lease Queue</flq>
                     </OptionValues>
                 </pd-allocator>
                 <option_data>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Some cleanup to make the dhcpv4 and dhcpv6 allocators look the same.