### PR TITLE
Add options to dhcrelay for circuit_id and remote_id

### DIFF
--- a/src/etc/inc/plugins.inc.d/dhcrelay.inc
+++ b/src/etc/inc/plugins.inc.d/dhcrelay.inc
@@ -90,6 +90,8 @@ function dhcrelay_xmlrpc_sync()
 
 function dhcrelay_configure_id($verbose = false, $id_map = null)
 {
+    global $config;
+
     if (!plugins_argument_map($id_map)) {
         return;
     }
@@ -186,6 +188,30 @@ function dhcrelay_configure_id($verbose = false, $id_map = null)
 
         $cmd_frmt[] = '-i %s';
         $cmd_args[] = $device;
+
+        $circuit_id_values = [
+            'index' => '', // This is the default behaviour
+            'name' => $device,
+            'vlan' => !empty($ifconfig_details[$device]['vlan']['tag']) ? $ifconfig_details[$device]['vlan']['tag'] : '',
+        ];
+
+        $circuit_id = $circuit_id_values[$relay->circuit_id->getValue()];
+        if (!empty($circuit_id)) {
+            $cmd_frmt[] = '-C %s';
+            $cmd_args[] = $circuit_id;
+        }
+
+        $remote_id_values = [
+            'addr' => '', // This is the default behaviour
+            'mac' => $ifconfig_details[$device]['macaddr'],
+            'host' => $config['system']['hostname'],
+        ];
+
+        $remote_id = $remote_id_values[$relay->remote_id->getValue()];
+        if (!empty($remote_id)) {
+            $cmd_frmt[] = '-R %s';
+            $cmd_args[] = $remote_id;
+        }
 
         $has_servers = false;
 

--- a/src/etc/inc/plugins.inc.d/dhcrelay.inc
+++ b/src/etc/inc/plugins.inc.d/dhcrelay.inc
@@ -189,25 +189,13 @@ function dhcrelay_configure_id($verbose = false, $id_map = null)
         $cmd_frmt[] = '-i %s';
         $cmd_args[] = $device;
 
-        $circuit_id_values = [
-            'index' => '', // This is the default behaviour
-            'name' => $device,
-            'vlan' => !empty($ifconfig_details[$device]['vlan']['tag']) ? $ifconfig_details[$device]['vlan']['tag'] : '',
-        ];
-
-        $circuit_id = $circuit_id_values[$relay->circuit_id->getValue()];
-        if (!empty($circuit_id)) {
+        $circuit_id = $relay->circuit_id->getValue();
+        if ($family == 'inet' && !empty($circuit_id)) {
             $cmd_frmt[] = '-C %s';
             $cmd_args[] = $circuit_id;
         }
 
-        $remote_id_values = [
-            'addr' => '', // This is the default behaviour
-            'mac' => $ifconfig_details[$device]['macaddr'],
-            'host' => $config['system']['hostname'],
-        ];
-
-        $remote_id = $remote_id_values[$relay->remote_id->getValue()];
+        $remote_id = $relay->remote_id->getValue();
         if (!empty($remote_id)) {
             $cmd_frmt[] = '-R %s';
             $cmd_args[] = $remote_id;

--- a/src/etc/inc/plugins.inc.d/dhcrelay.inc
+++ b/src/etc/inc/plugins.inc.d/dhcrelay.inc
@@ -90,8 +90,6 @@ function dhcrelay_xmlrpc_sync()
 
 function dhcrelay_configure_id($verbose = false, $id_map = null)
 {
-    global $config;
-
     if (!plugins_argument_map($id_map)) {
         return;
     }
@@ -189,16 +187,14 @@ function dhcrelay_configure_id($verbose = false, $id_map = null)
         $cmd_frmt[] = '-i %s';
         $cmd_args[] = $device;
 
-        $circuit_id = $relay->circuit_id->getValue();
-        if ($family == 'inet' && !empty($circuit_id)) {
+        if ($family == 'inet' && !$relay->circuit_id->isEmpty()) {
             $cmd_frmt[] = '-C %s';
-            $cmd_args[] = $circuit_id;
+            $cmd_args[] = $relay->circuit_id->getValue();
         }
 
-        $remote_id = $relay->remote_id->getValue();
-        if (!empty($remote_id)) {
+        if (!$relay->remote_id->isEmpty()) {
             $cmd_frmt[] = '-R %s';
-            $cmd_args[] = $remote_id;
+            $cmd_args[] = $relay->remote_id->getValue();
         }
 
         $has_servers = false;

--- a/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/Api/SettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/Api/SettingsController.php
@@ -39,7 +39,7 @@ class SettingsController extends ApiMutableModelControllerBase
 
     public function searchRelayAction()
     {
-        $search_result = $this->searchBase('relays', ['enabled', 'interface', 'destination', 'agent_info'], 'interface');
+        $search_result = $this->searchBase('relays', ['enabled', 'interface', 'destination', 'agent_info', 'circuit_id', 'remote_id'], 'interface');
         $status_by_uuid = [];
 
         foreach (json_decode((new Backend())->configdpRun('service list', [self::$internalModelName]), true) as $service) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/forms/dialogRelay.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/forms/dialogRelay.xml
@@ -33,6 +33,18 @@
         </grid_view>
     </field>
     <field>
+        <id>relay.circuit_id</id>
+        <label>Circuit id</label>
+        <type>dropdown</type>
+        <help>Choose which value should be sent as the relay agent circuit ID.</help>
+    </field>
+    <field>
+        <id>relay.remote_id</id>
+        <label>Remote id</label>
+        <type>dropdown</type>
+        <help>Choose which value should be sent as the relay agent remote ID.</help>
+    </field>
+    <field>
         <id>relay.carp_depend_on</id>
         <label>Depend on (CARP)</label>
         <type>dropdown</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/forms/dialogRelay.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/DHCRelay/forms/dialogRelay.xml
@@ -35,13 +35,13 @@
     <field>
         <id>relay.circuit_id</id>
         <label>Circuit id</label>
-        <type>dropdown</type>
+        <type>text</type>
         <help>Choose which value should be sent as the relay agent circuit ID.</help>
     </field>
     <field>
         <id>relay.remote_id</id>
         <label>Remote id</label>
-        <type>dropdown</type>
+        <type>text</type>
         <help>Choose which value should be sent as the relay agent remote ID.</help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
@@ -23,6 +23,24 @@
             <agent_info type="BooleanField">
                 <Required>Y</Required>
             </agent_info>
+            <circuit_id type="OptionField">
+                <Default>index</Default>
+                <OptionValues>
+                    <index>Interface index</index>
+                    <name>Interface name</name>
+                    <vlan>VLAN ID</vlan>
+                </OptionValues>
+                <Required>Y</Required>
+            </circuit_id>
+            <remote_id type="OptionField">
+                <Default>addr</Default>
+                <OptionValues>
+                    <addr>Destination address</addr>
+                    <mac>MAC address</mac>
+                    <host>Hostname</host>
+                </OptionValues>
+                <Required>Y</Required>
+            </remote_id>
             <carp_depend_on type="VirtualIPField">
                 <type>carp</type>
                 <key>mvc</key>

--- a/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
@@ -23,24 +23,8 @@
             <agent_info type="BooleanField">
                 <Required>Y</Required>
             </agent_info>
-            <circuit_id type="OptionField">
-                <Default>index</Default>
-                <OptionValues>
-                    <index>Interface index</index>
-                    <name>Interface name</name>
-                    <vlan>VLAN ID</vlan>
-                </OptionValues>
-                <Required>Y</Required>
-            </circuit_id>
-            <remote_id type="OptionField">
-                <Default>addr</Default>
-                <OptionValues>
-                    <addr>Destination address</addr>
-                    <mac>MAC address</mac>
-                    <host>Hostname</host>
-                </OptionValues>
-                <Required>Y</Required>
-            </remote_id>
+            <circuit_id type="TextField" />
+            <remote_id type="TextField" />
             <carp_depend_on type="VirtualIPField">
                 <type>carp</type>
                 <key>mvc</key>

--- a/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/DHCRelay/DHCRelay.xml
@@ -23,8 +23,8 @@
             <agent_info type="BooleanField">
                 <Required>Y</Required>
             </agent_info>
-            <circuit_id type="TextField" />
-            <remote_id type="TextField" />
+            <circuit_id type="StrictTextField" />
+            <remote_id type="StrictTextField" />
             <carp_depend_on type="VirtualIPField">
                 <type>carp</type>
                 <key>mvc</key>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md

---

**Describe the problem**

https://forum.opnsense.org/index.php?topic=40110.0

Post the change to openbsd's dhcrelay the circuit/remote id values changed from interface names to interface indexes which do not have obvious mappings and could theoretically change with configuration changes and reboots.

---

**Describe the proposed solution**

This adds two new fields to each relay entry allowing the user to pick what data should be presented in these fields.
I've included the most common values that vendors populate these fields with but I'm open to others.

<img width="903" height="447" alt="Screenshot 2026-07-17 at 20 11 39" src="https://github.com/user-attachments/assets/cc53bf9d-cb92-4e0e-a348-a0199b8e4b5e" />