### PR TITLE
 mvc: fix unqualified Exception

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/FileObject.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/FileObject.php
@@ -58,7 +58,7 @@ class FileObject
             if (!flock($this->fhandle, $operation)) {
                 fclose($this->fhandle);
                 $this->fhandle = null;
-                throw new Exception('Unable to open file in requested mode.');
+                throw new \Exception('Unable to open file in requested mode.');
             }
         }
     }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Crash due to unqualified `Exception` in namespaced `FileObject.php`:

`Error: Class "OPNsense\Core\Exception" not found in /usr/local/opnsense/mvc/app/library/OPNsense/Core/FileObject.php:61`

---

**Describe the proposed solution**

Ensure resolution to PHP's built-in `\Exception`.

---

**Related issue**

N/A