### PR TITLE
feat: Kea DHCPv6 - Hostwatch can be disabled

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Kea/forms/generalSettings6.xml
@@ -69,6 +69,13 @@
         <help>Automatically add a basic set of firewall rules to allow dhcp traffic, more fine grained controls can be offered manually when disabling this option.</help>
     </field>
     <field>
+        <id>dhcpv6.general.prefix_watcher_discover</id>
+        <label>Bypass Hostwatch (Force native NDP)</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Passes the --discover flag to the prefix watcher to disable Hostwatch data and force reliance on the kernel's native NDP tables. This prevents Kea from injecting PD routes on physical bridge members instead of the bridge interface itself.</help>
+    </field>
+    <field>
         <type>header</type>
         <label>Lease Expiration</label>
         <collapse>true</collapse>

--- a/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Kea/KeaDhcpv6.xml
@@ -43,6 +43,10 @@
                 <Required>Y</Required>
                 <Default>1</Default>
             </fwrules>
+            <prefix_watcher_discover type="BooleanField">
+                <default>0</default>
+                <Required>N</Required>
+            </prefix_watcher_discover>
         </general>
         <lexpire>
             <hold_reclaimed_time type="IntegerField">

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -39,9 +39,7 @@ from lib.kea_ctrl import KeaCtrl
 def use_ndp_discover():
     try:
         tree = xml.etree.ElementTree.parse('/conf/config.xml')
-        node = tree.find('./OPNsense/Kea/dhcp6/general/prefix_watcher_discover')
-        if node is not None and node.text == '1':
-            return True
+        return tree.find('./OPNsense/Kea/dhcp6/general/prefix_watcher_discover').text == '1'
     except Exception:
         pass
     return False

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -31,8 +31,20 @@ import time
 import ujson
 import subprocess
 import syslog
+import xml.etree.ElementTree
 
 from lib.kea_ctrl import KeaCtrl
+
+
+def use_ndp_discover():
+    try:
+        tree = xml.etree.ElementTree.parse('/conf/config.xml')
+        node = tree.find('./OPNsense/Kea/dhcp6/general/prefix_watcher_discover')
+        if node is not None and node.text == '1':
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def yield_lease_records(service='dhcp6', limit=256, poll_interval=10):
@@ -77,8 +89,13 @@ class Hostwatch:
     def reload(self):
         self._def_local_db.clear()
 
+        cmd = ['/usr/local/opnsense/scripts/interfaces/list_hosts.py', '--proto', 'inet6', '--ndp']
+
+        if use_ndp_discover():
+            cmd.append('--discover')
+
         out = subprocess.run(
-            ['/usr/local/opnsense/scripts/interfaces/list_hosts.py', '--proto', 'inet6', '--ndp'],
+            cmd,
             capture_output=True,
             text=True
         ).stdout


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

---

**Describe the problem**

Kea DHCPv6 Prefix Delegation route injection fails when operating on a bridged interface. The kea_prefix_watcher.py script relies on list_hosts.py, which uses Hostwatch data by default.

On a bridge setup, Hostwatch associates traffic with the underlying physical member interface rather than the logical bridge interface. As a result, list_hosts.py returns multiple conflicting entries, causing the prefix watcher to attempt injecting the PD route onto the physical interface instead of the bridge, which fails at the OS level.

---

**Describe the proposed solution**

Add an advanced configuration option in the GUI to bypass Hostwatch data and force reliance on NDP tables for prefix routing.

Changes:
1. **Model & Form**: Added a prefix_watcher_discover boolean field and exposed it as an advanced checkbox (Bypass Hostwatch) in the Kea DHCPv6 form.
2. **Script Logic**: Updated kea_prefix_watcher.py to read this new setting. If enabled, it appends the --discover flag when calling list_hosts.py.

---

**Related issue**

https://github.com/opnsense/core/issues/10677