### PR TITLE
ui: tabulator: Add _showMaximized() modal that can show a grid close to full screen

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
@@ -37,3 +37,19 @@
         </tr>
     </tfoot>
 </table>
+
+{# _showMaximized() modal, it is here so z-index is always below an input dialog/backdrop #}
+<div id="{{ table_id }}-maximize-modal" class="modal fade bootgrid-maximize-modal" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-body"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+    $.extend(jQuery.fn.UIBootgrid.translations, {
+        maximizeGrid: "{{ lang._('Maximize grid') }}",
+        minimizeGrid: "{{ lang._('Minimize grid') }}"
+    });
+</script>

--- a/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_bootgrid_table.volt
@@ -37,19 +37,3 @@
         </tr>
     </tfoot>
 </table>
-
-{# _showMaximized() modal, it is here so z-index is always below an input dialog/backdrop #}
-<div id="{{ table_id }}-maximize-modal" class="modal fade bootgrid-maximize-modal" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-body"></div>
-        </div>
-    </div>
-</div>
-
-<script>
-    $.extend(jQuery.fn.UIBootgrid.translations, {
-        maximizeGrid: "{{ lang._('Maximize grid') }}",
-        minimizeGrid: "{{ lang._('Minimize grid') }}"
-    });
-</script>

--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -353,7 +353,9 @@
             infos: "{{ lang._('Showing %s to %s') | format('{{ctx.start}}','{{ctx.end}}') }}",
             resetGrid: "{{ lang._('Reset grid layout') }}",
             searchColumns: "{{ lang._('Search columns') }}",
-            expand: "{{ lang._('Click to expand/collapse cell') }}"
+            expand: "{{ lang._('Click to expand/collapse cell') }}",
+            maximizeGrid: "{{ lang._('Maximize grid') }}",
+            minimizeGrid: "{{ lang._('Minimize grid') }}"
         });
 
         $.fn.selectpicker.defaults = $.fn.selectpicker.defaults || {};

--- a/src/opnsense/www/css/opnsense-bootgrid-layout.css
+++ b/src/opnsense/www/css/opnsense-bootgrid-layout.css
@@ -88,3 +88,27 @@
         flex: 1;
     }
 }
+
+/* _showMaximized() modal */
+.bootgrid-maximize-modal {
+    overflow: hidden !important;
+}
+
+.bootgrid-maximize-modal .modal-dialog {
+    width: calc(100vw - 30px);
+    max-width: none;
+    max-height: calc(100dvh - 80px);
+    margin: 65px 15px 15px !important;
+}
+
+.bootgrid-maximize-modal .modal-content {
+    max-height: calc(100dvh - 80px);
+    overflow: hidden;
+}
+
+.bootgrid-maximize-modal .modal-body {
+    max-height: calc(100dvh - 80px);
+    overflow: auto;
+    overscroll-behavior: contain;
+    box-sizing: border-box;
+}

--- a/src/opnsense/www/css/opnsense-bootgrid-layout.css
+++ b/src/opnsense/www/css/opnsense-bootgrid-layout.css
@@ -98,7 +98,8 @@
     width: calc(100vw - 30px);
     max-width: none;
     max-height: calc(100dvh - 80px);
-    margin: 65px 15px 15px !important;
+    /* _showMaximized() calculates top margin */
+    margin: 0px 0px 0px 8px !important;
 }
 
 .bootgrid-maximize-modal .modal-content {

--- a/src/opnsense/www/css/opnsense-bootgrid-layout.css
+++ b/src/opnsense/www/css/opnsense-bootgrid-layout.css
@@ -95,7 +95,7 @@
 }
 
 .bootgrid-maximize-modal .modal-dialog {
-    width: calc(100vw - 30px);
+    width: calc(100vw - 16px);
     max-width: none;
     max-height: calc(100dvh - 80px);
     /* _showMaximized() calculates top margin */

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -654,6 +654,10 @@ class UIBootgrid {
     }
 
     _onDimensionChange() {
+        if (this.$maximizeModal) {
+            return;
+        }
+
         const scrollbarGutterOffset = 16;
         const defaultHeight = 120;
 
@@ -1081,6 +1085,46 @@ class UIBootgrid {
         }
     }
 
+    _showMaximized() {
+        if (this.$maximizeModal) {
+            this.$maximizeModal.modal('hide');
+            return;
+        }
+
+        const $header = $(`#${this.id}-header`);
+        const $table = this.$element;
+        const $placeholder = $('<span>').insertBefore($header);
+        const $modal = $(`#${this.id}-maximize-modal`);
+        const $maximizeBtn = $(`#${this.id}-maximize`);
+
+        this.$maximizeModal = $modal;
+        $modal.find('.modal-body').append($header, $table);
+        $maximizeBtn.attr({
+            title: this.translations.minimizeGrid,
+            'aria-label': this.translations.minimizeGrid
+        }).find('.icon').removeClass('fa-expand').addClass('fa-xmark');
+
+        $modal.one('shown.bs.modal', () => {
+            this.table.setHeight(false);
+            $table.css({height: '', minHeight: '', maxHeight: ''});
+            $table.find('.tabulator-tableholder').css({height: '', maxHeight: ''});
+            this.table.redraw(true);
+        });
+
+        $modal.one('hidden.bs.modal', () => {
+            $placeholder.after($header, $table).remove();
+            $maximizeBtn.attr({
+                title: this.translations.maximizeGrid,
+                'aria-label': this.translations.maximizeGrid
+            }).find('.icon').removeClass('fa-xmark').addClass('fa-expand');
+            this.$maximizeModal = null;
+            this._onDimensionChange();
+            this.table.redraw(true);
+        });
+
+        $modal.modal('show');
+    }
+
     _renderActionBar() {
         if (!this.options.navigation) {
             return;
@@ -1182,6 +1226,20 @@ class UIBootgrid {
             });
 
             $(`#${this.id}-actions-group`).append($resetBtn);
+        }
+
+        // Maximize grid button
+        if ($(`#${this.id}-maximize-modal`).length) {
+            const $maximizeBtn = $(`
+                <button id="${this.id}-maximize" class="btn btn-default" type="button"
+                        title="${this.translations.maximizeGrid}" aria-label="${this.translations.maximizeGrid}">
+                    <span class="icon fa-solid fa-expand"></span>
+                </button>
+            `).on('click', () => {
+                this._showMaximized();
+            });
+
+            $(`#${this.id}-actions-group`).append($maximizeBtn);
         }
     }
 

