### PR TITLE
Firewall: NAT: Source NAT: Hide command footer if snat_mode is automatic

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -50,12 +50,16 @@
 
         function updateSnatModeUI() {
             if (entrypoint !== 'source_nat') {
-                $('#rule_grid_container').removeClass('snat-mode-hidden');
+                $('#rule_grid_container').removeClass('snat-mode-hidden snat-mode-readonly');
                 return;
             }
+
             const snatMode = $('#filter\\.general\\.snat_mode').val();
             const isDisabled = snatMode === 'disabled';
+            const isReadonly = snatMode === 'automatic';
+
             $('#rule_grid_container').toggleClass('snat-mode-hidden', isDisabled);
+            $('#rule_grid_container').toggleClass('snat-mode-readonly', isReadonly);
         }
 
         function showDialogAlert(type, title, message) {
@@ -781,6 +785,9 @@
         }
     }
     .snat-mode-hidden {
+        display: none;
+    }
+    .snat-mode-readonly [class*="command-"] {
         display: none;
     }
 </style>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

When snat_mode is automatic, users are not expected to add rules or use any of the footer commands.

---

**Describe the proposed solution**

Hide them via css.

Theoretically it could also be done with the command filters in the grid, but the grid loads asynchronous, so the endpoint we use to decide this might not have fired yet and we would have to wrap everything into promises.

---

**Related issue**

If this pull request relates to an issue, link it here.
