### PR TITLE
mvc: PortField now rejects whitespaces in port ranges during validation

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -226,26 +226,38 @@ class PortField extends BaseListField
         if ($this->enableRanges) {
             // add valid ranges to options
             foreach (explode(",", $this->internalValue) as $data) {
-                if (strpos($data, "-") !== false) {
-                    $tmp = explode('-', $data);
-                    if (count($tmp) == 2) {
-                        if (
-                            filter_var(
-                                $tmp[0],
-                                FILTER_VALIDATE_INT,
-                                ['options' => ['min_range' => 1, 'max_range' => 65535]]
-                            ) !== false &&
-                            filter_var(
-                                $tmp[1],
-                                FILTER_VALIDATE_INT,
-                                ['options' => ['min_range' => 1, 'max_range' => 65535]]
-                            ) !== false &&
-                            $tmp[0] < $tmp[1]
-                        ) {
-                            $this->internalOptionList[$data] = $data;
-                        }
-                    }
+                if (strpos($data, "-") === false) {
+                    continue;
                 }
+
+                $tmp = explode('-', $data);
+
+                if (count($tmp) != 2) {
+                    continue;
+                }
+
+                // Reject any whitespaces
+                if ($tmp[0] !== trim($tmp[0]) || $tmp[1] !== trim($tmp[1])) {
+                    continue;
+                }
+
+                if (
+                    filter_var(
+                        $tmp[0],
+                        FILTER_VALIDATE_INT,
+                        ['options' => ['min_range' => 1, 'max_range' => 65535]]
+                    ) === false ||
+                    filter_var(
+                        $tmp[1],
+                        FILTER_VALIDATE_INT,
+                        ['options' => ['min_range' => 1, 'max_range' => 65535]]
+                    ) === false ||
+                    $tmp[0] >= $tmp[1]
+                ) {
+                    continue;
+                }
+
+                $this->internalOptionList[$data] = $data;
             }
         }
         return parent::getValidators();

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php
@@ -86,6 +86,20 @@ class PortFieldTest extends Field_Framework_TestCase
     }
 
     /**
+     * reject whitespaces around port numbers
+     */
+    public function testWhitespaceInvalid()
+    {
+        $field = new PortField();
+        $field->setEnableRanges("Y");
+        $field->eventPostLoading();
+        foreach (['80 ', ' 80', '1024-65535 ', ' 1024-65535', '1024 -65535', '1024-65535'] as $value) {
+            $field->setValue($value);
+            $this->assertNotEmpty($this->validate($field), "Whitespace should be invalid");
+        }
+    }
+
+    /**
      * all items valid
      */
     public function testValidValueList()

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/PortFieldTest.php
@@ -93,7 +93,7 @@ class PortFieldTest extends Field_Framework_TestCase
         $field = new PortField();
         $field->setEnableRanges("Y");
         $field->eventPostLoading();
-        foreach (['80 ', ' 80', '1024-65535 ', ' 1024-65535', '1024 -65535', '1024-65535'] as $value) {
+        foreach (['80 ', ' 80', '1024-65535 ', ' 1024-65535', '1024 -65535', '1024- 65535'] as $value) {
             $field->setValue($value);
             $this->assertNotEmpty($this->validate($field), "Whitespace should be invalid");
         }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: 
https://github.com/opnsense/core/issues/10477