### PR TITLE
Firewall: Rules: initiate tree expansion based on interface selection value

### DIFF
--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -623,7 +623,7 @@ function filter_core_rules_system($fw, $defaults)
                                 // only try to add gateway rules for traffic leaving this interface
                                 // when the correct protocol is assigned to the interface
                                 $fw->registerFilterRule(
-                                    100000,
+                                    10000,
                                     ['from' => "({$ifcfg['if']})", 'direction' => 'out', 'gateway' => $gwname,
                                     'destination' => ['network' => $ifdescr, "not" => true],
                                     'statetype' => 'keep',

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -66,14 +66,23 @@
 
         // read interface from URL hash once, for the first grid load
         let pendingUrlInterface = getUrlHash('interface') || null;
+        let previousGroupType = null;
+        let currentGroupType = null;
 
-        const ruleTypeMap = {
-            '0': { uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-            '2': { uuid: "floating", label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
-            '3': { uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
-            '4': { uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
-            '5': { uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-        };
+        $("#interface_select").on('changed.bs.select', function() {
+            const groupData = $(this).data();
+            currentGroupType = Object.entries(groupData.store)
+                                .find(([, group]) => group.items?.some(item => item.value === $("#interface_select").val()))
+                                ?.[0] ?? null;
+        });
+
+        const ruleTypeMap = [
+            { idx: 0, uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            { idx: 2, uuid: "floating", label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
+            { idx: 3, uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
+            { idx: 4, uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
+            { idx: 5, uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+        ];
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).
         //      An exact match is not always possible, using the first digit is the best assumption currently.
@@ -108,21 +117,30 @@
 
             clear(buckets);
 
-            // (re)initialize mising buckets
-            for (const [idx, type] of Object.entries(ruleTypeMap)) {
-                const index = Number(idx);
+            // (re)initialize missing buckets
+            for (const type of ruleTypeMap) {
+                let bucket = buckets.some(bucket => bucket.idx === type.idx);
 
-                const exists = buckets.some(bucket => Number(bucket.idx) === index);
-
-                if (!exists) {
-                    buckets.splice(index, 0, createBucket({
+                if (!bucket) {
+                    buckets.push(createBucket({
                         ...type,
-                        idx: index,
                         _persistence: false,
                         _expanded: false,
                         categories: type.label,
                         category_colors: [{ name: type.label }],
                     }));
+                    buckets = buckets.sort((a, b) => a.idx - b.idx);
+                }
+            }
+
+            // determine tree expansion state of top-level buckets
+            for (const bucket of buckets) {
+                if (["auto0", "auto1"].includes(bucket.uuid)) {
+                    bucket._expanded = false;
+                } else if (bucket.groupType === currentGroupType || currentGroupType === "any") {
+                    bucket._expanded = true;
+                } else if (currentGroupType !== previousGroupType) {
+                    bucket._expanded = false;
                 }
             }
 
@@ -183,6 +201,7 @@
             };
 
             removeEmptyGroups(buckets);
+            previousGroupType = currentGroupType;
 
             return Object.assign({}, response, { rows: buckets });
         }
@@ -205,49 +224,7 @@
                 dataTree              : true,
                 dataTreeChildField    : "children",
                 dataTreeElementColumn : "categories",
-                dataTreeStartExpanded : function(row, level) {
-                    const data = row.getData();
-                    if (data._persistence && !data?._expanded) {
-                        // expansion state determined by user interaction
-                        return false;
-                    }
-
-                    if (data?._expanded) {
-                        // inline reload of data, non-persisted open state
-                        return true;
-                    }
-
-                    // always stay collapsed if this tree is for the automatically generated rules
-                    if (data.uuid === "auto0" || data.uuid === "auto1") {
-                        return false;
-                    }
-
-                    const interfaceSelection = $("#interface_select").val();
-
-                    // expand if user selected "all rules"
-                    if (interfaceSelection === "__any") {
-                        return true;
-                    }
-
-                    // find group by interface selection value
-                    // note that "group" does not refer to interface groups here,
-                    // but rather the interface selectpicker groups: "floating", "groups", "interfaces"
-                    const groupData = $("#interface_select").data();
-                    let found = null;
-                    for (const [groupName, group] of Object.entries(groupData.store)) {
-                        if (group.items?.some(item => item.value === interfaceSelection)) {
-                            found = groupName;
-                            break;
-                        }
-                    }
-
-                    // unconditionally expand if the selected interface type matches the group type
-                    if (found === data.groupType || found === "any") {
-                        return true;
-                    }
-
-                    return false;
-                },
+                dataTreeStartExpanded : (row, level) => row.getData()._expanded,
                 rowFormatter: function(row) {
                     const data = row.getData();
                     const $element = $(row.getElement());
@@ -494,7 +471,7 @@
                             * whose name matches ruleTypeMap, while real category buckets continue
                             * to render normal category tag icons.
                             */
-                            const ruleType = Object.values(ruleTypeMap).find(r => r.uuid === row.uuid);
+                            const ruleType = ruleTypeMap.find(r => r.uuid === row.uuid);
 
                             const name = ruleType ? ruleType.tooltip : (cat.name || "");
                             const icon = ruleType ? ruleType.icon : "fa-fw fa-tag";
@@ -855,6 +832,37 @@
         const table = grid.bootgrid('getTable');
         table.on('dataTreeRowExpanded', (row) => onTreeEvent(row, true));
         table.on('dataTreeRowCollapsed', (row) => onTreeEvent(row, false));
+
+        // "selectableRowsCheck" doesn't execute when the header checkbox is used,
+        // work around this by checking on row selection
+        table.on('rowSelected', (row) => {
+            const data = row.getData();
+            if (data.isGroup) {
+                // "select all" triggered, deselect current row since it's a group, but select any nested row that isn't a group recursively
+                row.deselect();
+                const children = row.getTreeChildren();
+                const getAllRows = (rows) => {
+                    const result = [];
+
+                    for (const row of rows) {
+                        const rowData = row.getData();
+                        // do not select rows that aren't visible to avoid confusion (_expanded == false)
+                        if (!rowData.isGroup && rowData.uuid.includes("-") && row.getTreeParent().getData()._expanded) {
+                            result.push(row);
+                            continue;
+                        }
+
+                        result.push(...getAllRows(row.getTreeChildren() || []));
+                    }
+
+                    return result;
+                };
+
+                for (const selectableRow of getAllRows(children)) {
+                    selectableRow.select();
+                }
+            }
+        });
 
         grid.on('loaded.rs.jquery.bootgrid', function () {
             updateStatisticColumns(); // ensures inspect columns are consistent after reload

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -1181,12 +1181,6 @@
         pointer-events: none;
     }
 
-    /* hide rowselect checkbox if tree is enabled, it does not work properly */
-    .tree-enabled .tabulator-col.tabulator-row-header input[type="checkbox"] {
-        visibility: hidden;
-        pointer-events: none;
-    }
-
     /* Do not allow Source/Destination selectpickers to grow infinitely */
     #row_rule\.source_net .bootstrap-select > .dropdown-toggle,
     #row_rule\.destination_net .bootstrap-select > .dropdown-toggle {

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -68,12 +68,12 @@
         let pendingUrlInterface = getUrlHash('interface') || null;
 
         const ruleTypeMap = {
-            '0': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
-            '1': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
-            '2': { label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary" },
-            '3': { label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning" },
-            '4': { label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info" },
-            '5': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
+            '0': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '1': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '2': { label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
+            '3': { label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
+            '4': { label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
+            '5': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
         };
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).
@@ -93,29 +93,27 @@
                 return row["%categories"] || row.categories || "";
             };
 
-            const makeBucket = function(label, uuid, categoryColors) {
-                return {
-                    // ensure uuid is as unique as possible for persistence handling
-                    uuid           : uuid,
-                    isGroup        : true,
-                    _label         : label,          // internal
-                    categories     : label,
-                    /*
-                    * Bucket rows reuse the category formatter.
-                    * For category buckets, this copies the first child's category metadata
-                    * so the bucket can render the same category icon/color as its rules.
-                    * For rule type buckets, a synthetic categoryColors entry is supplied.
-                    */
-                    category_colors: categoryColors,
-                    children       : []
-                };
-            };
-
-            const createBucket = function(parent, label, uuid, categoryColors) {
+            const createBucket = function(parent, label, uuid, categoryColors, groupType = null, persistence=true) {
                 let bucket = parent.children.find(child => child.isGroup && child._label === label);
 
                 if (!bucket) {
-                    bucket = makeBucket(label, uuid, categoryColors);
+                    bucket = {
+                        // ensure uuid is as unique as possible for persistence handling
+                        uuid           : uuid,
+                        isGroup        : true,
+                        _label         : label,          // internal
+                        categories     : label,
+                        _persistence   : persistence,    // internal
+                        _groupType     : groupType,      // internal
+                        /*
+                        * Bucket rows reuse the category formatter.
+                        * For category buckets, this copies the first child's category metadata
+                        * so the bucket can render the same category icon/color as its rules.
+                        * For rule type buckets, a synthetic categoryColors entry is supplied.
+                        */
+                        category_colors: categoryColors,
+                        children       : []
+                    };
                     parent.children.push(bucket);
                 }
 
@@ -142,7 +140,9 @@
                     root,
                     ruleTypeLabel,
                     `ruletype${ruleTypeDigit}`,
-                    [{ name: ruleTypeLabel }]
+                    [{ name: ruleTypeLabel }],
+                    ruleType.groupType,
+                    false,
                 );
 
                 if (treeViewEnabled && row.is_automatic !== true && categoryLabel !== "") {
@@ -196,6 +196,32 @@
                 dataTree              : true,
                 dataTreeChildField    : "children",
                 dataTreeElementColumn : "categories",
+                dataTreeStartExpanded : function(row, level) {
+                    const data = row.getData();
+                    if (data._persistence) {
+                        // expansion state determined by user interaction
+                        return false;
+                    }
+
+                    // find group by interface selection value
+                    // note that "group" does not refer to interface groups here,
+                    // but rather the interface selectpicker groups: "floating", "groups", "interfaces"
+                    const interfaceSelection = $("#interface_select").val();
+                    const groupData = $("#interface_select").data();
+                    let found = null;
+                    for (const [groupName, group] of Object.entries(groupData.store)) {
+                        if (group.items?.some(item => item.value === interfaceSelection)) {
+                            found = groupName;
+                            break;
+                        }
+                    }
+
+                    if (found === data._groupType || found === "any") {
+                        return true;
+                    }
+
+                    return false;
+                },
                 rowFormatter: function(row) {
                     const data = row.getData();
                     const $element = $(row.getElement());
@@ -854,7 +880,7 @@
 
                     return data;
                 },
-                false,
+                true,
                 function (data) {  // post_callback, apply the URL hash logic
                     const $select = $('#interface_select');
                     const interfaceCandidate = (!interfaceInitialized && pendingUrlInterface)

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -95,24 +95,6 @@
                 ...props
             };
         }
-        
-        function bucketById(buckets, uuid) {
-            for (const bucket of buckets) {
-                if (bucket.uuid === uuid) {
-                    return bucket;
-                }
-
-                if (Array.isArray(bucket.children)) {
-                    const found = bucketById(bucket.children, uuid);
-
-                    if (found) {
-                        return found;
-                    }
-                }
-            }
-
-            return null;
-        }
 
         function responseHandler(response) {
             // recursively clear children but keep buckets intact
@@ -156,6 +138,8 @@
                     // We're dealing with a category, create bucket id based on this row
                     const bucketId = `${bucket.uuid}category${String(categoryLabel).replace(/[^a-z0-9]/gi, '')}`;
                     
+                    // categories with the same name may appear multiple times due to ordering,
+                    // indexMap tracks these to uniquely identify them.
                     if (!(bucketId in indexMap)) {
                         indexMap[bucketId] = 0;
                     }
@@ -830,23 +814,36 @@
 
         });
 
+        function onTreeEvent(row, open) {
+            const getBucketById = (buckets, uuid) => {
+                for (const bucket of buckets) {
+                    if (bucket.uuid === uuid) {
+                        return bucket;
+                    }
+
+                    if (Array.isArray(bucket.children)) {
+                        const found = getBucketById(bucket.children, uuid);
+
+                        if (found) {
+                            return found;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            const bucket = getBucketById(buckets, row.getData().uuid);
+            if ('_expanded' in bucket) {
+                bucket._expanded = open;
+            }
+        }
+
         // persist expansion state of rule type categories
         // during the lifetime of the page, resets on page reload
         const table = grid.bootgrid('getTable');
-        table.on('dataTreeRowExpanded', (row) => {
-            const bucket = bucketById(buckets, row.getData().uuid);
-
-            if ('_expanded' in bucket) {
-                bucket._expanded = true;
-            }
-        })
-        table.on('dataTreeRowCollapsed', (row) => {
-            const bucket = bucketById(buckets, row.getData().uuid);
-
-            if ('_expanded' in bucket) {
-                bucket._expanded = false;
-            }
-        })
+        table.on('dataTreeRowExpanded', (row) => onTreeEvent(row, true));
+        table.on('dataTreeRowCollapsed', (row) => onTreeEvent(row, false));
 
         grid.on('loaded.rs.jquery.bootgrid', function () {
             updateStatisticColumns(); // ensures inspect columns are consistent after reload

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -115,6 +115,18 @@
         }
 
         function responseHandler(response) {
+            // recursively clear children but keep buckets intact
+            const clear = (buckets) => {
+                for (const bucket of buckets) {
+                    if (Array.isArray(bucket.children)) {
+                        clear(bucket.children);
+                        bucket.children = [];
+                    }
+                }
+            }
+
+            clear(buckets);
+
             // (re)initialize mising buckets
             for (const [idx, type] of Object.entries(ruleTypeMap)) {
                 const index = Number(idx);
@@ -129,22 +141,9 @@
                         _expanded: false,
                         categories: type.label,
                         category_colors: [{ name: type.label }],
-                        _parent: null
                     }));
                 }
             }
-
-            // recursively clear children but keep buckets intact
-            const clear = (buckets) => {
-                for (const bucket of buckets) {
-                    if (Array.isArray(bucket.children)) {
-                        clear(bucket.children);
-                        bucket.children = [];
-                    }
-                }
-            }
-
-            clear(buckets);
 
             const indexMap = {};
             let lastBucketId = null;
@@ -154,7 +153,7 @@
 
                 const categoryLabel = row["%categories"] || row.categories || "";
                 if (treeViewEnabled && row.is_automatic !== true && categoryLabel !== "") {
-                    // create bucket id based on this row
+                    // We're dealing with a category, create bucket id based on this row
                     const bucketId = `${bucket.uuid}category${String(categoryLabel).replace(/[^a-z0-9]/gi, '')}`;
                     
                     if (!(bucketId in indexMap)) {
@@ -167,27 +166,22 @@
                     }
 
                     const id = `${bucketId}${indexMap[bucketId]}`;
-                    
-                    let tmp = bucket.children.find(child => child.uuid === id);
+                    let newBucket = bucket.children.find(child => child.uuid === id);
 
-                    if (!tmp) {
-                        const newBucket = createBucket({
+                    if (!newBucket) {
+                        newBucket = createBucket({
                             uuid: id,
                             _persistence: true,
                             categories: categoryLabel,
                             category_colors: row.category_colors,
-                            _parent: bucket.uuid
                         });
                         bucket.children.push(newBucket);
-                        bucket = newBucket;
-                    } else {
-                        bucket = tmp;
                     }
 
+                    bucket = newBucket;
                     lastBucketId = bucketId;
                 }
 
-                row._parent = bucket.uuid;
                 bucket.children.push(row);
             });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -69,11 +69,10 @@
 
         const ruleTypeMap = {
             '0': { uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-            '1': { uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
             '2': { uuid: "floating", label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
             '3': { uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
             '4': { uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
-            '5': { uuid: "auto2", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '5': { uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
         };
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).
@@ -84,7 +83,7 @@
         };
 
         const getRuleType = function(row) {
-            return buckets[getRuleTypeDigit(row)] || null;
+            return buckets.find(r => r.idx === getRuleTypeDigit(row)) || null;
         };
 
         let buckets = [];

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -217,10 +217,21 @@
                         return true;
                     }
 
+                    // always stay collapsed if this tree is for the automatically generated rules
+                    if (data.uuid === "auto0" || data.uuid === "auto1") {
+                        return false;
+                    }
+
+                    const interfaceSelection = $("#interface_select").val();
+
+                    // expand if user selected "all rules"
+                    if (interfaceSelection === "__any") {
+                        return true;
+                    }
+
                     // find group by interface selection value
                     // note that "group" does not refer to interface groups here,
                     // but rather the interface selectpicker groups: "floating", "groups", "interfaces"
-                    const interfaceSelection = $("#interface_select").val();
                     const groupData = $("#interface_select").data();
                     let found = null;
                     for (const [groupName, group] of Object.entries(groupData.store)) {
@@ -230,6 +241,7 @@
                         }
                     }
 
+                    // unconditionally expand if the selected interface type matches the group type
                     if (found === data.groupType || found === "any") {
                         return true;
                     }

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -68,114 +68,146 @@
         let pendingUrlInterface = getUrlHash('interface') || null;
 
         const ruleTypeMap = {
-            '0': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-            '1': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-            '2': { label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
-            '3': { label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
-            '4': { label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
-            '5': { label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '0': { uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '1': { uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            '2': { uuid: "floating", label: "{{ lang._('Floating rules') }}", icon: "fa-layer-group", tooltip: "{{ lang._('Floating rule') }}", color: "text-primary", groupType: "floating" },
+            '3': { uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
+            '4': { uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
+            '5': { uuid: "auto2", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
         };
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).
         //      An exact match is not always possible, using the first digit is the best assumption currently.
         const getRuleTypeDigit = function(row) {
             const sortOrder = row.sort_order ? row.sort_order.toString() : "";
-            return sortOrder.charAt(0);
+            return Number(sortOrder.charAt(0));
         };
 
         const getRuleType = function(row) {
-            return ruleTypeMap[getRuleTypeDigit(row)] || null;
+            return buckets[getRuleTypeDigit(row)] || null;
         };
 
-        // Lives outside the grid, so the logic of the response handler can be changed after grid initialization
-        function dynamicResponseHandler(response) {
-            const getCategoryLabel = function(row) {
-                return row["%categories"] || row.categories || "";
+        let buckets = [];
+        function createBucket(props) {
+            return {
+                isGroup: true,
+                children: [],
+                ...props
             };
-
-            const createBucket = function(parent, label, uuid, categoryColors, groupType = null, persistence=true) {
-                let bucket = parent.children.find(child => child.isGroup && child._label === label);
-
-                if (!bucket) {
-                    bucket = {
-                        // ensure uuid is as unique as possible for persistence handling
-                        uuid           : uuid,
-                        isGroup        : true,
-                        _label         : label,          // internal
-                        categories     : label,
-                        _persistence   : persistence,    // internal
-                        _groupType     : groupType,      // internal
-                        /*
-                        * Bucket rows reuse the category formatter.
-                        * For category buckets, this copies the first child's category metadata
-                        * so the bucket can render the same category icon/color as its rules.
-                        * For rule type buckets, a synthetic categoryColors entry is supplied.
-                        */
-                        category_colors: categoryColors,
-                        children       : []
-                    };
-                    parent.children.push(bucket);
+        }
+        
+        function bucketById(buckets, uuid) {
+            for (const bucket of buckets) {
+                if (bucket.uuid === uuid) {
+                    return bucket;
                 }
 
-                return bucket;
-            };
+                if (Array.isArray(bucket.children)) {
+                    const found = bucketById(bucket.children, uuid);
 
-            const root = { children: [] };
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
 
+            return null;
+        }
+
+        function responseHandler(response) {
+            // (re)initialize mising buckets
+            for (const [idx, type] of Object.entries(ruleTypeMap)) {
+                const index = Number(idx);
+
+                const exists = buckets.some(bucket => Number(bucket.idx) === index);
+
+                if (!exists) {
+                    buckets.splice(index, 0, createBucket({
+                        ...type,
+                        idx: index,
+                        _persistence: false,
+                        _expanded: false,
+                        categories: type.label,
+                        category_colors: [{ name: type.label }],
+                        _parent: null
+                    }));
+                }
+            }
+
+            // recursively clear children but keep buckets intact
+            const clear = (buckets) => {
+                for (const bucket of buckets) {
+                    if (Array.isArray(bucket.children)) {
+                        clear(bucket.children);
+                        bucket.children = [];
+                    }
+                }
+            }
+
+            clear(buckets);
+
+            const indexMap = {};
+            let lastBucketId = null;
             response.rows.forEach(row => {
-                const ruleType = getRuleType(row);
-                const ruleTypeDigit = getRuleTypeDigit(row) || "other";
-                const ruleTypeLabel = ruleType.label || "{{ lang._('Other rules') }}";
-                const categoryLabel = getCategoryLabel(row);
+                // Find bucket this row belongs to. If it doesn't exist, create it.
+                let bucket = getRuleType(row);
 
-                /*
-                * The first tree level is the default view, and always based on the rule priority/type.
-                *
-                * Automatic rules
-                *   rule
-                * Interface rules
-                *   rule
-                */
-                const ruleTypeBucket = createBucket(
-                    root,
-                    ruleTypeLabel,
-                    `ruletype${ruleTypeDigit}`,
-                    [{ name: ruleTypeLabel }],
-                    ruleType.groupType,
-                    false,
-                );
-
+                const categoryLabel = row["%categories"] || row.categories || "";
                 if (treeViewEnabled && row.is_automatic !== true && categoryLabel !== "") {
-                    /*
-                    * When tree view is enabled, categorized non-automatic rules are grouped
-                    * one level deeper by category below their rule priority/type bucket.
-                    *
-                    * Automatic rules and uncategorized rules stay directly below their rule
-                    * priority/type bucket to avoid redundant or low-value nesting.
-                    *
-                    * Automatic rules
-                    *   rule
-                    * Interface rules
-                    *   rule
-                    *   Web (Category)
-                    *     rule
-                    *   Mail (Category)
-                    *     rule
-                    */
-                    const categoryBucket = createBucket(
-                        ruleTypeBucket,
-                        categoryLabel,
-                        `ruletype${ruleTypeDigit}category${String(categoryLabel).replace(/[^a-z0-9]/gi, '')}`,
-                        row.category_colors || []
-                    );
+                    // create bucket id based on this row
+                    const bucketId = `${bucket.uuid}category${String(categoryLabel).replace(/[^a-z0-9]/gi, '')}`;
+                    
+                    if (!(bucketId in indexMap)) {
+                        indexMap[bucketId] = 0;
+                    }
 
-                    categoryBucket.children.push(row);
-                } else {
-                    ruleTypeBucket.children.push(row);
+                    if (bucketId !== lastBucketId && lastBucketId !== null) {
+                        // moved to next category
+                        indexMap[lastBucketId]++;
+                    }
+
+                    const id = `${bucketId}${indexMap[bucketId]}`;
+                    
+                    let tmp = bucket.children.find(child => child.uuid === id);
+
+                    if (!tmp) {
+                        const newBucket = createBucket({
+                            uuid: id,
+                            _persistence: true,
+                            categories: categoryLabel,
+                            category_colors: row.category_colors,
+                            _parent: bucket.uuid
+                        });
+                        bucket.children.push(newBucket);
+                        bucket = newBucket;
+                    } else {
+                        bucket = tmp;
+                    }
+
+                    lastBucketId = bucketId;
                 }
+
+                row._parent = bucket.uuid;
+                bucket.children.push(row);
             });
 
-            return Object.assign({}, response, { rows: root.children });
+            const removeEmptyGroups = (items) => {
+                for (let i = items.length - 1; i >= 0; i--) {
+                    const item = items[i];
+
+                    if (Array.isArray(item.children)) {
+                        if (item.children.length === 0) {
+                            items.splice(i, 1);
+                        } else {
+                            removeEmptyGroups(item.children);
+                        }
+                    }
+                }
+            };
+
+            removeEmptyGroups(buckets);
+
+            return Object.assign({}, response, { rows: buckets });
         }
 
         $('#download_rules').click(function(e){
@@ -198,9 +230,14 @@
                 dataTreeElementColumn : "categories",
                 dataTreeStartExpanded : function(row, level) {
                     const data = row.getData();
-                    if (data._persistence) {
+                    if (data._persistence && !data?._expanded) {
                         // expansion state determined by user interaction
                         return false;
+                    }
+
+                    if (data?._expanded) {
+                        // inline reload of data, non-persisted open state
+                        return true;
                     }
 
                     // find group by interface selection value
@@ -216,7 +253,7 @@
                         }
                     }
 
-                    if (found === data._groupType || found === "any") {
+                    if (found === data.groupType || found === "any") {
                         return true;
                     }
 
@@ -275,7 +312,7 @@
                     return request;
                 },
                 // convert the flat rows into a tree view
-                responseHandler: dynamicResponseHandler,
+                responseHandler: responseHandler,
 
                 headerFormatters: {
                     enabled: function (column) {
@@ -468,20 +505,15 @@
                             * whose name matches ruleTypeMap, while real category buckets continue
                             * to render normal category tag icons.
                             */
-                            const ruleType = Object.values(ruleTypeMap).find(type => type.label === cat.name);
+                            const ruleType = Object.values(ruleTypeMap).find(r => r.uuid === row.uuid);
 
-                            if (isGroup && ruleType) {
-                                return `
-                                    <span class="category-icon" data-toggle="tooltip" title="${ruleType.tooltip}">
-                                        <i class="fa ${ruleType.icon} fa-fw ${ruleType.color}"></i>
-                                    </span>`;
-                            }
-
+                            const name = ruleType ? ruleType.tooltip : (cat.name || "");
+                            const icon = ruleType ? ruleType.icon : "fa-fw fa-tag";
+                            const classColor = ruleType? ruleType.color : '';
                             const bgColor = cat.color ? ` style="color:${cat.color};"` : '';
-
                             return `
-                                <span class="category-icon" data-toggle="tooltip" title="${cat.name}">
-                                    <i class="fa fa-fw fa-tag"${bgColor}></i>
+                                <span class="category-icon" data-toggle="tooltip" title="${name}">
+                                    <i class="fa fa-fw ${icon} ${classColor}" ${bgColor}></i>
                                 </span>`;
                         }).join(' ');
 
@@ -803,6 +835,24 @@
             },
 
         });
+
+        // persist expansion state of rule type categories
+        // during the lifetime of the page, resets on page reload
+        const table = grid.bootgrid('getTable');
+        table.on('dataTreeRowExpanded', (row) => {
+            const bucket = bucketById(buckets, row.getData().uuid);
+
+            if ('_expanded' in bucket) {
+                bucket._expanded = true;
+            }
+        })
+        table.on('dataTreeRowCollapsed', (row) => {
+            const bucket = bucketById(buckets, row.getData().uuid);
+
+            if ('_expanded' in bucket) {
+                bucket._expanded = false;
+            }
+        })
 
         grid.on('loaded.rs.jquery.bootgrid', function () {
             updateStatisticColumns(); // ensures inspect columns are consistent after reload

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -745,10 +745,12 @@ class UIBootgrid {
         });
 
         const rememberTree = (row, open) => {
-            const id = row.getData()[this.options.datakey];
-            if (!id) return;
+            const data = row.getData();
+            const id = data[this.options.datakey];
+            if (!data._persistence || !id) return;
             open ? this.rememberedTreeIds.add(id) : this.rememberedTreeIds.delete(id);
             localStorage.setItem(this.treeStorageKey, JSON.stringify([...this.rememberedTreeIds]));
+            this._setPersistence(true);
             this._maintainScrollPosition(this.scrollPos);
         };
 

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -747,11 +747,12 @@ class UIBootgrid {
         const rememberTree = (row, open) => {
             const data = row.getData();
             const id = data[this.options.datakey];
+            // maintain scroll position regardless of persistence state
+            this._maintainScrollPosition(this.scrollPos);
             if (!data._persistence || !id) return;
             open ? this.rememberedTreeIds.add(id) : this.rememberedTreeIds.delete(id);
             localStorage.setItem(this.treeStorageKey, JSON.stringify([...this.rememberedTreeIds]));
             this._setPersistence(true);
-            this._maintainScrollPosition(this.scrollPos);
         };
 
         this.table.on('dataTreeRowExpanded',  (row) => rememberTree(row, true));


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

See discussion in https://github.com/opnsense/core/issues/10358

---

**Describe the proposed solution**

If you now select an interface, the `interface rules` category tree will automatically open, if you select a group, the `group` tree will open. First-level groups (`interface rules`, `groups`, `floating`, `automatically generated`) are not persisted, while categories (user-defined) are.

This means that if you expand your own category, reloading the page will keep the expansion, but the first-level group where this category lives in may or may not render expanded, depending on interface type selection.

If you select "All rules", all first-level categories will expand.

---

**Related issue**

https://github.com/opnsense/core/issues/10358
