### PR TITLE
hostwatch: pin warning banner to enabled flag

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Hostdiscovery/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Hostdiscovery/Api/ServiceController.php
@@ -59,8 +59,8 @@ class ServiceController extends ApiMutableServiceControllerBase
                 'ether_address' => $rec[1],
                 'ip_address' => $rec[2],
                 'organization_name' => $rec[3],
-                'first_seen' => $rec[4] ?? '',
-                'last_seen' => $rec[5] ?? ''
+                'first_seen' => $rec[4],
+                'last_seen' => $rec[5]
             ];
         }
         return $this->searchRecordsetBase($records);

--- a/src/opnsense/mvc/app/controllers/OPNsense/Hostdiscovery/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Hostdiscovery/Api/ServiceController.php
@@ -59,8 +59,8 @@ class ServiceController extends ApiMutableServiceControllerBase
                 'ether_address' => $rec[1],
                 'ip_address' => $rec[2],
                 'organization_name' => $rec[3],
-                'first_seen' => $rec[4],
-                'last_seen' => $rec[5]
+                'first_seen' => $rec[4] ?? '',
+                'last_seen' => $rec[5] ?? ''
             ];
         }
         return $this->searchRecordsetBase($records);

--- a/src/opnsense/mvc/app/library/OPNsense/System/Status/HostDiscoveryStatus.php
+++ b/src/opnsense/mvc/app/library/OPNsense/System/Status/HostDiscoveryStatus.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\System\Status;
+
+use OPNsense\System\AbstractStatus;
+use OPNsense\System\SystemStatusCode;
+use OPNsense\Hostdiscovery\Hostwatch;
+
+class HostDiscoveryStatus extends AbstractStatus
+{
+    public function __construct()
+    {
+        $this->internalPriority = 2;
+        $this->internalPersistent = true;
+        $this->internalTitle = gettext('Host discovery status');
+        $this->internalIsBanner = true;
+        $this->internalScope[] = '/ui/hostdiscovery/settings';
+    }
+
+    public function collectStatus()
+    {
+        if ((new Hostwatch())->general->enabled->isEmpty()) {
+            $this->internalMessage = gettext('Host discovery service is disabled, the hosts currently known by this firewall are fetched via ARP and NDP');
+            $this->internalStatus = SystemStatusCode::WARNING;
+        }
+    }
+}

--- a/src/opnsense/mvc/app/views/OPNsense/Hostdiscovery/settings.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Hostdiscovery/settings.volt
@@ -57,14 +57,6 @@
                                 }
                                 return params;
                             },
-                            responseHandler: function (response) {
-                                if (response.rows.length > 0 && response.rows[0].source == 'discovery') {
-                                    $("#legacy_alert").hide();
-                                } else {
-                                    $("#legacy_alert").show();
-                                }
-                                return response;
-                            }
                         }
                         });
                     } else {
@@ -96,11 +88,6 @@
     </div>
     <!-- Tab: Hosts -->
     <div id="hosts" class="tab-pane fade in">
-        <div style="padding: 10px;">
-            <div id="legacy_alert" class="alert alert-warning" role="alert" style="display: none;">
-                {{ lang._('Host discovery service is disabled, below the hosts currently known by this firewall via ARP and NDP') }}
-            </div>
-        </div>
         <table id="grid-hosts" class="table table-condensed table-hover table-striped table-responsive">
             <thead>
                 <tr>

--- a/src/opnsense/scripts/interfaces/list_hosts.py
+++ b/src/opnsense/scripts/interfaces/list_hosts.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
                     record = [row['interface'], row['mac-address'], row['ip-address']]
                     if inputargs.verbose:
                         record.append(OUI().get_vendor(row['mac-address'], ''))
+                        record.extend(['', '']) # match "discover" output
                     result['rows'].append(record)
         if 'inet6' in inputargs.proto and inputargs.ndp:
             sp = subprocess.run(['/usr/sbin/ndp', '-an'], capture_output=True, text=True)
@@ -116,5 +117,6 @@ if __name__ == '__main__':
                     record = [line_parts[2], line_parts[1], line_parts[0].split('%', 1)[0]]
                     if inputargs.verbose:
                         record.append(OUI().get_vendor(line_parts[1], ''))
+                        record.extend(['', '']) # match "discover" output
                     result['rows'].append(record)
     print(ujson.dumps(result))


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Banner stating ARP or NDP is used to fetch hosts also shows when no results are found (e.g. due to a search query). This is because at least one row is required to determine discovery source.

---

**Describe the proposed solution**

Easiest solution is to pin it on the `enabled` flag as is done in this PR. Alternatively, we can add a column showing the source, pinning it on the data as was the intent before.

---

**Related issue**

https://github.com/opnsense/core/issues/10196
