### PR TITLE
Services: Kea DHCP: DHCPv4 - add optional per-subnet interface assignment

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
@@ -1,5 +1,11 @@
 <form>
     <field>
+        <id>subnet4.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>Optionally bind this subnet to a specific interface. This is only needed when the interface has no address within this subnet (e.g. when handing out an additional routed block); when left empty Kea selects the subnet by matching the interface address. The interface must also be selected in the general settings.</help>
+    </field>
+    <field>
         <id>subnet4.subnet</id>
         <label>Subnet</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
@@ -94,6 +94,18 @@ class KeaDhcpv4 extends BaseModel
                 $messages->appendMessage(new Message(gettext("Either a client ID or a MAC address should be specified."), $key . ".hw_address"));
             }
         }
+        // validate changed subnets
+        $this_interfaces = $this->general->interfaces->getValues();
+        foreach ($this->subnets->subnet4->iterateItems() as $subnet) {
+            if (!$validateFullModel && !$subnet->isFieldChanged()) {
+                continue;
+            }
+            if (!$subnet->interface->isEmpty() && !in_array($subnet->interface->getValue(), $this_interfaces)) {
+                $messages->appendMessage(
+                    new Message(gettext('Interface is not selected in the general settings.'), $subnet->__reference . ".interface")
+                );
+            }
+        }
 
         return $messages;
     }
@@ -180,6 +192,11 @@ class KeaDhcpv4 extends BaseModel
             /* add valid-lifetime at this level if given */
             if ($subnet->valid_lifetime->isSet()) {
                 $record['valid-lifetime'] = $subnet->valid_lifetime->asInt();
+            }
+            /* optionally bind this subnet to a specific interface (e.g. an additional routed block) */
+            $device = Util::getRealInterface($subnet->interface->getValue(), 'inet');
+            if (!empty($device)) {
+                $record['interface'] = $device;
             }
             /* add allocator if selected */
             if (!$subnet->allocator->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Kea/dhcp4</mount>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <description>Kea DHCPv4 configuration</description>
     <items>
         <general>
@@ -85,6 +85,7 @@
         </ha>
         <subnets>
             <subnet4 type="ArrayField">
+                <interface type="InterfaceField"/>
                 <subnet type="NetworkField">
                     <NetMaskRequired>Y</NetMaskRequired>
                     <AddressFamily>ipv4</AddressFamily>


### PR DESCRIPTION
**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- **Model used:** Claude Opus 4.8 (via Claude Code)
- **Extent of AI involvement:** The patch was drafted by the model, closely mirroring
  the existing DHCPv6 `interface` implementation. XML/model lint and PHP were verified,
  and the change was applied and tested by the submitter on a live 26.1.11 install
  (see Testing below).

---

**Describe the problem**

A DHCPv4 subnet in the Kea GUI can only be tied to an interface *implicitly*, by the
interface owning an address inside the subnet's CIDR (Kea's subnet-selection for
directly connected clients). There is no per-subnet `interface` field for DHCPv4 —
it exists only for DHCPv6.

As a consequence it is impossible to serve a subnet that is not addressed on any
interface, e.g. an additional routed block delivered over the same L2. Kea itself
supports a per-subnet `interface` parameter for exactly this case, and with the default
`dhcp-socket-type: raw` it can then answer clients on the selected interface without
owning an address in that subnet.

---

**Describe the proposed solution**

Add an optional per-subnet `interface` field to DHCPv4, mirroring the existing DHCPv6
implementation:

- **model** (`KeaDhcpv4.xml`): new optional `InterfaceField` on `subnet4`. Unlike DHCPv6
  it is *not* required, so leaving it empty preserves the current address-matching
  behaviour and existing configurations are unaffected. Model version bumped to `1.0.6`.
- **config generation** (`KeaDhcpv4.php`): emit `"interface"` into the `subnet4` record
  when set, via `Util::getRealInterface(..., 'inet')` — same pattern as DHCPv6.
- **validation** (`KeaDhcpv4.php`): warn when the chosen interface is not selected in the
  general settings (only checked when the field is set).
- **form** (`dialogSubnet4.xml`): expose it as a dropdown, placed as the first field so it
  shows as the leading column in the subnets grid, matching the DHCPv6 layout. (No
  grouping by interface, since unlike DHCPv6 the field is optional and often empty.)

Guarded by `if (!empty($device))`, so an empty field produces byte-for-byte the same
config as before — purely additive, no migration required.

---

**Testing**

Applied on a live OPNsense **26.1.11** install and exercised end-to-end:

- The subnets grid now shows an **Interface** column as the first column (parity with
  DHCPv6), populated with the interface description or left blank when unset.
- Subnet **with** an interface selected renders the expected key in the generated
  `/usr/local/etc/kea/kea-dhcp4.conf`:
