### PR TITLE
ui: override selectpicker defaults for translations

### DIFF
--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -341,6 +341,9 @@
             searchColumns: "{{ lang._('Search columns') }}",
             expand: "{{ lang._('Click to expand/collapse cell') }}"
         });
+
+        $.fn.selectpicker.defaults = $.fn.selectpicker.defaults || {};
+        $.extend($.fn.selectpicker.defaults, {noneSelectedText: '{{ lang._('Nothing selected') }}'});
     </script>
 
   </body>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**
Some default selectpicker strings aren't translated

---

**Describe the proposed solution**

Translate them in `default.volt`, like with the other jquery modules

---

**Related issue**

N/A
