### PR TITLE
dashboard: restore stacked layout for interfaces widget when narrow 

### DIFF
--- a/src/opnsense/www/js/widgets/Interfaces.js
+++ b/src/opnsense/www/js/widgets/Interfaces.js
@@ -27,8 +27,6 @@
 export default class Interfaces extends BaseTableWidget {
     constructor() {
         super();
-
-        this.width = null;
     }
 
     getGridOptions() {
@@ -41,8 +39,7 @@ export default class Interfaces extends BaseTableWidget {
     getMarkup() {
         let $container = $('<div></div>');
         let $if_table = this.createTable('if-table', {
-            headerPosition: 'none',
-            headerBreakpoint: 0
+            headerPosition: 'none'
         });
 
         $container.append($if_table);
@@ -105,14 +102,7 @@ export default class Interfaces extends BaseTableWidget {
     }
 
     onWidgetResize(elem, width, height) {
-        const crossedBreakpoint = (this.width <= 450) !== (width <= 450);
-
-        if (!crossedBreakpoint) return false;
-
         $('.interface-info-detail').parent().toggle(width > 450);
-        super.refreshStyles('if-table');
-        this.width = width;
-
-        return true;
+        return super.onWidgetResize(elem, width, height);
     }
 }


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:
- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:
- Model used: Claude Opus 4.8 (Anthropic)
- Extent of AI involvement: The model inspected the widget source, identified the root cause. I tested the change on my own 26.7 box and confirmed the behaviour before submitting.

---
**Describe the problem**
On the Dashboard, the Interfaces widget no longer collapses to a stacked layout when the widget is narrow (regressed in 26.7 GA; last worked in the 26.7 RCs / 26.1 series). Interface name, media, and IPv4/IPv6 cells render as cramped side-by-side columns and wrap mid-value, so addresses are hard to read.

Root cause: `Interfaces.js` created its table with `headerBreakpoint: 0`. In `BaseTableWidget.createTable`, the stacked and column size-states are keyed on `0` and `headerBreakpoint` respectively, so a breakpoint of `0` collides the two keys and the column state overwrites the stacked one — the stacked layout becomes unreachable at any width. `onWidgetResize` had also stopped delegating to the base handler, so no width-based state selection ran.

---
**Describe the proposed solution**
Drop `headerBreakpoint: 0` (falling back to the default 450) so the base again has distinct stacked and column size-states, and delegate layout-state selection back to `super.onWidgetResize`, while keeping the media-column toggle. The widget now stacks below the breakpoint and shows columns above it, matching the other table widgets and the pre-regression behaviour.

The `borderBoxSize` resize fix in `opnsense_widget_manager.js` is untouched. Tested on 26.7 (amd64): narrow widget stacks and is legible; wide widget shows columns.

---
**Related issue**
Fixes #10562