### PR TITLE
firmware: don't reboot into a half-applied major upgrade

### DIFF
--- a/src/etc/rc.syshook.d/early/05-upgrade
+++ b/src/etc/rc.syshook.d/early/05-upgrade
@@ -3,8 +3,17 @@
 # Perform major updates
 
 for STAGE in K B P; do
-	if opnsense-update -${STAGE}; then
+	opnsense-update -${STAGE}
+	STATUS=${?}
+
+	if [ "${STATUS}" -eq 0 ]; then
 		echo "Rebooting now."
 		reboot
+		break
+	elif [ "${STATUS}" -ne 1 ]; then
+		# the stage was pending but could not be applied; the
+		# stages behind it must not run on top of the damage
+		echo "Upgrade stage ${STAGE} failed (${STATUS}), aborting."
+		break
 	fi
 done

--- a/src/opnsense/scripts/firmware/upgrade.sh
+++ b/src/opnsense/scripts/firmware/upgrade.sh
@@ -31,11 +31,11 @@ REQUEST="UPGRADE"
 
 if output_cmd opnsense-update -u; then
 	if output_cmd /usr/local/etc/rc.syshook upgrade; then
-		# pending kernel applies before reboot
-		if output_cmd opnsense-update -K -c; then
-			output_cmd opnsense-update -K
+		# pending kernel applies before reboot, but if that apply
+		# fails rebooting would only make matters worse
+		if ! output_cmd opnsense-update -K -c || output_cmd opnsense-update -K; then
+			output_reboot keep-log
 		fi
-		output_reboot keep-log
 	fi
 
 	output_txt "The upgrade was aborted due to an error."


### PR DESCRIPTION
Two places in the major upgrade path assume the destructive stages cannot fail, and
both of them reboot afterwards.

The first is upgrade.sh. It checks for a pending kernel with `opnsense-update -K -c`,
applies it with `opnsense-update -K`, throws the result away and reboots regardless.
The apply is the dangerous part: opnsense-update consumes the pending marker first,
moves /boot/kernel to kernel.old and untars the new kernel straight into place. If
the extraction dies halfway (out of space, I/O error) you are left with a partial
/boot/kernel, no marker to retry from, and a reboot already on its way. The loader
boots /boot/kernel by default, so a remote box comes back... to the loader prompt,
waiting for someone with console access to type `boot kernel.old`. After this change
the reboot only happens when there was no pending kernel or the apply came back
clean; a failure drops through to the existing abort path, whose
`opnsense-update -es` conveniently also flushes the deferred sets, so the boot hook
below won't try to finish the job on top of the damage.

The second is the early syshook, 05-upgrade. It loops K, B, P and reboots after the
first stage that reports success. The problem is that `opnsense-update -K` exits 1
both when there is nothing pending (the normal every-boot case) and when the apply
actually blew up, so the loop cannot tell "no kernel to do, move along" from "the
kernel is now in pieces" — and in the latter case it will happily install base and
packages on top and reboot.

I first tried gating the loop with `-c`, but that has its own trap: RELEASE is baked
into the opnsense-update binary at build time, so on the first boot of a major
upgrade the still-old updater sees a version mismatch and `-K -c` reports true with
nothing pending, which would have broken the normal flow. So the loop now keeps
exit 1 as "nothing pending" and treats anything else as a failed apply and stops.
Current opnsense-update only ever exits 0 or 1, so behaviour with today's updater is
completely unchanged; the companion PR (opnsense/update#106) makes failed applies
exit 2 and, more importantly, puts the old kernel back when the install fails.

Also added a `break` after the reboot call so we stop feeding stages to a system
that is already going down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
