### PR TITLE
Firewall: NAT: Destination NAT: Add validations for No RDR, prevent target and local-port being set

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/DNat.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/DNat.php
@@ -67,6 +67,20 @@ class DNat extends BaseModel
                         ));
                     }
                 }
+
+                if (!$rule->nordr->isEmpty() && !$rule->target->isEmpty()) {
+                    $messages->appendMessage(new Message(
+                        gettext("Target must be empty when No RDR is set."),
+                        $rule->target->__reference
+                    ));
+                }
+
+                if (!$rule->nordr->isEmpty() && !$rule->{'local-port'}->isEmpty()) {
+                    $messages->appendMessage(new Message(
+                        gettext("Port must be empty when No RDR is set."),
+                        $rule->{'local-port'}->__reference
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**
Fixes: https://github.com/opnsense/core/issues/10445

In my tests it looks like we only have to validate here.

In rules debug it looks fine when "target" and "local-port" are both empty:
`no rdr on hn3 from {any} to {192.168.1.1}`