### PR TITLE
Firewall: Add migration assistant banner to legacy rules page

### DIFF
--- a/src/www/firewall_rules.php
+++ b/src/www/firewall_rules.php
@@ -700,6 +700,15 @@ $( document ).ready(function() {
           $config['interfaces'][$selected_if]['descr'] : strtoupper($selected_if))) ?>
 <?php endif ?>
 <?php endif ?>
+<?php
+        print_info_box(
+            gettext("This legacy firewall page is deprecated and will be replaced by the new firewall rules interface.") . "<br />" .
+            gettext("Use the migration assistant to export existing legacy firewall rules and import them into the new interface.") . "<br /><br />" .
+            '<a class="btn btn-primary" href="/ui/firewall/migration">' .
+                '<i class="fa fa-external-link fa-fw"></i> ' . gettext("Open migration assistant") .
+            '</a> '
+        );
+?>
         <section class="col-xs-12">
           <div class="content-box">
             <form action="firewall_rules.php?if=<?=$selected_if;?>" method="post" name="iform" id="iform">


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The migration assistant is used for firewall rules and outbound NAT, it has changed its spot in the menu, making it potentially less discoverable.

---

**Describe the proposed solution**

This banner hints to the migration assistant, the same way as in the Outbound NAT page.

---

**Related issue**

Related to this: https://github.com/opnsense/core/pull/10373
