### PR TITLE
ui: opnsense-dark theme - fix collapsed sidebar stray line and restore rail divider, Closes: #8263

### DIFF
--- a/src/opnsense/www/themes/opnsense-dark/assets/stylesheets/main.scss
+++ b/src/opnsense/www/themes/opnsense-dark/assets/stylesheets/main.scss
@@ -308,12 +308,14 @@ main.page-content.col-lg-12 {
   width: 70px;
   overflow: hidden;
   background-color: transparent !important;
+  border: none !important;
   > div {
     &.row {
       height: 100% !important;
       > nav.page-side-nav {
         width: 70px;
         height: 100% !important;
+        border-right: 1px solid rgba(217, 217, 217, 0.5);
       }
     }
     > nav > #mainmenu > div > {
@@ -326,6 +328,7 @@ main.page-content.col-lg-12 {
         padding-right: 0px;
         padding-top: 12px;
         border-bottom: 2px transparent;
+        border-right: 1px solid rgba(217, 217, 217, 0.5);
         > span {
           &.fa, &.fa-solid, &.glyphicon {
             visibility: visible;

--- a/src/opnsense/www/themes/opnsense-dark/build/css/main.css
+++ b/src/opnsense/www/themes/opnsense-dark/build/css/main.css
@@ -6889,6 +6889,7 @@ main.page-content.col-lg-12 {
   width: 70px;
   overflow: hidden;
   background-color: transparent !important;
+  border: none !important;
 }
 #navigation.col-sidebar-left > div.row {
   height: 100% !important;
@@ -6896,6 +6897,7 @@ main.page-content.col-lg-12 {
 #navigation.col-sidebar-left > div.row > nav.page-side-nav {
   width: 70px;
   height: 100% !important;
+  border-right: 1px solid rgba(217, 217, 217, 0.5);
 }
 #navigation.col-sidebar-left > div > nav > #mainmenu > div > a.list-group-item {
   font-size: 14px;
@@ -6906,6 +6908,7 @@ main.page-content.col-lg-12 {
   padding-right: 0px;
   padding-top: 12px;
   border-bottom: 2px transparent;
+  border-right: 1px solid rgba(217, 217, 217, 0.5);
 }
 #navigation.col-sidebar-left > div > nav > #mainmenu > div > a.list-group-item > span.fa, #navigation.col-sidebar-left > div > nav > #mainmenu > div > a.list-group-item > span.fa-solid, #navigation.col-sidebar-left > div > nav > #mainmenu > div > a.list-group-item > span.glyphicon {
   visibility: visible;


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Anthropic Claude
- Extent of AI involvement: Assisted with diagnosing the regression (tracing it through the theme SCSS and the history of #8263). I reviewed the change and tested it on a live 26.7 system before submitting.

---

**Describe the problem**

In the opnsense-dark theme a stray vertical line appears in the WebGUI when the sidebar is collapsed and a menu flyout is opened (#8263).
<img width="533" height="190" alt="407962300-7fb7707c-3847-483b-a00b-0f7ca5ecae31" src="https://github.com/user-attachments/assets/5ce79d96-a4ce-41d1-8e47-851617b2ff45" />
#8263 was addressed in 464bd59 by removing the forced `border-right: ... !important` from `#navigation.col-sidebar-left`. That commit also dropped the `border: none !important` on the same element, which had been suppressing the base `.page-side` `border-right`, so the base border now bleeds through in the collapsed state and the line reappears (as reported for 25.7 and Firefox 140 in the thread).

The commit message for 464bd59 notes removal "was not the fix I preferred" and that setting a border on an element below `<aside>` "does not offer the same result." That approach fails when only a single element is bordered: the buttons overpaint it, leaving the line visible only in the gaps.

---

**Describe the proposed solution**

The light theme already solves exactly this - it borders both `nav.page-side-nav` and each collapsed `.list-group-item`, so the divider renders as one continuous edge. The dark theme simply never ported those two rules. This PR ports them, plus restores the `border: none !important` reset that stops the stray line:

- `border: none !important` on `#navigation.col-sidebar-left` removes the bleeding base `.page-side` border (fixes the reported line).
- `border-right` on `nav.page-side-nav` and on the collapsed `.list-group-item` restore the rail divider, matching the light theme.

The divider uses the dark theme's own panel-edge colour `rgba(217, 217, 217, 0.5)` (the same value used by `.page-foot` and `.page-content-head`), so the sidebar edge lines up tonally with the footer.

Result: the stray line is gone, and the collapsed sidebar now has the same rail divider as the light theme instead of a bare edge. The expanded sidebar is unaffected. Both the SCSS source and the compiled `build/css/main.css` are updated, consistent with 464bd59.

---

**Related issue**

Closes: #8263