### PR TITLE
dashboard: skip acl check when requested

### DIFF
--- a/Scripts/dashboard-acl.sh
+++ b/Scripts/dashboard-acl.sh
@@ -42,14 +42,14 @@ for WIDGET in ${WIDGETS}; do
 		continue
 	fi
 
-       REGISTERED=
-       SKIP=false
+    REGISTERED=
+    SKIP=false
 
 	for METAFILE in ${METADATA}; do
-              if xmllint "${METAFILE}" --xpath 'boolean(//*[filename="'"${FILENAME}"'" and skipaclcheck="true"])' 2>/dev/null | grep -q true; then
-                     SKIP=true
-                     break
-              fi
+        if xmllint "${METAFILE}" --xpath 'boolean(//*[filename="'"${FILENAME}"'" and skipaclcheck="true"])' 2>/dev/null | grep -q true; then
+            SKIP=true
+            break
+        fi
 q
 		if grep -q "<filename>${FILENAME}</filename>" ${METAFILE}; then
 			REGISTERED=$(xmllint ${METAFILE} --xpath '//*[filename="'"${FILENAME}"'"]//endpoints//endpoint' | \
@@ -58,9 +58,9 @@ q
 		fi
 	done
 
-       if [ "${SKIP}" = true ]; then
-              continue
-       fi
+    if [ "${SKIP}" = true ]; then
+        continue
+    fi
 
 	ENDPOINTS=$( (grep -o 'this\.ajaxCall([^,)]*' ${WIDGET} | cut -c 15-; \
 	    grep -o 'super\.openEventSource([^,)]*' ${WIDGET} | cut -c 23-) | \

--- a/Scripts/dashboard-acl.sh
+++ b/Scripts/dashboard-acl.sh
@@ -46,11 +46,11 @@ for WIDGET in ${WIDGETS}; do
     SKIP=false
 
 	for METAFILE in ${METADATA}; do
-        if xmllint "${METAFILE}" --xpath 'boolean(//*[filename="'"${FILENAME}"'" and skipaclcheck="true"])' 2>/dev/null | grep -q true; then
+        if xmllint "${METAFILE}" --xpath 'boolean(//*[filename="'"${FILENAME}"'" and skiplint="true"])' 2>/dev/null | grep -q true; then
             SKIP=true
             break
         fi
-q
+
 		if grep -q "<filename>${FILENAME}</filename>" ${METAFILE}; then
 			REGISTERED=$(xmllint ${METAFILE} --xpath '//*[filename="'"${FILENAME}"'"]//endpoints//endpoint' | \
 			    sed -e 's:^[^>]*>::' -e 's:<[^<]*$::' | sort)

--- a/Scripts/dashboard-acl.sh
+++ b/Scripts/dashboard-acl.sh
@@ -42,6 +42,26 @@ for WIDGET in ${WIDGETS}; do
 		continue
 	fi
 
+       REGISTERED=
+       SKIP=false
+
+	for METAFILE in ${METADATA}; do
+              if xmllint "${METAFILE}" --xpath 'boolean(//*[filename="'"${FILENAME}"'" and skipaclcheck="true"])' 2>/dev/null | grep -q true; then
+                     SKIP=true
+                     break
+              fi
+q
+		if grep -q "<filename>${FILENAME}</filename>" ${METAFILE}; then
+			REGISTERED=$(xmllint ${METAFILE} --xpath '//*[filename="'"${FILENAME}"'"]//endpoints//endpoint' | \
+			    sed -e 's:^[^>]*>::' -e 's:<[^<]*$::' | sort)
+			break
+		fi
+	done
+
+       if [ "${SKIP}" = true ]; then
+              continue
+       fi
+
 	ENDPOINTS=$( (grep -o 'this\.ajaxCall([^,)]*' ${WIDGET} | cut -c 15-; \
 	    grep -o 'super\.openEventSource([^,)]*' ${WIDGET} | cut -c 23-) | \
 	    tr -d "'" | tr -d '`' | sed 's:\$.*:*:' | sort -u)
@@ -50,16 +70,6 @@ for WIDGET in ${WIDGETS}; do
 		echo "No endpoints found for ${WIDGET}"
 		continue
 	fi
-
-	REGISTERED=
-
-	for METAFILE in ${METADATA}; do
-		if grep -q "<filename>${FILENAME}</filename>" ${METAFILE}; then
-			REGISTERED=$(xmllint ${METAFILE} --xpath '//*[filename="'"${FILENAME}"'"]//endpoints//endpoint' | \
-			    sed -e 's:^[^>]*>::' -e 's:<[^<]*$::' | sort)
-			break
-		fi
-	done
 
 	if [ -z "${REGISTERED}" ]; then
 		echo "Did not find metadata for ${WIDGET}"

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -229,7 +229,7 @@
     <livelog>
         <filename>LiveLog.js</filename>
         <link>/ui/diagnostics/log/core/system</link>
-        <skipaclcheck>true</skipaclcheck>
+        <skiplint>true</skiplint>
         <translations>
             <title>Live Log</title>
             <noaccess>No access</noaccess>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -229,8 +229,7 @@
     <livelog>
         <filename>LiveLog.js</filename>
         <link>/ui/diagnostics/log/core/system</link>
-        <endpoints>
-        </endpoints>
+        <skipaclcheck>true</skipaclcheck>
         <translations>
             <title>Live Log</title>
             <noaccess>No access</noaccess>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.5
- Extent of AI involvement:

`xmllint` xpath expression

---

**Describe the problem**

New live log widget requires access to dynamic endpoints (these can be from plugins) fetched through the menu system. This already controls accessibility, so the ACL check thorugh the metadata isn't possible in this particular case.

---

**Describe the proposed solution**

Introduce a tag that skips the acl check.

---

**Related issue**

If this pull request relates to an issue, link it here.
