### PR TITLE
kea: allow hostname-only DHCP reservations

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation4.xml
@@ -9,7 +9,7 @@
         <id>reservation.ip_address</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address to offer to the client</help>
+        <help>IP address to offer to the client. Leave empty for a hostname-only reservation (dynamic IP).</help>
     </field>
     <field>
         <id>reservation.hw_address</id>
@@ -27,7 +27,7 @@
         <id>reservation.hostname</id>
         <label>Hostname</label>
         <type>text</type>
-        <help>Offer a hostname to the client</help>
+        <help>Hostname to associate with this client. When set without an IP address, Kea assigns a dynamic address from the pool and stamps this hostname on the lease record.</help>
     </field>
     <field>
         <id>reservation.description</id>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogReservation6.xml
@@ -9,7 +9,7 @@
         <id>reservation.ip_address</id>
         <label>IP address</label>
         <type>text</type>
-        <help>IP address to offer to the client</help>
+        <help>IP address to offer to the client. Leave empty for a hostname-only reservation (dynamic IP).</help>
     </field>
     <field>
         <id>reservation.prefix</id>
@@ -33,7 +33,7 @@
         <id>reservation.hostname</id>
         <label>Hostname</label>
         <type>text</type>
-        <help>Offer a hostname to the client</help>
+        <help>Hostname to associate with this client. When set without an IP address or prefix, Kea assigns a dynamic address from the pool and stamps this hostname on the lease record.</help>
     </field>
     <field>
         <id>reservation.domain_search</id>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -85,8 +85,11 @@ class KeaDhcpv4 extends BaseModel
             if ($subnet_node) {
                 $subnet = $subnet_node->subnet->getValue();
             }
-            if (!Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
+            if (!$reservation->ip_address->isEmpty() && !Util::isIPInCIDR($reservation->ip_address->getValue(), $subnet)) {
                 $messages->appendMessage(new Message(gettext("Address not in specified subnet"), $key . ".ip_address"));
+            }
+            if ($reservation->ip_address->isEmpty() && $reservation->hostname->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("A hostname is required when no IP address is specified."), $key . ".hostname"));
             }
             if (!$reservation->client_id->isEmpty() && !$reservation->hw_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Either a client ID or a MAC address should be specified, but not both"), $key . ".hw_address"));

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.php
@@ -67,8 +67,8 @@ class KeaDhcpv6 extends BaseModel
             if (!Util::isIPv6PrefixInPrefix($reservation->prefix->getValue(), $subnet) && !$reservation->prefix->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Prefix not in specified subnet"), $key . ".prefix"));
             }
-            if ($reservation->ip_address->isEmpty() && $reservation->prefix->isEmpty()) {
-                $messages->appendMessage(new Message(gettext("Either an IP address or a Prefix should be specified."), $key . ".ip_address"));
+            if ($reservation->ip_address->isEmpty() && $reservation->prefix->isEmpty() && $reservation->hostname->isEmpty()) {
+                $messages->appendMessage(new Message(gettext("Either an IP address, a prefix, or a hostname must be specified."), $key . ".ip_address"));
             }
             if (!$reservation->duid->isEmpty() && !$reservation->hw_address->isEmpty()) {
                 $messages->appendMessage(new Message(gettext("Either a DUID or an MAC address should be specified, but not both"), $key . ".duid"));


### PR DESCRIPTION
Important notices

Before you submit a pull request, we ask you kindly to acknowledge the following:

[x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
[x]vI opened an issue first for non-trivial changes and linked it below.
[x] AI tools were used to create at least part of the code submitted herewith.
 
 This PR offers a fix for https://github.com/opnsense/core/issues/10208
 
Kea's reservation model supports hostname-only reservations — a MAC address (or
client ID / DUID) matched against a hostname, with no fixed IP address. When a
matching client requests a lease, Kea assigns a dynamic address from the pool
and substitutes the reserved hostname in the lease record. If DDNS is configured,
that hostname is used for the DNS update. Cooperative clients may also adopt the
hostname from the DHCP response, though this is client-dependent and not
guaranteed.

This is particularly useful on networks with embedded devices — IoT sensors,
thermostats, access points, printers — that do not support direct hostname
configuration and would otherwise negotiate generic or vendor-default names.
A hostname-only reservation pins a meaningful, collision-free name to the device
by MAC address in the lease database, without also locking it to a specific IP
address.

OPNsense currently requires an IP address on every reservation. The only blocker
is a missing null-guard in performValidation(): isIPInCIDR("", ...) returns
false unconditionally, so saving with an empty IP address always fails. The conf
emitter (getConfigSubnets()) already omits the ip-address field when empty
and produces valid Kea JSON.

Changes:

* `KeaDhcpv4.php`: guard the CIDR check with a non-empty test before calling
  isIPInCIDR; require a hostname when no IP address is given.
* `KeaDhcpv6.php`: same null-guard; accept hostname as a valid third alternative
  to ip_address / prefix in the "at least one must be set" check.
* `dialogReservation4.xml`, `dialogReservation6.xml`: update IP address and
  hostname field help text to describe the hostname-only behaviour.