### PR TITLE
dashboard: truncate long service names in services widget

### DIFF
--- a/src/opnsense/www/js/widgets/Services.js
+++ b/src/opnsense/www/js/widgets/Services.js
@@ -89,7 +89,7 @@ export default class Services extends BaseTableWidget {
             }
 
             let $tile = $(`
-                <div class="flextable-row" style="padding: 0 10px 0 10px;"><div class="service-tile" style="display: flex; align-items: center;grid-column: -2 / -1;">
+                <div class="flextable-row" style="padding: 0 10px 0 10px;"><div class="service-tile" style="display: flex; align-items: center; min-width: 0; grid-column: -2 / -1;">
                     ${padSpan}${this.serviceControl(actions, statusColor)}
                     <div style="
                         padding: 4px;


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Claude (Anthropic)
- Extent of AI involvement: Assisted with rooting out cause. Change was verified and tested manually on a live 26.7.2_2 installation.

---

**Describe the problem**

Long service names in the Services dashboard widget overflow and render underneath adjacent services:
<img width="445" height="433" alt="Screenshot 2026-08-14 at 17 23 24" src="https://github.com/user-attachments/assets/07ad41a8-4145-428a-a4c7-a8e9fb1b9e43" />

The service name div already declares `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`, but it never engages: `.service-tile` is a flex item of `.flextable-row` (`display: flex` in dashboard.css), and its default `min-width: auto` prevents it shrinking below the nowrap text's min-content width. The tile therefore overflows its `minmax(200px, 1fr)` grid track and the inner div is never constrained.

---

**Describe the proposed solution**

Add `min-width: 0` to the `.service-tile` inline style, allowing the tile to shrink to its grid track so the existing ellipsis styling takes effect. Long names now truncate; the full name remains available via the existing tooltip.
Verified on OPNsense 26.7.2_2.
<img width="445" height="440" alt="Screenshot 2026-08-14 at 17 47 36" src="https://github.com/user-attachments/assets/12063170-9399-44cc-8fd7-567bb027fa95" />

---

**Related issue**

n/a
