### PR TITLE
MVC: UI: Parenthesize the filtered static value so Volt applies the default before negating it, avoiding undefined array key warnings

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -60,11 +60,11 @@
                         {% endif %}
                         </colgroup>
                         {% if section['type'] %}
-                        <thead {% if not section['static']|default(false) %} style="cursor: pointer;"{% endif %}>
+                        <thead {% if not (section['static']|default(false)) %} style="cursor: pointer;"{% endif %}>
                         <tr{% if section['advanced']|default(false) %} data-advanced="true"{% endif %}>
                             <th colspan="3">
                                 <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
-                                    {% if not section['static']|default(false) %}
+                                    {% if not (section['static']|default(false)) %}
                                     {% if section['collapse']|default(false)%}
                                     <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     {% else %}
@@ -78,7 +78,7 @@
                         </tr>
                         </thead>
                         {% endif %}
-                        <tbody {%if not section['static']|default(false) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
+                        <tbody {%if not (section['static']|default(false)) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
                         {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
                         <tr>
                             <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -52,11 +52,11 @@
             {% endif %}
             </colgroup>
             {% if section['type'] %}
-            <thead {% if not section['static']|default(false) %} style="cursor: pointer;"{% endif %}>
+            <thead {% if not (section['static']|default(false)) %} style="cursor: pointer;"{% endif %}>
             <tr{% if section['advanced']|default(false) %} data-advanced="true"{% endif %}>
                 <th colspan="3">
                     <div style="padding-bottom: 5px; padding-top: 5px; font-size: 16px;">
-                        {% if not section['static']|default(false) %}
+                        {% if not (section['static']|default(false)) %}
                         {% if section['collapse']|default(false) %}
                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                         {% else %}
@@ -70,7 +70,7 @@
             </tr>
             </thead>
             {% endif %}
-            <tbody {%if not section['static']|default(false) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
+            <tbody {%if not (section['static']|default(false)) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
             {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
             <tr>
                 <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

[24-Jul-2026 14:41:55 Europe/Berlin] PHP Warning:  Undefined array key "static" in /var/lib/php/cache/_usr_local_opnsense_mvc_app_views_layout_partials_base_form.volt.php on line 42
[24-Jul-2026 14:41:55 Europe/Berlin] PHP Warning:  Undefined array key "static" in /var/lib/php/cache/_usr_local_opnsense_mvc_app_views_layout_partials_base_dialog.volt.php on line 50