--- a/src/opnsense/www/js/opnsense_bootgrid.js
+++ b/src/opnsense/www/js/opnsense_bootgrid.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Deciso B.V.
+ * Copyright (C) 2025-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -888,6 +888,10 @@ class UIBootgrid {
         this.table.on('scrollVertical', (top) => {
             this.scrollPos = top;
         });
+        this.table.on('renderComplete', (top) => {
+            /* tooltips may stick, remove them on redraw */
+            $("div.tooltip.fade.top.in").remove();
+        });
     }
 
     _renderFooter() {
@@ -1094,8 +1098,27 @@ class UIBootgrid {
         const $header = $(`#${this.id}-header`);
         const $table = this.$element;
         const $placeholder = $('<span>').insertBefore($header);
-        const $modal = $(`#${this.id}-maximize-modal`);
+        const $modal = $('<div class="modal fade bootgrid-maximize-modal" role="dialog">');
         const $maximizeBtn = $(`#${this.id}-maximize`);
+        $modal.append(`
+            <div class="modal-backdrop fade in"></div>
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-body"></div>
+                </div>
+            </div>
+        `);
+
+        $modal.find('.modal-content').css({
+            'margin-top': $("header.page-head").outerHeight(),
+            'margin-bottom': 0,
+            'margin-left': 0,
+            'margin-right': 0,
+            'height': $("#navigation").outerHeight()
+        });
+
+        /* ensure model is "stacked" properly to allow the next dialog to overlay it */
+        $(`#${this.id}`).after($modal);
 
         this.$maximizeModal = $modal;
         $modal.find('.modal-body').append($header, $table);
@@ -1117,12 +1140,13 @@ class UIBootgrid {
                 title: this.translations.maximizeGrid,
                 'aria-label': this.translations.maximizeGrid
             }).find('.icon').removeClass('fa-xmark').addClass('fa-expand');
+            this.$maximizeModal.remove();
             this.$maximizeModal = null;
             this._onDimensionChange();
             this.table.redraw(true);
         });
 
-        $modal.modal('show');
+        $modal.modal({ backdrop: 'static', keyboard: false });
     }
 
     _renderActionBar() {
@@ -1209,8 +1233,8 @@ class UIBootgrid {
         // Reset button
         if (this.options.resetButton) {
             let $resetBtn = $(`
-                <button id="${this.id}-reset" class="btn btn-default" type="button"
-                        title="${this.persistence ? this.translations.resetGrid : ''}">
+                <button id="${this.id}-reset" class="btn btn-default" type="button" data-toggle="tooltip"
+                        title="${this.translations.resetGrid}">
                     <span class="icon fa-solid fa-share-square"></span>
                 </button>
             `).on('click', (e) => {
@@ -1229,18 +1253,16 @@ class UIBootgrid {
         }
 
         // Maximize grid button
-        if ($(`#${this.id}-maximize-modal`).length) {
-            const $maximizeBtn = $(`
-                <button id="${this.id}-maximize" class="btn btn-default" type="button"
-                        title="${this.translations.maximizeGrid}" aria-label="${this.translations.maximizeGrid}">
-                    <span class="icon fa-solid fa-expand"></span>
-                </button>
-            `).on('click', () => {
-                this._showMaximized();
-            });
+        const $maximizeBtn = $(`
+            <button id="${this.id}-maximize" class="btn btn-default" type="button" data-toggle="tooltip"
+                    title="${this.translations.maximizeGrid}" aria-label="${this.translations.maximizeGrid}">
+                <span class="icon fa-solid fa-expand"></span>
+            </button>
+        `).on('click', () => {
+            this._showMaximized();
+        });
 
-            $(`#${this.id}-actions-group`).append($maximizeBtn);
-        }
+        $(`#${this.id}-actions-group`).append($maximizeBtn);
     }
 
     _renderFooterCommands() {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.5
- Extent of AI involvement: CSS, I don't like CSS :)

---

**Describe the problem**

On smaller viewports like 1080p monitors or mobile devices, all the cruft around the grid can starve the actual grid for most available space.

On large screens you also generically profit from this, as you can see more rows and fill your whole screen with more information.

---

**Describe the proposed solution**

The maximize grid button opens a modal that contains the grid. It uses as much space as possible, and improves interaction on touch devices as there are no sticky headers or columns anymore.

The modal itself is always below dialogs, so you can interact normally and add new rows.

This makes pages like the Firewall actually usable on screens as small as a normal iPhone without a hazzle.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10130
