### PR TITLE
firewall: re-add a simplified applyAction, for 17b84612

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
@@ -494,4 +494,12 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
             }
         );
     }
+
+    public function applyAction()
+    {
+        if (!$this->request->isPost()) {
+            return ["status" => "error"];
+        }
+        return ["status" => (new Backend())->configdRun('filter reload')];
+    }
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**
https://github.com/opnsense/core/blob/7ccf782160ef5af99b9ee9c19a7697d18bf06b0f/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt#L1319

Accidentally removed it completely here:
https://github.com/opnsense/core/commit/17b84612eb21373d1dc464b1dc75560d477953f5

Forgot its not a standard reconfigureAction.

Means we also shouldn't change the name of it.
