### PR TITLE
VPN: OpenVPN: Exporter: Fix that linked user do not show, skip lazy loading the model because we require the commonname volatile field

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/Api/ExportController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/Api/ExportController.php
@@ -196,7 +196,7 @@ class ExportController extends ApiControllerBase
             foreach (Config::getInstance()->object()->system->user as $user) {
                 $usernames[] = (string)$user->name;
             }
-            foreach ((new Cert(true))->cert->iterateItems() as $cert) {
+            foreach ((new Cert())->cert->iterateItems() as $cert) {
                 if ($cert->caref == $server['caref']) {
                     $result[(string)$cert->refid] = [
                         "description" => (string)$cert->descr,


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10402

---

**Describe the proposed solution**

<img width="768" height="589" alt="image" src="https://github.com/user-attachments/assets/0e103e39-b853-4104-bb1f-f918236398f1" />
