### PR TITLE
menu: fix for Favorites entries navigation when sidebar collapsed

### DIFF
--- a/src/opnsense/www/js/opnsense_favorites.js
+++ b/src/opnsense/www/js/opnsense_favorites.js
@@ -68,6 +68,7 @@ $(document).ready(function () {
 
     $favPanel.on('click', '.list-group-item', function (e) {
         e.preventDefault();
+        if (!e.originalEvent) return;
         const cls = getRefClass($(this));
         if (cls) {
             $favPanel.collapse('hide');


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

With the menu sidebar collapsed to icons, hovering a Favorites entry instantly navigates to it, so you can't scroll the list. The collapsed sidebar simulates a click on hover (to open the submenu). Ordinary links ignore this because jQuery won't follow an href from a simulated click, but Favorites (given its different link/click handling) initiates a real native click on the underlying item. 

---

**Describe the proposed solution**

Ensure the handler ignores simulated hover-clicks and only acts on genuine clicks.

---

**Related issue**

If this pull request relates to an issue, link it here.
