### PR TITLE
mvc: add new validators to TextField: AllowSpaces, AllowNewlines, AllowSpecial

### DIFF
--- a/plist
+++ b/plist
@@ -658,6 +658,7 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/OptionField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ProtocolField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/StrictTextField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/UniqueIdField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/UpdateOnlyTextField.php
@@ -1121,6 +1122,7 @@
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/OptionFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/ProtocolFieldTest.php
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/StrictTextFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/UpdateOnlyTextFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/VirtualIPFieldTest.php

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/StrictTextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/StrictTextField.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Base\FieldTypes;
+
+/**
+ * Class StrictTextField
+ * @package OPNsense\Base\FieldTypes
+ */
+class StrictTextField extends TextField
+{
+    /**
+     * @var bool allow spaces and tabs
+     */
+    protected $internalAllowSpaces = false;
+
+    /**
+     * @var bool allow newlines
+     */
+    protected $internalAllowNewlines = false;
+
+    /**
+     * @var bool allow special control characters
+     */
+    protected $internalAllowSpecial = false;
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
@@ -60,7 +60,7 @@ class TextField extends BaseField
     /**
      * @var bool allow special control characters
      */
-    protected $internalAllowSpecial = false;
+    protected $internalAllowSpecial = true;
 
     /**
      * set validation mask

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/TextField.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2015 Deciso B.V.
+ * Copyright (C) 2015-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 
 namespace OPNsense\Base\FieldTypes;
 
+use OPNsense\Base\Validators\CallbackValidator;
 use OPNsense\Base\Validators\Regex;
 
 /**
@@ -47,12 +48,51 @@ class TextField extends BaseField
     protected $internalMask = null;
 
     /**
+     * @var bool allow spaces and tabs
+     */
+    protected $internalAllowSpaces = true;
+
+    /**
+     * @var bool allow newlines
+     */
+    protected $internalAllowNewlines = true;
+
+    /**
+     * @var bool allow special control characters
+     */
+    protected $internalAllowSpecial = false;
+
+    /**
      * set validation mask
      * @param string $value regexp validation mask
      */
     public function setMask($value)
     {
         $this->internalMask = $value;
+    }
+
+    /**
+     * @param string $value Y/N
+     */
+    public function setAllowSpaces($value): void
+    {
+        $this->internalAllowSpaces = strtoupper(trim($value)) === 'Y';
+    }
+
+    /**
+     * @param string $value Y/N
+     */
+    public function setAllowNewlines($value): void
+    {
+        $this->internalAllowNewlines = strtoupper(trim($value)) === 'Y';
+    }
+
+    /**
+     * @param string $value Y/N
+     */
+    public function setAllowSpecial($value): void
+    {
+        $this->internalAllowSpecial = strtoupper(trim($value)) === 'Y';
     }
 
     /**
@@ -71,13 +111,32 @@ class TextField extends BaseField
     {
         $validators = parent::getValidators();
         if ($this->internalValue != null) {
-            if ($this->internalValue != null && $this->internalMask != null) {
+            $validators[] = new CallbackValidator([
+                "callback" => function ($value) {
+                    if (!$this->internalAllowSpaces && strpbrk($value, " \t") !== false) {
+                        return [gettext("Text may not contain spaces or tabs.")];
+                    }
+
+                    if (!$this->internalAllowNewlines && strpbrk($value, "\n\r") !== false) {
+                        return [gettext("Text may not contain newlines.")];
+                    }
+
+                    if (!$this->internalAllowSpecial && strpbrk($value, "\0\v\f") !== false) {
+                        return [gettext("Text may not contain special control characters.")];
+                    }
+
+                    return [];
+                }
+            ]);
+
+            if ($this->internalMask != null) {
                 $validators[] = new Regex([
                     'message' => $this->getValidationMessage(),
                     'pattern' => trim($this->internalMask),
                 ]);
             }
         }
+
         return $validators;
     }
 }

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/StrictTextFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/StrictTextFieldTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Base\FieldTypes;
+
+// @CodingStandardsIgnoreStart
+require_once 'Field_Framework_TestCase.php';
+// @CodingStandardsIgnoreEnd
+
+use OPNsense\Base\FieldTypes\StrictTextField;
+
+class StrictTextFieldTest extends Field_Framework_TestCase
+{
+    /**
+     * test construct
+     */
+    public function testCanBeCreated()
+    {
+        $this->assertInstanceOf('\OPNsense\Base\FieldTypes\StrictTextField', new StrictTextField());
+    }
+
+    /**
+     * spaces and tabs fail validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpacesDefault()
+    {
+        $field = new StrictTextField();
+        $field->setValue("foo bar\tbaz");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * spaces and tabs pass validation when AllowSpaces=Y
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpacesEnabled()
+    {
+        $field = new StrictTextField();
+        $field->setAllowSpaces('Y');
+        $field->setValue("foo bar\tbaz");
+
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * newlines fail validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowNewlinesDefault()
+    {
+        $field = new StrictTextField();
+        $field->setValue("foo\nbar\rbaz");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * newlines pass validation when AllowNewlines=Y
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowNewlinesEnabled()
+    {
+        $field = new StrictTextField();
+        $field->setAllowNewlines('Y');
+        $field->setValue("foo\nbar\rbaz");
+
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * special control characters fail validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpecialDefault()
+    {
+        $field = new StrictTextField();
+        $field->setValue("foo\0bar\vbaz\fqux");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * special control characters pass validation when AllowSpecial=Y
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpecialEnabled()
+    {
+        $field = new StrictTextField();
+        $field->setAllowSpecial('Y');
+        $field->setValue("foo\0bar\vbaz\fqux");
+
+        $this->assertEmpty($this->validate($field));
+    }
+}

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
@@ -412,7 +412,7 @@ class TextFieldTest extends Field_Framework_TestCase
     }
 
     /**
-     * special control characters fail validation by default
+     * special control characters pass validation by default
      * no mask (TextField default)
      * not required (BaseField default)
      */
@@ -421,21 +421,21 @@ class TextFieldTest extends Field_Framework_TestCase
         $field = new TextField();
         $field->setValue("foo\0bar\vbaz\fqux");
 
-        $this->assertNotEmpty($this->validate($field));
+        $this->assertEmpty($this->validate($field));
     }
 
     /**
-     * special control characters pass validation when AllowSpecial=Y
+     * special control characters fail validation when AllowSpecial=N
      * no mask (TextField default)
      * not required (BaseField default)
      */
