### PR TITLE
dashboard: fix JavaScript bugs in dashboard widget code

### DIFF
--- a/src/opnsense/www/js/opnsense_widget_manager.js
+++ b/src/opnsense/www/js/opnsense_widget_manager.js
@@ -194,7 +194,7 @@ class WidgetManager  {
             this.widgetClasses[id].onVisibilityChanged(!document.hidden);
         });
 
-        if (!id in this.widgetTranslations) {
+        if (!(id in this.widgetTranslations)) {
             console.error('Missing translations for widget', id);
         }
 

--- a/src/opnsense/www/js/widgets/BaseWidget.js
+++ b/src/opnsense/www/js/widgets/BaseWidget.js
@@ -65,9 +65,9 @@ class BaseWidget {
             if (key in widget_config &&
                 widget_config[key] !== null &&
                 widget_config[key] !== undefined &&
-                (typeof(widget_config[key] === 'array') && widget_config[key].length !== 0) &&
-                (typeof(widget_config[key] === 'object') && Object.keys(widget_config[key]).length !== 0) &&
-                (typeof(widget_config[key] === 'string') && widget_config[key].length !== 0)
+                !(Array.isArray(widget_config[key]) && widget_config[key].length === 0) &&
+                !(typeof widget_config[key] === 'object' && !Array.isArray(widget_config[key]) && Object.keys(widget_config[key]).length === 0) &&
+                !(typeof widget_config[key] === 'string' && widget_config[key].length === 0)
             ) {
                 if (value.type === 'select_multiple') {
                     const optionsArr = value.options.map(v => v.value);

--- a/src/opnsense/www/js/widgets/Firewall.js
+++ b/src/opnsense/www/js/widgets/Firewall.js
@@ -119,7 +119,7 @@ export default class Firewall extends BaseTableWidget {
         });
 
         $tableContainer.append($top_table);
-        $tableContainer.append(`<div style="margin-top: 2em"><b>${this.translations.events}</b><div>`);
+        $tableContainer.append(`<div style="margin-top: 2em"><b>${this.translations.events}</b></div>`);
         $tableContainer.append($rule_table);
 
         $container.append($tableContainer);
@@ -184,8 +184,8 @@ export default class Firewall extends BaseTableWidget {
                 /* Format time based on client browser locale */
                 (new Intl.DateTimeFormat(undefined, {hour: 'numeric', minute: 'numeric'})).format(new Date(data.__timestamp__)),
                 this.ifMap[data.interface] ?? data.interface,
-                `<span class="ip-tooltip" style="cursor: pointer; data-toggle="tooltip" title="${data.src}">${data.src}</span>`,
-                `<span class="ip-tooltip" style="cursor: pointer; data-toggle="tooltip" title="${data.dst}">${data.dst}</span>`,
+                `<span class="ip-tooltip" style="cursor: pointer;" data-toggle="tooltip" title="${data.src}">${data.src}</span>`,
+                `<span class="ip-tooltip" style="cursor: pointer;" data-toggle="tooltip" title="${data.dst}">${data.dst}</span>`,
                 data.dstport ?? ''
             ]
         ]);

--- a/src/opnsense/www/js/widgets/Interfaces.js
+++ b/src/opnsense/www/js/widgets/Interfaces.js
@@ -75,7 +75,7 @@ export default class Interfaces extends BaseTableWidget {
                 </div>
             `).prop('outerHTML'));
 
-            let media = (!'media' in intf_data ? intf_data.cell_mode : intf_data.media) ?? '';
+            let media = (!('media' in intf_data) ? intf_data.cell_mode : intf_data.media) ?? '';
             row.push($(`
                 <div class="interface-info-detail">
                     <div>${media}</div>

--- a/src/opnsense/www/js/widgets/KeaLeases.js
+++ b/src/opnsense/www/js/widgets/KeaLeases.js
@@ -60,7 +60,7 @@ export default class KeaLeases extends BaseTableWidget {
         }
 
         const config = await this.getWidgetConfig();
-        const limit = parseInt(config.leasesToShow);
+        const limit = parseInt(config.leasesToShow ?? '2', 10) || 2;
 
         const leasesRequestBody = JSON.stringify({
             rowCount: limit,

--- a/src/opnsense/www/js/widgets/OpenVPNClients.js
+++ b/src/opnsense/www/js/widgets/OpenVPNClients.js
@@ -82,8 +82,9 @@ export default class OpenVPNClients extends BaseTableWidget {
             }
 
             if (!session.is_client) {
+                const existingClients = servers[id].clients;
                 servers[id] = session;
-                servers[id].clients = null;
+                servers[id].clients = existingClients;
             } else {
 
                 servers[id].clients.push(session);

--- a/src/opnsense/www/js/widgets/SystemInformation.js
+++ b/src/opnsense/www/js/widgets/SystemInformation.js
@@ -50,7 +50,7 @@ export default class SystemInformation extends BaseTableWidget {
         const data = await this.ajaxCall('/api/diagnostics/system/system_information');
         let rows = [];
         for (let [key, value] of Object.entries(data)) {
-            if (!key in this.translations) {
+            if (!(key in this.translations)) {
                 console.error('Missing translation for ' + key);
                 continue;
             }

--- a/src/opnsense/www/js/widgets/Wireguard.js
+++ b/src/opnsense/www/js/widgets/Wireguard.js
@@ -70,7 +70,7 @@ export default class Wireguard extends BaseTableWidget {
 
     displayError(message) {
         $('#wgTunnelTable').empty().append(
-            $('<div class="error-message"></div>').append('<a href="/ui/wireguard/general"></a>').text(message)
+            $('<div class="error-message"></div>').append($('<a href="/ui/wireguard/general"></a>').text(message))
         );
     }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

Multiple JavaScript bugs in the dashboard widget code cause silent failures and crashes:

1. `BaseWidget.js`: `typeof(widget_config[key] === 'array')` passes a boolean into `typeof` instead of the value itself, always returning `'boolean'`. Type checks for empty arrays, objects, and strings never work — widget config options never fall back to their defaults.

2. `SystemInformation.js`, `Interfaces.js`, `opnsense_widget_manager.js`: `!x in obj` is parsed as `(!x) in obj` due to operator precedence — the guards never trigger.

3. `Firewall.js` (line 122): Closing `</div>` written as `<div>`, producing broken DOM structure.

4. `Firewall.js` (lines 187–188): `style` attribute missing closing quote — `data-toggle` and `title` are swallowed into the style value, breaking tooltips.

5. `Wireguard.js`: Error message interpolated directly into HTML instead of using jQuery `.text()`, risking unescaped content.

6. `KeaLeases.js`: `parseInt(config.leasesToShow)` without a fallback returns `NaN` when the config is empty, breaking the API request.

7. `OpenVPNClients.js`: When a server session appears before its client sessions in the API response, the `clients` array is overwritten with `null`, causing a crash on the next `.push()` call.

---

**Describe the proposed solution**

Each fix is minimal and targeted:

- `BaseWidget.js`: Replace broken `typeof()` checks with `Array.isArray()` and proper `typeof` comparisons.
- `SystemInformation.js`, `Interfaces.js`, `opnsense_widget_manager.js`: Add parentheses to correctly express `!(x in obj)`.
- `Firewall.js`: Fix closing tag and style attribute quote.
- `Wireguard.js`: Use `$('<a>').text(message)` instead of template literal interpolation.
- `KeaLeases.js`: Add null-coalescing fallback consistent with `DnsmasqLeases.js`.
- `OpenVPNClients.js`: Preserve the existing `clients` array when overwriting the server entry.

---

**Related issue**

None — self-contained bug fixes.