### PR TITLE
interfaces: actually release the IPv4 DHCP lease on teardown

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -883,7 +883,19 @@ function interface_reset($interface, $ifacecfg = false, $suspend = false)
 
     switch ($ifcfg['ipaddr'] ?? 'none') {
         case 'dhcp':
+            /*
+             * Stop the supervisor first: it owns the restart timer, so
+             * signalling dhclient directly would only get it respawned.
+             * daemon(8) forwards the TERM to dhclient and exits.
+             */
             killbypid("/var/run/dhclient.{$device}.pid");
+            /*
+             * Only a real teardown gives up the lease; a suspend is a
+             * temporary reconfigure and must keep the address claimed.
+             */
+            if (!$suspend) {
+                interface_dhcp_release($device);
+            }
             break;
         default:
             break;
@@ -3318,6 +3330,40 @@ function interfaces_dhcp_split($option)
     }
 
     return $args;
+}
+
+/*
+ * Give up the current IPv4 lease properly.
+ *
+ * /sbin/dhclient(8) from FreeBSD base has no release mode (getopt string is
+ * "bc:dl:np:qu"), so the DHCPRELEASE is emitted by a helper instead.  It must
+ * run after dhclient is gone -- it needs port 68 and dhclient holds it -- but
+ * before interfaces_addresses_flush(), because RFC 2131 requires the release
+ * to be unicast from the leased address.
+ */
+function interface_dhcp_release($device)
+{
+    /* the address is the source of the release; without it there is nothing to send */
+    if (empty($device) || !file_exists("/var/db/dhclient.leases.{$device}")) {
+        return;
+    }
+
+    /*
+     * hard bound: a release is never answered, so it must not be able to
+     * stall the GUI. Resolve `timeout` via $PATH rather than hardcoding
+     * /usr/bin or /bin -- confirmed to differ across OPNsense/FreeBSD
+     * builds (this system has it at /bin/timeout, not /usr/bin/timeout;
+     * a hardcoded wrong path makes mwexecf() fail to launch anything,
+     * silently, with interface_reset() otherwise appearing to succeed).
+     *
+     * Do NOT mute this call (default $mute is already false) -- a muted
+     * mwexecf() is exactly what made the /usr/bin/timeout path bug
+     * invisible in the first place. Let real failures reach syslog.
+     */
+    mwexecf(
+        'timeout -k 1 3 /usr/local/opnsense/scripts/interfaces/dhclient-release.py %s',
+        [$device]
+    );
 }
 
 function interface_dhcp_configure($interface = 'wan')

