### PR TITLE
Check all items are numeric before apply range to dnat automatic firewall rule

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -239,7 +239,9 @@ function filter_configure_sync($verbose = false, $load_aliases = true)
     }
 
     foreach ((new OPNsense\Firewall\DNat())->rule->sortedBy(['sequence']) as $key => $rule) {
-        $fw->registerForwardRule(600, $rule->getNodeContent());
+        $node = $rule->getNodeContent();
+        $node['local-port'] = $rule->{'local-port'}->normalizedPort();
+        $fw->registerForwardRule(600, $node);
     }
 
     /**

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -653,8 +653,13 @@ function filter_core_rules_system($fw, $defaults)
             if (!empty($dnatrule['destination']['port']) && !empty($dnatrule['local-port'])) {
                 $tmprule['destination']['port'] = $dnatrule['local-port'];
                 $parts = explode('-', $dnatrule['destination']['port']);
-                if (count($parts) == 2 && is_numeric($parts[0]) && is_numeric($parts[1]) && is_numeric($dnatrule['local-port'])) {
-                    $range_end = $parts[1] - $parts[0] + $dnatrule['local-port'];
+                if (count($parts) == 2 && is_numeric($parts[0]) && is_numeric($parts[1])) {
+                    $known = \OPNsense\Base\FieldTypes\PortField::getWellKnown($dnatrule['local-port']);
+                    if (!empty($known)) {
+                        $tmprule['destination']['port'] = array_shift($known);
+                    }
+
+                    $range_end = $parts[1] - $parts[0] + $tmprule['destination']['port'];
                     $tmprule['destination']['port'] .= sprintf('-%s', $range_end);
                 }
             } elseif (!empty($dnatrule['local-port'])) {

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -653,7 +653,7 @@ function filter_core_rules_system($fw, $defaults)
             if (!empty($dnatrule['destination']['port']) && !empty($dnatrule['local-port'])) {
                 $tmprule['destination']['port'] = $dnatrule['local-port'];
                 $parts = explode('-', $dnatrule['destination']['port']);
-                if (count($parts) == 2) {
+                if (count($parts) == 2 && is_numeric($parts[0]) && is_numeric($parts[1]) && is_numeric($dnatrule['local-port'])) {
                     $range_end = $parts[1] - $parts[0] + $dnatrule['local-port'];
                     $tmprule['destination']['port'] .= sprintf('-%s', $range_end);
                 }

--- a/src/etc/inc/filter.lib.inc
+++ b/src/etc/inc/filter.lib.inc
@@ -651,14 +651,10 @@ function filter_core_rules_system($fw, $defaults)
                 'descr' => $dnatrule['descr']
             ];
             if (!empty($dnatrule['destination']['port']) && !empty($dnatrule['local-port'])) {
-                $tmprule['destination']['port'] = $dnatrule['local-port'];
-                $parts = explode('-', $dnatrule['destination']['port']);
-                if (count($parts) == 2 && is_numeric($parts[0]) && is_numeric($parts[1])) {
-                    $known = \OPNsense\Base\FieldTypes\PortField::getWellKnown($dnatrule['local-port']);
-                    if (!empty($known)) {
-                        $tmprule['destination']['port'] = array_shift($known);
-                    }
+                $tmprule['destination']['port'] = $rule->{'local-port'}->normalizedPort();
 
+                $parts = explode('-', $rule->destination->port->normalizedPort());
+                if (count($parts) == 2) {
                     $range_end = $parts[1] - $parts[0] + $tmprule['destination']['port'];
                     $tmprule['destination']['port'] .= sprintf('-%s', $range_end);
                 }

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/ForwardRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/ForwardRule.php
@@ -139,11 +139,6 @@ class ForwardRule extends Rule
                 } elseif (Util::isPort($tmp['local-port'])) {
                     $tmp['localport'] = $tmp['local-port'];
                     if (!empty($tmp['to_port']) && strpos($tmp['to_port'], ':') !== false) {
-                        $known = PortField::getWellKnown($tmp['local-port']);
-                        if (!empty($known)) {
-                            $tmp['localport'] = $tmp['local-port'] = array_shift($known);
-                        }
-
                         $to_ports = explode(':', $tmp['to_port']);
                         $tmp['localport'] .= ':' . ($tmp['local-port'] + $to_ports[1] - $to_ports[0]);
                     }

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/ForwardRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/ForwardRule.php
@@ -139,6 +139,11 @@ class ForwardRule extends Rule
                 } elseif (Util::isPort($tmp['local-port'])) {
                     $tmp['localport'] = $tmp['local-port'];
                     if (!empty($tmp['to_port']) && strpos($tmp['to_port'], ':') !== false) {
+                        $known = PortField::getWellKnown($tmp['local-port']);
+                        if (!empty($known)) {
+                            $tmp['localport'] = $tmp['local-port'] = array_shift($known);
+                        }
+
                         $to_ports = explode(':', $tmp['to_port']);
                         $tmp['localport'] .= ':' . ($tmp['local-port'] + $to_ports[1] - $to_ports[0]);
                     }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -266,7 +266,7 @@ class PortField extends BaseListField
     /**
      * @return string
      */
-    function normalizedPort() {
+    public function normalizedPort() {
         $known = self::getWellKnown($this->getValue());
 
         if (!empty($known)) {

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -267,12 +267,12 @@ class PortField extends BaseListField
      * @return string
      */
     function normalizedPort() {
-        $known = self::getWellKnown((string)$this);
+        $known = self::getWellKnown($this->getValue());
 
         if (!empty($known)) {
             return array_shift($known);
         }
 
-        return (string)$this;
+        return $this->getValue();
     }
 }

--- a/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/PortField.php
@@ -262,4 +262,17 @@ class PortField extends BaseListField
         }
         return parent::getValidators();
     }
+
+    /**
+     * @return string
+     */
+    function normalizedPort() {
+        $known = self::getWellKnown((string)$this);
+
+        if (!empty($known)) {
+            return array_shift($known);
+        }
+
+        return (string)$this;
+    }
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.

---

**Describe the problem**

DNAT fails to apply when altering destination port and original destination port is a well known port containing a hypen AND rule is set to register a firewall rule.

---

**Describe the proposed solution**

Checks parts of the port range are all numbers before trying to do arithmetic.

---

**Related issue**

#10711