### PR TITLE
memory stats: update cache

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -163,6 +163,7 @@ class SystemController extends ApiControllerBase
             'vm.stats.vm.v_page_count',
             'vm.stats.vm.v_inactive_count',
             'vm.stats.vm.v_cache_count',
+            'vm.stats.vm.v_laundry_count',
             'vm.stats.vm.v_free_count',
             'kstat.zfs.misc.arcstats.size'
         ])), true);
@@ -170,7 +171,7 @@ class SystemController extends ApiControllerBase
         if (!empty($mem['vm.stats.vm.v_page_count'])) {
             $pc = $mem['vm.stats.vm.v_page_count'];
             $ic = $mem['vm.stats.vm.v_inactive_count'];
-            $cc = $mem['vm.stats.vm.v_cache_count'];
+            $cc = ($mem['vm.stats.vm.v_cache_count'] ?? 0) + ($mem['vm.stats.vm.v_laundry_count'] ?? 0);
             $fc = $mem['vm.stats.vm.v_free_count'];
             $result['memory']['total'] = $mem['hw.physmem'];
             $result['memory']['total_frmt'] = sprintf('%d', $mem['hw.physmem'] / 1024 / 1024);

--- a/src/opnsense/scripts/health/library/OPNsense/RRD/Stats/Memory.php
+++ b/src/opnsense/scripts/health/library/OPNsense/RRD/Stats/Memory.php
@@ -38,24 +38,39 @@ class Memory extends Base
             'vm.stats.vm.v_active_count',
             'vm.stats.vm.v_inactive_count',
             'vm.stats.vm.v_free_count',
-            'vm.stats.vm.v_cache_count',
-            'vm.stats.vm.v_wire_count'
+            'vm.stats.vm.v_wire_count',
+            'vm.stats.vm.v_laundry_count',
+            'hw.pagesize',
+            'kstat.zfs.misc.arcstats.size'
         ];
 
         $memory = $this->shellCmd($frmt);
 
         if (!empty($memory)) {
-            $percentages = [];
             $data = [];
-            foreach ($memory as $idx => $item) {
-                // strip vm.stats.vm.v_ and collect into $result
-                $tmp = explode(':', substr($item, 14));
-                $data[$tmp[0]] = trim($tmp[1]);
-                if ($idx > 0) {
-                    $percentages[explode('_', $tmp[0])[0]] = ($data[$tmp[0]] / $data['page_count']) * 100.0;
+            foreach ($memory as $item) {
+                $parts = explode(':', $item, 2);
+                if (count($parts) === 2) {
+                    $data[trim($parts[0])] = (float)trim($parts[1]);
                 }
             }
-            return $percentages;
+
+            $page_count = max(1.0, (float)($data['vm.stats.vm.v_page_count'] ?? 1.0));
+            $arc_size = $data['kstat.zfs.misc.arcstats.size'] ?? 0.0;
+            $pagesize = max(1.0, (float)($data['hw.pagesize'] ?? 4096.0));
+            $arc_pages = $arc_size / $pagesize;
+
+            $laundry_pages = $data['vm.stats.vm.v_laundry_count'] ?? 0.0;
+            $wire_pages = max(0.0, ($data['vm.stats.vm.v_wire_count'] ?? 0.0) - $arc_pages);
+            $cache_pages = $laundry_pages + $arc_pages;
+
+            return [
+                'active' => (($data['vm.stats.vm.v_active_count'] ?? 0.0) / $page_count) * 100.0,
+                'inactive' => (($data['vm.stats.vm.v_inactive_count'] ?? 0.0) / $page_count) * 100.0,
+                'free' => (($data['vm.stats.vm.v_free_count'] ?? 0.0) / $page_count) * 100.0,
+                'wire' => ($wire_pages / $page_count) * 100.0,
+                'cache' => ($cache_pages / $page_count) * 100.0,
+            ];
         }
 
         return [];


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Gemini 3.5 Flash (extended)
- Extent of AI involvement: Helped with code validation.

---

**Describe the problem**

The cache metric on the RRD stats is broken.

---

**Describe the proposed solution**

IMO it should use the new cache "laundry" variable and add to that the ARC on ZFS systems.

---

**Related issue**

https://github.com/opnsense/core/issues/10522