### PR TITLE
Interfaces: Devices: Gif: Fix typo in reconfigure_gifs, variable gre should be gif

### DIFF
--- a/src/opnsense/scripts/interfaces/reconfigure_gifs.php
+++ b/src/opnsense/scripts/interfaces/reconfigure_gifs.php
@@ -75,15 +75,15 @@ foreach (array_keys($gifs_todo) as $gifif) {
 $ifdetails = legacy_interfaces_details();
 foreach ($gif_configure as $gif) {
     $reconfigure = false;
-    if (isset($ifdetails[$gre['gifif']])) {
+    if (isset($ifdetails[$gif['gifif']])) {
         /* when reconfiguring, we need to remove addresses (at least for IPv6) to prevent old ones left behind */
         $reconfigure = true;
-        interfaces_addresses_flush($gre['gifif'], 4, $ifdetails);
-        interfaces_addresses_flush($gre['gifif'], 6, $ifdetails);
+        interfaces_addresses_flush($gif['gifif'], 4, $ifdetails);
+        interfaces_addresses_flush($gif['gifif'], 6, $ifdetails);
     }
     _interfaces_gif_configure($gif);
     if ($reconfigure) {
         /* re-apply additional addresses and hook routing */
-        interfaces_restart_by_device(false, [$gre['gifif']]);
+        interfaces_restart_by_device(false, [$gif['gifif']]);
     }
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

[30-Jul-2026 10:37:29 Europe/Berlin] PHP Warning:  Undefined variable $gre in /usr/local/opnsense/scripts/interfaces/reconfigure_gifs.php on line 78
[30-Jul-2026 10:37:29 Europe/Berlin] PHP Warning:  Trying to access array offset on null in /usr/local/opnsense/scripts/interfaces/reconfigure_gifs.php on line 78
[30-Jul-2026 10:37:29 Europe/Berlin] PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in /usr/local/opnsense/scripts/interfaces/reconfigure_gifs.php on line 78