### PR TITLE
Firewall: Rules: add banner if no rules defined

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -105,9 +105,6 @@
         }
 
         function responseHandler(response) {
-            // remove empty ruleset message banner if applicable
-            $('#{{formGridFilterRule["table_id"]}}-banner').remove();
-
             // recursively clear children but keep buckets intact
             const clear = (buckets) => {
                 for (const bucket of buckets) {
@@ -870,7 +867,10 @@
         grid.on('loaded.rs.jquery.bootgrid', function () {
             updateStatisticColumns(); // ensures inspect columns are consistent after reload
 
-            // check if interface/group type is selected, and if so, display an in-table message if there are no interface rules defined
+            // remove empty ruleset message banner if applicable
+            $('#{{formGridFilterRule["table_id"]}}-banner').remove();
+
+            // check if interface/group type is selected, and if so, display an in-table message if there are no rules defined
             if ((currentGroupType === "groups" || currentGroupType === "interfaces") && !buckets.find(b => b.groupType === currentGroupType)) {
                 let ifLabel = '';
                 for (const group of Object.values($('#interface_select').data().store)) {
@@ -887,7 +887,6 @@
                         {{ lang._('All incoming connections on this interface will be blocked until you add a pass rule. ') }}
                         {{ lang._('Exceptions for automatically generated or floating rules may apply.') }}
                     `));
-
             }
         });
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -256,6 +256,8 @@
                 rowCount: [500,20,50,100,200,1000,2000,-1],
                 initialSearchPhrase: getUrlHash('search'),
                 requestHandler: function(request){
+                    // remove empty ruleset message banner if applicable
+                    $('#{{formGridFilterRule["table_id"]}}-banner').remove();
                     // Add category selectpicker
                     if ( $('#category_filter').val().length > 0) {
                         request['category'] = $('#category_filter').val();
@@ -866,6 +868,26 @@
 
         grid.on('loaded.rs.jquery.bootgrid', function () {
             updateStatisticColumns(); // ensures inspect columns are consistent after reload
+
+            // check if interface/group type is selected, and if so, display an in-table message if there are no interface rules defined
+            if ((currentGroupType === "groups" || currentGroupType === "interfaces") && !buckets.find(b => b.groupType === currentGroupType)) {
+                let ifLabel = '';
+                for (const group of Object.values($('#interface_select').data().store)) {
+                    const item = group.items.find(item => item.value === $('#interface_select').val());
+                    if (item) {
+                        ifLabel = item.label;
+                        break;
+                    }
+                }
+                $("#{{formGridFilterRule['table_id']}}-header")
+                    .after($('<div id="{{formGridFilterRule["table_id"]}}-banner" class="alert alert-info text-center __ml __mr" style="font-weight: 400;">')
+                    .text(`
+                        {{ lang._('No %s rules have been defined. ') | format('${ifLabel}') }}
+                        {{ lang._('All incoming connections on this interface will be blocked until you add a pass rule. ') }}
+                        {{ lang._('Exceptions for automatically generated or floating rules may apply.') }}
+                    `));
+
+            }
         });
 
         // Track if user has actually changed a dropdown, or it was the controller

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -105,6 +105,9 @@
         }
 
         function responseHandler(response) {
+            // remove empty ruleset message banner if applicable
+            $('#{{formGridFilterRule["table_id"]}}-banner').remove();
+
             // recursively clear children but keep buckets intact
             const clear = (buckets) => {
                 for (const bucket of buckets) {
@@ -256,8 +259,6 @@
                 rowCount: [500,20,50,100,200,1000,2000,-1],
                 initialSearchPhrase: getUrlHash('search'),
                 requestHandler: function(request){
-                    // remove empty ruleset message banner if applicable
-                    $('#{{formGridFilterRule["table_id"]}}-banner').remove();
                     // Add category selectpicker
                     if ( $('#category_filter').val().length > 0) {
                         request['category'] = $('#category_filter').val();


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

In the current firewall rules page, it isn't immediately obvious there are no firewall rules defined, as the floating and automatically generated sections are always rendered.

---

**Describe the proposed solution**

Show a message indicating all traffic will be blocked on this interface until a pass rule is applied, same as the legacy firewall pages:

<img width="1301" height="334" alt="image" src="https://github.com/user-attachments/assets/e0b2ed57-e40b-4805-874b-0dd473bfaed1" />


---

**Related issue**

If this pull request relates to an issue, link it here.
