### PR TITLE
IPsec: add support for DNS search domains in address pools

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogPool.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/IPsec/forms/dialogPool.xml
@@ -23,4 +23,12 @@
         <allownew>true</allownew>
         <help>DNS servers to push as configuration payload (RFC4306 3.15 - Value 3 and 10). Accepts multiple IPv4/IPv6 addresses.</help>
     </field>
+    <field>
+        <id>pool.domains</id>
+        <label>DNS Search Domain(s)</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>DNS search domains to push as configuration payload. Accepts multiple domains.</help>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.xml
@@ -343,6 +343,9 @@
                     <AsList>Y</AsList>
                     <ValidationMessage>Entry is not a valid IPv4 or IPv6 address.</ValidationMessage>
                 </dns>
+                <domains type="TextField">
+                    <Required>N</Required>
+                </domains>
             </Pool>
         </Pools>
         <VTIs>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT

---

**Describe the problem**

This change exposes the strongSwan `domains` pool option in the OPNsense IPsec GUI.

The backend already supports arbitrary pool attributes, therefore no PHP or configuration generator changes are required. This PR only extends the MVC model and the pool dialog.

---

**Describe the proposed solution**

The `domains` option configures the IKEv2 Configuration Payload `INTERNAL_DNS_DOMAIN`, allowing clients to automatically receive one or more DNS search domains.

This enables clients to resolve short host names such as nas, printer, fileserver instead of requiring fully qualified names.

---

**Related issue**

No issues were created, because this feature was missing.
