### PR TITLE
mvc: translate grid view labels

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php
@@ -316,6 +316,8 @@ class ControllerBase extends ControllerRoot
                             continue 2;
                         } elseif ($key == 'sequence') {
                             $this_sequence = (string)$item;
+                        } elseif ($key == 'label') {
+                            $record[$key] = gettext((string)$item);
                         } else {
                             $record[$key] = (string)$item;
                         }


### PR DESCRIPTION
## Summary

- translate labels declared inside `grid_view`
- preserve the existing handling for all other grid view properties

## Root cause

`getFormGrid()` translates a field's regular `label`, but a `grid_view/label` is copied into the grid record afterwards without passing through `gettext()`. This overwrites the translated field label with its untranslated grid-specific label.

For example, the Source NAT grid uses grid-specific labels such as `Source`, `Port`, and `Destination`, so those column headers remain in English even when the active locale contains translations for them.

## Impact

Grid-specific column labels now use the active locale consistently with regular field labels.

## Validation

- `php -l src/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php`
- `git diff --check`
- verified on OPNsense 26.7 with the Chinese locale; the Source NAT headers render as translated values
