### PR TITLE
menu: make legacy pages consistent for Favorites on touch devices

### DIFF
--- a/src/www/fbegin.inc
+++ b/src/www/fbegin.inc
@@ -173,7 +173,7 @@ $aclObj = new \OPNsense\Core\ACL();
     <header class="page-content-head">
       <div class="container-fluid">
         <ul class="list-inline">
-          <li><h1><?= html_safe(gentitle($menuBreadcrumbs)) ?><?php if (!empty($menuSelectedUrl)): ?><i class="menu-favorite-star <?= $menuSelectedIsFavorite ? 'fa fa-star' : 'fa fa-star-o' ?>" data-menu-url="<?= html_safe($menuSelectedUrl) ?>" data-toggle="tooltip" data-container="body" data-placement="bottom" title="<?= html_safe($menuSelectedIsFavorite ? gettext('Remove Favorite') : gettext('Add Favorite')) ?>"></i><?php endif; ?></h1></li>
+          <li><h1<?php if (!empty($menuSelectedUrl)): ?> tabindex="-1"<?php endif; ?>><?= html_safe(gentitle($menuBreadcrumbs)) ?><?php if (!empty($menuSelectedUrl)): ?><i class="menu-favorite-star <?= $menuSelectedIsFavorite ? 'fa fa-star' : 'fa fa-star-o' ?>" data-menu-url="<?= html_safe($menuSelectedUrl) ?>" data-toggle="tooltip" data-container="body" data-placement="bottom" title="<?= html_safe($menuSelectedIsFavorite ? gettext('Remove Favorite') : gettext('Add Favorite')) ?>"></i><?php endif; ?></h1></li>
           <li class="btn-group-container">
             <form method="post">
               <?php


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Missed legacy pages being made consistent in #10718 . Sorry.

---

**Describe the proposed solution**

Make consistent.

---

**Related issue**

N/A