### PR TITLE
captive portal: adjust accounting interval to Acct-Interim-Interval

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/CaptivePortal/Api/AccessController.php
@@ -315,6 +315,7 @@ class AccessController extends ApiControllerBase
                                         (string)$cpZone->zoneid,
                                         $CPsession['sessionId'],
                                         $authProps['session_timeout'] ?? null,
+                                        $authProps['Acct-Interim-Interval'] ?? null
                                     ]
                                 );
                             }

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/Radius.php
@@ -615,7 +615,12 @@ class Radius extends Base implements IAuthConnector
                                     $this->lastAuthProperties['session_timeout'] = radius_cvt_int($resa['data']);
                                     break;
                                 case 85: // Acct-Interim-Interval
-                                    $this->lastAuthProperties['Acct-Interim-Interval'] = radius_cvt_int($resa['data']);
+                                    $interval = radius_cvt_int($resa['data']);
+                                    if (empty($interval) || $interval < 60) { // RFC 2869, section 5.16
+                                        syslog(LOG_WARNING, 'Radius: ignoring invalid Acct-Interim-Interval: ' . $interval);
+                                        break;
+                                    }
+                                    $this->lastAuthProperties['Acct-Interim-Interval'] = $interval;
                                     break;
                                 case RADIUS_FRAMED_IP_ADDRESS:
                                     $this->lastAuthProperties['Framed-IP-Address'] = radius_cvt_addr($resa['data']);

--- a/src/opnsense/scripts/captiveportal/lib/db.py
+++ b/src/opnsense/scripts/captiveportal/lib/db.py
@@ -101,13 +101,13 @@ class DB(object):
         # migration: add "accounting_interval" column to session_restrictions
         cur.execute("PRAGMA table_info(session_restrictions)")
         if not any([row[1] == 'accounting_interval' for row in cur.fetchall()]):
-            cur.execute("ALTER TABLE session_restrictions ADD COLUMN accounting_interval INT")
+            cur.execute("ALTER TABLE session_restrictions ADD COLUMN accounting_interval INT DEFAULT 600")
             self._connection.commit()
 
         # migration: add "last_update_time" column to accounting_state
         cur.execute("PRAGMA table_info(accounting_state)")
         if not any([row[1] == 'last_update_time' for row in cur.fetchall()]):
-            cur.execute("ALTER TABLE accounting_state ADD COLUMN last_update_time NUMBER")
+            cur.execute("ALTER TABLE accounting_state ADD COLUMN last_update_time NUMBER DEFAULT 0")
             self._connection.commit()
 
         cur.close()
@@ -638,7 +638,7 @@ class DB(object):
 
         self._connection.commit()
 
-    def update_session_restrictions(self, zoneid, sessionid, session_timeout, accounting_interval=None):
+    def update_session_restrictions(self, zoneid, sessionid, session_timeout, accounting_interval):
         """ upsert session restrictions
         :param zoneid: zone id
         :param sessionid: session id
@@ -647,6 +647,7 @@ class DB(object):
         :return: string "add"/"update" to signal the performed action to the client
         """
         cur = self._connection.cursor()
+        accounting_interval = 600 if not accounting_interval else accounting_interval
         qry_params = {'zoneid': zoneid, 'sessionid': sessionid, 'session_timeout': session_timeout, 'accounting_interval': accounting_interval}
         sql_update = """update session_restrictions
                         set session_timeout = :session_timeout,

--- a/src/opnsense/scripts/captiveportal/lib/db.py
+++ b/src/opnsense/scripts/captiveportal/lib/db.py
@@ -647,23 +647,46 @@ class DB(object):
         :return: string "add"/"update" to signal the performed action to the client
         """
         cur = self._connection.cursor()
