### PR TITLE
Reporting: Traffic - guard traffic_top.py against malformed/truncated iftop lines

### DIFF
--- a/src/opnsense/scripts/interfaces/traffic_top.py
+++ b/src/opnsense/scripts/interfaces/traffic_top.py
@@ -135,8 +135,18 @@ if __name__ == '__main__':
         for line in iftop_data[intf].split('\n'):
             if line.find('=>') > -1 or line.find('<=') > -1:
                 parts = line.split()
-                if parts[0].find('.') == -1 and parts[0].find(':') == -1:
+                if parts and parts[0].find('.') == -1 and parts[0].find(':') == -1:
                     parts.pop(0)
+                # skip malformed/truncated iftop lines; under load iftop may
+                # emit partial rows (fewer columns) or non-host output that
+                # still contains "=>"/"<=". Require the expected column count
+                # and a valid host address before using the row.
+                if len(parts) < 6:
+                    continue
+                try:
+                    ip = ipaddress.ip_address(parts[0])
+                except ValueError:
+                    continue
                 item = {
                     'address': parts[0],
                     'rate': parts[2],
@@ -146,14 +156,10 @@ if __name__ == '__main__':
                     'tags': []
                 }
                 # attach tags (type of address)
-                try:
-                    ip = ipaddress.ip_address(parts[0])
-                    if ip in all_local_addresses:
-                        item['tags'].append('local')
-                    if ip.is_private:
-                        item['tags'].append('private')
-                except subprocess.TimeoutExpired:
-                    pass
+                if ip in all_local_addresses:
+                    item['tags'].append('local')
+                if ip.is_private:
+                    item['tags'].append('private')
 
                 if line.find('=>') > -1:
                     other_end = item


### PR DESCRIPTION
Closes #10574.

### Problem

`traffic_top.py` (backing **Reporting → Traffic → Top talkers** and the **Diagnostics: Traffic** page) parses every `iftop` line containing `=>`/`<=` as a full host row.

Under load — e.g. the Traffic page polled by several browser tabs at once, each invocation spawning one `iftop` per interface via `ThreadPoolExecutor` — `iftop` can emit malformed output and the parser aborts, failing the `interface show top` configd action with exit status 1. Two distinct crashes were observed on a live system:

1. **Truncated row** (fewer columns) → `IndexError` on `parts[2]`/`parts[5]`:
   ```
   File "/usr/local/opnsense/scripts/interfaces/traffic_top.py", line 142, in <module>
       'rate': parts[2],
   IndexError: list index out of range
   ```
2. **Non-host output** that still contains `=>`/`<=` (e.g. a mangled footer line) → `parts[0]` is not an address, so `ipaddress.ip_address()` raises `ValueError`, which the surrounding `except subprocess.TimeoutExpired` does not catch:
   ```
   ip = ipaddress.ip_address(parts[0])
   ValueError: 'receive' does not appear to be an IPv4 or IPv6 address
   ```

Both are intermittent and load-dependent; the number of monitored interfaces raises the odds. This is the root cause behind the symptom previously worked around at the PHP layer in #4611 (which only added an `is_array($data)` guard around the `foreach`).

### Fix

Require the expected column count and validate `parts[0]` as an IP before using the row; skip anything else. Also guard the leading-index `pop()` against an empty split, and drop the incorrect `TimeoutExpired` handler now that the address is validated up front.

### Testing

- Reproduced **both** crashes on a live firewall under concurrent load (multiple Diagnostics/Traffic tabs / concurrent `interface show top` invocations).
- Unit-tested the parsing against representative `iftop` output: valid IPv4 and IPv6 rows parse correctly with the right `local`/`private` tags, while truncated rows and non-host lines are skipped with no exception. The pre-patch parser raises `IndexError`/`ValueError` on the same input.