### PR TITLE
Firewall: Rules and NAT: Group invalid rules to the end of the ruleset. These rules are skipped by PF processing because they do not have a valid interface.

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
@@ -63,6 +63,12 @@ class DNatController extends FilterBaseController
 
         $results =  $this->searchBase("rule", null, "sequence", $filter_funct);
 
+        $configObj = Config::getInstance()->object();
+
+        /* carry results */
+        $results =  $this->searchBase("rule", null, "sequence", $filter_funct);
+        $configObj = Config::getInstance()->object();
+
         /* carry results */
         foreach ($results['rows'] as &$record) {
             /* offer list of colors to be used by the frontend  */
@@ -77,8 +83,26 @@ class DNatController extends FilterBaseController
             // This is only used for visualization to ensure the tabulator tree renders
             // rules in the correct order, similar to firewall rules.
             // It does not influence the processing order of the ruleset by sequence.
-            $record['sort_order'] = sprintf('%d.0%06d', 400000, (int)($record['sequence'] ?? 0));
-            $record['prio_group'] = '400000';
+            $interfaces = !empty($record['interface']) ? explode(',', $record['interface']) : [];
+            $has_interface = false;
+
+            foreach ($interfaces as $interface) {
+                if (isset($configObj?->interfaces?->$interface)) {
+                    $has_interface = true;
+                    break;
+                }
+            }
+
+            // Default
+            $priority = 400000;
+
+            // Invalid rules (not applied by PF)
+            if (!empty($interfaces) && !$has_interface) {
+                $priority = 600000;
+            }
+
+            $record['sort_order'] = sprintf('%d.0%06d', $priority, (int)($record['sequence'] ?? 0));
+            $record['prio_group'] = (string)$priority;
         }
 
         foreach (Util::getAntiLockout() as $if => $ports) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
@@ -62,11 +62,6 @@ class DNatController extends FilterBaseController
         };
 
         $results =  $this->searchBase("rule", null, "sequence", $filter_funct);
-
-        $configObj = Config::getInstance()->object();
-
-        /* carry results */
-        $results =  $this->searchBase("rule", null, "sequence", $filter_funct);
         $configObj = Config::getInstance()->object();
 
         /* carry results */

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
@@ -167,7 +167,6 @@ class FilterRuleContainerField extends ContainerField
 
         // default
         return 400000;
-
     }
 }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
@@ -167,6 +167,7 @@ class FilterRuleContainerField extends ContainerField
 
         // default
         return 400000;
+
     }
 }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/FilterRuleField.php
