### PR TITLE
firewall: unify automatic source NAT networks #10539

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -206,38 +206,21 @@ function filter_configure_sync($verbose = false, $load_aliases = true)
     }
 
     /* automatic outbound rules */
-    if (
-        empty($config['nat']['outbound']['mode']) ||
-          in_array($config['nat']['outbound']['mode'], ['automatic', 'hybrid'])
-    ) {
-        $intfv4 = [];
+    foreach (filter_auto_source_nat($fw) as $interface => $networks) {
+        foreach ([500, null] as $dstport) {
+            $rule = [
+                'descr' => 'Automatic outbound rule',
+                'destination' => ['any' => true],
+                'dstport' => $dstport,
+                'interface' => $interface,
+                'ipprotocol' => 'inet',
+                'log' => !empty($config['syslog']['logoutboundnat']),
+                'staticnatport' => !empty($dstport),
+            ];
 
-        foreach ($fw->getInterfaceMapping() as $intf => $intfcf) {
-            if (!empty($intfcf['ifconfig']['ipv4']) && empty($intfcf['gateway'])) {
-                $intfv4[] = $intf;
-            }
-        }
-
-        /* add VPN and local networks */
-        $intfv4 = array_merge($intfv4, filter_core_get_default_nat_outbound_networks());
-        foreach ($fw->getInterfaceMapping() as $intf => $ifcfg) {
-            /* XXX VPN is allowed but not OpenVPN dropping /tmp/ovpnxy_router(v6) file */
-            if (substr($ifcfg['if'], 0, 4) != 'ovpn' && !empty($ifcfg['gateway'])) {
-                foreach ([500, null] as $dstport) {
-                    $rule = [
-                        'descr' => 'Automatic outbound rule',
-                        'destination' => ['any' => true],
-                        'dstport' => $dstport,
-                        'interface' => $intf,
-                        'ipprotocol' => 'inet',
-                        'log' => !empty($config['syslog']['logoutboundnat']),
-                        'staticnatport' => !empty($dstport),
-                    ];
-                    foreach ($intfv4 as $network) {
-                        $rule['source'] = ['network' => $network];
-                        $fw->registerSNatRule(200, $rule);
-                    }
-                }
+            foreach ($networks as $network => $unused) {
+                $rule['source'] = ['network' => $network];
+                $fw->registerSNatRule(200, $rule);
             }
         }
     }

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -170,35 +170,28 @@ function filter_core_get_port_alias($aliasname, $aliases = [], $aliasObject = nu
     return $response;
 }
 
-
 /**
- * Collect vpn networks for outbound rules
+ * return automatic source NAT data
  */
-function filter_core_get_default_nat_outbound_networks()
+function filter_auto_source_nat($fw = null)
 {
-    global $config;
+    $outbound = config_read_array('nat', 'outbound', false);
+    $ret = [];
 
-    $result = ['127.0.0.0/8'];
+    if (in_array($outbound['mode'] ?? '', ['', 'automatic', 'hybrid'])) {
+        $fw ??= filter_core_get_initialized_plugin_system();
 
-    require_once 'plugins.inc.d/openvpn.inc'; /* XXX for openvpn_legacy() */
+        $networks = array_merge(...array_values(plugins_run('outbound_net', [$fw])));
 
-    // Add openvpn networks
-    foreach (['server', 'client'] as $section) {
-        if (openvpn_legacy($section)) {
-            foreach (config_read_array('openvpn', "openvpn-{$section}", false) as $ovpn) {
-                if (!isset($ovpn['disable']) && !empty($ovpn['tunnel_network'])) {
-                    $result[] = $ovpn['tunnel_network'];
-                }
+        foreach ($fw->getInterfaceMapping() as $interface => $ifcfg) {
+            /* XXX VPN is allowed but not OpenVPN dropping /tmp/ovpnxy_router(v6) file */
+            if (substr($ifcfg['if'], 0, 4) != 'ovpn' && !empty($ifcfg['gateway'])) {
+                $ret[$interface] = $networks;
             }
         }
     }
 
-    // Add ipsec network pool if specified
-    if (!empty($config['ipsec']['client']['pool_address']) && !empty($config['ipsec']['client']['pool_netbits'])) {
-        $result[] = "{$config['ipsec']['client']['pool_address']}/{$config['ipsec']['client']['pool_netbits']}";
-    }
-
-    return $result;
+    return $ret;
 }
 
 /**

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3473,7 +3473,6 @@ function DHCP_Config_File_Substitutions($wancfg, $wanif, $dhclientconf)
     return $dhclientconf;
 }
 
-
 /* convert fxp0 -> wan, etc. */
 function convert_real_interface_to_friendly_interface_name($interface = 'wan')
 {

--- a/src/etc/inc/plugins.inc.d/ipsec.inc
+++ b/src/etc/inc/plugins.inc.d/ipsec.inc
@@ -1675,3 +1675,24 @@ function ipsec_configure_device($device)
 {
     ipsec_configure_vti(false, $device);
 }
+
+function ipsec_get_default_nat_outbound_networks($unused_fw = null)
+{
+    global $config;
+
+    $result = [];
+
+    if (!empty($config['ipsec']['client']['pool_address']) && !empty($config['ipsec']['client']['pool_netbits'])) {
+        $network = "{$config['ipsec']['client']['pool_address']}/{$config['ipsec']['client']['pool_netbits']}";
+        $result[$network] = $network;
+    }
+
+    return $result;
+}
+
+function ipsec_run()
+{
+    return [
+        'outbound_net' => 'ipsec_get_default_nat_outbound_networks',
+    ];
+}

--- a/src/etc/inc/plugins.inc.d/openvpn.inc
+++ b/src/etc/inc/plugins.inc.d/openvpn.inc
@@ -1307,3 +1307,27 @@ function openvpn_refresh_crls()
         }
     }
 }
+
+function openvpn_get_default_nat_outbound_networks($unused_fw = null)
+{
+    $result = [];
+
+    foreach (['server', 'client'] as $section) {
+        if (openvpn_legacy($section)) {
+            foreach (config_read_array('openvpn', "openvpn-{$section}", false) as $ovpn) {
+                if (!isset($ovpn['disable']) && !empty($ovpn['tunnel_network'])) {
+                    $result[$ovpn['tunnel_network']] = $ovpn['tunnel_network'];
+                }
+            }
+        }
+    }
+
+    return $result;
+}
+
+function openvpn_run()
+{
+    return [
+        'outbound_net' => 'openvpn_get_default_nat_outbound_networks',
+    ];
+}

--- a/src/etc/inc/plugins.inc.d/pf.inc
+++ b/src/etc/inc/plugins.inc.d/pf.inc
@@ -252,3 +252,28 @@ function pf_xmlrpc_sync()
 
     return $result;
 }
+
+function pf_run()
+{
+    return [
+        'outbound_nat' => 'filter_auto_source_nat',
+        'outbound_net' => 'pf_get_default_nat_outbound_networks',
+    ];
+}
+
+function pf_get_default_nat_outbound_networks($fw = null)
+{
+    $fw ??= filter_core_get_initialized_plugin_system();
+    $loopback = '127.0.0.0/8';
+    $result = [];
+
+    foreach ($fw->getInterfaceMapping() as $intf => $intfcf) {
+        if (!empty($intfcf['ifconfig']['ipv4']) && empty($intfcf['gateway'])) {
+            $result[$intf] = sprintf(gettext('%s networks'), $intfcf['descr']);
+        }
+    }
+
+    $result[$loopback] = $loopback;
+
+    return $result;
+}

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/SourceNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/SourceNatController.php
@@ -27,6 +27,7 @@
  */
 namespace OPNsense\Firewall\Api;
 
+use OPNsense\Core\Backend;
 use OPNsense\Core\Config;
 use OPNsense\Firewall\Util;
 
@@ -62,87 +63,28 @@ class SourceNatController extends FilterBaseController
         ];
     }
 
-    // XXX: These are synthetic, display only for user convenience.
-    //      The backend should generate them in the same way, but there is no relation to this.
     private function getAutomaticOutboundNatRules(): array
     {
+        $automatic_rules = (json_decode((new Backend())->configdRun('filter list automatic_outbound_nat'), true))['pf'] ?? [];
         $config = Config::getInstance()->object();
-        $source_networks = [];
-        $nat_interfaces = [];
-
-        if (!isset($config->interfaces)) {
-            return [];
-        }
-
-        foreach ($config->interfaces->children() as $if => $ifcfg) {
-            $if = (string)$if;
-            $ipaddr = (string)($ifcfg->ipaddr ?? '');
-            $gateway = (string)($ifcfg->gateway ?? '');
-            $device = (string)($ifcfg->if ?? '');
-            $descr = (string)($ifcfg->descr ?? '');
-
-            if ($descr === '') {
-                $descr = strtoupper($if);
-            }
-
-            /*
-             * Only IPv4 interfaces participate in the automatic outbound NAT preview.
-             * DHCP counts as IPv4 for WAN style interfaces.
-             */
-            $has_ipv4 = in_array($ipaddr, ['dhcp', 'pppoe'], true) || Util::isIpv4Address($ipaddr);
-            if (!$has_ipv4) {
-                continue;
-            }
-
-            /*
-             * Raw config does not resolve gateway status like filter_core_getInterfaceMapping().
-             * DHCP WANs usually have no static gateway in the interface node, but should still
-             * be treated as automatic outbound NAT interfaces.
-             */
-            $is_wan_candidate = in_array($ipaddr, ['dhcp', 'pppoe'], true) ||
-            ($gateway !== '' && $gateway !== 'none');
-
-            if ($is_wan_candidate && substr($device, 0, 4) !== 'ovpn') {
-                $nat_interfaces[] = [
-                    'interface' => $if,
-                    'descr' => $descr,
-                ];
-            } else {
-                $source_networks[] = $if;
-            }
-        }
-
         $rows = [];
         $sequence = 1;
-        $source_net = implode(',', $source_networks);
 
-        foreach ($nat_interfaces as $natintf) {
-            $target = $natintf['interface'] . 'ip';
+        foreach ($automatic_rules as $interface => $source_networks) {
+            $descr = (string)($config->interfaces->{$interface}->descr ?? strtoupper($interface));
+            $source_net = implode(',', array_keys($source_networks));
             $rows[] = [
-                'uuid' => 'automatic_isakmp_' . $natintf['interface'],
+                'uuid' => 'automatic_isakmp_' . $interface,
                 'enabled' => '1',
-                'nonat' => '0',
-                'nosync' => '0',
                 'sequence' => (string)$sequence,
-                'interface' => $natintf['interface'],
-                '%interface' => $natintf['descr'],
+                'interface' => $interface,
+                '%interface' => $descr,
                 'ipprotocol' => 'inet',
                 '%ipprotocol' => 'IPv4',
                 'protocol' => 'any',
-                '%protocol' => '*',
                 'source_net' => $source_net,
-                'source_not' => '0',
-                'source_port' => '',
-                'destination_net' => 'any',
-                'destination_not' => '0',
                 'destination_port' => '500',
-                'target' => $target,
-                'target_port' => '',
                 'staticnatport' => '1',
-                'log' => '0',
-                'categories' => '',
-                'tag' => '',
-                'tagged' => '',
                 'description' => gettext('Auto created rule for ISAKMP'),
                 'is_automatic' => true,
                 'sort_order' => sprintf('%d.0%06d', 500000, $sequence),
@@ -150,30 +92,16 @@ class SourceNatController extends FilterBaseController
             ];
             $sequence++;
             $rows[] = [
-                'uuid' => 'automatic_' . $natintf['interface'],
+                'uuid' => 'automatic_' . $interface,
                 'enabled' => '1',
-                'nonat' => '0',
-                'nosync' => '0',
                 'sequence' => (string)$sequence,
-                'interface' => $natintf['interface'],
-                '%interface' => $natintf['descr'],
+                'interface' => $interface,
+                '%interface' => $descr,
                 'ipprotocol' => 'inet',
                 '%ipprotocol' => 'IPv4',
                 'protocol' => 'any',
-                '%protocol' => '*',
                 'source_net' => $source_net,
-                'source_not' => '0',
-                'source_port' => '',
-                'destination_net' => 'any',
-                'destination_not' => '0',
-                'destination_port' => '',
-                'target' => $target,
-                'target_port' => '',
                 'staticnatport' => '0',
-                'log' => '0',
-                'categories' => '',
-                'tag' => '',
-                'tagged' => '',
                 'description' => gettext('Auto created rule'),
                 'is_automatic' => true,
                 'sort_order' => sprintf('%d.0%06d', 500000, $sequence),
@@ -181,6 +109,7 @@ class SourceNatController extends FilterBaseController
             ];
             $sequence++;
         }
+
         return $rows;
     }
 

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -66,6 +66,13 @@ parameters:
 type:script_output
 message:dump legacy outbound nat in mvc format
 
+[list.automatic_outbound_nat]
+command:pluginctl -r outbound_nat
+parameters:
+type:script_output
+cache_ttl:60
+message:list automatic source nat rules
+
 [list.pfsync]
 command:/usr/local/opnsense/scripts/filter/list_pfsync.py
 parameters: %s

--- a/src/www/firewall_nat_out.php
+++ b/src/www/firewall_nat_out.php
@@ -565,22 +565,8 @@ include("head.inc");
             </table>
           </div>
         </section>
-<?php   endif; ?>
-<?php
-      // when automatic or hybrid, display "auto" table.
-      if ($mode == "automatic" || $mode == "hybrid"):
-        $fw = filter_core_get_initialized_plugin_system();
-        $intfv4 = array();
-        $intfnatv4 = array();
-        foreach ($fw->getInterfaceMapping() as $intf => $intfcf) {
-            if (!empty($intfcf['ifconfig']['ipv4']) && empty($intfcf['gateway'])) {
-                $intfv4[] = sprintf(gettext('%s networks'), $intfcf['descr']);
-            } elseif (substr($intfcf['if'], 0, 4) != 'ovpn' && !empty($intfcf['gateway'])) {
-                $intfnatv4[] = $intfcf;
-            }
-        }
-        $intfv4 = array_merge($intfv4, filter_core_get_default_nat_outbound_networks());
-?>
+<?php endif ?>
+<?php if ($mode == 'automatic' || $mode == 'hybrid'): ?>
         <section class="col-xs-12">
           <div class="__mb"></div>
           <div class="table-responsive content-box">
@@ -604,20 +590,20 @@ include("head.inc");
                   </tr>
               </thead>
               <tbody>
-<?php
-              foreach ($intfnatv4 as $natintf):
-?>
+<?php foreach (filter_auto_source_nat() as $natintf => $networks): ?>
+<?php   $networks_safe = html_safe(implode(', ', array_values($networks))); ?>
+<?php   $natintf_safe = html_safe(convert_friendly_interface_to_friendly_descr($natintf)); ?>
                 <tr>
                   <td>&nbsp;</td>
                   <td>
                     <span class="fa fa-play text-success" data-toggle="tooltip" title="<?=gettext("automatic outbound nat");?>"></span>
                   </td>
-                  <td><?= htmlspecialchars($natintf['descr']); ?></td>
-                  <td><?= implode(', ', $intfv4);?></td>
+                  <td><?= $natintf_safe ?></td>
+                  <td><?= $networks_safe ?></td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm">500</td>
-                  <td class="hidden-xs hidden-sm"><?= htmlspecialchars($natintf['descr']); ?></td>
+                  <td class="hidden-xs hidden-sm"><?= $natintf_safe ?></td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm"><?=gettext("YES");?></td>
                   <td><?=gettext('Auto created rule for ISAKMP');?></td>
@@ -627,25 +613,21 @@ include("head.inc");
                   <td>
                     <span class="fa fa-play text-success" data-toggle="tooltip" title="<?=gettext("automatic outbound nat");?>"></span>
                   </td>
-                  <td><?= htmlspecialchars($natintf['descr']); ?></td>
-                  <td><?= implode(', ', $intfv4);?></td>
+                  <td><?= $natintf_safe ?></td>
+                  <td><?= $networks_safe ?></td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm">*</td>
-                  <td class="hidden-xs hidden-sm"><?= htmlspecialchars($natintf['descr']); ?></td>
+                  <td class="hidden-xs hidden-sm"><?= $natintf_safe ?></td>
                   <td class="hidden-xs hidden-sm">*</td>
                   <td class="hidden-xs hidden-sm"><?=gettext("NO");?></td>
                   <td><?=gettext('Auto created rule');?></td>
                 </tr>
-<?php
-        endforeach;
-?>
+<?php endforeach ?>
               </table>
             </div>
           </section>
-<?php
-      endif;
-?>
+<?php endif ?>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Bring a bit of structure into this legacy code: move the "plugin" parts to its own "oubound_net" run target, collect it with the new filter_auto_source_nat() and just iterate over it from the code that needs this.  We do all of this to provide a possible configd target to expose the actual automatic rules skeleton to the MVC source NAT GUI.

```
      # pluginctl -r outbound_nat
      {
        "pf": {
          "wan": {
            "lan": "LAN networks",
            "lo0": "Loopback networks",
            "127.0.0.0/8": "127.0.0.0/8"
          }
        }
      }
```