### PR TITLE
Firewall: Rules: use strnatcasecmp() for interface list

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -392,7 +392,7 @@ class FilterController extends FilterBaseController
         $result['any']['items'][] = $makeItem('__any', gettext('All rules'), 'any');
 
         foreach ($result as &$section) {
-            usort($section['items'], fn($a, $b) => strcasecmp($a['label'], $b['label']));
+            usort($section['items'], fn($a, $b) => strnatcasecmp($a['label'], $b['label']));
         }
 
         return $result;


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The current list is sorted like:

```
VLAN 1
VLAN 10
VLAN 100
VLAN 11
```

It should be sorted

```
VLAN 1
VLAN 10
VLAN 11
VLAN 100
```
---

**Describe the proposed solution**

Use the natural-order equivalent of `strcasecmp()`

---

**Related issue**

N/A
