### PR TITLE
trust: use serialNumberHex for CRL so high-bit serials aren't dropped

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CrlController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Trust/Api/CrlController.php
@@ -336,9 +336,12 @@ class CrlController extends ApiControllerBase
                     /* add all cert serial numbers to crl */
                     foreach ($crl_certs as $cert) {
                         $tmp = @openssl_x509_parse(base64_decode((string)$cert->crt));
-                        if ($tmp !== false && isset($tmp['serialNumber'])) {
+                        if ($tmp !== false && isset($tmp['serialNumberHex'])) {
+                            /* serialNumber (decimal) is unreliable for serials with the high bit
+                               set; use serialNumberHex so MSB serials aren't collapsed to zero */
+                            $serial = new \phpseclib3\Math\BigInteger($tmp['serialNumberHex'], 16);
                             $x509_crl->setRevokedCertificateExtension(
-                                (string)$tmp['serialNumber'],
+                                (string)$serial,
                                 'id-ce-cRLReasons',
                                 self::$status_codes[(string)$cert->reason]
                             );


### PR DESCRIPTION
### Problem

Revoked certificates whose serial number has the high bit set (first byte
>= 0x80) are omitted from the internally generated CRL and collapse into a
single `Serial Number: 00` entry, leaving those certificates effectively
un-revoked (e.g. OpenVPN clients can still connect). With random 128-bit
serials this silently affects roughly half of all revocations.

### Cause

`CrlController::setAction()` builds the CRL from
`openssl_x509_parse()['serialNumber']` (signed decimal), which is unreliable
for serials with the high bit set. The same controller already uses the
canonical `serialNumberHex` for the index.txt export.

### Solution

Use `serialNumberHex` and pass a `phpseclib3\Math\BigInteger` to
`setRevokedCertificateExtension()`.

### Testing

On a CA with 29 mixed revocations (12 serials < 0x80, 17 >= 0x80):
- before: CRL contained 13 entries incl. one bogus `Serial Number: 00`
- after:  CRL contains all 29 correct serials, no `00` entry
- verified the previously-connectable OpenVPN client is now rejected

Fixes: #10558
Related: #7935

### AI disclosure

- Model used: Claude Opus 4.8 (via Claude Code)
- Extent: AI performed the root-cause analysis, wrote the patch and drafted this
  text; I reproduced the issue on a production system, verified the fix
  operationally, and authored the contribution.
