### PR TITLE
Firewall: NAT: Destination NAT: Fix searchBase and import/export of nested containers

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/Api/DNatController.php
@@ -61,7 +61,17 @@ class DNatController extends FilterBaseController
             return empty($category) || array_intersect($catids, $category);
         };
 
-        $results =  $this->searchBase("rule", null, "sequence", $filter_funct);
+        $results = $this->searchBase(
+            "rule",
+            [
+                "uuid", "sequence", "interface", "ipprotocol", "protocol",
+                "source.network", "source.port", "destination.network", "destination.port",
+                "target", "local-port", "poolopts", "category", "descr",
+                "tag", "tagged", "natreflection", "pass"
+            ],
+            "sequence",
+            $filter_funct
+        );
         $configObj = Config::getInstance()->object();
 
         /* carry results */

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ArrayField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/ArrayField.php
@@ -289,9 +289,16 @@ class ArrayField extends BaseField
         $iterator =  $include_static ? $this->iterateItems() : parent::iterateItems();
         foreach ($iterator as $akey => $anode) {
             $record = [];
+            // XXX: flatten nested containers, same one level limitation as ArrayField::add()
             foreach ($anode->iterateItems() as $tag => $node) {
                 if (!in_array($tag, $exclude)) {
-                    $record[$tag] = (string)$node;
+                    if ($node->isContainer()) {
+                        foreach ($node->iterateItems() as $subtag => $subnode) {
+                            $record["{$tag}.{$subtag}"] = (string)$subnode;
+                        }
+                    } else {
+                        $record[$tag] = (string)$node;
+                    }
                 }
             }
             if (is_callable($callback)) {
@@ -376,9 +383,15 @@ class ArrayField extends BaseField
                 $results['updated'] += 1;
             }
             $results['uuids'][$node->getAttributes()['uuid']] = $idx;
+            // XXX: resolve flattened containers, same one level limitation as ArrayField::add()
             foreach ($record as $fieldname => $content) {
-                if (isset($node->$fieldname)) {
-                    $node->$fieldname = (string)$content;
+                $path = explode('.', $fieldname, 2);
+                if (isset($node->{$path[0]})) {
+                    if (isset($path[1]) && isset($node->{$path[0]}->{$path[1]})) {
+                        $node->{$path[0]}->{$path[1]} = (string)$content;
+                    } elseif (!isset($path[1])) {
+                        $node->{$path[0]} = (string)$content;
+                    }
                 }
             }
             if (is_callable($node_callback)) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.5
- Extent of AI involvement: Finding the issue in the ArrayField

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10691

The ArrayField change fixes the import/export issue for fields like ```destination.port```, but comments in ``ArrayField::add()`` state that only supporting a single level is something to be cleaned up, so not sure if adding more to that limitation is the right fix or just makes the issue worse.