### PR TITLE
fix: pattern for carp_status using wildcard

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/ACL/ACL.xml
@@ -24,7 +24,7 @@
         <name>Interfaces: Virtual IPs: Status</name>
         <patterns>
             <pattern>ui/diagnostics/interface/vip</pattern>
-            <pattern>api/diagnostics/interface/carp_status</pattern>
+            <pattern>api/diagnostics/interface/carp_status/*</pattern>
             <pattern>api/diagnostics/interface/get_vip_status</pattern>
             <pattern>api/diagnostics/interface/get_pfsync_nodes</pattern>
         </patterns>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

When using the API endpoint `/api/diagnostics/interface/carp_status/maintenance` using `POST` to set the node into CARP maintenance mode, I get a 403 Forbidden, even if the user has granted access to all pages.

I have the following error in the backend logs:
```
 uri /api/diagnostics/interface/carp_status/maintenance not accessible for user <user> using api key <key>
```` 

---

**Describe the proposed solution**

The problem seems to be related to ACL.
I have added a `/*` in the pattern of the API endpoint in the related ACL file to make it work with the corresponding privilege.