-    public function testAllowSpecialEnabled()
+    public function testAllowSpecialDisabled()
     {
         $field = new TextField();
-        $field->setAllowSpecial('Y');
+        $field->setAllowSpecial('N');
         $field->setValue("foo\0bar\vbaz\fqux");
 
-        $this->assertEmpty($this->validate($field));
+        $this->assertNotEmpty($this->validate($field));
     }
 
 }

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/TextFieldTest.php
@@ -356,4 +356,86 @@ class TextFieldTest extends Field_Framework_TestCase
 
         $this->assertContains('Regex', $this->validate($field));
     }
+
+    /**
+     * spaces and tabs pass validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpacesDefault()
+    {
+        $field = new TextField();
+        $field->setValue("foo bar\tbaz");
+
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * spaces and tabs fail validation when AllowSpaces=N
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpacesDisabled()
+    {
+        $field = new TextField();
+        $field->setAllowSpaces('N');
+        $field->setValue("foo bar\tbaz");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * newlines pass validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowNewlinesDefault()
+    {
+        $field = new TextField();
+        $field->setValue("foo\nbar\rbaz");
+
+        $this->assertEmpty($this->validate($field));
+    }
+
+    /**
+     * newlines fail validation when AllowNewlines=N
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowNewlinesDisabled()
+    {
+        $field = new TextField();
+        $field->setAllowNewlines('N');
+        $field->setValue("foo\nbar\rbaz");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * special control characters fail validation by default
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpecialDefault()
+    {
+        $field = new TextField();
+        $field->setValue("foo\0bar\vbaz\fqux");
+
+        $this->assertNotEmpty($this->validate($field));
+    }
+
+    /**
+     * special control characters pass validation when AllowSpecial=Y
+     * no mask (TextField default)
+     * not required (BaseField default)
+     */
+    public function testAllowSpecialEnabled()
+    {
+        $field = new TextField();
+        $field->setAllowSpecial('Y');
+        $field->setValue("foo\0bar\vbaz\fqux");
+
+        $this->assertEmpty($this->validate($field));
+    }
+
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.5
- Extent of AI involvement: Extending the test

---

Fixes: https://github.com/opnsense/core/issues/10397

