### PR TITLE
mvc: create runInterfaceRegistation and use it from all required spots

### DIFF
--- a/src/etc/inc/config.inc
+++ b/src/etc/inc/config.inc
@@ -211,14 +211,7 @@ function write_config($desc = '', $backup = true)
         }
     }
 
-    /**
-     * XXX: Temporary construction.
-     *      When called via a legacy interface configure page, we might want to register new interfaces, but
-     *      in cases we just want to save our changes (not related to interfaces), we risk raising errors for
-     *      missing imports.
-     *      Eventually relevant callers should call 'interface invoke registration', which is the same as
-     *      mvc components use now (but can't be called here without side effects)
-     */
+    /* XXX temporary workaround for legacy interface creation */
     try {
         plugins_interfaces();
     } catch (Throwable $e) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
@@ -402,4 +402,15 @@ class ApiControllerBase extends ControllerRoot
 
         return $this->response->send();
     }
+
+    /**
+     * run interface registration check and cache invalidation
+     */
+    public function runInterfaceRegistration()
+    {
+        $backend = new Backend();
+
+        $backend->configdRun('interface invoke registration');
+        $backend->configdRun('!interface list assign-opts', false, 20);
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableServiceControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiMutableServiceControllerBase.php
@@ -195,7 +195,7 @@ abstract class ApiMutableServiceControllerBase extends ApiControllerBase
             }
 
             if ($this->invokeInterfaceRegistration()) {
-                $backend->configdRun('interface invoke registration');
+                $this->runInterfaceRegistration();
             }
 
             if ($this->invokeFirewallReload()) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/GroupController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/GroupController.php
@@ -1,31 +1,29 @@
 <?php
 
-/**
- *    Copyright (C) 2023 Deciso B.V.
+/*
+ * Copyright (C) 2023 Deciso B.V.
+ * All rights reserved.
  *
- *    All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *    Redistribution and use in source and binary forms, with or without
- *    modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- *    1. Redistributions of source code must retain the above copyright notice,
- *       this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
- *    2. Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *
- *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *    POSSIBILITY OF SUCH DAMAGE.
- *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 namespace OPNsense\Firewall\Api;
@@ -76,7 +74,7 @@ class GroupController extends ApiMutableModelControllerBase
         $result = $this->setBase("group", "ifgroupentry", $uuid);
         if ($refactored) {
             // interface renamed
-            (new Backend())->configdRun('interface invoke registration');
+            $this->runInterfaceRegistration();
         }
         return $result;
     }
@@ -137,7 +135,7 @@ class GroupController extends ApiMutableModelControllerBase
         $ret = ['status' => 'failed'];
 
         if ($this->request->isPost()) {
-            (new Backend())->configdRun('interface invoke registration');
+            $this->runInterfaceRegistration();
             (new Backend())->configdRun('filter reload skip_alias');
             $ret = ['status' => 'ok'];
         }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/BridgeSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/BridgeSettingsController.php
@@ -130,6 +130,7 @@ class BridgeSettingsController extends ApiMutableModelControllerBase
     {
         if ($this->request->isPost()) {
             (new Backend())->configdRun("interface bridge configure");
+            $this->runInterfaceRegistration();
             return ["status" => "ok"];
         } else {
             return ["status" => "failed"];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GifSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GifSettingsController.php
@@ -172,6 +172,7 @@ class GifSettingsController extends ApiMutableModelControllerBase
     {
         if ($this->request->isPost()) {
             (new Backend())->configdRun("interface gif configure");
+            $this->runInterfaceRegistration();
             return ["status" => "ok"];
         } else {
             return ["status" => "failed"];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GreSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GreSettingsController.php
@@ -172,6 +172,7 @@ class GreSettingsController extends ApiMutableModelControllerBase
     {
         if ($this->request->isPost()) {
             (new Backend())->configdRun("interface gre configure");
+            $this->runInterfaceRegistration();
             return ["status" => "ok"];
         } else {
             return ["status" => "failed"];

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/LaggSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/LaggSettingsController.php
@@ -170,6 +170,7 @@ class LaggSettingsController extends ApiMutableModelControllerBase
     {
         if ($this->request->isPost()) {
             (new Backend())->configdRun("interface lagg configure");
+            $this->runInterfaceRegistration();
             return array("status" => "ok");
         } else {
             return array("status" => "failed");

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/LoopbackSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/LoopbackSettingsController.php
@@ -67,6 +67,7 @@ class LoopbackSettingsController extends ApiMutableModelControllerBase
         if ($this->request->isPost()) {
             $backend = new Backend();
             $result['status'] = strtolower(trim($backend->configdRun('interface loopback configure')));
+            $this->runInterfaceRegistration();
         }
         return $result;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VlanSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VlanSettingsController.php
@@ -193,6 +193,7 @@ class VlanSettingsController extends ApiMutableModelControllerBase
         $result = array("status" => "failed");
         if ($this->request->isPost()) {
             $result['status'] = strtolower(trim((new Backend())->configdRun('interface vlan configure')));
+            $this->runInterfaceRegistration();
         }
         return $result;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VxlanSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VxlanSettingsController.php
@@ -67,6 +67,7 @@ class VxlanSettingsController extends ApiMutableModelControllerBase
         if ($this->request->isPost()) {
             $backend = new Backend();
             $result['status'] = strtolower(trim($backend->configdRun('interface vxlan configure')));
+            $this->runInterfaceRegistration();
         }
         return $result;
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/OpenVPN/Api/ServiceController.php
@@ -243,9 +243,8 @@ class ServiceController extends ApiControllerBase
             return ['result' => 'failed'];
         }
 
-        $backend = new Backend();
-        $backend->configdRun('openvpn configure');
-        $backend->configdRun('interface invoke registration');
+        (new Backend())->configdRun('openvpn configure');
+        $this->runInterfaceRegistration();
 
         return ['result' => 'ok'];
     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServiceController.php
@@ -55,7 +55,7 @@ class ServiceController extends ApiMutableServiceControllerBase
         }
 
         $backend = new Backend();
-        $backend->configdRun('interface invoke registration');
+        $this->runInterfaceRegistration();
         $backend->configdRun('template reload ' . escapeshellarg(static::$internalServiceTemplate));
         $backend->configdpRun('wireguard configure');
 

--- a/src/opnsense/service/conf/actions.d/actions_interface.conf
+++ b/src/opnsense/service/conf/actions.d/actions_interface.conf
@@ -76,7 +76,7 @@ message:request arp table
 command:/usr/local/opnsense/scripts/interfaces/list_assign_options.php
 parameters:
 type:script_output
-cache_ttl:30
+cache_ttl:60
 message:show assignable interfaces
 
 [remove.arp]


### PR DESCRIPTION
1. Fix the stale cache after applying new interfaces/devices in existing paths
2. Allow to call it from controllers who do not use invokeInterfaceRegistration()
3. Add device applies to the mix