### PR TITLE
Firewall: NAT: Source NAT: skip rendering rules when mode is not advanced (manual) or hybrid

### DIFF
--- a/src/etc/inc/plugins.inc.d/pf.inc
+++ b/src/etc/inc/plugins.inc.d/pf.inc
@@ -173,8 +173,13 @@ function pf_firewall($fw)
         $fw->registerFilterRule($rule->getPriority(), $content);
     }
 
-    foreach ($mdlFilter->snatrules->rule->sortedBy(['sequence']) as $key => $rule) {
-         $fw->registerSNatRule(50, $rule->serialize());
+    if (
+        !empty($config['nat']['outbound']['mode']) &&
+        in_array($config['nat']['outbound']['mode'], ['advanced', 'hybrid'])
+    ) {
+        foreach ($mdlFilter->snatrules->rule->sortedBy(['sequence']) as $key => $rule) {
+            $fw->registerSNatRule(50, $rule->serialize());
+        }
     }
 
     foreach ($mdlFilter->onetoone->rule->sortedBy(['sequence']) as $key => $rule) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The old Outbound rules go through this pipeline: 
https://github.com/opnsense/core/blob/283ce7026ada0264b6fd618bd17d0229b42a3f7a/src/etc/inc/filter.inc#L193-L197

The new SNAT rules go through here:
https://github.com/opnsense/core/blob/283ce7026ada0264b6fd618bd17d0229b42a3f7a/src/etc/inc/plugins.inc.d/pf.inc#L176-L178

---

**Describe the proposed solution**

Implement the same condition for the SNAT rules.
What happens to the automatic rule registering in Outbound is still something up for discussion I guess?

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10471
