### PR TITLE
menu: hide Favorites star unless title area hovered/tapped

### DIFF
--- a/src/opnsense/mvc/app/views/layouts/default.volt
+++ b/src/opnsense/mvc/app/views/layouts/default.volt
@@ -284,7 +284,7 @@
         <header class="page-content-head">
           <div class="container-fluid">
             <ul class="list-inline">
-              <li><h1>{{title | default("")}}{% if menuSelectedUrl is defined and menuSelectedUrl != '' %}<i class="menu-favorite-star {% if menuSelectedIsFavorite %}fa fa-star{% else %}fa fa-star-o{% endif %}" data-menu-url="{{ menuSelectedUrl | safe }}" data-toggle="tooltip" data-container="body" data-placement="bottom" title="{% if menuSelectedIsFavorite %}{{ lang._('Remove Favorite') }}{% else %}{{ lang._('Add Favorite') }}{% endif %}"></i>{% endif %}</h1></li>
+              <li><h1{% if menuSelectedUrl is defined and menuSelectedUrl != '' %} tabindex="-1"{% endif %}>{{title | default("")}}{% if menuSelectedUrl is defined and menuSelectedUrl != '' %}<i class="menu-favorite-star {% if menuSelectedIsFavorite %}fa fa-star{% else %}fa fa-star-o{% endif %}" data-menu-url="{{ menuSelectedUrl | safe }}" data-toggle="tooltip" data-container="body" data-placement="bottom" title="{% if menuSelectedIsFavorite %}{{ lang._('Remove Favorite') }}{% else %}{{ lang._('Add Favorite') }}{% endif %}"></i>{% endif %}</h1></li>
               <li class="btn-group-container" id="service_status_container"></li>
             </ul>
           </div>

--- a/src/opnsense/www/css/opnsense-favorites.css
+++ b/src/opnsense/www/css/opnsense-favorites.css
@@ -13,4 +13,20 @@
   vertical-align: middle;
   position: relative;
   top: -0.1em;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.page-content-head h1:hover .menu-favorite-star {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .page-content-head h1:focus-within .menu-favorite-star {
+    opacity: 1;
+  }
+}
+
+.page-content-head h1:focus {
+  outline: none;
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Some concern has been expressed that moving the Favorites star on each leaf page to just after the title, rather than at the right-hand side, means it is too prominent and potentially annoying for some users.

---

**Describe the proposed solution**

Hide the star unless the title/star area is hovered over (or tapped on touch devices).

Desktop:

https://github.com/user-attachments/assets/f48a9e6a-e892-4cea-bf8a-c6e1f361ee90

Mobile:

https://github.com/user-attachments/assets/05772c53-fa30-4783-8120-0a669cc7644e



---

**Related issue**

N/A