--- a/src/opnsense/scripts/interfaces/dhclient-release.py
+++ b/src/opnsense/scripts/interfaces/dhclient-release.py
@@ -1,0 +1,163 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2026 SilentandUnknown <SilentansUnknown@proton.me>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+"""Send a one-shot DHCPRELEASE (RFC 2131 4.4.4) for an interface's current lease.
+
+/sbin/dhclient in FreeBSD base has no -r; this reproduces just the RELEASE.
+Fire-and-forget: no reply is defined for RELEASE, so we never block on the server.
+"""
+import errno
+import os
+import random
+import re
+import socket
+import struct
+import subprocess
+import sys
+
+LEASE_DB = '/var/db/dhclient.leases.%s'
+DHCLIENT_CONF = '/var/etc/dhclient.%s.conf'
+BOOTP_MIN_LEN = 300     # sbin/dhclient/dhcp.h -- real dhclient pads every message to this
+# bind()/sendto() failures that mean "the address is already gone" rather
+# than a real problem -- expected after an expired lease or a downed link,
+# not worth logging as an error now that the caller no longer mutes us.
+BENIGN_ERRNOS = {errno.EADDRNOTAVAIL, errno.ENETUNREACH, errno.ENETDOWN, errno.EHOSTUNREACH}
+
+
+def last_lease(path):
+    try:
+        with open(path, 'r') as f:
+            blob = f.read()
+    except OSError:
+        return None
+    best = None
+    for m in re.finditer(r'lease\s*\{(.*?)\n\}', blob, re.S):
+        body = m.group(1)
+        ip = re.search(r'\bfixed-address\s+([\d.]+)\s*;', body)
+        sid = re.search(r'\boption\s+dhcp-server-identifier\s+([\d.]+)\s*;', body)
+        if ip and sid:
+            best = (ip.group(1), sid.group(1))
+    return best
+
+
+def hwaddr(dev):
+    out = subprocess.run(['/sbin/ifconfig', dev], capture_output=True, text=True).stdout
+    m = re.search(r'\bether\s+([0-9a-f:]{17})', out)
+    return bytes.fromhex(m.group(1).replace(':', '')) if m else None
+
+
+def client_id(dev, mac):
+    """Option 61 payload, matching whatever the original DHCPREQUEST sent.
+
+    If the release doesn't send the same identifier the request used, the
+    server's lease binding won't match and the release silently fails to
+    take effect.  dhclient.conf can carry an explicit identifier in either
+    of the two forms dhclient's own parser accepts for a byte-string
+    option, and interfaces.inc can generate both:
+
+      send dhcp-client-identifier "name";        <- 'dhcphostname' is set
+      send dhcp-client-identifier 01:aa:bb:...;  <- 'adv_dhcp_send_options'
+
+    The quoted form is a raw string with no RFC 2132 type byte; the hex
+    form is the literal option payload, type byte included if the user
+    wrote one.  Anything else is left to the default MAC-derived type-1
+    form, which is what dhclient itself sends when told nothing.
+    """
+    try:
+        with open(DHCLIENT_CONF % dev, 'r') as f:
+            conf = f.read()
+    except OSError:
+        conf = ''
+    # anchored to the start of a line so a commented-out statement in a
+    # user-supplied override config can't be mistaken for a live one
+    m = re.search(r'^\s*send\s+dhcp-client-identifier\s+([^;\n]+);', conf, re.M)
+    if m:
+        val = m.group(1).strip()
+        if len(val) >= 2 and val.startswith('"') and val.endswith('"'):
+            return val[1:-1].encode('latin-1', errors='replace')
+        if re.match(r'^[0-9A-Fa-f]{1,2}(:[0-9A-Fa-f]{1,2})*$', val):
+            return bytes(int(b, 16) for b in val.split(':'))
+    return b'\x01' + mac
+
+
+def main():
+    if len(sys.argv) != 2:
+        return 2
+    dev = sys.argv[1]
+    if not re.match(r'^[0-9A-Za-z_.]+$', dev):
+        return 2
+    lease = last_lease(LEASE_DB % dev)
+    mac = hwaddr(dev)
+    if not lease or not mac:
+        # Nothing to give back (no usable lease, or a non-ethernet device).
+        # Not an error: the caller no longer mutes us, so don't log noise.
+        return 0
+    ciaddr, server = lease
+    cid = client_id(dev, mac)
+
+    pkt = struct.pack('!4B I 2H 4s 4s 4s 4s 16s 64s 128s 4s',
+                      1, 1, 6, 0, random.getrandbits(32), 0, 0,
+                      socket.inet_aton(ciaddr), b'\0' * 4, b'\0' * 4, b'\0' * 4,
+                      mac.ljust(16, b'\0'), b'', b'', bytes([99, 130, 83, 99]))
+    pkt += bytes([53, 1, 7])                                   # DHCPRELEASE
+    pkt += bytes([54, 4]) + socket.inet_aton(server)           # server identifier
+    pkt += bytes([61, len(cid)]) + cid                         # client identifier
+    pkt += bytes([255])                                        # end of options
+    # dhclient(8) pads every BOOTP message out to BOOTP_MIN_LEN; trailing
+    # zeroes are PAD options. Some servers/relays drop short messages, so
+    # match base dhclient's real on-wire size exactly.
+    if len(pkt) < BOOTP_MIN_LEN:
+        pkt += b'\0' * (BOOTP_MIN_LEN - len(pkt))
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if hasattr(socket, 'SO_REUSEPORT'):
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    try:
+        s.bind((ciaddr, 68))
+        s.sendto(pkt, (server, 67))
+    except OSError as exc:
+        s.close()
+        if exc.errno in BENIGN_ERRNOS:
+            # The address/link is already gone (expired lease, downed WAN,
+            # etc.) -- there's nothing left to release, not a real failure.
+            return 0
+        sys.stderr.write('dhclient-release: %s: %s\n' % (dev, exc))
+        return 1
+    s.close()
+    # RFC 2131: the lease is void once released; drop it so a restart cannot REBOOT it.
+    try:
+        os.unlink(LEASE_DB % dev)
+    except OSError:
+        pass
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
FreeBSD base /sbin/dhclient has no release mode (getopt string is "bc:dl:np:qu" -- confirmed against its source, DHCPRELEASE does not appear anywhere in it). interface_reset() currently just kills the dhclient/daemon(8) supervisor pair via SIGTERM, so the ISP-side lease is never actually freed -- a subsequent renew often just hands back the same address. See opnsense/core#3628 (2019, still open on current master).

