### PR TITLE
kea: allow hostname-only DHCP reservations for DHCPv4 and DHCPv6

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
@@ -9,7 +9,7 @@
         <id>reservation.ip_address</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address to offer to the client</help>
+        <help>IP address to offer to the client. Leave empty for a hostname-only reservation (dynamic IP, fixed DNS name via DDNS).</help>
     </field>
     <field>
         <id>reservation.hw_address</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
@@ -9,7 +9,7 @@
         <id>reservation.ip_address</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address to offer to the client</help>
+        <help>IP address to offer to the client. Leave empty for a hostname-only reservation (dynamic IP, fixed DNS name via DDNS).</help>
     </field>
     <field>
         <id>reservation.prefix</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -85,8 +85,11 @@ class KeaDhcpv4 extends BaseModel
             if ($subnet_node) {
                 $subnet = $subnet_node->subnet->getValue();
             }
-            if (!Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
+            if (!$reservation->ip_address->isEmpty() && !Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
                 $messages->appendMessage(new Message(gettext("Address not in specified subnet"), $key . ".ip_address"));
+            }
+            if ($reservation->ip_address->isEmpty() && $reservation->hostname->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("A hostname is required when no IP address is specified."), $key . ".hostname"));
             }
             if (!$reservation->client_id->isEmpty() && !$reservation->hw_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Either a client ID or a MAC address should be specified, but not both"), $key . ".hw_address"));

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -67,8 +67,8 @@ class KeaDhcpv6 extends BaseModel
             if (!Util::isIPv6PrefixInPrefix($reservation->prefix->getValue(), $subnet) && !$reservation->prefix->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Prefix not in specified subnet"), $key . ".prefix"));
             }
-            if ($reservation->ip_address->isEmpty() && $reservation->prefix->isEmpty()) {
-                $messages->appendMessage(new Message(gettext("Either an IP address or a Prefix should be specified."), $key . ".ip_address"));
+            if ($reservation->ip_address->isEmpty() && $reservation->prefix->isEmpty() && $reservation->hostname->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("Either an IP address, a prefix, or a hostname must be specified."), $key . ".ip_address"));
             }
             if (!$reservation->duid->isEmpty() && !$reservation->hw_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Either a DUID or an MAC address should be specified, but not both"), $key . ".duid"));


### PR DESCRIPTION
Kea's reservation model supports hostname-only reservations — a MAC address (or
client ID / DUID) matched against a hostname, with no fixed IP address. When a
matching client requests a lease, Kea assigns a dynamic address from the pool
and substitutes the reserved hostname in the lease record. If DDNS is configured,
that hostname is used for the DNS update. Cooperative clients may also adopt the
hostname from the DHCP response, though this is client-dependent and not
guaranteed.

This is particularly useful on networks with embedded devices — IoT sensors,
thermostats, access points, printers — that do not support direct hostname
configuration and would otherwise negotiate generic or vendor-default names.
A hostname-only reservation pins a meaningful, collision-free name to the device
by MAC address in the lease database, without also locking it to a specific IP
address.

OPNsense currently requires an IP address on every reservation. The only blocker
is a missing null-guard in `performValidation()`: `isIPInCIDR("", ...)` returns
false unconditionally, so saving with an empty IP address always fails. The conf
emitter (`getConfigSubnets()`) already omits the `ip-address` field when empty
and produces valid Kea JSON.

## Changes

**`src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php`**
- Guard the CIDR check with `!$reservation->ip_address->isEmpty()` so an empty
  IP address is not treated as invalid.
- Add a new check requiring a hostname when IP address is also empty, ensuring
  every reservation still has a meaningful offer.

**`src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php`**
- Relax the existing "either an IP address or a prefix must be specified" check
  to also accept hostname as a valid third option.
- Update the error message accordingly.

**`src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml`**
**`src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml`**
- Update help text on the IP address field to document the hostname-only use case.

## Testing

Tested on OPNsense 26.1 (Kea 2.x):
- Saved a hostname-only reservation (MAC + hostname, no IP) via the UI — accepted
  without error.
- Confirmed `kea-dhcp4.conf` contains the reservation without an `ip-address`
  field, which Kea accepts cleanly.
- DHCP client with the matching MAC received a dynamic lease; the reserved
  hostname was recorded in the lease in place of the client-supplied hostname.
- Existing reservations with a fixed IP address continue to work unchanged.
- Attempting to save a reservation with neither IP nor hostname produces the
  expected validation error.