@@ -124,6 +124,19 @@ class FilterRuleContainerField extends ContainerField
     {
         $configObj = Config::getInstance()->object();
         $interfaces = $this->interface->getValues();
+        $has_interface = false;
+
+        foreach ($interfaces as $interface) {
+            if (isset($configObj?->interfaces?->$interface)) {
+                $has_interface = true;
+                break;
+            }
+        }
+
+        // Invalid rules (not applied by PF)
+        if (!empty($interfaces) && !$has_interface) {
+            return 600000;
+        }
 
         /* XXX this is an approximation of the complex situation and will be removed eventually */
         if (count($interfaces) != 1 || !$this->interfacenot->isEmpty()) {

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
@@ -30,6 +30,7 @@ namespace OPNsense\Firewall\FieldTypes;
 
 use OPNsense\Base\FieldTypes\ArrayField;
 use OPNsense\Base\FieldTypes\ContainerField;
+use OPNsense\Core\Config;
 
 /**
  * Class SourceNatRuleContainerField
@@ -95,6 +96,33 @@ class SourceNatRuleContainerField extends ContainerField
 
         return $result;
     }
+
+    /**
+     * Return the rule priority group.
+     *
+     * @return int
+     */
+    public function getPriority()
+    {
+        $configObj = Config::getInstance()->object();
+        $interfaces = $this->interface->getValues();
+        $has_interface = false;
+
+        foreach ($interfaces as $interface) {
+            if (isset($configObj?->interfaces?->$interface)) {
+                $has_interface = true;
+                break;
+            }
+        }
+
+        // Invalid rules (not applied by PF)
+        if (!empty($interfaces) && !$has_interface) {
+            return 600000;
+        }
+
+        // Default
+        return 400000;
+    }
 }
 
 /**
@@ -124,8 +152,8 @@ class SourceNatRuleField extends ArrayField
              * rules, but should still expose sort_order for tree view grouping.
              * If automatic rules are added later, they should either be 100000 (start) or 500000 (end of ruleset).
              */
-            $node->sort_order = sprintf("%d.0%06d", 400000, (string)$node->sequence);
-            $node->prio_group = "400000";
+            $node->sort_order = sprintf("%d.0%06d", $node->getPriority(), (string)$node->sequence);
+            $node->prio_group = (string)$node->getPriority();
         }
 
         return parent::actionPostLoadingEvent();

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -82,6 +82,7 @@
             { idx: 3, uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
             { idx: 4, uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
             { idx: 5, uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
+            { idx: 6, uuid: "invalid", label: "{{ lang._('Invalid rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Invalid rules that are not processed') }}", color: "text-secondary", groupType: null },
         ];
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -82,7 +82,7 @@
             { idx: 3, uuid: "group", label: "{{ lang._('Group rules') }}", icon: "fa-sitemap", tooltip: "{{ lang._('Group rule') }}", color: "text-warning", groupType: "groups" },
             { idx: 4, uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info", groupType: "interfaces" },
             { idx: 5, uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary", groupType: null },
-            { idx: 6, uuid: "invalid", label: "{{ lang._('Invalid rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Invalid rules that are not processed') }}", color: "text-secondary", groupType: null },
+            { idx: 6, uuid: "defunct", label: "{{ lang._('Defunct rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Defunct rules that are not processed') }}", color: "text-secondary", groupType: null },
         ];
 
         // XXX: The "prio_group.sequence" combination in "sort_order" (300000.0000010) is not always static, e.g. in group rules it could also be (300010.0000010).

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -773,8 +773,8 @@
 
             if (row.isGroup) return false;
 
-            // Defunct rules can only be deleted or copied.
             if (getRuleTypeDigit(row) === 6 && !["delete", "copy"].includes(type)) {
+                // Defunct rules can only be deleted or copied.
                 return false;
             }
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -335,95 +335,6 @@
                     },
                 },
                 formatters:{
-                    commands: function (column, row) {
-                        // All formatters except category must skip processing bucket rows in tree view
-                        if (row.isGroup) {
-                            return "";
-                        }
-                        const rowId = row.uuid || "";
-                        const hasUuid = rowId.includes("-");
-
-                        // Defunct rules can only be deleted
-                        if (getRuleTypeDigit(row) === 6) {
-                            return `
-                                <button type="button" class="btn btn-xs btn-default command-delete
-                                    bootgrid-tooltip" data-row-id="${rowId}"
-                                    title="{{ lang._('Delete') }}">
-                                    <span class="fa fa-fw fa-trash-o"></span>
-                                </button>
-                            `;
-                        }
-
-                        const logSearchCommand = (rid, log) => {
-                            const loggingEnabled = log === '1' || log === true;
-                            if (!loggingEnabled) return '';
-
-                            return `
-                                <a href="/ui/diagnostics/firewall/log#${new URLSearchParams({field:'rid',operator:'=',value:rid})}"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="btn btn-xs btn-default bootgrid-tooltip"
-                                title="{{ lang._('View log entries for this rule') }}">
-                                    <i class="fa fa-fw fa-search"></i>
-                                </a>
-                            `;
-                        };
-
-                        // If UUID is invalid, its an internal rule, use the #ref field to show a lookup button.
-                        if (!hasUuid) {
-                            const ref = (row["ref"] || "");
-
-                            // optional lookup button if ref exists
-                            const lookupRefCommand = ref ? `
-                                <a href="/${ref}" target="_blank" rel="noopener noreferrer"
-                                class="btn btn-xs btn-default bootgrid-tooltip"
-                                title="{{ lang._('Lookup rule reference') }}">
-                                    <i class="fa fa-fw fa-link"></i>
-                                </a>
-                            ` : '';
-
-                            return `
-                                ${logSearchCommand(rowId, row.log)}
-                                ${lookupRefCommand}
-                            `;
-                        }
-
-                        return `
-                            <button type="button" class="btn btn-xs btn-default command-move_before
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Move selected rule before this rule') }}">
-                                <span class="fa fa-fw fa-arrow-left"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-toggle_log bootgrid-tooltip"
-                                data-row-id="${row.uuid}" data-value="${row.log}"
-                                title="${row.log == '1'
-                                    ? '{{ lang._("Disable Logging") }}'
-                                    : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-edit
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Edit') }}">
-                                <span class="fa fa-fw fa-pencil"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-copy
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Clone') }}">
-                                <span class="fa fa-fw fa-clone"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-delete
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Delete') }}">
-                                <span class="fa fa-fw fa-trash-o"></span>
-                            </button>
-
-                            ${logSearchCommand(rowId, row.log)}
-                        `;
-                    },
                     // Disable rowtoggle for internal rules
                     rowtoggle: function (column, row) {
                         if (row.isGroup) {
@@ -733,7 +644,20 @@
                     },
                     sequence: 500
                 },
+                lookup_ref: {
+                    filter: (cell) => commandFilter(cell, "lookup_ref"),
+                    classname: "fa fa-fw fa-link",
+                    title: "{{ lang._('Lookup rule reference') }}",
+                    sequence: 10,
+                    method: function(event, cell) {
+                        const row = cell.getData();
+                        if (row?.ref) {
+                            window.open(`/${row.ref}`, "_blank", "noopener,noreferrer");
+                        }
+                    },
+                },
                 move_before: {
+                    filter: (cell) => commandFilter(cell, "move_before"),
                     method: function(event) {
                         // Ensure exactly one rule is selected to be moved
                         const selected = $("#{{ formGridFilterRule['table_id'] }}").bootgrid("getSelectedRows");
@@ -785,9 +709,11 @@
                     sequence: 10
                 },
                 toggle_log: {
-                    method: function(event) {
+                    filter: (cell) => commandFilter(cell, "toggle_log"),
+                    method: function(event, cell) {
                         const uuid = $(this).data("row-id");
-                        const log = String(+$(this).data("value") ^ 1);
+                        const row = cell.getData();
+                        const log = String(+row.log ^ 1);
                         ajaxCall(
                             `/api/firewall/filter/toggle_rule_log/${uuid}/${log}`,
                             {},
@@ -807,13 +733,63 @@
                             'POST'
                         );
                     },
-                    classname: 'fa fa-fw fa-exclamation-circle',
-                    title: "{{ lang._('Toggle Logging') }}",
+                    classname: (cell) => {
+                        const row = cell.getData();
+                        return (row.log === "1" || row.log === true) ? "fa fa-fw fa-bell" : "fa fa-fw fa-bell-slash";
+                    },
+                    title: (cell) => {
+                        const row = cell.getData();
+                        return (row.log === "1" || row.log === true) ? '{{ lang._("Disable Logging") }}' : '{{ lang._("Enable Logging") }}';
+                    },
                     sequence: 20
+                },
+                log_search: {
+                    filter: (cell) => commandFilter(cell, "log_search"),
+                    classname: "fa fa-fw fa-search",
+                    title: "{{ lang._('View log entries for this rule') }}",
+                    sequence: 999,
+                    method: function(event, cell) {
+                        const row = cell.getData();
+                        const params = new URLSearchParams({field:'rid',operator:'=',value:row.uuid || ""});
+                        window.open(`/ui/diagnostics/firewall/log#${params}`, "_blank", "noopener,noreferrer");
+                    }
+                },
+                delete: {
+                    filter: (cell) => commandFilter(cell, "delete"),
+                },
+                copy: {
+                    filter: (cell) => commandFilter(cell, "copy"),
+                },
+                edit: {
+                    filter: (cell) => commandFilter(cell, "edit"),
                 }
             },
 
         });
+
+        function commandFilter(cell, type = "") {
+            const row = cell.getData();
+            const hasUuid = row.uuid?.includes("-") ?? false;
+
+            if (row.isGroup) return false;
+
+            // Defunct rules can only be deleted or copied.
+            if (getRuleTypeDigit(row) === 6 && !["delete", "copy"].includes(type)) {
+                return false;
+            }
+
+            if (type === "lookup_ref") {
+                // lookup_ref only allowed without a valid UUID
+                return !hasUuid;
+            }
+
+            if (type === "log_search") {
+                // requires both a UUID and enabled logging
+                return hasUuid && (row.log === "1" || row.log === true);
+            }
+
+            return hasUuid;
+        }
 
         function onTreeEvent(row, open) {
             const getBucketById = (buckets, uuid) => {

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -136,7 +136,7 @@
 
             // determine tree expansion state of top-level buckets
             for (const bucket of buckets) {
-                if (["auto0", "auto1"].includes(bucket.uuid)) {
+                if (["auto0", "auto1", "defunct"].includes(bucket.uuid)) {
                     bucket._expanded = false;
                 } else if (bucket.groupType === currentGroupType || currentGroupType === "any") {
                     bucket._expanded = true;

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/filter_rule.volt
@@ -343,6 +343,17 @@
                         const rowId = row.uuid || "";
                         const hasUuid = rowId.includes("-");
 
+                        // Defunct rules can only be deleted
+                        if (getRuleTypeDigit(row) === 6) {
+                            return `
+                                <button type="button" class="btn btn-xs btn-default command-delete
+                                    bootgrid-tooltip" data-row-id="${rowId}"
+                                    title="{{ lang._('Delete') }}">
+                                    <span class="fa fa-fw fa-trash-o"></span>
+                                </button>
+                            `;
+                        }
+
                         const logSearchCommand = (rid, log) => {
                             const loggingEnabled = log === '1' || log === true;
                             if (!loggingEnabled) return '';
@@ -420,7 +431,7 @@
                         }
 
                         const rowId = row.uuid || '';
-                        if (!rowId.includes('-')) {
+                        if (!rowId.includes('-') || getRuleTypeDigit(row) === 6) {
                             return '';
                         }
 

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -269,64 +269,6 @@
                     },
                 },
                 formatters:{
-                    commands: function (column, row) {
-                        if (row.isGroup) {
-                            return "";
-                        }
-                        let rowId = row.uuid;
-
-                        if (row.prio_group == 600000) {
-                            return `
-                                <button type="button" class="btn btn-xs btn-default command-delete
-                                    bootgrid-tooltip" data-row-id="${rowId}"
-                                    title="{{ lang._('Delete') }}">
-                                    <span class="fa fa-fw fa-trash-o"></span>
-                                </button>
-                            `;
-                        } else if (!rowId.includes('-')) {
-                            return `
-                                <a href="/system_advanced_firewall.php" target="_blank" rel="noopener noreferrer"
-                                class="btn btn-xs btn-default bootgrid-tooltip"
-                                title="{{ lang._('Lookup rule reference') }}">
-                                    <span class="fa fa-fw fa-link"></span>
-                                </a>
-                            `;
-                        }
-
-                        return `
-                            <button type="button" class="btn btn-xs btn-default command-move_before
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Move selected rule before this rule') }}">
-                                <span class="fa fa-fw fa-arrow-left"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-toggle_log bootgrid-tooltip"
-                                data-row-id="${row.uuid}" data-value="${row.log}"
-                                title="${row.log == '1'
-                                    ? '{{ lang._("Disable Logging") }}'
-                                    : '{{ lang._("Enable Logging") }}'}">
-                                <i class="fa fa-fw ${row.log == '1' ? 'fa-bell' : 'fa-bell-slash'}"></i>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-edit
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Edit') }}">
-                                <span class="fa fa-fw fa-pencil"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-copy
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Clone') }}">
-                                <span class="fa fa-fw fa-clone"></span>
-                            </button>
-
-                            <button type="button" class="btn btn-xs btn-default command-delete
-                                bootgrid-tooltip" data-row-id="${rowId}"
-                                title="{{ lang._('Delete') }}">
-                                <span class="fa fa-fw fa-trash-o"></span>
-                            </button>
-                        `;
-                    },
                     rowtoggle: function (column, row) {
                         const rowId = row.uuid || '';
                         if (row.isGroup || !rowId.includes('-') || row.prio_group == 600000) {
@@ -499,7 +441,17 @@
                     },
                     sequence: 500
                 },
+                lookup_ref: {
+                    filter: (cell) => commandFilter(cell, "lookup_ref"),
+                    classname: "fa fa-fw fa-link",
+                    title: "{{ lang._('Lookup rule reference') }}",
+                    sequence: 10,
+                    method: function(event, cell) {
+                        window.open(`/system_advanced_firewall.php`, "_blank", "noopener,noreferrer");
+                    },
+                },
                 move_before: {
+                    filter: (cell) => commandFilter(cell),
                     method: function(event) {
                         const selected = $("#{{ formGridRule['table_id'] }}").bootgrid("getSelectedRows");
                         if (selected.length !== 1) {
@@ -547,9 +499,11 @@
                     sequence: 10
                 },
                 toggle_log: {
-                    method: function(event) {
+                    filter: (cell) => commandFilter(cell),
+                    method: function(event, cell) {
                         const uuid = $(this).data("row-id");
-                        const log = String(+$(this).data("value") ^ 1);
+                        const row = cell.getData();
+                        const log = String(+row.log ^ 1);
                         ajaxCall(
                             `/api/firewall/${entrypoint}/toggle_rule_log/${uuid}/${log}`,
                             {},
@@ -569,12 +523,46 @@
                             'POST'
                         );
                     },
-                    classname: 'fa fa-fw fa-exclamation-circle',
-                    title: "{{ lang._('Toggle Logging') }}",
+                    classname: (cell) => {
+                        const row = cell.getData();
+                        return row.log === "1" ? "fa fa-fw fa-bell" : "fa fa-fw fa-bell-slash";
+                    },
+                    title: (cell) => {
+                        const row = cell.getData();
+                        return row.log === "1" ? '{{ lang._("Disable Logging") }}' : '{{ lang._("Enable Logging") }}';
+                    },
                     sequence: 20
+                },
+                delete: {
+                    filter: (cell) => commandFilter(cell, "delete"),
+                },
+                copy: {
+                    filter: (cell) => commandFilter(cell, "copy"),
+                },
+                edit: {
+                    filter: (cell) => commandFilter(cell, "edit"),
                 }
             },
         });
+
+        function commandFilter(cell, type="") {
+            const row = cell.getData();
+            const hasUuid = row.uuid?.includes("-") ?? false;
+
+            if (row.isGroup) return false;
+
+            if (row.prio_group == 600000 && !["delete", "copy"].includes(type)) {
+                // Defunct rules can only be deleted or copied.
+                return false;
+            }
+
+            if (type === "lookup_ref") {
+                // lookup_ref only allowed without a valid UUID
+                return !hasUuid;
+            }
+
+            return hasUuid;
+        }
 
         function onTreeEvent(row, open) {
             const getBucketById = (buckets, uuid) => {

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -275,7 +275,15 @@
                         }
                         let rowId = row.uuid;
 
-                        if (!rowId.includes('-')) {
+                        if (row.prio_group == 600000) {
+                            return `
+                                <button type="button" class="btn btn-xs btn-default command-delete
+                                    bootgrid-tooltip" data-row-id="${rowId}"
+                                    title="{{ lang._('Delete') }}">
+                                    <span class="fa fa-fw fa-trash-o"></span>
+                                </button>
+                            `;
+                        } else if (!rowId.includes('-')) {
                             return `
                                 <a href="/system_advanced_firewall.php" target="_blank" rel="noopener noreferrer"
                                 class="btn btn-xs btn-default bootgrid-tooltip"
@@ -321,7 +329,7 @@
                     },
                     rowtoggle: function (column, row) {
                         const rowId = row.uuid || '';
-                        if (row.isGroup || !rowId.includes('-')) {
+                        if (row.isGroup || !rowId.includes('-') || row.prio_group == 600000) {
                             return '';
                         }
                         const isEnabled =

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -84,7 +84,7 @@
             { idx: 100000, uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
             { idx: 400000, uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info" },
             { idx: 500000, uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
-            { idx: 600000, uuid: "invalid", label: "{{ lang._('Invalid rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Invalid rules that are not processed') }}", color: "text-secondary" },
+            { idx: 600000, uuid: "defunct", label: "{{ lang._('Defunct rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Defunct rules that are not processed') }}", color: "text-secondary" },
         ];
 
         const getRuleType = function(row) {

--- a/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Firewall/nat_rule.volt
@@ -84,6 +84,7 @@
             { idx: 100000, uuid: "auto0", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
             { idx: 400000, uuid: "interface", label: "{{ lang._('Interface rules') }}", icon: "fa-ethernet", tooltip: "{{ lang._('Interface rule') }}", color: "text-info" },
             { idx: 500000, uuid: "auto1", label: "{{ lang._('Automatically generated rules') }}", icon: "fa-magic", tooltip: "{{ lang._('Automatically generated rules') }}", color: "text-secondary" },
+            { idx: 600000, uuid: "invalid", label: "{{ lang._('Invalid rules') }}", icon: "fa-exclamation-triangle", tooltip: "{{ lang._('Invalid rules that are not processed') }}", color: "text-secondary" },
         ];
 
         const getRuleType = function(row) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10532
