### PR TITLE
Unbound: switch AAAA-only mode from respip to block_a_wdata

### DIFF
--- a/src/etc/inc/plugins.inc.d/unbound.inc
+++ b/src/etc/inc/plugins.inc.d/unbound.inc
@@ -213,8 +213,7 @@ function unbound_generate_config()
             $dns64_config .= "\ndns64-prefix: {$general['dns64prefix']}";
         }
         if (!empty($general['noarecords'])) {
-            $module_config .= 'respip ';
-            $dns64_config .= "\nresponse-ip: 0.0.0.0/0 redirect";
+            $dns64_config .= "\nlocal-zone: \".\" block_a_wdata";
         }
         $module_config .= 'dns64 ';
     }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: n/a
- Extent of AI involvement: n/a

---

**Describe the problem**

Unbound 1.25 broke OPNsense's AAAA-only mode, as described in #10312.

---

**Describe the proposed solution**

The previous implementation used the respip module to remove all IPv4 addresses (0.0.0.0/0) from responses.
The new implementation defines the root zone `.` as a local `block_a_wdata` zone, which removes all A records while remaining transparent for local data. This zone type was introduced in Unbound 1.26.0 as a direct response to this issue. https://github.com/upstream-main/unbound/commit/79e100a7fbb45bee3a409f2add927dbee563d35d

---

**Related issue**

Closes #10312.