### PR TITLE
firewall: skip alias on rules GUI reload

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/AliasController.php
@@ -329,8 +329,8 @@ class AliasController extends ApiMutableModelControllerBase
     {
         if ($this->request->isPost()) {
             $backend = new Backend();
-            $backend->configdRun('template reload OPNsense/Filter');
             $backend->configdRun("filter reload skip_alias");
+            $backend->configdRun('template reload OPNsense/Filter');
             $bckresult = json_decode($backend->configdRun("filter refresh_aliases"), true);
             if (!empty($bckresult['messages'])) {
                 throw new UserException(implode("\n", $bckresult['messages']), gettext("Alias"));

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/FilterBaseController.php
@@ -500,6 +500,6 @@ abstract class FilterBaseController extends ApiMutableModelControllerBase
         if (!$this->request->isPost()) {
             return ["status" => "error"];
         }
-        return ["status" => (new Backend())->configdRun('filter reload')];
+        return ["status" => (new Backend())->configdRun('filter reload skip_alias')];
     }
 }


### PR DESCRIPTION
Also align the alias load path in the controller with how !skip_alias serializes the sequence after rules reload inside filter_configure_sync().

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

Firewall reload is more expensive than necessary.

---

**Describe the proposed solution**

Skip alias on apply on new rules/nat GUI.

---

**Related issue**

N/A
