### PR TITLE
Firewall: Rules: Add max-pkt-rate (Rate limiting)

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -294,26 +294,6 @@
         </grid_view>
     </field>
     <field>
-        <id>rule.max-pkt-rate-number</id>
-        <label>Max packet rate [packets]</label>
-        <type>text</type>
-        <help>Maximum number of packets allowed during the configured time interval.</help>
-        <advanced>true</advanced>
-        <grid_view>
-            <visible>false</visible>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.max-pkt-rate-seconds</id>
-        <label>Max packet rate [seconds]</label>
-        <type>text</type>
-        <help>Time interval in seconds over which the maximum packet rate is measured.</help>
-        <advanced>true</advanced>
-        <grid_view>
-            <visible>false</visible>
-        </grid_view>
-    </field>
-    <field>
         <id>rule.sched</id>
         <label>Schedule</label>
         <type>dropdown</type>
@@ -522,6 +502,31 @@
             The default virusprot table comes with a default block rule in floating rules,
             alternatively specify your own table here
         </help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Rate limiting</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>rule.max-pkt-rate-number</id>
+        <label>Max packet rate [packets]</label>
+        <type>text</type>
+        <help>Maximum number of packets allowed during the configured time interval.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.max-pkt-rate-seconds</id>
+        <label>Max packet rate [seconds]</label>
+        <type>text</type>
+        <help>Time interval in seconds over which the maximum packet rate is measured.</help>
         <advanced>true</advanced>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -508,6 +508,26 @@
         </grid_view>
     </field>
     <field>
+        <id>rule.max-pkt-rate-number</id>
+        <label>Max packet rate [packets]</label>
+        <type>text</type>
+        <help>Maximum number of packets allowed during the configured time interval.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.max-pkt-rate-seconds</id>
+        <label>Max packet rate [seconds]</label>
+        <type>text</type>
+        <help>Time interval in seconds over which the maximum packet rate is measured.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <type>header</type>
         <label>Traffic shaping</label>
         <advanced>true</advanced>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -294,6 +294,26 @@
         </grid_view>
     </field>
     <field>
+        <id>rule.max-pkt-rate-number</id>
+        <label>Max packet rate [packets]</label>
+        <type>text</type>
+        <help>Maximum number of packets allowed during the configured time interval.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.max-pkt-rate-seconds</id>
+        <label>Max packet rate [seconds]</label>
+        <type>text</type>
+        <help>Time interval in seconds over which the maximum packet rate is measured.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>rule.sched</id>
         <label>Schedule</label>
         <type>dropdown</type>
@@ -502,26 +522,6 @@
             The default virusprot table comes with a default block rule in floating rules,
             alternatively specify your own table here
         </help>
-        <advanced>true</advanced>
-        <grid_view>
-            <visible>false</visible>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.max-pkt-rate-number</id>
-        <label>Max packet rate [packets]</label>
-        <type>text</type>
-        <help>Maximum number of packets allowed during the configured time interval.</help>
-        <advanced>true</advanced>
-        <grid_view>
-            <visible>false</visible>
-        </grid_view>
-    </field>
-    <field>
-        <id>rule.max-pkt-rate-seconds</id>
-        <label>Max packet rate [seconds]</label>
-        <type>text</type>
-        <help>Time interval in seconds over which the maximum packet rate is measured.</help>
         <advanced>true</advanced>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -58,6 +58,7 @@ class FilterRule extends Rule
         'icmp6-type' => 'parsePlain,icmp6-type {,}',
         'flags' => 'parsePlain, flags ',
         'state' => 'parseState',
+        'max-pkt-rate' => 'parsePlain, max-pkt-rate ',
         'set-prio' => 'parsePlain, set prio ',
         'prio' => 'parsePlain, prio ',
         'tos' => 'parsePlain, tos ',
@@ -216,6 +217,11 @@ class FilterRule extends Rule
                         }
                     }
                 }
+            }
+            // restructure packet rate
+            if (!empty($rule['max-pkt-rate-number']) && !empty($rule['max-pkt-rate-seconds'])) {
+                $rule['max-pkt-rate'] =
+                    $rule['max-pkt-rate-number'] . "/" . $rule['max-pkt-rate-seconds'];
             }
             // restructure state settings for easier output parsing
             if (!empty($rule['statetype']) && (empty($rule['type']) || $rule['type'] == 'pass')) {

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -260,6 +260,32 @@
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>2147483647</MaximumValue>
                 </max-src-conn-rates>
+                <max-pkt-rate-number type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>4294967</MaximumValue>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Packet rate number and seconds must either both be set or left empty.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>max-pkt-rate-seconds</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
+                </max-pkt-rate-number>
+                <max-pkt-rate-seconds type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>2147483647</MaximumValue>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Packet rate number and seconds must either both be set or left empty.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>max-pkt-rate-number</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
+                </max-pkt-rate-seconds>
                 <overload type="ModelRelationField">
                     <Model>
                         <aliases>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10571

Test:

```
root@opn-dev-02:# cat /tmp/rules.debug | grep -i max-pkt-rate
pass in quick on hn2 inet from {any} to {any} keep state max-pkt-rate 3/400 label "159adc3b-6d02-48b3-b077-25abcb8bae54"
root@opn-dev-02:# pfctl -s rules | grep -i max-pkt-rate
pass in quick on hn2 inet all flags S/SA max-pkt-rate 3/400 keep state label "159adc3b-6d02-48b3-b077-25abcb8bae54"
```