### PR TITLE
Implement deny unknown and permit reservation without IP.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
@@ -9,7 +9,7 @@
         <id>reservation.ip_address</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address to offer to the client</help>
+        <help>IP address to offer to the client. Leave empty to create a reservation without a fixed IP (useful for deny unknown clients).</help>
     </field>
     <field>
         <id>reservation.hw_address</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -28,6 +28,17 @@
         <help>List of pools, one per line in range or subnet format (e.g. 192.168.0.100 - 192.168.0.200 , 192.0.2.64/26</help>
     </field>
     <field>
+        <id>subnet4.deny_unknown_clients</id>
+        <label>Deny unknown clients</label>
+        <type>checkbox</type>
+        <help>When enabled, only clients with a reservation will receive an IP from the pool. Unknown clients will be denied.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>subnet4.valid_lifetime</id>
         <label>Valid lifetime</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -85,7 +85,7 @@ class KeaDhcpv4 extends BaseModel
             if ($subnet_node) {
                 $subnet = $subnet_node->subnet->getValue();
             }
-            if (!Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
+            if (!$reservation->ip_address->isEmpty() && !Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
                 $messages->appendMessage(new Message(gettext("Address not in specified subnet"), $key . ".ip_address"));
             }
             if (!$reservation->client_id->isEmpty() && !$reservation->hw_address->isEmpty()) {
@@ -192,7 +192,11 @@ class KeaDhcpv4 extends BaseModel
             }
             /* add pools */
             foreach ($subnet->pools->getValues() as $pool) {
-                $record['pools'][] = ['pool' => $pool];
+                $pool_entry = ['pool' => $pool];
+                if (!$subnet->deny_unknown_clients->isEmpty()) {
+                    $pool_entry['client-class'] = 'KNOWN';
+                }
+                $record['pools'][] = $pool_entry;
             }
             /* static reservations */
             foreach ($this->reservations->reservation->iterateItems() as $key => $reservation) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>
@@ -96,6 +96,10 @@
                         </check001>
                     </Constraints>
                 </subnet>
+                <deny_unknown_clients type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </deny_unknown_clients>
                 <valid_lifetime type="IntegerField">
                     <MinimumValue>0</MinimumValue>
                 </valid_lifetime>


### PR DESCRIPTION
Add a "know" class, when the ip is given by the reservation, we can accept only know class client.
Permit add reservation without fixed IP. So you can reserve only "MACADDR" to be used with "deny unknow class".
It can be used together or not.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below. 
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

There are two related missing features in the Kea DHCPv4 implementation:

1. There is no way to restrict a pool to only serve clients that have a reservation (deny unknown clients). This is a common requirement for networks where only pre-approved devices should receive an IP from a specific pool.

2. Reservations currently require a fixed IP address. This prevents creating MAC-only reservations, which are needed when using "deny unknown clients" — you want to allow a client into the pool without pinning it to a specific address.

---

**Describe the proposed solution**

**Feature 1: Deny unknown clients per subnet**

Added a `deny_unknown_clients` boolean field to the subnet4 model. When enabled, all pools in that subnet are generated with `"client-class": "KNOWN"` in the Kea configuration. The `KNOWN` class is a Kea built-in that matches only clients with an existing host reservation, effectively denying unknown clients from obtaining a lease from the pool.

**Feature 2: Reservations without fixed IP**

Removed the requirement for `ip_address` on DHCPv4 reservations. The `UniqueConstraint` is preserved but naturally skips validation when the field is empty (built-in framework behavior for non-required fields). The validation in `performValidation()` now only checks subnet membership when an IP is actually provided. Config generation already handles this correctly since it only emits `ip-address` when the field is non-empty.

These two features work together: you can enable "deny unknown clients" on a subnet and create MAC-only reservations to whitelist devices without assigning them a static IP — they will receive a dynamic address from the pool instead.

---

**Related issue**
 #10208