A prior attempt to fix this, PR #3275, stalled and was closed as "timeout" rather than on a clean technical rejection, but the thread did surface one real, legitimate objection: it shipped a checked-in binary (a swapped-in ISC dhclient), which is a genuine maintenance/ security liability for a firewall OS. It also carried ~10 lines of unrelated theme/CSS changes for new GUI buttons, which drew separate maintainer friction.

This patch avoids both: no binary, no package dependency, and no www/theme files touched at all. Instead of swapping clients, it hand- builds and sends a correct DHCPRELEASE (RFC 2131 4.4.4) from a small in-tree Python helper, using the last lease recorded in /var/db/dhclient.leases.<if>.

This is a real correctness fix to existing behavior, not a new feature -- interface_reset() is already called from real interactive paths (disabling an interface, deleting one, console re-addressing; see src/www/interfaces.php, apply_pending_if_changes.php, setaddr.php, console.inc), and $suspend already correctly distinguishes those genuine-release actions from routine reconfigures. No new UI is added or required.

Verified via live packet capture in an isolated VM lab (OPNsense 26.7 nano image in QEMU, WAN on a private socket network, dnsmasq + tcpdump standing in for the ISP, zero contact with any real network): interface_reset('wan') emits a correctly-formed, RFC-2131-compliant DHCPRELEASE, unicast from the leased address to the recorded server, padded to the real dhclient's 300-byte BOOTP minimum.

All three client-identifier (option 61) forms interfaces.inc can generate were exercised live in that lab, each confirmed both on the wire and by the server's own reaction:

  config                          option 61 sent        dnsmasq
  ------------------------------- ---------------------- -----------
  (none)                          01:52:54:00:00:00:01   lease freed
  dhcphostname "opnlab-cid-7"     raw string, 12 bytes    lease freed
  adv send 01:aa:bb:cc:dd:ee:ff   01:aa:bb:cc:dd:ee:ff    lease freed

As a negative control, a release deliberately sent with the wrong (MAC-derived) identifier while the lease was bound to a custom one was logged by dnsmasq as "unknown lease" and the binding was NOT released -- confirming the identifier handling is load-bearing, not cosmetic.

Implementation notes:
- The release must run after dhclient's supervisor is confirmed gone (it holds port 68) but before any address flush, since the release must be sent from the still-assigned leased address per RFC 2131.
- Failures during the release attempt are not muted: real errors (bad args, exec failures, timeouts) reach syslog, while the specific benign cases -- address already gone after an expired lease or a downed link (EADDRNOTAVAIL, ENETUNREACH, ENETDOWN, EHOSTUNREACH) -- are treated as a normal no-op rather than logged as an error.
- The release call is wrapped in a hard timeout, since RFC 2131 releases are fire-and-forget with no defined reply, and must not be able to stall the caller on a dead link.
- client_id() parses both value forms dhclient's own parser accepts for a byte-string option, since interfaces.inc can emit either: a quoted string (from dhcphostname, no RFC 2132 type byte) or a colon-hex byte list (reachable via adv_dhcp_send_options). Anything it can't confidently parse falls back to the MAC-derived type-1 form, which is what dhclient sends when told nothing.

Fixes: #3628

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:
Model used: Claude (Anthropic), via Claude Code — Sonnet and Opus across different phases of the work.
  - Extent of AI involvement: All code, the VM-lab test harness, and live packet-capture verification were
  performed by Claude Code agents. A human directed the work throughout — scoping the fix, deciding what to
  test, reviewing each verification pass, and deciding whether/how to submit — but did not hand-write the
  patch or test scripts.


