### PR TITLE
Interfaces: Devices: Gif: add noclamp flag

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -541,7 +541,9 @@ function _interfaces_gif_configure($gif)
         ]);
     }
 
-    $flags = (empty($gif['link1']) ? "-" : "") . "link1 " . (empty($gif['link2']) ? "-" : "") . "link2";
+    $flags = (empty($gif['link1']) ? '-' : '') . 'link1 ' .
+        (empty($gif['link2']) ? '-' : '') . 'link2 ' .
+        (empty($gif['noclamp']) ? '-' : '') . 'noclamp';
     legacy_interface_flags($gif['gifif'], $flags);
 
     legacy_interface_flags($gif['gifif'], 'up');

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogGif.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogGif.xml
@@ -55,6 +55,17 @@
         </grid_view>
     </field>
     <field>
+        <id>gif.noclamp</id>
+        <label>Disable IPv6 MTU clamping</label>
+        <type>checkbox</type>
+        <help>Do not clamp the effective MTU to 1280 bytes when the outer tunnel protocol is IPv6.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>gif.link1</id>
         <label>ECN friendly behavior</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/Gif.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/Gif.xml
@@ -42,6 +42,7 @@
             <descr type="DescriptionField"/>
             <link1 type="BooleanField"/>
             <link2 type="BooleanField"/>
+            <noclamp type="BooleanField"/>
         </gif>
     </items>
 </model>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10633

Test:

```
gif0: flags=100e051<UP,POINTOPOINT,RUNNING,LINK1,LINK2,MULTICAST,LOWER_UP> metric 0 mtu 1280
	options=80000<LINKSTATE>
	tunnel inet6 2003:XXX:ad24 --> 2003:XXX:ad28
	inet 192.168.40.1 --> 192.168.40.2 netmask 0xffffffff
	groups: gif
	options=1<NOCLAMP>
	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
```