### PR TITLE
mvc: remove grouped ModelRelationField option handling

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ModelRelationField.php
@@ -111,12 +111,10 @@ class ModelRelationField extends BaseListField
                 }
 
                 $className = str_replace('.', '\\', $modelData['source']);
-                $groupKey = isset($modelData['group']) ? $modelData['group'] : null;
                 $displayKeys = explode(',', $modelData['display']);
                 $displayFormat = !empty($modelData['display_format']) ? $modelData['display_format'] : "%s";
 
                 $searchItems = $this->getCachedData($className, $modelData['items'], $force);
-                $groups = [];
                 foreach ($searchItems as $uuid => $node) {
                     $descriptions = [];
                     foreach ($displayKeys as $displayKey) {
@@ -129,12 +127,6 @@ class ModelRelationField extends BaseListField
                                 continue 2;
                             }
                         }
-                    }
-                    if (!empty($groupKey)) {
-                        if (!isset($node[$groupKey]) || isset($groups[$node[$groupKey]])) {
-                            continue;
-                        }
-                        $groups[$node[$groupKey]] = 1;
                     }
                     self::$internalCacheOptionList[$this->internalCacheKey][$uuid] = vsprintf(
                         $displayFormat,


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The group option collapsed multiple related model rows into a single display entry while still storing the UUID of one concrete source row. This makes the selected relation dependent on iteration order and is not a stable representation of the grouped object.

References:
https://github.com/opnsense/core/commit/fe571ac442efe76c3a1efd3e6f90b8ec4cb6e7bd

---

**Describe the proposed solution**

Frr was the only consumer (I could grep in core and plugins, don't know if external ones exist), I reworked how the relationship is displayed there to make it more obvious to the user how items relate to each other, and also prevent that the wrong items get deleted. Configs should be more coherent now.

It's also not perfect, but more "obvious" lets say.
It also helps with the addition of internalModelUseSafeDelete in FRR.

https://github.com/opnsense/plugins/commit/0798cde9041fe7aa9316eda966e19b2b5c5b5506
https://github.com/opnsense/plugins/commit/d3c3e7962857a77b198459115f1c0bd6e663f2f8
https://github.com/opnsense/plugins/commit/cb9a5d6d6944a56c26d0ef41838705060d520f44

