### PR TITLE
Firewall: Rules [new]: Add hint banner about Inspect button to explain it unhides automatic rules

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -1153,8 +1153,7 @@
     </div>
     <!-- grid -->
     <div id="inspect_hint_banner" class="alert alert-info" style="display: none;">
-        <i class="fa fa-info-circle"></i>
-        {{ lang._('Automatic firewall rules are hidden by default. To show them, press the Inspect button.') }}
+        {{ lang._('Automatic firewall rules are hidden by default. Press the %s button to reveal them.') | format('<i class="fa fa-fw fa-eye"></i>&nbsp;' ~ lang._('Inspect')) }}
     </div>
     {{ partial('layout_partials/base_bootgrid_table', formGridFilterRule + {'command_width': '180'}) }}
 </div>

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -57,8 +57,11 @@
         let treeViewEnabled = localStorage.getItem("firewall_rule_tree") === "1";
         $('#toggle_tree_button').toggleClass('active btn-primary', treeViewEnabled);
 
+        const inspectKeyExists = localStorage.getItem("firewall_rule_inspect") !== null;
         let inspectEnabled = localStorage.getItem("firewall_rule_inspect") === "1";
+
         $('#toggle_inspect_button').toggleClass('active btn-primary', inspectEnabled);
+        $('#inspect_hint_banner').toggle(!inspectKeyExists);
 
         function updateStatisticColumns() {
             grid.bootgrid(inspectEnabled ? "setColumns" : "unsetColumns", ['statistics']);
@@ -829,6 +832,7 @@
         $('#toggle_inspect_button').click(function () {
             inspectEnabled = !inspectEnabled;
             localStorage.setItem("firewall_rule_inspect", inspectEnabled ? "1" : "0");
+            $('#inspect_hint_banner').hide();
             $(this).toggleClass('active btn-primary', inspectEnabled);
             updateStatisticColumns();
             grid.bootgrid("reload");
@@ -1148,6 +1152,10 @@
         </div>
     </div>
     <!-- grid -->
+    <div id="inspect_hint_banner" class="alert alert-info" style="display: none;">
+        <i class="fa fa-info-circle"></i>
+        {{ lang._('Automatic firewall rules are hidden by default. To show them, press the Inspect button.') }}
+    </div>
     {{ partial('layout_partials/base_bootgrid_table', formGridFilterRule + {'command_width': '180'}) }}
 </div>
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

If the Inspect button has never been pressed before in a browser, the banner will show to advertise that it unhides automatic firewall rules, hopefully helping first time users better who are not as adventurous to click the few available buttons nor read the documentation (but hopefully read the banner)