### PR TITLE
firewall: avoid emitting reply-to on block rules as well

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2016-2017 Deciso B.V.
+ * Copyright (C) 2016-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -192,8 +192,8 @@ class FilterRule extends Rule
                 $rule['disabled'] = true;
                 $this->log("Gateway protocol mismatch");
             }
-            if (!empty($rule['gateway']) && !empty($rule['type']) && $rule['type'] != 'pass') {
-                unset($rule['gateway']);
+            if (!empty($rule['type']) && $rule['type'] != 'pass') {
+                unset($rule['gateway'], $rule['reply-to']);
                 $this->log("Gateway not allowed for block rules");
             }
             if (!isset($rule['quick'])) {

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -193,7 +193,7 @@ class FilterRule extends Rule
                 $this->log("Gateway protocol mismatch");
             }
             if (!empty($rule['type']) && $rule['type'] != 'pass') {
-                unset($rule['gateway'], $rule['reply-to']);
+                unset($rule['gateway'], $rule['reply']);
                 $this->log("Gateway not allowed for block rules");
             }
             if (!isset($rule['quick'])) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

---

> /tmp/rules.debug:1355: route-to, reply-to and dup-to are not supported on block rules
> /tmp/rules.debug:1355: skipping rule due to errors
> /tmp/rules.debug:1355: rule expands to no valid combination

> block in quick on igc0 reply-to ( igc0 x.x.x.x ) inet from $alias to {any} label "abcdefxxxx"

---

**Describe the proposed solution**

Remove reply-to the same way that 20070de6 did it.

---

**Related issue**

N/A