-        accounting_interval = 600 if not accounting_interval else accounting_interval
-        qry_params = {'zoneid': zoneid, 'sessionid': sessionid, 'session_timeout': session_timeout, 'accounting_interval': accounting_interval}
-        sql_update = """update session_restrictions
-                        set session_timeout = :session_timeout,
-                        accounting_interval = :accounting_interval
-                        where zoneid = :zoneid and sessionid = :sessionid"""
+
+        has_accounting_interval = True if accounting_interval else False
+
+        qry_params = {
+            "zoneid": zoneid,
+            "sessionid": sessionid,
+            "session_timeout": session_timeout,
+            **({"accounting_interval": accounting_interval} if has_accounting_interval else {}),
+        }
+
+        sql_update = f"""
+            UPDATE session_restrictions
+            SET session_timeout = :session_timeout
+                {", accounting_interval = :accounting_interval" if has_accounting_interval else ""}
+            WHERE zoneid = :zoneid AND sessionid = :sessionid
+        """
 
         cur.execute(sql_update, qry_params)
+
         if cur.rowcount == 0:
-            sql_insert = """insert into session_restrictions(zoneid, sessionid, session_timeout, accounting_interval)
-                            values (:zoneid, :sessionid, :session_timeout, :accounting_interval)"""
+            sql_insert = f"""
+                INSERT INTO session_restrictions (
+                    zoneid,
+                    sessionid,
+                    session_timeout
+                    {", accounting_interval" if has_accounting_interval else ""}
+                )
+                VALUES (
+                    :zoneid,
+                    :sessionid,
+                    :session_timeout
+                    {", :accounting_interval" if has_accounting_interval else ""}
+                )
+            """
             cur.execute(sql_insert, qry_params)
             self._connection.commit()
-            return 'add'
-        else:
-            self._connection.commit()
-            return 'update'
+            return "add"
+
+        self._connection.commit()
+        return "update"
 
     def cleanup_sessions(self):
         """ cleanup removed sessions, but wait for accounting to finish when busy

--- a/src/opnsense/scripts/captiveportal/lib/db.py
+++ b/src/opnsense/scripts/captiveportal/lib/db.py
@@ -98,6 +98,18 @@ class DB(object):
             """)
             self._connection.commit()
 
+        # migration: add "accounting_interval" column to session_restrictions
+        cur.execute("PRAGMA table_info(session_restrictions)")
+        if not any([row[1] == 'accounting_interval' for row in cur.fetchall()]):
+            cur.execute("ALTER TABLE session_restrictions ADD COLUMN accounting_interval INT")
+            self._connection.commit()
+
+        # migration: add "last_update_time" column to accounting_state
+        cur.execute("PRAGMA table_info(accounting_state)")
+        if not any([row[1] == 'last_update_time' for row in cur.fetchall()]):
+            cur.execute("ALTER TABLE accounting_state ADD COLUMN last_update_time NUMBER")
+            self._connection.commit()
+
         cur.close()
 
     def sessions_per_address(self, zoneid, ip_address='', mac_address=''):
@@ -626,23 +638,25 @@ class DB(object):
 
         self._connection.commit()
 
-    def update_session_restrictions(self, zoneid, sessionid, session_timeout):
+    def update_session_restrictions(self, zoneid, sessionid, session_timeout, accounting_interval=None):
         """ upsert session restrictions
         :param zoneid: zone id
         :param sessionid: session id
         :param session_timeout: timeout in seconds
+        :param accounting_interval: Acct-Interim-Interval dictated by RADIUS backend
         :return: string "add"/"update" to signal the performed action to the client
         """
         cur = self._connection.cursor()
-        qry_params = {'zoneid': zoneid, 'sessionid': sessionid, 'session_timeout': session_timeout}
+        qry_params = {'zoneid': zoneid, 'sessionid': sessionid, 'session_timeout': session_timeout, 'accounting_interval': accounting_interval}
         sql_update = """update session_restrictions
-                        set session_timeout = :session_timeout
+                        set session_timeout = :session_timeout,
+                        accounting_interval = :accounting_interval
                         where zoneid = :zoneid and sessionid = :sessionid"""
 
         cur.execute(sql_update, qry_params)
         if cur.rowcount == 0:
