### PR TITLE
wireguard: heal interface when configured tunneladdress is missing

### DIFF
--- a/src/opnsense/scripts/wireguard/wg-service-control.php
+++ b/src/opnsense/scripts/wireguard/wg-service-control.php
@@ -72,6 +72,11 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up', $reload = false)
 
     mwexecf('/usr/bin/wg syncconf %s %s', [$server->interface, $server->cnfFilename]);
 
+    /* drop leftover/default addresses before re-applying aliases */
+    $details = legacy_interfaces_details((string)$server->interface);
+    interfaces_addresses_flush((string)$server->interface, 4, $details);
+    interfaces_addresses_flush((string)$server->interface, 6, $details);
+
     foreach ($server->tunneladdress->getValues() as $alias) {
         $proto = strpos($alias, ':') === false ? "inet" : "inet6";
         mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
@@ -160,6 +165,25 @@ function wg_stop($server)
     syslog(LOG_NOTICE, "wireguard instance {$server->name} ({$server->interface}) stopped");
 }
 
+
+/* true if any configured tunneladdress is on the device right now */
+function wg_has_tunneladdress($server, $ifdetails)
+{
+    $device = (string)$server->interface;
+    if (empty($ifdetails[$device])) {
+        return false;
+    }
+    $live = array_merge(
+        array_column($ifdetails[$device]['ipv4'] ?? [], 'ipaddr'),
+        array_column($ifdetails[$device]['ipv6'] ?? [], 'ipaddr')
+    );
+    foreach ($server->tunneladdress->getValues() as $alias) {
+        if (in_array(explode('/', $alias, 2)[0], $live, true)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * Calculate a hash which determines if we are able to reconfigure without a restart of the tunnel.
@@ -275,11 +299,25 @@ if (isset($opts['h']) || empty($args) || !in_array($args[0], ['start', 'stop', '
                             );
                         }
 
+                        $missing_address = (
+                            !empty($ifdetails[(string)$node->interface]) &&
+                            !wg_has_tunneladdress($node, $ifdetails)
+                        );
+
                         if (
                             @md5_file($node->cnfFilename) != get_stat_hash($statHandle)['file'] ||
-                            empty($ifdetails[(string)$node->interface])
+                            empty($ifdetails[(string)$node->interface]) ||
+                            $missing_address
                         ) {
                             $reload = false;
+
+                            if ($missing_address) {
+                                syslog(
+                                    LOG_NOTICE,
+                                    "wireguard instance {$node->name} ({$node->interface}) " .
+                                    "tunneladdress missing on device, forcing reconfigure."
+                                );
+                            }
 
                             if (get_stat_hash($statHandle)['interface'] != wg_reconfigure_hash($node)) {
                                 // Fluent reloading not supported for this instance, make sure the user is informed


### PR DESCRIPTION
Ref: #10106
Ref: #10094

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude (Opus 4.7) via Claude Code CLI
- Extent of AI involvement: AI assistance was used to analyze the OPNsense source paths (interfaces.inc, plugins.inc.d/wireguard.inc, wg-service-control.php), draft the patch iterations, and structure the reproducer scripts. The bug was reproduced and the patch verified manually on a pair of OPNsense 26.1.8_5 test VMs (one patched, one unpatched as control), and the patch deployed and observed on a production HA pair before submission. All code was reviewed and refined across multiple iterations before submitting.

---

**Describe the problem**

The wg interface can end up with only the if_wg(4) default `0.0.0.2/8` when something destroys+recreates the device without a follow-up `wg_start` (e.g. `interface_configure()` running before `plugins_configure('vpn')`). Routing to peers breaks and `configctl wireguard configure` doesn't heal it because the stat-hash check short-circuits when the cnf-file md5 is unchanged. The only workaround today is toggling the instance via the GUI (disable+apply, enable+apply) to force the hash to differ, which isn't discoverable.

---

**Describe the proposed solution**

Two changes to `wg-service-control.php`:

1. `wg_start()` flushes addresses on the device before re-applying the tunneladdress aliases. Same `interfaces_addresses_flush()` helper that the existing "can not reconfigure without stopping it first" branch already uses, just applied unconditionally so any kernel-assigned default or stale alias is cleared.
2. In the `configure` action, a new `wg_has_tunneladdress()` predicate is added to the outer condition. When the device exists but the configured tunneladdress is missing from it, a full reconfigure is forced regardless of the stat-hash, with an explicit syslog notice.

Tested on 26.1.8_5. The bug reproduces deterministically with `ifconfig wgN destroy && ifconfig wg create name wgN && ifconfig wgN group wireguard` followed by `configctl wireguard configure` (no-op without the patch, restores tunneladdress with it).

---

**Related issue**

#10106, #10094