### PR TITLE
ui: tabulator: Do not freeze commands column on touchscreen devices, as their viewports are most likely very constrained

### DIFF
--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -540,7 +540,8 @@ class UIBootgrid {
                     title: field.label,
                     resizable: false,
                     sequence: field.sequence ?? null,
-                    frozen: true,
+                    // If a touchscreen is detected, unfreeze commands (most likely small device/tablet)
+                    frozen: !window.matchMedia('(any-pointer: coarse)').matches,
                     headerSort: false,
                     headerHozAlign: "center",
                     selectable: true


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

On very small viewports, most prominently on touchscreen devices, grids like the firewall become unusable since the frozen command column consumes all available space.

---

**Describe the proposed solution**

Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/0cc5d8e5-39bc-4154-a436-8753cf1fa922" />

-> Frozen commands column make this unusable.

After:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/01e349ad-ad6b-42fd-b193-88e2778bac44" />

-> You can freely scroll now in the available space, commands are at the end of the horizontal scroll.

---

**Related issue**

For: https://github.com/opnsense/core/issues/10130
