### PR TITLE
Kea: Hook up reservation.next_server

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -211,6 +211,10 @@ class KeaDhcpv4 extends BaseModel
                     $res['client-id'] = $reservation->client_id->getValue();
                 }
 
+                if (!$reservation->next_server->isEmpty()) {
+                    $res['next-server'] = $reservation->next_server->getValue();
+                }
+
                 // Add DHCP option-data elements for reservations
                 $optdata = $this->collectOptionData($reservation->option_data);
                 /* append raw options */

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>
@@ -318,6 +318,10 @@
                     <IsDNSName>Y</IsDNSName>
                 </hostname>
                 <description type="DescriptionField"/>
+                <next_server type="NetworkField">
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <AddressFamily>ipv4</AddressFamily>
+                </next_server>
                 <option_data>
                     <domain_name_servers type="NetworkField">
                         <NetMaskAllowed>N</NetMaskAllowed>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [ Y ] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ Y ] I opened an issue first for non-trivial changes and linked it below.
- [ No ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

This field was added to the Kea dialogReservation4.xml form in https://github.com/opnsense/core/pull/8890, however this specific option was not properly hooked up and did not generate the expected config, preventing netboot scenarios that rely on next-server from being set on a per-reservation basis (the per-subnet variant of this option does work fine).

---

**Describe the proposed solution**

This commit hooks it up to generate the expected "next-server" Kea config entry on a per-reservation basis, allowing netboot to work on a per-reservation basis.

---

**Related issue**

https://github.com/opnsense/core/issues/10343