### PR TITLE
Kea: Add widget to show Kea DHCPv4 and DHCPv6 leases

### DIFF
--- a/plist
+++ b/plist
@@ -2268,6 +2268,7 @@
 /usr/local/opnsense/www/js/widgets/Interfaces.js
 /usr/local/opnsense/www/js/widgets/IpsecLeases.js
 /usr/local/opnsense/www/js/widgets/IpsecTunnels.js
+/usr/local/opnsense/www/js/widgets/KeaLeases.js
 /usr/local/opnsense/www/js/widgets/LiveLog.js
 /usr/local/opnsense/www/js/widgets/Mbuf.js
 /usr/local/opnsense/www/js/widgets/Memory.js

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -41,9 +41,15 @@ abstract class LeasesController extends ApiControllerBase
     {
         $selected_interfaces = $this->request->get('selected_interfaces');
 
-        $records = $this->getLeaseRecords();
-
         $backend = new Backend();
+
+        if (empty($this->configd_fetch_leases)) {
+            $records = [];
+        } else {
+            $leases = json_decode($backend->configdpRun($this->configd_fetch_leases), true) ?? [];
+            $records = $leases['records'] ?? [];
+        }
+
         $interfaces = [];
 
         $mac_db = json_decode($backend->configdRun('interface list macdb'), true) ?? [];
@@ -56,8 +62,18 @@ abstract class LeasesController extends ApiControllerBase
             ];
         }
 
+        $stats = [
+            'active' => 0,
+            'inactive' => 0,
+            'total' => 0,
+        ];
 
         foreach ($records as &$record) {
+            // Stats
+            $stats['total']++;
+            $isActive = $record['state'] === 0;
+            $stats[$isActive ? 'active' : 'inactive']++;
+
             // Interface
             $record['if_descr'] = '';
             $record['if_name'] = '';
@@ -75,6 +91,7 @@ abstract class LeasesController extends ApiControllerBase
             return empty($selected_interfaces) || in_array($key['if_name'], $selected_interfaces);
         });
 
+        $response['stats'] = $stats;
         $response['interfaces'] = $interfaces;
         return $response;
     }
@@ -101,38 +118,5 @@ abstract class LeasesController extends ApiControllerBase
         }
 
         return ['status' => 'ok'];
-    }
-
-    public function statsAction()
-    {
-        $records = $this->getLeaseRecords();
-
-        $stats = [
-            'active' => 0,
-            'inactive' => 0,
-            'total' => 0,
-        ];
-
-        foreach ($records as $record) {
-            $stats['total']++;
-            if ($record['state'] === 0) {
-                $stats['active']++;
-            } else {
-                $stats['inactive']++;
-            }
-        }
-
-        return $stats;
-    }
-
-    protected function getLeaseRecords()
-    {
-        if (empty($this->configd_fetch_leases)) {
-            return [];
-        }
-
-        $backend = new Backend();
-        $leases = json_decode($backend->configdpRun($this->configd_fetch_leases), true) ?? [];
-        return $leases['records'] ?? [];
     }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/Api/LeasesController.php
@@ -39,15 +39,13 @@ abstract class LeasesController extends ApiControllerBase
 
     public function searchAction()
     {
-        if (empty($this->configd_fetch_leases)) {
-            return [];
-        }
-
         $selected_interfaces = $this->request->get('selected_interfaces');
+
+        $records = $this->getLeaseRecords();
+
         $backend = new Backend();
         $interfaces = [];
 
-        $leases = json_decode($backend->configdpRun($this->configd_fetch_leases), true) ?? [];
         $mac_db = json_decode($backend->configdRun('interface list macdb'), true) ?? [];
 
         $ifmap = [];
@@ -58,23 +56,19 @@ abstract class LeasesController extends ApiControllerBase
             ];
         }
 
