### PR TITLE
Firewall: Rules: Add af-to (address family translation) to filter rules

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogFilterRule.xml
@@ -659,6 +659,31 @@
             <visible>false</visible>
         </grid_view>
     </field>
+    <field>
+        <type>header</type>
+        <label>Address family translation</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>rule.af-to-source</id>
+        <label>Translation source</label>
+        <type>text</type>
+        <help>Source address used after translating the packet to the opposite address family. Address family translation is only valid for inbound pass rules using an explicit IPv4 or IPv6 version.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.af-to-destination</id>
+        <label>Translation destination</label>
+        <type>text</type>
+        <help>Optional destination address or network used after translating the packet to the opposite address family.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
     <!-- Not exposed in dialog, do not exist in model, only for grid -->
     <field>
         <id>rule.statistics</id>

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -67,6 +67,7 @@ class FilterRule extends Rule
         'dn' =>  'parsePlain',
         'divert-to' => 'parsePlain,divert-to ',
         'label' => 'parsePlain,label ",",63',
+        'af-to' => 'parsePlain, af-to ',  // af-to always appears after the label in pfctl
         'descr' => 'parseComment'
     );
 
@@ -303,6 +304,14 @@ class FilterRule extends Rule
                     $rule['dn'] = sprintf('%s (%s, %s)', $shaper1['type'], $shaper1['id'], $shaper2['id']);
                 } else {
                     $rule['dn'] = sprintf('%s %s', $shaper1['type'], $shaper1['id']);
+                }
+            }
+            // restructure address family translation
+            if (!empty($rule['af-to-source'])) {
+                $address_family = $rule['ipprotocol'] === 'inet' ? 'inet6' : 'inet';
+                $rule['af-to'] = sprintf('%s from %s', $address_family, $rule['af-to-source']);
+                if (!empty($rule['af-to-destination'])) {
+                    $rule['af-to'] .= sprintf(' to %s', $rule['af-to-destination']);
                 }
             }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
@@ -285,6 +285,52 @@ class Filter extends BaseModel
                                 $rule->replyto->__reference
                             ));
                         }
+                        // af-to validation
+                        if (!$rule->{'af-to-destination'}->isEmpty() && $rule->{'af-to-source'}->isEmpty()) {
+                            $messages->appendMessage(
+                                new Message(
+                                    gettext("Translation destination requires a translation source."),
+                                    $rule->{'af-to-source'}->__reference
+                                )
+                            );
+                        } elseif (!$rule->{'af-to-source'}->isEmpty()) {
+                            if ($rule->action != 'pass') {
+                                $messages->appendMessage(new Message(
+                                    gettext("Address family translation is only valid for pass rules."),
+                                    $rule->{'af-to-source'}->__reference
+                                ));
+                            }
+                            if ($rule->direction != 'in') {
+                                $messages->appendMessage(new Message(
+                                    gettext("Address family translation is only valid for inbound rules."),
+                                    $rule->{'af-to-source'}->__reference
+                                ));
+                            }
+                            if (!in_array((string)$rule->ipprotocol, ['inet', 'inet6'], true)) {
+                                $messages->appendMessage(new Message(
+                                    gettext("An address family must be selected when using address family translation."),
+                                    $rule->ipprotocol->__reference
+                                ));
+                            }
+                            if ($rule->statetype == 'none') {
+                                $messages->appendMessage(new Message(
+                                    gettext("Address family translation requires state tracking."),
+                                    $rule->{'af-to-source'}->__reference
+                                ));
+                            }
+                            if (!$rule->gateway->isEmpty()) {
+                                $messages->appendMessage(new Message(
+                                    gettext("Address family translation cannot be combined with route-to."),
+                                    $rule->gateway->__reference
+                                ));
+                            }
+                            if (!$rule->replyto->isEmpty()) {
+                                $messages->appendMessage(new Message(
+                                    gettext("Address family translation cannot be combined with reply-to."),
+                                    $rule->replyto->__reference
+                                ));
+                            }
+                        }
                     }
                 }
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -192,6 +192,13 @@
                     <ConfigdPopulateAct>filter list diverts</ConfigdPopulateAct>
                     <ValidationMessage>Specify a valid divert-to target.</ValidationMessage>
                 </divert-to>
+                <af-to-source type="NetworkField">
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                </af-to-source>
+                <af-to-destination type="NetworkField">
+                    <NetMaskRequired>Y</NetMaskRequired>
+                    <Strict>Y</Strict>
+                </af-to-destination>
                 <gateway type="JsonKeyValueStoreField">
                     <ConfigdPopulateAct>interface gateways list -g</ConfigdPopulateAct>
                     <ValidationMessage>Specify a valid gateway from the list matching the networks ip protocol.</ValidationMessage>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10570

This adds both NAT64 and NAT46 capabilities as it seems.

Test:

The test are the rules specified in the pf.conf(5) manpage:

```
root@opn-dev-02:# cat /tmp/rules.debug | grep -i af-to
pass in quick on hn3 inet from {any} to {any} keep state label "5fa6810f-0ca6-4dab-bbc9-7984498e2d0b" af-to inet6 from 2001:db8::1 to 2001:db8::/96 # translation
pass in quick on hn3 inet6 from {any} to {64:ff9b::/96} keep state label "eb8ec833-4395-4bfb-86a1-2a22ca8bf7c1" af-to inet from 198.51.100.1 to 0.0.0.0/0 # translation
root@opn-dev-02:# pfctl -s rules | grep -i af-to
pass in quick on hn3 inet all flags S/SA keep state label "5fa6810f-0ca6-4dab-bbc9-7984498e2d0b" af-to inet6 from 2001:db8::1 to 2001:db8::/96
pass in quick on hn3 inet6 from any to 64:ff9b::/96 flags S/SA keep state label "eb8ec833-4395-4bfb-86a1-2a22ca8bf7c1" af-to inet from 198.51.100.1 to any
```