### PR TITLE
Services: DHCPv4 - Add DHCP4 compatability options

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
@@ -71,7 +71,6 @@
     <field>
         <id>dhcpv4.general.compatibility</id>
         <label>Compatibility Options</label>
-        <style>selectpicker</style>
         <type>select_multiple</type>
         <advanced>true</advanced>
         <help>Enable optional Kea DHCPv4 compatibility flags for non-standard client environments. See Kea ARM § DHCPv4 Compatibility.</help>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings4.xml
@@ -69,6 +69,17 @@
         <help>Socket type used for DHCP communication</help>
     </field>
     <field>
+        <id>dhcpv4.general.compatibility</id>
+        <label>Compatibility Options</label>
+        <style>selectpicker</style>
+        <type>select_multiple</type>
+        <advanced>true</advanced>
+        <help>Enable optional Kea DHCPv4 compatibility flags for non-standard client environments. See Kea ARM § DHCPv4 Compatibility.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <type>header</type>
         <label>Lease Expiration</label>
         <collapse>true</collapse>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -404,6 +404,14 @@ class KeaDhcpv4 extends BaseModel
                 'server-port' => $ddns->general->server_port->asInt(),
             ];
         }
+        /* Compatibility flags */
+        if (!$this->general->compatibility->isEmpty()) {
+            $compat = [];
+            foreach (explode(',', (string)$this->general->compatibility) as $opt) {
+                $compat[$opt] = true;
+            }
+            $cnf['Dhcp4']['compatibility'] = $compat;
+        }
         File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 0600);
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -405,12 +405,8 @@ class KeaDhcpv4 extends BaseModel
             ];
         }
         /* Compatibility flags */
-        if (!$this->general->compatibility->isEmpty()) {
-            $compat = [];
-            foreach (explode(',', (string)$this->general->compatibility) as $opt) {
-                $compat[$opt] = true;
-            }
-            $cnf['Dhcp4']['compatibility'] = $compat;
+        foreach ($this->general->compatibility->getValues() as $opt) {
+            $cnf['Dhcp4']['compatibility'][$opt] = true;
         }
         File::file_put_contents($target, json_encode($cnf, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 0600);
     }

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.5</version>
+    <version>1.0.4</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>
@@ -38,6 +38,15 @@
                     <raw>raw</raw>
                 </OptionValues>
             </dhcp_socket_type>
+            <compatibility type="OptionField">
+                <Multiple>Y</Multiple>
+                <OptionValues>
+                    <exclude-first-last-24>exclude-first-last-24</exclude-first-last-24>
+                    <ignore-dhcp-server-identifier>ignore-dhcp-server-identifier</ignore-dhcp-server-identifier>
+                    <ignore-rai-link-selection>ignore-rai-link-selection</ignore-rai-link-selection>
+                    <lenient-option-parsing>lenient-option-parsing</lenient-option-parsing>
+                </OptionValues>
+            </compatibility>
         </general>
         <lexpire>
             <hold_reclaimed_time type="IntegerField">


### PR DESCRIPTION
Adds a new Compatibility section in the KEA DHCPv4 form:
  - Exclude .0 / .255 from dynamic allocation (exclude-first-last-24)
  - Ignore DHCP server identifier in client requests
  - Ignore RAI link-selection sub-option
  - Lenient option parsing

All four default off. The config emitter writes the 'compatibility' block as the first key inside 'Dhcp4' (only emitted when at least one flag is set)

Refs: https://kea.readthedocs.io/en/stable/arm/dhcp4-srv.html#dhcp4-compatibility"

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.7
- Extent of AI involvement: tree search for related functions, resolving XML version issue during testing, framework for PR.
- Doing QA regression testing on a dual headed opnsense HA configuration

---

**Describe the problem**

Kea created a "compatibility" section to allow for deviations from documented standards. For instance, in the pool 172.16.0.0/20, assigning the IP address 172.16.8.0 and 172.16.8.255 are both valid addresses however many applications don't actually analyze this and just assume that .0 and 255 are invalid. To prevent having to create 16 pools for the above address assignment (172.16.0.1-254, 172.16.1.1-254, etc), it can create the single pool and avoid issuing those difficult addresses.  Each compatibility option was to deal with real world incompatibility issues that exist today in some networks.

---

**Describe the proposed solution**

This adds a Compatibility single SelectMultipleFiend at the bottom of General settings. The following items were selects:

- exclude-first-last-24
- ignore-dhcp-server-identifier
- ignore-rai-link-selection
- leinent-option-parsing

If any are checked off, it creates under the Dhcp4 block a compatibility block:

"Dhcp4": {
    "compatibility": {
        "exclude-first-last-24": true
    }
}

---

**Related issue**

Refs: https://kea.readthedocs.io/en/stable/arm/dhcp4-srv.html#dhcp4-compatibility
This closes #10332 
