### PR TITLE
Add HOSTARTS mirror (Algiers, Algeria)

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/repositories/opnsense.xml
@@ -37,6 +37,10 @@
             <description>HiHo (HTTPS, Zurich, CH)</description>
         </mirror>
         <mirror>
+            <url>https://mirror.hostarts.dz/opnsense</url>
+            <description>HOSTARTS (HTTPS, Algiers, DZ)</description>
+        </mirror>
+        <mirror>
             <url>https://mirror-opnsense.serverbase.ch</url>
             <description>ServerBase AG (HTTPS, Zurich, CH)</description>
         </mirror>


### PR DESCRIPTION
Adding a new community mirror in Algiers, Algeria — the first OPNsense mirror in Algeria.

- **URL:** https://mirror.hostarts.dz/opnsense
- **Full tree** (~234 GB), synced twice daily from the LeaseWeb Amsterdam mirror
- **HTTPS** (Let's Encrypt), directory listings enabled; rsync also available at rsync://mirror.hostarts.dz/opnsense/
- **Connection:** 1 Gbps, hosted by HOSTARTS (https://hostarts.dz), AS329667
- The same host runs official/listed mirrors for AlmaLinux, MariaDB, Remi, ELRepo and others

Contact: Houssam Chergui — h.chergui@hostarts.com
