### PR TITLE
routing: fix HTTP 500 when deleting a non-existent gateway

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
@@ -200,6 +200,9 @@ class SettingsController extends ApiMutableModelControllerBase
         if ($this->request->isPost()) {
             if ($uuid != null) {
                 $gateway = $this->getModel()->getNodeByReference('gateway_item.' . $uuid);
+                if ($gateway === null) {
+                    return $result; // unknown uuid -> {"result":"failed"}, mirrors toggleGatewayAction()
+                }
                 $cfg = Config::getInstance()->object();
                 foreach ($cfg->interfaces->children() as $tag => $interface) {
                     if ((string)$interface->gateway == (string)$gateway->name) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Routing/Api/SettingsController.php
@@ -201,7 +201,7 @@ class SettingsController extends ApiMutableModelControllerBase
             if ($uuid != null) {
                 $gateway = $this->getModel()->getNodeByReference('gateway_item.' . $uuid);
                 if ($gateway === null) {
-                    return $result; // unknown uuid -> {"result":"failed"}, mirrors toggleGatewayAction()
+                    return $result;
                 }
                 $cfg = Config::getInstance()->object();
                 foreach ($cfg->interfaces->children() as $tag => $interface) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Opus 4.8
- Extent of AI involvement: testing, surfacing the issue and writing a nice commit message instead of my gibberish

---

**Describe the problem**

delGatewayAction() dereferenced the result of getNodeByReference() without a null check, so an unknown uuid reached "(string)$gateway->name" on null and raised an error, which the API renders as HTTP 500 ("Unexpected error, check log for details").

This is a super minor issue and only surfaces while using the API extensively.

---

**Describe the proposed solution**

Guard the lookup and return the already-initialised {"result":"failed"} instead, matching the inherited del* verbs and the adjacent toggleGatewayAction(), which already null-check getNodeByReference().

---

**Related issue**

none found
