### PR TITLE
menu: fix Favorites star rendering

### DIFF
--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -284,10 +284,7 @@
         <header class="page-content-head">
           <div class="container-fluid">
             <ul class="list-inline">
-              <li><h1>{{title | default("")}}</h1></li>
-{% if menuSelectedUrl is defined and menuSelectedUrl != '' %}
-              <li><i class="menu-favorite-star {% if menuSelectedIsFavorite %}fa fa-star{% else %}fa fa-star-o{% endif %}" data-menu-url="{{ menuSelectedUrl | safe }}" data-toggle="tooltip" data-placement="bottom" title="{% if menuSelectedIsFavorite %}{{ lang._('Remove Favorite') }}{% else %}{{ lang._('Add Favorite') }}{% endif %}"></i></li>
-{% endif %}
+              <li><h1>{{title | default("")}}{% if menuSelectedUrl is defined and menuSelectedUrl != '' %}<i class="menu-favorite-star {% if menuSelectedIsFavorite %}fa fa-star{% else %}fa fa-star-o{% endif %}" data-menu-url="{{ menuSelectedUrl | safe }}" data-toggle="tooltip" data-container="body" data-placement="bottom" title="{% if menuSelectedIsFavorite %}{{ lang._('Remove Favorite') }}{% else %}{{ lang._('Add Favorite') }}{% endif %}"></i>{% endif %}</h1></li>
               <li class="btn-group-container" id="service_status_container"></li>
             </ul>
           </div>

--- a/src/opnsense/www/css/opnsense-favorites.css
+++ b/src/opnsense/www/css/opnsense-favorites.css
@@ -9,14 +9,8 @@
 
 .page-content-head .menu-favorite-star {
   font-size: 14px;
-  display: inline-block;
-}
-
-.page-content-head .list-inline {
-  display: flex;
-  align-items: center;
-}
-
-.page-content-head .list-inline > .btn-group-container {
-  margin-left: auto;
+  margin-left: 0.5em;
+  vertical-align: middle;
+  position: relative;
+  top: -0.1em;
 }

--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -173,10 +173,7 @@ $aclObj = new \OPNsense\Core\ACL();
     <header class="page-content-head">
       <div class="container-fluid">
         <ul class="list-inline">
-          <li><h1><?= html_safe(gentitle($menuBreadcrumbs)) ?></h1></li>
-<?php if (!empty($menuSelectedUrl)): ?>
-          <li><i class="menu-favorite-star <?= $menuSelectedIsFavorite ? 'fa fa-star' : 'fa fa-star-o' ?>" data-menu-url="<?= html_safe($menuSelectedUrl) ?>" data-toggle="tooltip" data-placement="bottom" title="<?= html_safe($menuSelectedIsFavorite ? gettext('Remove Favorite') : gettext('Add Favorite')) ?>"></i></li>
-<?php endif; ?>
+          <li><h1><?= html_safe(gentitle($menuBreadcrumbs)) ?><?php if (!empty($menuSelectedUrl)): ?><i class="menu-favorite-star <?= $menuSelectedIsFavorite ? 'fa fa-star' : 'fa fa-star-o' ?>" data-menu-url="<?= html_safe($menuSelectedUrl) ?>" data-toggle="tooltip" data-container="body" data-placement="bottom" title="<?= html_safe($menuSelectedIsFavorite ? gettext('Remove Favorite') : gettext('Add Favorite')) ?>"></i><?php endif; ?></h1></li>
           <li class="btn-group-container">
             <form method="post">
               <?php


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The previous PR looked terrible on mobile, particularly when the heading wraps on the screen. I suck at CSS.

---

**Describe the proposed solution**

This ensures the star always sticks at the end of the text.

---

**Related issue**

N/A