### PR TITLE
Firewall: NAT: download/upload rules as csv

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
@@ -171,4 +171,14 @@ class DNatController extends FilterBaseController
     {
         return $this->toggleRuleLogBase($uuid, $log, 'rule');
     }
+
+    public function downloadRulesAction()
+    {
+        return $this->downloadRulesBase('rule', ['sort_order', 'prio_group']);
+    }
+
+    public function uploadRulesAction()
+    {
+        return $this->downloadRulesBase('rule', ['sort_order', 'prio_group']);
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
@@ -179,6 +179,6 @@ class DNatController extends FilterBaseController
 
     public function uploadRulesAction()
     {
-        return $this->downloadRulesBase('rule', ['sort_order', 'prio_group']);
+        return $this->uploadRulesBase('rule', ['sort_order', 'prio_group']);
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
@@ -454,4 +454,110 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
 
         return ['status' => 'ok'];
     }
+
+    /**
+     * Export a rule collection as CSV.
+     *
+     * @param string $node_reference: Model node reference to export, e.g. "rules.rule"
+     * @param array $ignore_fields: List of fields to omit from the exported CSV, e.g. "sort_order" as its a volatile field
+     * @param array $alias_fields: List of fields whose stored value is an alias UUID
+     *                             but should be exported as the alias name instead, e.g. "overload" table
+     * @return void
+     */
+    protected function downloadRulesBase($node_reference, array $ignore_fields = [], array $alias_fields = [])
+    {
+        if (!$this->request->isGet()) {
+            return;
+        }
+
+        /* categories have unique names, export names instead of ids so we can easily map them on other targets */
+        $categories = [];
+        foreach ((new Category())->categories->category->iterateItems() as $key => $category) {
+            $categories[$key] = $category->name->getValue();
+        }
+
+        $aliases = [];
+        if (!empty($alias_fields)) {
+            foreach ((new Alias())->aliases->alias->iterateItems() as $key => $alias) {
+                $aliases[$key] = $alias->name->getValue();
+            }
+        }
+
+        $node = $this->getModel();
+        foreach (explode('.', $node_reference) as $ref) {
+            $node = $node->$ref;
+        }
+
+        $this->exportCsv($node->asRecordSet(
+            false,
+            $ignore_fields,
+            function ($node, $record) use ($categories, $aliases, $alias_fields) {
+                if (!empty($record['categories'])) {
+                    $cats = [];
+                    foreach (explode(',', $record['categories']) as $key) {
+                        if (isset($categories[$key])) {
+                            $cats[] = $categories[$key];
+                        }
+                    }
+                    $record['categories'] = implode(',', $cats);
+                }
+
+                foreach ($alias_fields as $field) {
+                    if (!empty($record[$field]) && isset($aliases[$record[$field]])) {
+                        $record[$field] = $aliases[$record[$field]];
+                    }
+                }
+
+                return array_merge(['@uuid' => $node->getAttribute('uuid')], $record);
+            }
+        ));
+    }
+
+    protected function uploadRulesBase($node_reference, array $ignored_fields = [], array $alias_fields = [])
+    {
+        if (!$this->request->isPost() || !$this->request->hasPost('payload')) {
+            return ['status' => 'failed'];
+        }
+
+        /* categories have unique names, need to map them to uuids */
+        $categories = [];
+        foreach ((new Category())->categories->category->iterateItems() as $key => $category) {
+            $categories[$category->name->getValue()] = $key;
+        }
+
+        $aliases = [];
+        if (!empty($alias_fields)) {
+            foreach ((new Alias())->aliases->alias->iterateItems() as $key => $alias) {
+                $aliases[$alias->name->getValue()] = $key;
+            }
+        }
+
+        return $this->importCsv(
+            $node_reference,
+            $this->request->getPost('payload'),
+            ['@uuid'],
+            function (&$record) use ($categories, $aliases, $alias_fields, $ignored_fields) {
+                if (!empty($record['categories'])) {
+                    /* only map what we know, ignore the rest */
+                    $cats = [];
+                    foreach (explode(',', $record['categories']) as $key) {
+                        if (isset($categories[$key])) {
+                            $cats[] = $categories[$key];
+                        }
+                    }
+                    $record['categories'] = implode(',', $cats);
+                }
+
+                foreach ($alias_fields as $field) {
+                    if (!empty($record[$field]) && isset($aliases[$record[$field]])) {
+                        $record[$field] = $aliases[$record[$field]];
+                    }
+                }
+
+                foreach ($ignored_fields as $field) {
+                    unset($record[$field]);
+                }
+            }
+        );
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -410,74 +410,12 @@ class FilterController extends FilterBaseController
 
     public function downloadRulesAction()
     {
-        if ($this->request->isGet()) {
-            /* categories have unique names, export names instead of ids so we can easily map them on other targets */
-            $categories = [];
-            $aliases = [];
-            foreach ((new Category())->categories->category->iterateItems() as $key => $category) {
-                $categories[$key] = $category->name->getValue();
-            }
-            foreach ((new Alias())->aliases->alias->iterateItems() as $key => $alias) {
-                $aliases[$key] = $alias->name->getValue();
-            }
-            /* XXX: as shaper1/2 don't have functional keys, we can only export uuid's here */
-            $this->exportCsv($this->getModel()->rules->rule->asRecordSet(
-                false,
-                ['sort_order', 'prio_group'],
-                function ($node, $record) use ($categories, $aliases) {
-                    if (!empty($record['categories'])) {
-                        $cats = [];
-                        foreach (explode(',', $record['categories']) as $key) {
-                            if (isset($categories[$key])) {
-                                $cats[] = $categories[$key];
-                            }
-                        }
-                        $record['categories'] = implode(',', $cats);
-                    }
-                    if (!empty($record['overload']) && isset($aliases[$record['overload']])) {
-                        $record['overload'] = $aliases[$record['overload']];
-                    }
-                    return array_merge(['@uuid' => $node->getAttribute('uuid')], $record);
-                }
-            ));
-        }
+        return $this->downloadRulesBase('rules.rule', ['sort_order', 'prio_group'], ['overload']);
     }
 
     public function uploadRulesAction()
     {
-        if ($this->request->isPost() && $this->request->hasPost('payload')) {
-            /* catgories have unique names, need to map them to uuids */
-            $categories = [];
-            $aliases = [];
-            foreach ((new Category())->categories->category->iterateItems() as $key => $category) {
-                $categories[$category->name->getValue()] = $key;
-            }
-            foreach ((new Alias())->aliases->alias->iterateItems() as $key => $alias) {
-                $aliases[$alias->name->getValue()] = $key;
-            }
-            return $this->importCsv(
-                'rules.rule',
-                $this->request->getPost('payload'),
-                ['@uuid'],
-                function (&$record) use ($categories, $aliases) {
-                    if (!empty($record['categories'])) {
-                        /* only map what we know, ignore the rest */
-                        $cats = [];
-                        foreach (explode(',', $record['categories']) as $key) {
-                            if (isset($categories[$key])) {
-                                $cats[] = $categories[$key];
-                            }
-                        }
-                        $record['categories'] = implode(',', $cats);
-                    }
-                    if (!empty($record['overload']) && isset($aliases[$record['overload']])) {
-                        $record['overload'] = $aliases[$record['overload']];
-                    }
-                }
-            );
-        } else {
-            return ['status' => 'failed'];
-        }
+        return $this->uploadRulesBase('rules.rule', ['sort_order', 'prio_group'], ['overload']);
     }
 
     public function flushInspectCacheAction()

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -408,6 +408,7 @@ class FilterController extends FilterBaseController
         return $result;
     }
 
+    // XXX: as shaper1/2 don't have functional keys, we can only export uuid's here
     public function downloadRulesAction()
     {
         return $this->downloadRulesBase('rules.rule', ['sort_order', 'prio_group'], ['overload']);

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/NptController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/NptController.php
@@ -92,4 +92,14 @@ class NptController extends FilterBaseController
     {
         return $this->toggleRuleLogBase($uuid, $log, 'npt.rule');
     }
+
+    public function downloadRulesAction()
+    {
+        return $this->downloadRulesBase('npt.rule', ['sort_order', 'prio_group']);
+    }
+
+    public function uploadRulesAction()
+    {
+        return $this->uploadRulesBase('npt.rule', ['sort_order', 'prio_group']);
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/OneToOneController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/OneToOneController.php
@@ -98,4 +98,14 @@ class OneToOneController extends FilterBaseController
     {
         return $this->toggleRuleLogBase($uuid, $log, 'onetoone.rule');
     }
+
+    public function downloadRulesAction()
+    {
+        return $this->downloadRulesBase('onetoone.rule', ['sort_order', 'prio_group']);
+    }
+
+    public function uploadRulesAction()
+    {
+        return $this->uploadRulesBase('onetoone.rule', ['sort_order', 'prio_group']);
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/SourceNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/SourceNatController.php
@@ -94,4 +94,14 @@ class SourceNatController extends FilterBaseController
     {
         return $this->toggleRuleLogBase($uuid, $log, 'snatrules.rule');
     }
+
+    public function downloadRulesAction()
+    {
+        return $this->downloadRulesBase('snatrules.rule', ['sort_order', 'prio_group']);
+    }
+
+    public function uploadRulesAction()
+    {
+        return $this->uploadRulesBase('snatrules.rule', ['sort_order', 'prio_group']);
+    }
 }

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -409,6 +409,33 @@
                 },
             },
             commands: {
+                upload_rules: {
+                    onRendered: function () {
+                        const $el = $(this);
+                        $el.data('title', "{{ lang._('Import rules') }}");
+                        $el.data('endpoint', `/api/firewall/${entrypoint}/upload_rules`);
+                        $el.SimpleFileUploadDlg({
+                            onAction: function () {
+                                $("#{{formGridRule['table_id']}}").bootgrid('reload');
+                                $(document).trigger("settings-changed");
+                            }
+                        });
+                    },
+                    footer: true,
+                    classname: 'fa fa-fw fa-upload',
+                    title: "{{ lang._('Import csv') }}",
+                    sequence: 400
+                },
+                download_rules: {
+                    footer: true,
+                    classname: 'fa fa-fw fa-table',
+                    title: "{{ lang._('Export as csv') }}",
+                    method: function (e) {
+                        e.preventDefault();
+                        window.open(`/api/firewall/${entrypoint}/download_rules`);
+                    },
+                    sequence: 500
+                },
                 move_before: {
                     method: function(event) {
                         const selected = $("#{{ formGridRule['table_id'] }}").bootgrid("getSelectedRows");


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

NAT rules should have the same download/upload actions available as firewall rules currently do.

---

**Describe the proposed solution**

Move downloadRules and uploadRules into FilterBaseController and use them in all MVC Filter/NAT controllers.

---

**Related issue**

Required for: https://github.com/opnsense/core/issues/9515
