### PR TITLE
Services: Kea DHCPv4/6: Fix missing visual cues for manual mode in DDNS and DHCPv4/6

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/ddnsSettings.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/ddnsSettings.xml
@@ -1,5 +1,9 @@
 <form>
     <field>
+        <type>header</type>
+        <label>Service</label>
+    </field>
+    <field>
         <id>ddns.general.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
@@ -11,6 +15,10 @@
         <type>checkbox</type>
         <advanced>true</advanced>
         <help>Disable configuration file generation and manage the file (/usr/local/etc/kea/kea-dhcp-ddns.conf) manually.</help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>General settings</label>
     </field>
     <field>
         <id>ddns.general.server_ip</id>

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/ddns.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/ddns.volt
@@ -33,6 +33,24 @@
             updateServiceControlUI('kea');
         });
 
+        /* Manual configuration, hide all config elements except the service section*/
+        $("#ddns\\.general\\.manual_config").change(function(){
+            let manual_config = $(this).is(':checked');
+            if (manual_config) {
+                if (!$("#show_advanced_frm_generalsettings").hasClass('fa-toggle-on')) {
+                    /* enforce advanced mode so the user notices the checkbox */
+                    $("#show_advanced_frm_generalsettings").click();
+                }
+            }
+            $("#frm_generalsettings").find('table').each(function(){
+                if (manual_config && $(this).find('#ddns\\.general\\.manual_config').length == 0) {
+                    $(this).hide();
+                } else {
+                    $(this).show();
+                }
+            });
+        });
+
         $("#reconfigureAct").SimpleActionButton({
             onPreAction: function() {
                 const dfObj = new $.Deferred();

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv4.volt
@@ -199,7 +199,7 @@
     <li><a data-toggle="tab" href="#settings" id="tab_settings">{{ lang._('Settings') }}</a></li>
     <li><a data-toggle="tab" href="#subnets" id="tab_pools" class="is_managed"> {{ lang._('Subnets') }} </a></li>
     <li><a data-toggle="tab" href="#reservations" id="tab_reservations" class="is_managed"> {{ lang._('Reservations') }} </a></li>
-    <li><a data-toggle="tab" href="#options" id="tab_options">{{ lang._('Options') }}</a></li>
+    <li><a data-toggle="tab" href="#options" id="tab_options" class="is_managed">{{ lang._('Options') }}</a></li>
     <li><a data-toggle="tab" href="#ha-peers" id="tab_ha-peers" class="is_managed"> {{ lang._('HA Peers') }} </a></li>
 </ul>
 <div class="tab-content content-box">

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/dhcpv6.volt
@@ -237,7 +237,7 @@
     <li><a data-toggle="tab" href="#subnets" id="tab_pools" class="is_managed"> {{ lang._('Subnets') }} </a></li>
     <li><a data-toggle="tab" href="#pdpools" id="tab_reservations" class="is_managed"> {{ lang._('PD Pools') }} </a></li>
     <li><a data-toggle="tab" href="#reservations" id="tab_reservations" class="is_managed"> {{ lang._('Reservations') }} </a></li>
-    <li><a data-toggle="tab" href="#options" id="tab_options">{{ lang._('Options') }}</a></li>
+    <li><a data-toggle="tab" href="#options" id="tab_options" class="is_managed">{{ lang._('Options') }}</a></li>
     <li><a data-toggle="tab" href="#ha-peers" id="tab_ha-peers" class="is_managed"> {{ lang._('HA Peers') }} </a></li>
 </ul>
 <div class="tab-content content-box">


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Missed some spots over time, this brings the DDNS form to parity with the DHCPv4 and v6 form when manual mode is enabled. It also fixes missing classes that hide the option tab when manual mode is enabled.
