### PR TITLE
MVC:ui - refactor base_dialog and parseFormNode

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2015 Deciso B.V.
+ * Copyright (C) 2015-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -162,7 +162,17 @@ class ControllerBase extends ControllerRoot
      */
     private function parseFormNode($xmlNode)
     {
-        $result = [];
+        /* set defaults, always a root section (also used for advanced toggle) */
+        $result = [
+            'sections' => [
+                [
+                    'children' => [],
+                    'type'=> false
+                ]
+            ],
+            'advanced' => false,
+            'help' => false
+        ];
         foreach ($xmlNode as $key => $node) {
             switch ($key) {
                 case "tab":
@@ -188,7 +198,22 @@ class ControllerBase extends ControllerRoot
                     break;
                 case "field":
                     // field type, containing attributes
-                    $result[] = $this->parseFormNode($node);
+                    $field = $this->parseFormNode($node);
+                    foreach ([
+                        'advanced', 'help', 'hint', 'style', 'maxheight', 'width', 'allownew', 'readonly', 'type'
+                    ] as $f){
+                        if (!isset($field[$f])) {
+                            $field[$f] = false;
+                        } elseif (!empty($field[$f]) && in_array($f, ['advanced', 'help'])) {
+                            $result[$f] = true; /* top level booleans */
+                        }
+                    }
+                    if ($field['type'] == 'header') {
+                        $field['children'] = [];
+                        $result['sections'][] = $field;
+                    } else {
+                        $result['sections'][count($result['sections'])-1]['children'][] = $field;
+                    }
                     break;
                 case "help":
                 case "hint":
@@ -197,6 +222,9 @@ class ControllerBase extends ControllerRoot
                     if (strlen($text)) {
                         $result[$key] = gettext($text);
                     }
+                    break;
+                case "grid_view":
+                    // skip grid properties
                     break;
                 default:
                     // default behavior, copy in value as key/value data

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2025 Deciso B.V.
+ # Copyright (c) 2014-2026 Deciso B.V.
  # All rights reserved.
  #
  # Redistribution and use in source and binary forms, with or without modification,
@@ -33,27 +33,7 @@
  # label           :   dialog label
  #}
 
-{# Volt templates in php7 have issues with scope sometimes, copy input values to make them more unique #}
 {% set base_dialog_id=id %}
-{% set base_dialog_fields=fields %}
-{% set base_dialog_label=label %}
-
-{# Find if there are help supported or advanced field on this page #}
-{% set base_dialog_help=false %}
-{% set base_dialog_advanced=false %}
-{% for field in base_dialog_fields|default({})%}
-    {% for name,element in field %}
-        {% if name=='help' %}
-            {% set base_dialog_help=true %}
-        {% endif %}
-        {% if name=='advanced' %}
-            {% set base_dialog_advanced=true %}
-        {% endif %}
-    {% endfor %}
-    {% if base_dialog_help|default(false) and base_dialog_advanced|default(false) %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
 <div class="modal fade" id="{{base_dialog_id}}" tabindex="-1" role="dialog" aria-labelledby="{{base_dialog_id}}Label">
     <div class="modal-backdrop fade in"></div>
@@ -61,11 +41,12 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="{{ lang._('Close') }}"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="{{base_dialog_id}}Label">{{base_dialog_label}}</h4>
+                <h4 class="modal-title" id="{{base_dialog_id}}Label">{{label}}</h4>
             </div>
             <div class="modal-body">
                 <form id="frm_{{base_dialog_id}}">
-                  <div class="table-responsive">
+                {% for section in fields['sections'] %}
+                  <div class="table-responsive {{section['style']|default('')}}">
                     <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
                         <colgroup>
                         {% if msgzone_width is defined %}
@@ -78,67 +59,36 @@
                             <col style="width: 35%;" />
                         {% endif %}
                         </colgroup>
-                        <tbody>
-                        {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
+                        {% if section['type'] %}
+                        <thead {% if section['static']|default('false')=='false' %} style="cursor: pointer;"{% endif %}>
+                        <tr{% if section['advanced']|default('false')=='true' %} data-advanced="true"{% endif %}>
+                            <th colspan="3">
+                                <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
+                                    {% if section['static']|default('false')=='false' %}
+                                    {% if section['collapse']|default('false')=='true' %}
+                                    <i class="fa fa-angle-right" aria-hidden="true"></i>
+                                    {% else %}
+                                    <i class="fa fa-angle-down" aria-hidden="true"></i>
+                                    {% endif %}
+                                    &nbsp;
+                                    {% endif %}
+                                    <b>{{section['label']}}</b>
+                                </div>
+                            </th>
+                        </tr>
+                        </thead>
+                        {% endif %}
+                        <tbody class="collapsible">
+                        {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
                         <tr>
-                            <td>{% if base_dialog_advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
+                            <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
                             <td colspan="2" style="text-align:right;">
-                                {% if base_dialog_help|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_formDialog{{base_dialog_id}}"></i></a>{% endif %}
+                                {% if fields['help']|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_formDialog{{base_dialog_id}}"></i></a>{% endif %}
                             </td>
                         </tr>
                         {% endif %}
-                        {% for field in base_dialog_fields|default({})%}
-                            {# looks a bit buggy in the volt templates, field parameters won't reset properly here #}
-                            {% set advanced=false %}
-                            {% set help=false %}
-                            {% set hint=false %}
-                            {% set style=false %}
-                            {% set maxheight=false %}
-                            {% set width=false %}
-                            {% set allownew=false %}
-                            {% set readonly=false %}
-                            {% if field['type'] == 'ignore' %}
-                            {% elseif field['type'] == 'header' %}
-                              {# close table and start new one with header #}
-
-{#- macro base_dialog_header(field) #}
-      </tbody>
-    </table>
-  </div>
-  <div class="table-responsive {{field['style']|default('')}}">
-    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
-        <colgroup>
-        {% if msgzone_width is defined %}
-            <col class="col-md-3"/>
-            <col class="col-md-{{ 12 - 3 - msgzone_width }}"/>
-            <col class="col-md-{{ msgzone_width }}"/>
-        {% else %}
-            <col style="width: 25%;" />
-            <col style="width: 40%;" />
-            <col style="width: 35%;" />
-        {% endif %}
-        </colgroup>
-        <thead {% if field['static']|default('false')=='false' %} style="cursor: pointer;"{% endif %}>
-          <tr{% if field['advanced']|default('false')=='true' %} data-advanced="true"{% endif %}>
-            <th colspan="3">
-                <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
-                    {% if field['static']|default('false')=='false' %}
-                    {% if field['collapse']|default('false')=='true' %}
-                    <i class="fa fa-angle-right" aria-hidden="true"></i>
-                    {% else %}
-                    <i class="fa fa-angle-down" aria-hidden="true"></i>
-                    {% endif %}
-                    &nbsp;
-                    {% endif %}
-                    <b>{{field['label']}}</b>
-                </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody {%if field['static']|default('false')=='false'%}class="collapsible" {% if field['collapse']|default('false')=='true' %}style="display: none;"{%endif%}{%endif%}>
-{#- endmacro #}
-
-                            {% elseif field['type'] == 'subheader' %}
+                        {% for field in section['children']%}
+                            {% if field['type'] == 'subheader' %}
                                 <tr{% if field['advanced']|default('false') == 'true' %} data-advanced="true"{% endif %}>
                                     <td colspan="3">
                                         <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px; padding-left: 5px;">
@@ -148,13 +98,14 @@
                                         </div>
                                     </td>
                                 </tr>
-                            {% else %}
-                              {{ partial("layout_partials/form_input_tr",field)}}
+                            {% elseif field['type'] != 'ignore' %}
+                              {{ partial("layout_partials/form_input_tr", field)}}
                             {% endif %}
                         {% endfor %}
                         </tbody>
                     </table>
                   </div>
+                {% endfor %}
                 </form>
             </div>
             <div class="modal-footer">

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2025 Deciso B.V.
+ # Copyright (c) 2014-2026 Deciso B.V.
  # All rights reserved.
  #
  # Redistribution and use in source and binary forms, with or without modification,
@@ -35,89 +35,78 @@
 
 {# Find if there are help supported or advanced field on this page #}
 {% set base_form_id=id %}
-{% set help=false %}
-{% set advanced=false %}
-{% for field in fields|default({})%}
-{%     for name,element in field %}
-{%         if name=='help' %}
-{%             set help=true %}
-{%         endif %}
-{%         if name=='advanced' %}
-{%             set advanced=true %}
-{%         endif %}
-{%     endfor %}
-{%     if help|default(false) and advanced|default(false) %}
-{%         break %}
-{%     endif %}
-{% endfor %}
+
 <form id="{{base_form_id}}" class="form-inline" data-title="{{data_title|default('')}}">
-  <div class="table-responsive">
-    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
-        <colgroup>
-            <col style="width: 25%;" />
-            <col style="width: 40%;" />
-            <col style="width: 35%;" />
-        </colgroup>
-        <tbody>
-{% if advanced|default(false) or help|default(false) %}
-        <tr>
-            <td style="text-align:left">{% if advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
-            <td colspan="2" style="text-align:right">
-                {% if help|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
-            </td>
-        </tr>
-{% endif %}
-        {% for field in fields|default({})%}
-            {% if field['type'] == 'ignore' %}
-            {% elseif field['type'] == 'header' %}
-              {# close table and start new one with header #}
-
-{#- macro base_dialog_header(field) #}
-      </tbody>
-      <tfoot><tr><td colspan="3" style="padding: 0px;"></td></tr></tfoot>
-    </table>
-  </div>
-  <div class="table-responsive {{field['style']|default('')}}">
-    <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
-        <colgroup>
-            <col style="width: 25%;" />
-            <col style="width: 40%;" />
-            <col style="width: 35%;" />
-        </colgroup>
-        <thead {% if field['static']|default('false')=='false' %} style="cursor: pointer;"{% endif %} class="{{field['style']|default('')}}">
-          <tr {% if field['advanced']|default('false')=='true' %} data-advanced="true"{% endif %}>
-            <th colspan="3">
-                <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
-                    {% if field['static']|default('false')=='false' %}
-                    {% if field['collapse']|default('false')=='true' %}
-                    <i class="fa fa-angle-right" aria-hidden="true"></i>
-                    {% else %}
-                    <i class="fa fa-angle-down" aria-hidden="true"></i>
-                    {% endif %}
-                    &nbsp;
-                    {% endif %}
-                    <b>{{field['label']}}</b>
-                </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody {%if field['static']|default('false')=='false'%}class="collapsible" {% if field['collapse']|default('false')=='true' %}style="display: none;"{%endif%}{%endif%}>
-{#- endmacro #}
-
+    {% for section in fields['sections'] %}
+        <div class="table-responsive {{section['style']|default('')}}">
+        <table class="table table-striped table-condensed" style="table-layout: fixed; width: 100%;">
+            <colgroup>
+            {% if msgzone_width is defined %}
+                <col class="col-md-3"/>
+                <col class="col-md-{{ 12 - 3 - msgzone_width }}"/>
+                <col class="col-md-{{ msgzone_width }}"/>
             {% else %}
-              {{ partial("layout_partials/form_input_tr",field)}}
+                <col style="width: 25%;" />
+                <col style="width: 40%;" />
+                <col style="width: 35%;" />
             {% endif %}
-        {% endfor %}
-        {% if apply_btn_id|default('') != '' %}
-        <tr>
-            <td colspan="3"><button class="btn btn-primary" id="{{apply_btn_id}}" type="button"><b>{{ lang._('Apply') }}</b> <i id="{{base_form_id}}_progress" class=""></i></button></td>
-        </tr>
-        {% endif %}
-        </tbody>
-        <tfoot><tr><td colspan="3" style="padding: 0px;"></td></tr></tfoot>
-    </table>
-  </div>
+            </colgroup>
+            {% if section['type'] %}
+            <thead {% if section['static']|default('false')=='false' %} style="cursor: pointer;"{% endif %}>
+            <tr{% if section['advanced']|default('false')=='true' %} data-advanced="true"{% endif %}>
+                <th colspan="3">
+                    <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
+                        {% if section['static']|default('false')=='false' %}
+                        {% if section['collapse']|default('false')=='true' %}
+                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        {% else %}
+                        <i class="fa fa-angle-down" aria-hidden="true"></i>
+                        {% endif %}
+                        &nbsp;
+                        {% endif %}
+                        <b>{{section['label']}}</b>
+                    </div>
+                </th>
+            </tr>
+            </thead>
+            {% endif %}
+            <tbody class="collapsible">
+            {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
+            <tr>
+                <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
+                <td colspan="2" style="text-align:right;">
+                    {% if fields['help']|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_formDialog{{base_dialog_id}}"></i></a>{% endif %}
+                </td>
+            </tr>
+            {% endif %}
+            {% for field in section['children']%}
+                {% if field['type'] == 'subheader' %}
+                    <tr{% if field['advanced']|default('false') == 'true' %} data-advanced="true"{% endif %}>
+                        <td colspan="3">
+                            <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px; padding-left: 5px;">
+                                <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+                                &nbsp;
+                                <b>{{ field['label'] }}</b>
+                            </div>
+                        </td>
+                    </tr>
+                {% elseif field['type'] != 'ignore' %}
+                    {{ partial("layout_partials/form_input_tr", field)}}
+                {% endif %}
+            {% endfor %}
+            {% if loop.last and apply_btn_id|default('') != '' %}
+                    <tr>
+                        <td colspan="3">
+                            <button class="btn btn-primary" id="{{apply_btn_id}}" type="button"><b>{{ lang._('Apply') }}</b> <i id="{{base_form_id}}_progress" class=""></i></button>
+                        </td>
+                    </tr>
+            {% endif %}
+            </tbody>
+        </table>
+        </div>
+    {% endfor %}
 </form>
+
 
 {# Ensure all fields stay the same width relative to each other inside the modal #}
 <style>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2015 Deciso B.V.
+ # Copyright (c) 2014-2026 Deciso B.V.
  # All rights reserved.
  #
  # Redistribution and use in source and binary forms, with or without modification,
@@ -102,7 +102,7 @@
             <input type="checkbox"  class="{{style|default('')}}" id="{{ id }}" aria-label="{{label|safe}}">
         {% elseif type in ["select_multiple", "dropdown"] %}
             <div id="select_{{ id }}">
-            <select aria-label="{{label|safe}}" {% if type == 'select_multiple' %}multiple="multiple"{% endif %}
+            <select aria-label="{{label|safe}}" {% if type == 'select_multiple' %}multiple="multiple" title="{{ lang._('Nothing selected') }}"{% endif %}
                     data-size="{{size|default(10)}}"
                     id="{{ id }}"
                     class="{{style|default('selectpicker')}}"


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Simplify the form templates.

Move defaults to `parseFormNode()` and introduce "sections" with children to avoid some more magic in the volt templates.

Set default title on multi selectpickers as these sometimes seem to miss the "Nothing selected" phrase for some odd reason.

Functionally this should be a backward compatible change.

---

**Describe the proposed solution**

In order to improve the modal forms at some point, we need to get rid of some complexity to improve overview of places to hook new functionality in.

---

**Related issue**

https://github.com/opnsense/core/issues/9955

