### PR TITLE
Correctly map netflow indexes when there are gaps

### DIFF
--- a/src/opnsense/scripts/netflow/lib/parse.py
+++ b/src/opnsense/scripts/netflow/lib/parse.py
@@ -40,10 +40,27 @@ class Interfaces(object):
         """
         self._if_index = dict()
         sp = subprocess.run(['/usr/local/sbin/ifinfo'], capture_output=True, text=True)
-        interfaces = re.findall(r"Interface ([^ ]+)", sp.stdout)
+        interfaces = re.split(r'(?=^Interface )', sp.stdout, flags=re.MULTILINE)
 
-        for index, interface in enumerate(interfaces, start=1):
-            self._if_index["%s" % index] = interface
+        for interface_block in interfaces:
+            interface = self._parse_interface(interface_block)
+
+            if interface:
+                self._if_index[str(interface['index'])] = interface['name']
+
+    def _parse_interface(self, block):
+        """ extract fields from interface block
+        """
+        name = re.search(r'^Interface ([^ ]+)', block, re.MULTILINE)
+        index = re.search(r'^\s+index: (\d+)', block, re.MULTILINE)
+
+        if not name or not index:
+            return None
+
+        return {
+            'name': name.group(1),
+            'index': int(index.group(1))
+        }
 
     def if_device(self, if_index):
         """ convert index to device (if found)


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.

---

**Describe the problem**

When interfaces have been removed from the system there can be gaps in the indexes which breaks the mapping in the netflow aggregator.

---

**Describe the proposed solution**

Instead of assuming interfaces are returned in index order actually parse the output to gather the index values.

---

**Related issue**

#10541