### PR TITLE
config: stop trusting that config writes always succeed

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Core/Config.php
@@ -563,7 +563,7 @@ class Config extends Singleton
 
     /**
      * backup current config
-     * @return string target filename
+     * @return string|null target filename, null when the backup could not be written
      */
     public function backup($timestamp = null)
     {
@@ -583,7 +583,15 @@ class Config extends Singleton
         } else {
             $target_filename = "config-" . $timestamp . ".xml";
         }
-        File::file_put_contents($target_dir . $target_filename, file_get_contents($this->config_file), 0640);
+        $data = file_get_contents($this->config_file);
+        if (
+            $data === false ||
+            File::file_put_contents($target_dir . $target_filename, $data, 0640) !== strlen($data)
+        ) {
+            /* a partial backup would shadow the older intact ones on restore */
+            @unlink($target_dir . $target_filename);
+            return null;
+        }
 
         return $target_dir . $target_filename;
     }
@@ -747,14 +755,24 @@ class Config extends Singleton
         // update revision information ROOT.revision tag, align timestamp to backup output
         $revision = $this->updateRevision($revision, null, $time);
 
+        $backup_filename = null;
+
         if ($this->config_file_handle !== null) {
             if (flock($this->config_file_handle, LOCK_EX)) {
+                $data = (string)$this;
                 fseek($this->config_file_handle, 0);
                 chmod($this->config_file, 0640);
-                ftruncate($this->config_file_handle, 0);
-                fwrite($this->config_file_handle, (string)$this);
-                // flush, unlock, but keep the handle open
-                fflush($this->config_file_handle);
+                if (
+                    !ftruncate($this->config_file_handle, 0) ||
+                    fwrite($this->config_file_handle, $data) !== strlen($data) ||
+                    !fflush($this->config_file_handle) ||
+                    !fsync($this->config_file_handle)
+                ) {
+                    /* on-disk contents are undefined now, leave the backups untouched for recovery */
+                    flock($this->config_file_handle, LOCK_UN);
+                    throw new ConfigException("Unable to write config");
+                }
+                // flushed and synced, unlock later, but keep the handle open
                 $backup_filename = $backup ? $this->backup($time) : null;
                 if ($backup_filename) {
                     $this->auditLogChange($backup_filename, $revision);
@@ -763,6 +781,9 @@ class Config extends Singleton
                     // last processed event itself. (it's merely added for debug purposes)
                     $logger = new Syslog('config', null, LOG_LOCAL5);
                     $logger->info("config-event: new_config " . $backup_filename);
+                } elseif ($backup) {
+                    $logger = new Syslog('config', null, LOG_LOCAL5);
+                    $logger->error("config saved, but no backup of it could be written");
                 }
                 flock($this->config_file_handle, LOCK_UN);
                 $this->mtime = fstat($this->config_file_handle)['mtime'];
@@ -771,8 +792,10 @@ class Config extends Singleton
             }
         }
 
-        /* cleanup backups */
-        $this->cleanupBackups();
+        /* cleanup backups, but not when the new backup could not be written */
+        if (!$backup || $backup_filename !== null) {
+            $this->cleanupBackups();
+        }
     }
 
     /**


### PR DESCRIPTION
While digging into how config.xml is written I noticed that `Config::save()` never
looks at what `ftruncate()`, `fwrite()` and `fflush()` return. The file has already
been truncated at that point, so if the write comes up short — disk full is the easy
way to hit this — we end up with a truncated config.xml and no error anywhere.

It gets worse from there. `backup()` then copies that damaged file into the backup
directory (the `File::file_put_contents()` result is ignored too, and it even
`@touch`es the target first, so a completely failed write still leaves a zero-byte
"backup" behind), and `cleanupBackups()` prunes old backups purely by count. With
`backupcount` set to 1 that sequence deletes the last good backup, and the next boot
walks through the recovery loop in `init()`, finds nothing parseable, and lands on
the factory config. With the default of 100 you "only" lose the revision silently
and the system quietly restores an older backup on the next boot.

The both-files-broken scenario isn't hypothetical — 680846d65b already dealt with
the kernel-crash variant of it.

What this does:

`save()` builds the XML string once, checks the truncate, compares the byte count
from `fwrite()` against `strlen()`, and adds an `fsync()` so the data isn't still
sitting in the page cache while we start copying backups around. On any failure it
releases the lock and throws `ConfigException` — `write_config()` on the legacy side
already catches exactly that, so callers get a real failure instead of a thumbs up.

`backup()` now returns null when the source read or the copy fails, and unlinks the
partial file so it can't shadow the intact older backups during boot-time recovery.
Backup pruning is skipped whenever the new backup didn't make it to disk, so a
failed save can never eat the history anymore. A failed backup no longer passes in
silence either: the config was written, so save() doesn't throw for it, but it does
log an error now (previously the audit trail would just show a backup that was in
fact broken).

One thing reviewers may care about: `backup()` is public, so any out-of-tree caller
that assumed it always returns a string needs to cope with null on failure now. In
core the only caller is `save()` itself.

What it deliberately doesn't do: switch to write-temp-then-rename. That would be the
textbook fix, but the whole locking model here is `flock()` on a persistent handle,
plus `hasChanged()` doing `fstat()` on it, plus `loadFromStream()` readers waiting
on the writer's lock — rename swaps the inode out from under all of that. Overwriting
in place while keeping the handle open is load-bearing, so I stayed inside that
design.

`fsync()` needs PHP 8.1, which we are comfortably past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
