### PR TITLE
reporting: health: persist category/subject/granularity selection in the URL

### DIFF
--- a/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Diagnostics/health.volt
@@ -121,6 +121,14 @@
 
         const healthGraph = new HealthGraph('health-chart');
 
+        const syncUrlState = () => {
+            const params = new URLSearchParams(location.search);
+            params.set('category', $('#health-category-select').val());
+            params.set('subject', $('#health-subcategory-select').val());
+            params.set('granularity', $('#detail-select').val());
+            history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
+        };
+
         const reset = () => {
             $('#info-disabled').hide();
             $('#main').show();
@@ -128,6 +136,19 @@
             $('#spinner').show();
             healthGraph.initialize().then(async () => {
                 const rrdOptions = healthGraph.getRRDList();
+
+                const urlParams = new URLSearchParams(location.search);
+                const savedCategory = urlParams.get('category');
+                let savedSubject = urlParams.get('subject');
+                const savedGranularity = urlParams.get('granularity');
+
+                if (savedGranularity !== null && ['0', '1', '2', '3'].includes(savedGranularity)) {
+                    $('#detail-select').val(savedGranularity);
+                    // .val() alone doesn't fire the change handler, so seed the graph's
+                    // state directly or the first fetch below would use the old default
+                    healthGraph.currentDetailLevel = savedGranularity;
+                }
+
                 for (const [category, subitems] of Object.entries(rrdOptions.data)) {
 
                     let $select = $('#health-category-select');
@@ -155,8 +176,17 @@
                     });
 
                     $('#health-subcategory-select').selectpicker('refresh');
-                    // trigger first selection
-                    $('#health-subcategory-select').val(rrdOptions.data[selectedCategory][0]).trigger('changed.bs.select');
+
+                    // restore a saved subject on first load only, then fall back to the first entry
+                    const subjectToSelect = (savedSubject && rrdOptions.data[selectedCategory].includes(savedSubject))
+                        ? savedSubject
+                        : rrdOptions.data[selectedCategory][0];
+                    savedSubject = null;
+                    $('#health-subcategory-select').val(subjectToSelect);
+                    // bootstrap-select's button label only redraws on an explicit refresh,
+                    // not merely from a re-triggered changed.bs.select event
+                    $('#health-subcategory-select').selectpicker('refresh');
+                    $('#health-subcategory-select').trigger('changed.bs.select');
                 });
 
 
@@ -167,12 +197,18 @@
                     let system = `${sub}-${category}`;
                     await healthGraph.update(system);
                     $('#spinner').hide();
+                    syncUrlState();
                 });
 
                 $('.selectpicker').selectpicker('refresh');
 
-                // trigger event for first category
-                $('#health-category-select').val(Object.keys(rrdOptions.data)[0]).trigger('changed.bs.select');
+                // trigger event for first category, restoring a saved selection when still valid
+                const categoryToSelect = (savedCategory && rrdOptions.data.hasOwnProperty(savedCategory))
+                    ? savedCategory
+                    : Object.keys(rrdOptions.data)[0];
+                $('#health-category-select').val(categoryToSelect);
+                $('#health-category-select').selectpicker('refresh');
+                $('#health-category-select').trigger('changed.bs.select');
 
                 $("#reset-zoom").click(function() {
                     healthGraph.resetZoom();
@@ -186,6 +222,7 @@
                     $('#spinner').show();
                     await healthGraph.update(null, $(this).val());
                     $('#spinner').hide();
+                    syncUrlState();
                 });
 
                 $("#stacked-select").change(async function() {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 5, via Claude Code
- Extent of AI involvement: I described the bug and asked Claude Code to investigate, implement, and verify a fix. It located the relevant controller/view/JS, implemented the change, and verified it by provisioning a throwaway OPNsense 26.1.6 VM and driving the actual UI in a browser rather than relying on code review alone. That live test caught two real bugs on the first attempt (a granularity restore that silently used the wrong detail level, and a bootstrap-select button that didn't visually refresh after a restore), which were then fixed and re-verified the same way. I reviewed the diff and the test evidence before submitting this PR.

---

**Describe the problem**

Reloading the Reporting > Health page always resets the Category, Subject, and Granularity selectors back to their defaults, discarding whatever the user was looking at and making it impossible to bookmark or share a specific view.

---

**Describe the proposed solution**

Read the three selections from the URL query string on load, falling back to today's defaults when a value is absent or no longer valid (e.g. a removed interface), and keep the query string in sync via `history.replaceState()` as the user changes any of them.

Two implementation details worth flagging for review:
- Restoring a saved detail level needs to seed `HealthGraph.currentDetailLevel` directly, since setting the select's value alone doesn't fire its change handler.
- Restoring a saved category/subject needs an explicit `selectpicker('refresh')` call, since bootstrap-select only redraws its button label on that, not on a re-triggered `changed.bs.select` event. This was invisible before because the only value ever selected here programmatically was whatever the widget already displayed by default.

Verified on a throwaway OPNsense 26.1.6 VM: set a non-default selection, confirmed the URL updates, then hard-refreshed and confirmed both the visual dropdown state and the actual data fetch (network request) use the restored values, including a graceful fallback when a saved subject is no longer valid.

Screenshots/recording to follow in a comment.

---

**Related issue**

Ref: #10489