### PR TITLE
Firewall: fix 500 (TypeError) on alias getItem with unknown UUID

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -168,17 +168,15 @@ class AliasController extends ApiMutableModelControllerBase
     public function getItemAction($uuid = null)
     {
         $response = $this->getBase("alias", "aliases.alias", $uuid);
-        if (!empty($response['alias'])) {
-            $selected_aliases = array_keys($response['alias']['content']);
-            foreach ($this->getModel()->aliasIterator() as $alias) {
-                if (!in_array($alias['name'], $selected_aliases)) {
-                    $response['alias']['content'][$alias['name']] = [
-                      "selected" => 0, "value" => $alias['name']
-                    ];
-                }
-                // append descriptions
-                $response['alias']['content'][$alias['name']]['description'] = $alias['description'];
+        $selected_aliases = array_keys($response['alias']['content'] ?? []);
+        foreach ($this->getModel()->aliasIterator() as $alias) {
+            if (!in_array($alias['name'], $selected_aliases)) {
+                $response['alias']['content'][$alias['name']] = [
+                  "selected" => 0, "value" => $alias['name']
+                ];
             }
+            // append descriptions
+            $response['alias']['content'][$alias['name']]['description'] = $alias['description'];
         }
         return $response;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -168,15 +168,17 @@ class AliasController extends ApiMutableModelControllerBase
     public function getItemAction($uuid = null)
     {
         $response = $this->getBase("alias", "aliases.alias", $uuid);
-        $selected_aliases = array_keys($response['alias']['content']);
-        foreach ($this->getModel()->aliasIterator() as $alias) {
-            if (!in_array($alias['name'], $selected_aliases)) {
-                $response['alias']['content'][$alias['name']] = [
-                  "selected" => 0, "value" => $alias['name']
-                ];
+        if (!empty($response['alias'])) {
+            $selected_aliases = array_keys($response['alias']['content']);
+            foreach ($this->getModel()->aliasIterator() as $alias) {
+                if (!in_array($alias['name'], $selected_aliases)) {
+                    $response['alias']['content'][$alias['name']] = [
+                      "selected" => 0, "value" => $alias['name']
+                    ];
+                }
+                // append descriptions
+                $response['alias']['content'][$alias['name']]['description'] = $alias['description'];
             }
-            // append descriptions
-            $response['alias']['content'][$alias['name']]['description'] = $alias['description'];
         }
         return $response;
     }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below. <- problem is trivial
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Opus 4.8
- Extent of AI involvement: found the error while testing and helped locate the right class

---

**Describe the problem**

getItemAction() called array_keys($response['alias']['content']); for a UUID that does not resolve getBase() returns [], so the argument is null and on PHP 8 array_keys(null) raises a TypeError, which is unhandled and surfaces as HTTP 500. Guard the augmentation so an unknown UUID returns the empty base response (HTTP 200), consistent with the generic getItemAction behaviour.

---

**Describe the proposed solution**

Just an empty guard around the alias handler

---

**Related issue**

No related issue found