```
root@OPNsense:~ # opnsense-version -v
26.1.11_5
root@OPNsense:~ # opnsense-patch -f -a WMP 859cf8f
Fetched 859cf8f via https://github.com/WMP/core
Hmm...  Looks like a unified diff to me...
The text leading up to this was:
--------------------------
|From 859cf8fbfaaf5a6f0ade27f72d41139c389c3280 Mon Sep 17 00:00:00 2001
|From: Marcin Janowski <marcin.janowski@assecobs.pl>
|Date: Fri, 3 Jul 2026 12:41:48 +0200
|Subject: [PATCH] Services: Kea DHCP: DHCPv4 - add optional per-subnet
| interface assignment
|
|DHCPv4 subnets could only be tied to an interface implicitly, by the
|interface owning an address inside the subnet's CIDR. This made it
|impossible to hand out an additional routed block that is not addressed
|on any interface, even though Kea itself supports a per-subnet
|"interface" parameter for exactly this case (already exposed for
|DHCPv6).
|
|Add an optional "interface" field to subnet4, mirroring the existing
|DHCPv6 implementation:
|- model: new optional InterfaceField (empty keeps the current
|  address-matching behaviour, so existing configs are unaffected)
|- config generation: emit "interface" into the subnet4 record when set
|- validation: warn when the chosen interface is not selected in the
|  general settings
|- form: expose it as a dropdown
|
|Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
|---
| .../OPNsense/Kea/forms/dialogSubnet4.xml        |  6 ++++++
| .../mvc/app/models/OPNsense/Kea/KeaDhcpv4.php   | 17 +++++++++++++++++
| .../mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml   |  3 ++-
| 3 files changed, 25 insertions(+), 1 deletion(-)
|
|diff --git a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
|index 6579802bb7e..926442b92cd 100644
|--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
|+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml
--------------------------
Patching file opnsense/mvc/app/controllers/OPNsense/Kea/forms/dialogSubnet4.xml using Plan A...
Hunk #1 succeeded at 1.
Hmm...  The next patch looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
|index 63edd97f9d3..cd79953dcaf 100644
|--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
|+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php
--------------------------
Patching file opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.php using Plan A...
Hunk #1 succeeded at 94.
Hunk #2 succeeded at 193.
Hmm...  The next patch looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
|index b5139814d20..338e5e715bb 100644
|--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
|+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml
--------------------------
Patching file opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv4.xml using Plan A...
Hunk #1 succeeded at 1.
Hunk #2 succeeded at 85.
done
All patches have been applied successfully.  Have a nice day.
root@OPNsense:~ # cat /usr/local/etc/kea/kea-dhcp4.conf
{
    "Dhcp4": {
        "valid-lifetime": 4000,
        "decline-probation-period": 600,
        "interfaces-config": {
            "interfaces": [
                "vtnet0"
            ],
            "dhcp-socket-type": "raw",
            "service-sockets-max-retries": 5,
            "service-sockets-retry-wait-time": 5000
        },
        "lease-database": {
            "type": "memfile",
            "persist": true
        },
        "control-socket": {
            "socket-type": "unix",
            "socket-name": "\/var\/run\/kea\/kea4-ctrl-socket"
        },
        "loggers": [
            {
                "name": "kea-dhcp4",
                "output_options": [
                    {
                        "output": "syslog"
                    }
                ],
                "severity": "INFO"
            }
        ],
        "subnet4": [
            {
                "id": 1,
                "subnet": "10.10.0.0\/24",
                "next-server": "",
                "match-client-id": true,
                "option-data": [
                    {
                        "name": "domain-name",
                        "data": "internal"
                    }
                ],
                "pools": [
                    {
                        "pool": "10.10.0.10-10.10.0.100"
                    }
                ],
                "reservations": [],
                "user-context": {
                    "uuid": "14023052-13f8-461d-a522-0501d793b528",
                    "description": "test"
                }
            },
            {
                "id": 2,
                "subnet": "10.11.0.0\/24",
                "next-server": "",
                "match-client-id": true,
                "option-data": [
                    {
                        "name": "domain-name",
                        "data": "internal"
                    }
                ],
                "pools": [
                    {
                        "pool": "10.11.0.10-10.11.0.100"
                    }
                ],
                "reservations": [],
                "interface": "vtnet0",
                "user-context": {
                    "uuid": "bb3a0f57-61f3-4689-a80b-523150cf80ce",
                    "description": "test with set interface to WAN"
                }
            }
        ],
        "hooks-libraries": [
            {
                "library": "\/usr\/local\/lib\/kea\/hooks\/libdhcp_lease_cmds.so"
            },
            {
                "library": "\/usr\/local\/lib\/kea\/hooks\/libdhcp_host_cmds.so"
            }
        ]
    }
}root@OPNsense:~ # 
```
<img width="1152" height="1037" alt="Screenshot_20260703_132637" src="https://github.com/user-attachments/assets/7c7ea614-8357-4ffb-bf1b-0b1a4cc42caf" />
<img width="1152" height="1037" alt="Screenshot_20260703_132440" src="https://github.com/user-attachments/assets/a17aedaa-0995-4634-b8e7-6ea3f3251dfd" />

<img width="1879" height="497" alt="image" src="https://github.com/user-attachments/assets/36363d12-0e45-4c65-a477-ee7a6579db3d" />
