### PR TITLE
mvc: translate backend system status messages

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/SystemController.php
@@ -86,6 +86,10 @@ class SystemController extends ApiControllerBase
             $acl = new ACL();
 
             foreach ($statuses as $subsystem => $status) {
+                $statuses[$subsystem]['message'] = gettext($status['message']);
+                if (!empty($status['title'])) {
+                    $statuses[$subsystem]['title'] = gettext($status['title']);
+                }
                 unset($statuses[$subsystem]['scope']);
                 $statuses[$subsystem]['status'] = $order[$status['statusCode']];
                 if (!empty($status['location'])) {


### PR DESCRIPTION
**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: Assisted with root-cause analysis, preparing the minimal patch, and drafting the pull request description. The contributor reviewed the change and operationally tested it on OPNsense 26.7.

---

**Describe the problem**

System status messages are generated by a configd backend script that does
not use the language selected by the current GUI user. Consequently,
messages available in the gettext catalog are returned to the GUI in English.

---

**Describe the proposed solution**

Translate the backend-provided status message and title in the API
controller, where the current user's locale is available.

This preserves the backend status format and allows static status messages,
such as the Unbound manual override warning, to use the selected GUI language.

Tested with:

- `git diff --check`
- PHP syntax validation
- Operational verification on OPNsense 26.7 using the `zh_CN` locale

---

**Related issue**

None; this is a small localization fix discovered during operational testing.