-        if (!empty($leases) && isset($leases['records'])) {
-            $records = $leases['records'];
-            foreach ($records as &$record) {
-                // Interface
-                $record['if_descr'] = '';
-                $record['if_name'] = '';
-                if (!empty($record['if']) && isset($ifmap[$record['if']])) {
-                    $record['if_descr'] = $ifmap[$record['if']]['descr'];
-                    $record['if_name'] = $ifmap[$record['if']]['key'];
-                    $interfaces[$ifmap[$record['if']]['key']] = $ifmap[$record['if']]['descr'];
-                }
-                // Vendor
-                $mac = strtoupper(substr(str_replace(':', '', $record['hwaddr']), 0, 6));
-                $record['mac_info'] = isset($mac_db[$mac]) ? $mac_db[$mac] : '';
+
+        foreach ($records as &$record) {
+            // Interface
+            $record['if_descr'] = '';
+            $record['if_name'] = '';
+            if (!empty($record['if']) && isset($ifmap[$record['if']])) {
+                $record['if_descr'] = $ifmap[$record['if']]['descr'];
+                $record['if_name'] = $ifmap[$record['if']]['key'];
+                $interfaces[$ifmap[$record['if']]['key']] = $ifmap[$record['if']]['descr'];
             }
-        } else {
-            $records = [];
+            // Vendor
+            $mac = strtoupper(substr(str_replace(':', '', $record['hwaddr']), 0, 6));
+            $record['mac_info'] = isset($mac_db[$mac]) ? $mac_db[$mac] : '';
         }
 
         $response = $this->searchRecordsetBase($records, null, 'address', function ($key) use ($selected_interfaces) {
@@ -107,5 +101,38 @@ abstract class LeasesController extends ApiControllerBase
         }
 
         return ['status' => 'ok'];
+    }
+
+    public function statsAction()
+    {
+        $records = $this->getLeaseRecords();
+
+        $stats = [
+            'active' => 0,
+            'inactive' => 0,
+            'total' => 0,
+        ];
+
+        foreach ($records as $record) {
+            $stats['total']++;
+            if ($record['state'] === 0) {
+                $stats['active']++;
+            } else {
+                $stats['inactive']++;
+            }
+        }
+
+        return $stats;
+    }
+
+    protected function getLeaseRecords()
+    {
+        if (empty($this->configd_fetch_leases)) {
+            return [];
+        }
+
+        $backend = new Backend();
+        $leases = json_decode($backend->configdpRun($this->configd_fetch_leases), true) ?? [];
+        return $leases['records'] ?? [];
     }
 }

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases4.volt
@@ -50,6 +50,7 @@
             options: {
                 selection: true,
                 multiSelect: true,
+                initialSearchPhrase: getUrlHash('search'),
                 requestHandler: function(request) {
                     request['selected_interfaces'] = selected_interfaces;
                     return request;

--- a/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Kea/leases6.volt
@@ -50,6 +50,7 @@
             options: {
                 selection: true,
                 multiSelect: true,
+                initialSearchPhrase: getUrlHash('search'),
                 requestHandler: function(request) {
                     request['selected_interfaces'] = selected_interfaces;
                     return request;

--- a/src/opnsense/www/js/widgets/KeaLeases.js
+++ b/src/opnsense/www/js/widgets/KeaLeases.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export default class KeaLeases extends BaseTableWidget {
+
+    constructor(config) {
+        super(config);
+        this.configurable = true;
+        this.configChanged = false;
+    }
+
+    getGridOptions() {
+        return {
+            sizeToContent: 650
+        };
+    }
+
+    getMarkup() {
+        return this.createTable('keaLeasesTable', {
+            headerPosition: 'left'
+        });
+    }
+
+    async onWidgetTick() {
+        $('[data-toggle="tooltip"]').tooltip({container: 'body'});
+
+        const [settingsV4Response, settingsV6Response] = await Promise.all([
+            this.ajaxCall(`/api/kea/dhcpv4/${'get'}`),
+            this.ajaxCall(`/api/kea/dhcpv6/${'get'}`)
+        ]);
+        const dhcpv4Enabled = settingsV4Response?.dhcpv4?.general?.enabled === '1';
+        const dhcpv6Enabled = settingsV6Response?.dhcpv6?.general?.enabled === '1';
+        if (!dhcpv4Enabled && !dhcpv6Enabled) {
+            this.displayError(this.translations.unconfigured, '/ui/kea/dhcp/v4#settings');
+            return;
+        }
+
+        const config = await this.getWidgetConfig() || {};
+        const limit = parseInt(config.leasesToShow ?? '2', 10) || 2;
+
+        const requestBody = JSON.stringify({
+            rowCount: Math.max(1, limit),
+            sort: { expire: 'desc' }
+        });
+
+        const [leases4Response, leases6Response] = await Promise.all([
+            this.ajaxCall(`/api/kea/leases4/${'search'}`, requestBody, 'POST'),
+            this.ajaxCall(`/api/kea/leases6/${'search'}`, requestBody, 'POST')
+        ]);
+
+        const leases4Rows = leases4Response?.rows ?? [];
+        const leases6Rows = leases6Response?.rows ?? [];
+
+        const leases4Tag = leases4Rows.map(row => Object.assign({}, row, { leaseFamily: 'v4' }));
+        const leases6Tag = leases6Rows.map(row => Object.assign({}, row, { leaseFamily: 'v6' }));
+
+        const expireValue = n => Number(n?.expire) || 0;
+        // combine v4 and v6 leases, sort by expire time and limit to the configured number of leases to show
+        const leaseRows = leases4Tag.concat(leases6Tag).sort((a, b) => expireValue(b) - expireValue(a)).slice(0, Math.max(1, limit));
+
+        const leases4TotalCount = Number.isFinite(leases4Response?.total) ? leases4Response.total : leases4Rows.length;
+        const leases6TotalCount = Number.isFinite(leases6Response?.total) ? leases6Response.total : leases6Rows.length;
+        const leaseTotalCount = leases4TotalCount + leases6TotalCount;
+
+        if (leaseTotalCount === 0) {
+            this.displayError(this.translations.noleases, '/ui/kea/dhcp/leases4');
+            return;
+        }
+
+        if (!this.dataChanged('dhcp-leases', leaseRows) && !this.configChanged) {
+            return;
+        }
+        this.configChanged = false;
+
+        $('#keaLeasesTable').empty();
+        this.processLeases(leaseRows.slice(0, Math.max(1, limit)));
+        $('[data-toggle="tooltip"]').tooltip('hide');
+    }
+
+    displayError(message, linkHref) {
+        $('#keaLeasesTable').empty().append(
+            `<div class="error-message">${linkHref ? `<a href="${linkHref}">${message}</a>` : message}</div>`
+        );
+    }
+
+    processLeases(leaseRows) {
+        const stateLabels = ['assigned', 'declined', 'assigned expired', 'declined expired', 'expired-reclaimed'];
+        const normalizeState = row => {
+            const rawState = row?.state ?? '';
+            const numericState = Number(rawState);
+            if (Number.isInteger(numericState) && stateLabels[numericState]) {
+                return stateLabels[numericState];
+            }
+            return String(rawState);
+        };
+
+        let activeCount = 0;
+        let inactiveCount = 0
+
+        leaseRows.forEach(row => {
+            const state = normalizeState(row);
+            if (state === 'assigned') {
+                activeCount++;
+            } else {
+                inactiveCount++;
+            }
+        });
+
+        const summaryRow = `
+            <div>
+                <span>
+                    Active: ${activeCount} |
+                    Inactive: ${inactiveCount} |
+                    Total: ${leaseRows.length}
+                </span>
+            </div>
+        `;
+
+        super.updateTable('keaLeasesTable', [[summaryRow, '']], 'kea-summary');
+
+        leaseRows
+            .map(row => ({
+                hostname: row.hostname || this.translations.notavailable,
+                ipAddress: row.address || this.translations.notavailable,
+                hwaddr: row.hwaddr || this.translations.notavailable,
+                leaseFamily: row.leaseFamily || (String(row.address || '').includes(':') ? 'v6' : 'v4')
+            }))
+            .forEach(lease => {
+                const hostname = (lease.hostname === '*') ? this.translations.notavailable : lease.hostname;
+                const header = `
+                    <div style="display:flex;align-items:center;">
+                        <i class="fa fa-laptop fa-fw text-primary"
+                           style="margin-right:5px;"
+                           data-toggle="tooltip"
+                           title="${lease.hwaddr}"></i>
+                        <span style="font-weight:bold;">${hostname}</span>
+                    </div>
+                `;
+                const leasesPath = lease.leaseFamily === 'v6' ? 'leases6' : 'leases4';
+                const link = `/ui/kea/dhcp/${leasesPath}#search=${encodeURIComponent(lease.ipAddress)}`;
+                const row = `<div><a href="${link}">${lease.ipAddress}</a></div><div></div>`;
+                super.updateTable('keaLeasesTable', [[header, row]], `${lease.leaseFamily}-${lease.ipAddress}`);
+            });
+
+    }
+
+    async getWidgetOptions() {
+        return {
+            leasesToShow: {
+                id: 'leasesToShow',
+                title: this.translations.leasesselect,
+                type: 'select',
+                options: [
+                    { value: '2',  label: '2'  },
+                    { value: '5',  label: '5'  },
+                    { value: '10', label: '10' },
+                    { value: '20', label: '20' },
+                    { value: '30', label: '30' },
+                    { value: '40', label: '40' },
+                    { value: '50', label: '50' }
+                ],
+                default: '2',
+                required: true
+            }
+        };
+    }
+
+    async onWidgetOptionsChanged() {
+        this.configChanged = true;
+        await this.onWidgetTick();
+    }
+}

--- a/src/opnsense/www/js/widgets/KeaLeases.js
+++ b/src/opnsense/www/js/widgets/KeaLeases.js
@@ -48,44 +48,52 @@ export default class KeaLeases extends BaseTableWidget {
         $('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
         const [settingsV4Response, settingsV6Response] = await Promise.all([
-            this.ajaxCall(`/api/kea/dhcpv4/${'get'}`),
-            this.ajaxCall(`/api/kea/dhcpv6/${'get'}`)
+            this.ajaxCall(`/api/kea/dhcpv4/get`),
+            this.ajaxCall(`/api/kea/dhcpv6/get`)
         ]);
+
         const dhcpv4Enabled = settingsV4Response?.dhcpv4?.general?.enabled === '1';
         const dhcpv6Enabled = settingsV6Response?.dhcpv6?.general?.enabled === '1';
+
         if (!dhcpv4Enabled && !dhcpv6Enabled) {
             this.displayError(this.translations.unconfigured, '/ui/kea/dhcp/v4#settings');
             return;
         }
 
-        const config = await this.getWidgetConfig() || {};
-        const limit = parseInt(config.leasesToShow ?? '2', 10) || 2;
+        const config = await this.getWidgetConfig();
+        const limit = parseInt(config.leasesToShow ?? '2');
 
-        const requestBody = JSON.stringify({
-            rowCount: Math.max(1, limit),
+        const statsRequestBody = JSON.stringify({});
+        const leasesRequestBody = JSON.stringify({
+            rowCount: limit,
             sort: { expire: 'desc' }
         });
 
-        const [leases4Response, leases6Response] = await Promise.all([
-            this.ajaxCall(`/api/kea/leases4/${'search'}`, requestBody, 'POST'),
-            this.ajaxCall(`/api/kea/leases6/${'search'}`, requestBody, 'POST')
+        const [stats4Response, stats6Response, leases4Response, leases6Response] = await Promise.all([
+            this.ajaxCall(`/api/kea/leases4/stats`, statsRequestBody, 'GET'),
+            this.ajaxCall(`/api/kea/leases6/stats`, statsRequestBody, 'GET'),
+            this.ajaxCall(`/api/kea/leases4/search`, leasesRequestBody, 'POST'),
+            this.ajaxCall(`/api/kea/leases6/search`, leasesRequestBody, 'POST')
         ]);
 
         const leases4Rows = leases4Response?.rows ?? [];
         const leases6Rows = leases6Response?.rows ?? [];
 
-        const leases4Tag = leases4Rows.map(row => Object.assign({}, row, { leaseFamily: 'v4' }));
-        const leases6Tag = leases6Rows.map(row => Object.assign({}, row, { leaseFamily: 'v6' }));
+        // tag leasefamily for each lease
+        leases4Rows.forEach(row => row.leaseFamily = 'v4');
+        leases6Rows.forEach(row => row.leaseFamily = 'v6');
 
-        const expireValue = n => Number(n?.expire) || 0;
-        // combine v4 and v6 leases, sort by expire time and limit to the configured number of leases to show
-        const leaseRows = leases4Tag.concat(leases6Tag).sort((a, b) => expireValue(b) - expireValue(a)).slice(0, Math.max(1, limit));
+        // combine v4 and v6 leases and sort by expire time
+        const leaseRows = leases4Rows.concat(leases6Rows).sort((a, b) => b.expire - a.expire);
 
-        const leases4TotalCount = Number.isFinite(leases4Response?.total) ? leases4Response.total : leases4Rows.length;
-        const leases6TotalCount = Number.isFinite(leases6Response?.total) ? leases6Response.total : leases6Rows.length;
-        const leaseTotalCount = leases4TotalCount + leases6TotalCount;
+        // combine v4 and v6 lease counts
+        const stats = {
+            activeCount: (stats4Response?.active ?? 0) + (stats6Response?.active ?? 0),
+            inactiveCount: (stats4Response?.inactive ?? 0) + (stats6Response?.inactive ?? 0),
+            totalCount: (stats4Response?.total ?? 0) + (stats6Response?.total ?? 0)
+        };
 
-        if (leaseTotalCount === 0) {
+        if (stats.totalCount === 0) {
             this.displayError(this.translations.noleases, '/ui/kea/dhcp/leases4');
             return;
         }
@@ -96,7 +104,7 @@ export default class KeaLeases extends BaseTableWidget {
         this.configChanged = false;
 
         $('#keaLeasesTable').empty();
-        this.processLeases(leaseRows.slice(0, Math.max(1, limit)));
+        this.processLeases(leaseRows, stats);
         $('[data-toggle="tooltip"]').tooltip('hide');
     }
 
@@ -106,65 +114,42 @@ export default class KeaLeases extends BaseTableWidget {
         );
     }
 
-    processLeases(leaseRows) {
-        const stateLabels = ['assigned', 'declined', 'assigned expired', 'declined expired', 'expired-reclaimed'];
-        const normalizeState = row => {
-            const rawState = row?.state ?? '';
-            const numericState = Number(rawState);
-            if (Number.isInteger(numericState) && stateLabels[numericState]) {
-                return stateLabels[numericState];
-            }
-            return String(rawState);
-        };
-
-        let activeCount = 0;
-        let inactiveCount = 0
-
-        leaseRows.forEach(row => {
-            const state = normalizeState(row);
-            if (state === 'assigned') {
-                activeCount++;
-            } else {
-                inactiveCount++;
-            }
-        });
-
+    processLeases(leaseRows, stats) {
         const summaryRow = `
             <div>
                 <span>
-                    Active: ${activeCount} |
-                    Inactive: ${inactiveCount} |
-                    Total: ${leaseRows.length}
+                    Active: ${stats.activeCount} |
+                    Inactive: ${stats.inactiveCount} |
+                    Total: ${stats.totalCount}
                 </span>
             </div>
         `;
 
         super.updateTable('keaLeasesTable', [[summaryRow, '']], 'kea-summary');
 
-        leaseRows
-            .map(row => ({
-                hostname: row.hostname || this.translations.notavailable,
-                ipAddress: row.address || this.translations.notavailable,
-                hwaddr: row.hwaddr || this.translations.notavailable,
-                leaseFamily: row.leaseFamily || (String(row.address || '').includes(':') ? 'v6' : 'v4')
-            }))
-            .forEach(lease => {
-                const hostname = (lease.hostname === '*') ? this.translations.notavailable : lease.hostname;
-                const header = `
-                    <div style="display:flex;align-items:center;">
-                        <i class="fa fa-laptop fa-fw text-primary"
-                           style="margin-right:5px;"
-                           data-toggle="tooltip"
-                           title="${lease.hwaddr}"></i>
-                        <span style="font-weight:bold;">${hostname}</span>
-                    </div>
-                `;
-                const leasesPath = lease.leaseFamily === 'v6' ? 'leases6' : 'leases4';
-                const link = `/ui/kea/dhcp/${leasesPath}#search=${encodeURIComponent(lease.ipAddress)}`;
-                const row = `<div><a href="${link}">${lease.ipAddress}</a></div><div></div>`;
-                super.updateTable('keaLeasesTable', [[header, row]], `${lease.leaseFamily}-${lease.ipAddress}`);
-            });
+        const notAvailable = this.translations.notavailable;
 
+        leaseRows.forEach(lease => {
+            const hostname = (lease.hostname === '*' || !lease.hostname) ? notAvailable : lease.hostname;
+            const ipAddress = lease.address || notAvailable;
+            const hwaddr = lease.hwaddr || notAvailable;
+            const leaseFamily = lease.leaseFamily;
+
+            const header = `
+                <div style="display:flex;align-items:center;">
+                    <i class="fa fa-laptop fa-fw text-primary"
+                        style="margin-right:5px;"
+                        data-toggle="tooltip"
+                        title="${hwaddr}"></i>
+                    <span style="font-weight:bold;">${hostname}</span>
+                </div>
+            `;
+
+            const leasesPath = leaseFamily === 'v4' ? 'leases4' : 'leases6';
+            const link = `/ui/kea/dhcp/${leasesPath}#search=${encodeURIComponent(ipAddress)}`;
+            const row = `<div><a href="${link}">${ipAddress}</a></div><div></div>`;
+            super.updateTable('keaLeasesTable', [[header, row]], `${leaseFamily}-${ipAddress}`);
+        });
     }
 
     async getWidgetOptions() {

--- a/src/opnsense/www/js/widgets/KeaLeases.js
+++ b/src/opnsense/www/js/widgets/KeaLeases.js
@@ -61,17 +61,14 @@ export default class KeaLeases extends BaseTableWidget {
         }
 
         const config = await this.getWidgetConfig();
-        const limit = parseInt(config.leasesToShow ?? '2');
+        const limit = parseInt(config.leasesToShow);
 
-        const statsRequestBody = JSON.stringify({});
         const leasesRequestBody = JSON.stringify({
             rowCount: limit,
             sort: { expire: 'desc' }
         });
 
-        const [stats4Response, stats6Response, leases4Response, leases6Response] = await Promise.all([
-            this.ajaxCall(`/api/kea/leases4/stats`, statsRequestBody, 'GET'),
-            this.ajaxCall(`/api/kea/leases6/stats`, statsRequestBody, 'GET'),
+        const [leases4Response, leases6Response] = await Promise.all([
             this.ajaxCall(`/api/kea/leases4/search`, leasesRequestBody, 'POST'),
             this.ajaxCall(`/api/kea/leases6/search`, leasesRequestBody, 'POST')
         ]);
@@ -88,9 +85,9 @@ export default class KeaLeases extends BaseTableWidget {
 
         // combine v4 and v6 lease counts
         const stats = {
-            activeCount: (stats4Response?.active ?? 0) + (stats6Response?.active ?? 0),
-            inactiveCount: (stats4Response?.inactive ?? 0) + (stats6Response?.inactive ?? 0),
-            totalCount: (stats4Response?.total ?? 0) + (stats6Response?.total ?? 0)
+            activeCount: (leases4Response?.stats?.active ?? 0) + (leases6Response?.stats?.active ?? 0),
+            inactiveCount: (leases4Response?.stats?.inactive ?? 0) + (leases6Response?.stats?.inactive ?? 0),
+            totalCount: (leases4Response?.stats?.total ?? 0) + (leases6Response?.stats?.total ?? 0)
         };
 
         if (stats.totalCount === 0) {

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -401,6 +401,24 @@
             <notavailable>N/A</notavailable>
         </translations>
     </dnsmasqleases>
+    <kealeases>
+        <filename>KeaLeases.js</filename>
+        <link>/ui/kea/dhcp/v4#settings</link>
+        <endpoints>
+            <endpoint>/api/kea/dhcpv4/*</endpoint>
+            <endpoint>/api/kea/dhcpv6/*</endpoint>
+            <endpoint>/api/kea/leases4/*</endpoint>
+            <endpoint>/api/kea/leases6/*</endpoint>
+        </endpoints>
+        <translations>
+            <title>Kea DHCP</title>
+            <unconfigured>Kea is currently disabled.</unconfigured>
+            <noleases>No leases found.</noleases>
+            <leases>Leases</leases>
+            <leasesselect>Select amount of leases to show</leasesselect>
+            <notavailable>N/A</notavailable>
+        </translations>
+    </kealeases>
     <notes>
         <filename>Notes.js</filename>
         <endpoints>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -405,8 +405,8 @@
         <filename>KeaLeases.js</filename>
         <link>/ui/kea/dhcp/v4#settings</link>
         <endpoints>
-            <endpoint>/api/kea/dhcpv4/*</endpoint>
-            <endpoint>/api/kea/dhcpv6/*</endpoint>
+            <endpoint>/api/kea/dhcpv4/get</endpoint>
+            <endpoint>/api/kea/dhcpv6/get</endpoint>
             <endpoint>/api/kea/leases4/*</endpoint>
             <endpoint>/api/kea/leases6/*</endpoint>
         </endpoints>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: GPT-5 mini
- Extent of AI involvement: Used to write the query for concatenating and sorting v4 and v6 leases and to write normalizeState.

---

**Describe the problem**

A widget to show the Kea DHCP leases did not exists yet, only for dnsmasq DHCP leases. 

---

**Describe the proposed solution**

This pull request adds a widget that displays a list of the latest leases that Kea DHCP handed out. In addition to that, it displays the active, inactive and total lease count as well.

---

**Related issue**

If this pull request relates to an issue, link it here.
Closes: https://github.com/opnsense/core/issues/10191