### PR TITLE
fix (radvd): pref64 lifetime too low, causing CLAT dropouts

### DIFF
--- a/src/etc/inc/plugins.inc.d/radvd.inc
+++ b/src/etc/inc/plugins.inc.d/radvd.inc
@@ -306,6 +306,9 @@ function radvd_configure_do($verbose = false, $ignorelist = [])
 
         if (!$entry->nat64prefix->isEmpty()) {
             $radvdconf .= "    nat64prefix {$entry->nat64prefix->getValue()} {\n";
+            if (!$entry->AdvValidLifetime->isEmpty()) {
+                $radvdconf .= "        AdvValidLifetime {$entry->AdvValidLifetime->getValue()};\n";
+            }
             $radvdconf .= "    };\n";
         }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

the PREF64 lifetime doesn't follow `Valid Lifetime`, and with my configuration was only 16s (a scaled lifetime of 2) way lower then my valid or even preferred lifetime, and was causing the CLAT to drop out on my laptop

---

**Describe the proposed solution**

add `AdvValidLifetime` to the `nat64prefix` block
```
nat64prefix * {
    AdvValidLifetime 15000;
};
```

this fixes the scaled lifetime as verified by wireshark and despite being hard to find it's documented [here](https://github.com/radvd-project/radvd/blob/730e1c959b90f0c2f70e2854ac4e871f63822e03/radvd.conf.5.man#L832)