-            sql_insert = """insert into session_restrictions(zoneid, sessionid, session_timeout)
-                            values (:zoneid, :sessionid, :session_timeout)"""
+            sql_insert = """insert into session_restrictions(zoneid, sessionid, session_timeout, accounting_interval)
+                            values (:zoneid, :sessionid, :session_timeout, :accounting_interval)"""
             cur.execute(sql_insert, qry_params)
             self._connection.commit()
             return 'add'

--- a/src/opnsense/scripts/captiveportal/process_accounting_messages.php
+++ b/src/opnsense/scripts/captiveportal/process_accounting_messages.php
@@ -95,7 +95,7 @@ if ($result !== false) {
                 if (method_exists($authenticator, 'updateAccounting')) {
                     // send interim update event. Default to an interval of 600 seconds unless specified otherwise
                     $now = time();
-                    if (($now - intval($row['last_update_time'])) >= intval($row['accounting_interval'] ?: 600)) {
+                    if (($now - intval($row['last_update_time'])) >= intval($row['accounting_interval'])) {
                         $stmt = $db->prepare('update accounting_state
                                               set last_update_time = :time
                                               where zoneid = :zoneid

--- a/src/opnsense/scripts/captiveportal/process_accounting_messages.php
+++ b/src/opnsense/scripts/captiveportal/process_accounting_messages.php
@@ -49,6 +49,8 @@ $result = $db->query('
     ,           si.bytes_in
     ,           si.bytes_out
     ,           accs.state
+    ,           accs.last_update_time
+    ,           sr.accounting_interval
     from        cp_clients c
     inner join  session_restrictions sr on sr.zoneid = c.zoneid and sr.sessionid = c.sessionid
     left join   session_info si on c.zoneid = si.zoneid and c.sessionid = si.sessionid
@@ -64,10 +66,12 @@ if ($result !== false) {
         if ($authenticator != null) {
             if ($row['state'] == null) {
                 // new accounting state, send start event (if applicable)
-                $stmt = $db->prepare('insert into accounting_state(zoneid, sessionid, state)
-                                      values (:zoneid, :sessionid, \'RUNNING\')');
+                $stmt = $db->prepare('insert into accounting_state(zoneid, sessionid, state, last_update_time)
+                                      values (:zoneid, :sessionid, \'RUNNING\', :time)');
                 $stmt->bindParam(':zoneid', $row['zoneid']);
                 $stmt->bindParam(':sessionid', $row['sessionid']);
+                $now = time();
+                $stmt->bindParam(':time', $now);
                 $stmt->execute();
                 if (method_exists($authenticator, 'startAccounting')) {
                     // send start accounting event
@@ -83,15 +87,26 @@ if ($result !== false) {
                 $stmt->bindParam(':sessionid', $row['sessionid']);
                 $stmt->execute();
                 if (method_exists($authenticator, 'stopAccounting')) {
-                    $time_spend = time() - intval($row['created']);
-                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address'], $row['delete_reason']);
+                    $time_spent = time() - intval($row['created']);
+                    $authenticator->stopAccounting($row['username'], $row['sessionid'], $time_spent, $row['bytes_in'], $row['bytes_out'], $row['ip_address'], $row['delete_reason']);
                 }
             } elseif ($row['state'] != 'STOPPED') {
                 // send interim updates (if applicable)
                 if (method_exists($authenticator, 'updateAccounting')) {
-                    // send interim update event
-                    $time_spend = time() - intval($row['created']);
-                    $authenticator->updateAccounting($row['username'], $row['sessionid'], $time_spend, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
+                    // send interim update event. Default to an interval of 600 seconds unless specified otherwise
+                    $now = time();
+                    if (($now - intval($row['last_update_time'])) >= intval($row['accounting_interval'] ?: 600)) {
+                        $stmt = $db->prepare('update accounting_state
+                                              set last_update_time = :time
+                                              where zoneid = :zoneid
+                                              and sessionid = :sessionid');
+                        $stmt->bindParam(':time', $now);
+                        $stmt->bindParam(':sessionid', $row['sessionid']);
+                        $stmt->bindParam(':zoneid', $row['zoneid']);
+                        $stmt->execute();
+                        $time_spent = $now - intval($row['created']);
+                        $authenticator->updateAccounting($row['username'], $row['sessionid'], $time_spent, $row['bytes_in'], $row['bytes_out'], $row['ip_address']);
+                    }
                 }
             }
         }

--- a/src/opnsense/scripts/captiveportal/set_session_restrictions.py
+++ b/src/opnsense/scripts/captiveportal/set_session_restrictions.py
@@ -34,10 +34,11 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--zoneid', help='zone number to allow this user in', type=str, required=True)
 parser.add_argument('--sessionid', help='session id', type=str, required=True)
 parser.add_argument('--session_timeout', help='authentication source', type=str)
+parser.add_argument('--accounting_interval', help='accounting interval', type=str, default=None)
 args = parser.parse_args()
 
 
 response = {
-    'response': DB().update_session_restrictions(args.zoneid, args.sessionid, args.session_timeout)
+    'response': DB().update_session_restrictions(args.zoneid, args.sessionid, args.session_timeout, args.accounting_interval)
 }
 print(ujson.dumps(response))

--- a/src/opnsense/scripts/captiveportal/sql/init.sql
+++ b/src/opnsense/scripts/captiveportal/sql/init.sql
@@ -53,6 +53,7 @@ create table if not exists session_restrictions (
       zoneid int
 ,     sessionid varchar
 ,     session_timeout int
+,     accounting_interval int
 ,     primary key (zoneid, sessionid)
 ) ;
 
@@ -61,5 +62,6 @@ create table if not exists accounting_state (
       zoneid int
 ,     sessionid varchar
 ,     state varchar
+,     last_update_time number
 ,     primary key (zoneid, sessionid)
 ) ;

--- a/src/opnsense/scripts/captiveportal/sql/init.sql
+++ b/src/opnsense/scripts/captiveportal/sql/init.sql
@@ -53,7 +53,7 @@ create table if not exists session_restrictions (
       zoneid int
 ,     sessionid varchar
 ,     session_timeout int
-,     accounting_interval int
+,     accounting_interval int default (600)
 ,     primary key (zoneid, sessionid)
 ) ;
 
@@ -62,6 +62,6 @@ create table if not exists accounting_state (
       zoneid int
 ,     sessionid varchar
 ,     state varchar
-,     last_update_time number
+,     last_update_time number default (0)
 ,     primary key (zoneid, sessionid)
 ) ;

--- a/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
+++ b/src/opnsense/service/conf/actions.d/actions_captiveportal.conf
@@ -18,7 +18,7 @@ message:disconnect session %s (reason %s)
 
 [set.session_restrictions]
 command:/usr/local/opnsense/scripts/captiveportal/set_session_restrictions.py
-parameters:--zoneid=%s --sessionid=%s --session_timeout=%s
+parameters:--zoneid=%s --sessionid=%s --session_timeout=%s --accounting_interval=%s
 type:script_output
 message:set extra restrictions for session (%s) %s
 


### PR DESCRIPTION
This changes the default interval to 600, which is the recommended value according to RFC 2869.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

See https://github.com/opnsense/core/issues/10453 for a description of the issue.

---

**Describe the proposed solution**

Change the default accounting interum-update to 600 seconds, but if the RADIUS backend sends back an `Acct-Interim-Interval` in the `Access-Accept`, use that value instead (if valid).

Adds 2 columns to the captive portal database, `accounting_interval` in `session_restrictions` and `last_update_time` in `accounting_state`.

---

**Related issue**

Closes https://github.com/opnsense/core/issues/10453
