### PR TITLE
firewall: return graceful failure instead of 500 on rule not-found

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
@@ -391,9 +391,8 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
         $selected_node = $this->getModel()->getNodeByReference($node_reference . '.' . $selected_uuid);
 
         if ($target_node === null || $selected_node === null) {
-            throw new UserException(
-                gettext("Either source or destination is not a rule managed with this component")
-            );
+            return ["status" => "error",
+                    "message" => gettext("Either source or destination is not a rule managed with this component")];
         }
 
         $step_size = 50;
@@ -449,7 +448,7 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
         $node = $mdl->getNodeByReference($node_reference . '.' . $uuid);
 
         if ($node === null) {
-            throw new UserException(gettext('Rule not found'));
+            return ['status' => 'error', 'message' => gettext('Rule not found')];
         }
 
         $node->log = $log;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterController.php
@@ -286,10 +286,8 @@ class FilterController extends FilterBaseController
         $target_node = $this->getModel()->getNodeByReference('rules.rule.' . $target_uuid);
         $selected_node = $this->getModel()->getNodeByReference('rules.rule.' . $selected_uuid);
         if ($target_node === null || $selected_node === null) {
-            throw new UserException(
-                gettext("Either source or destination is not a rule managed with this component"),
-                gettext("Filter")
-            );
+            return ["status" => "error",
+                    "message" => gettext("Either source or destination is not a rule managed with this component")];
         } elseif (!$selected_node->prio_group->isEqual($target_node->prio_group)) {
             /* types don't match */
             $typeNames = [


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Opus 4.8
- Extent of AI involvement: testing, surfacing the code location and writing a nice commit message

---

**Describe the problem**

moveRuleBefore (FilterController and FilterBaseController::moveRuleBeforeBase) and toggleRuleLogBase threw a UserException when the referenced rule uuid did not exist.

Because api.php renders every thrown exception as HTTP 500, a non-existent uuid produced a 500, whereas the inherited del/set/toggle verbs return {"result":"failed"} and these very methods already return ["status" => "error", ...] for an invalid request method.

---

**Describe the proposed solution**

Return that same ["status" => "error", ...] shape for the not-found case so the outcome is consistent and no longer surfaces as a server error

Again, not something breaking but more a OCD topic to make it more streamlined.

---

**Related issue**

None found