### PR TITLE
modify the serializeToConfig to set the uuid of the new network ident…

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -149,7 +149,7 @@ class NetworkInterface extends BaseModel
                 /* We want the node to return the new network identifier as the uuid not
                 the internal random generated uuid by the ArrayField.
                 Assignments use identifier as the uuid in the config.xml */
-                $node = $this->getNodeByReference('interface.' . $key);
+                $this->getNodeByReference('interface.' . $key)?->setAttributeValue('uuid', $newIdentifier);
                 if ($node === null) {
                     throw new ModelException('Failed to locate interface node ' . $key . '
                     while updating uuid to the new network identifier');

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -30,6 +30,7 @@ namespace OPNsense\Interfaces;
 
 use OPNsense\Base\BaseModel;
 use OPNsense\Base\Messages\Message;
+use OPNsense\Base\ModelException;
 use OPNsense\Core\Config;
 use OPNsense\Core\FileObject;
 
@@ -137,12 +138,23 @@ class NetworkInterface extends BaseModel
         }
 
         foreach ($interfaces as $key => $intf) {
+            $newIdentifier = 'opt' . $next_if;
             if (!isset(Config::getInstance()->object()->interfaces->$key)) {
-                $newif = Config::getInstance()->object()->interfaces->addChild('opt' . $next_if);
+                $newif = Config::getInstance()->object()->interfaces->addChild($newIdentifier);
                 $newif->if = $intf['if'];
                 $newif->descr = $intf['descr'];
                 $newif->lock = $intf['lock'];
                 $next_if++;
+
+                /* We want the node to return the new network identifier as the uuid not
+                the internal random generated uuid by the ArrayField.
+                Assignments use identifier as the uuid in the config.xml */
+                $node = $this->getNodeByReference('interface.' . $key);
+                if ($node === null) {
+                    throw new ModelException('Failed to locate interface node ' . $key . '
+                    while updating uuid to the new network identifier');
+                }
+                $node->setAttributeValue('uuid', $newIdentifier);
             }
         }
         return true;

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -150,11 +150,6 @@ class NetworkInterface extends BaseModel
                 the internal random generated uuid by the ArrayField.
                 Assignments use identifier as the uuid in the config.xml */
                 $this->getNodeByReference('interface.' . $key)?->setAttributeValue('uuid', $newIdentifier);
-                if ($node === null) {
-                    throw new ModelException('Failed to locate interface node ' . $key . '
-                    while updating uuid to the new network identifier');
-                }
-                $node->setAttributeValue('uuid', $newIdentifier);
             }
         }
         return true;


### PR DESCRIPTION

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**
Upon creating an interface the using the assignment API, the endpoint returns
`{
    "result": "saved",
    "uuid": "a1ecb292-243d-43c8-b09b-268921dad206"
}`

However, the remaining Assignment API endpoints expect the interface name (e.g. `opt1`) rather than the generated UUID returned above.

Upon investigating, it was found that `ArrayField` generates a temporary UUID when creating the interface assignment. Later, during `NetworkInterface::serializeToConfig()`, the final interface identifier (`opt1`, `opt2`, etc.) is generated and written to the configuration. However, the in-memory UUID attribute is not updated to reflect the final interface identifier.

In addition, `search_item` shows that the expected UUIDs for interface assignments are actually the generated interface names rather than the temporary internal UUID.


```
{
    "rows": [
        {
            "uuid": "wan",
            "descr": "",
            "%descr": "WAN",
            "identifier": "wan",
            "icon": "fa fa-plug text-success",
            "optgroup": "hardware",
            "if": "vtnet0",
            "%if": "vtnet0 (52:54:00:12:34:56)",
            "lock": "0"
        },
        {
            "uuid": "opt1",
            "descr": "",
            "%descr": "OPT1",
            "identifier": "opt1",
            "icon": "fa fa-plug text-success",
            "optgroup": "vlan",
            "if": "vlan0.1",
            "%if": "vlan0.1  (Parent: vtnet0, Tag: 100)",
            "lock": "0"
        }
    ],
    "rowCount": 2,
    "total": 2,
    "current": 1
}
```

---

**Describe the proposed solution**
The fix updates the in-memory UUID attribute when the final interface identifier is generated in `NetworkInterface::serializeToConfig()`. This allows the `addBase` to return the final interface identifier as the  UUID instead of the temporarily internally generated UUID.


---

**Related issue**

Related to #10599 
