### PR TITLE
Interfaces: Assignments - add interface configuration settings in new assignments page

### DIFF
--- a/plist
+++ b/plist
@@ -830,10 +830,12 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/BridgeMemberField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/DUIDField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/DeviceField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/GatewayField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/IfDescField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/LaggInterfaceField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/LinkAddressField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NeighborField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VipField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VipInterfaceField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VipNetworkField.php

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
@@ -154,8 +154,22 @@ class AssignmentController extends ApiMutableModelControllerBase
                     if ($props['pending_action'] == 'delete') {
                         $this->cleanRules($key); /* remove associated rules */
                         unset(Config::getInstance()->object()->interfaces->$key);
-                    } elseif ($props['pending_action'] == 'relink') {
-                        Config::getInstance()->object()->interfaces->$key->if = $props['pending_if'];
+                    } else {
+                        /* update pending changes */
+                        $pending = $this->getModel()->interface->$key?->toLegacy() ?? [];
+                        foreach ($pending as $akey => $avalue) {
+                            if ($avalue !== '') {
+                                Config::getInstance()->object()->interfaces->$key->$akey = $avalue;
+                            } elseif (isset(Config::getInstance()->object()->interfaces->$key->$akey)) {
+                                unset(Config::getInstance()->object()->interfaces->$key->$akey);
+                            }
+
+                        }
+                        foreach (['enable', 'lock'] as $legacybool) {
+                            if (empty($pending[$legacybool])) {
+                                unset(Config::getInstance()->object()->interfaces->$key->$legacybool);
+                            }
+                        }
                     }
                 }
                 Config::getInstance()->save();

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
@@ -1,5 +1,9 @@
 <form>
     <field>
+        <type>header</type>
+        <label>Basic configuration</label>
+    </field>
+    <field>
         <id>interface.icon</id>
         <label>Status</label>
         <type>ignore</type>
@@ -13,6 +17,17 @@
         <label>Identifier</label>
         <type>info</type>
         <help>Technical identifier of the interface, used by hasync for example.</help>
+    </field>
+    <field>
+        <id>interface.enable</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>Enable this interface.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>interface.lock</id>
@@ -40,9 +55,417 @@
         </grid_view>
     </field>
     <field>
+        <type>header</type>
+        <label>Device configuration</label>
+    </field>
+    <field>
         <id>interface.if</id>
         <label>Device</label>
         <type>dropdown</type>
         <help>Device name to connect this interface to.</help>
+    </field>
+    <field>
+        <id>interface.promisc</id>
+        <label>Promiscuous mode</label>
+        <type>checkbox</type>
+        <help>Put interface into permanently promiscuous mode. Only to be used for specific usecases requiring the interface to receive all packets being received. When unsure, leave this disabled.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.mtu</id>
+        <label>MTU</label>
+        <type>text</type>
+        <help>If you leave this field blank, the adapter's default MTU will be used. This is typically 1500 bytes but can vary in some circumstances.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.mss</id>
+        <label>MSS</label>
+        <type>text</type>
+        <help>If you enter a value in this field, then MSS clamping for TCP connections to the value entered above minus 40 (IPv4) or 60 (IPv6) will be in effect (TCP/IP header size).</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Generic configuration</label>
+    </field>
+    <field>
+        <id>interface.blockpriv</id>
+        <label>Block private networks</label>
+        <type>checkbox</type>
+        <help>When set, this option blocks traffic from IP addresses that are reserved for private networks as per RFC 1918 as well as loopback, link-local and Carrier-grade NAT addresses. This option should only be set for WAN interfaces that use the public IP address space.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.blockbogons</id>
+        <label>Block bogon networks</label>
+        <type>checkbox</type>
+        <help>When set, this option blocks traffic from IP addresses that are reserved (but not RFC 1918) or not yet assigned by IANA. Bogons are prefixes that should never appear in the Internet routing table, and obviously should not appear as the source address in any packets you receive.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Address configuration [IPv4]</label>
+    </field>
+    <field>
+        <id>interface.type4</id>
+        <label>IPv4 Configuration Type</label>
+        <type>dropdown</type>
+        <style>selectpicker ipoption</style>
+        <help>The primary type for this interface for IPv4 communication.</help>
+        <grid_view>
+            <label>IPv4</label>
+            <formatter>ipv4typeformatter</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.ipaddr</id>
+        <label>IPv4 address</label>
+        <type>text</type>
+        <hint>192.168.1.1/24</hint>
+        <style>type4 type4_staticv4</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.alias-address</id>
+        <label>Alias IPv4 address</label>
+        <type>text</type>
+        <style>type4 type4_dhcp</style>
+        <help>The value in this field is used as a fixed alias IPv4 address by the DHCP client.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.alias-subnet</id>
+        <label>Alias IPv4 subnet mask</label>
+        <type>text</type>
+        <style>type4 type4_dhcp</style>
+        <help>The value in this field is used as a fixed alias IPv4 subnet by the DHCP client.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcprejectfrom</id>
+        <label>Reject Leases From</label>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <style>tokenize type4 type4_dhcp</style>
+        <help>If there are certain upstream DHCP servers that should be ignored, place the comma separated list of IP addresses of the DHCP servers to be ignored here. This is useful for rejecting leases from cable modems that offer private IPs when they lose upstream sync.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcphostname</id>
+        <label>Hostname</label>
+        <type>text</type>
+        <style>type4 type4_dhcp</style>
+        <help>The value in this field is sent as the DHCP client identifier and hostname when requesting a DHCP lease. Some ISPs may require this (for client identification).</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcphonourmtu</id>
+        <label>Honour MTU</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <style>type4 type4_dhcp</style>
+        <help>An ISP may incorrectly set an MTU value which can cause intermittent network disruption. By default this value will be ignored. Setting this option will allow to apply the MTU supplied by the ISP instead.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcpvlanprio</id>
+        <label>Use VLAN priority</label>
+        <type>dropdown</type>
+        <style>type4 type4_dhcp</style>
+        <help>Certain ISPs may require that DHCPv4 requests are sent with a specific VLAN priority.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Address configuration [IPv6]</label>
+    </field>
+    <field>
+        <id>interface.type6</id>
+        <label>IPv6 Configuration Type</label>
+        <type>dropdown</type>
+        <style>selectpicker ipoption</style>
+        <help>The primary type for this interface for IPv6 communication.</help>
+        <grid_view>
+            <label>IPv6</label>
+            <formatter>ipv6typeformatter</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.ipaddrv6</id>
+        <label>IPv6 address</label>
+        <type>text</type>
+        <hint>dead::beef/24</hint>
+        <style>type6 type6_staticv6</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>interface.dhcp6vlanprio</id>
+        <label>Use VLAN priority</label>
+        <type>dropdown</type>
+        <style>type6 type6_dhcp6</style>
+        <help>Certain ISPs may require that DHCPv6 requests are sent with a specific VLAN priority.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6-ia-pd-len</id>
+        <label>Prefix delegation size</label>
+        <type>text</type>
+        <style>type6 type6_dhcp6</style>
+        <help>The value in this field is the delegated prefix length provided by the DHCPv6 server.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6prefixonly</id>
+        <label>Request prefix only</label>
+        <type>checkbox</type>
+        <style>type6 type6_dhcp6</style>
+        <help>Only request an IPv6 prefix; do not request an IPv6 address.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_request_dns</id>
+        <label>Request DNS configuration</label>
+        <type>checkbox</type>
+        <style>type6 type6_dhcp6</style>
+        <help>Request DNS configuration from the server.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6-ia-pd-send-hint</id>
+        <label>Send prefix hint</label>
+        <type>checkbox</type>
+        <style>type6 type6_dhcp6</style>
+        <help>Send an IPv6 prefix hint to indicate the desired prefix size for delegation</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_rapid_commit</id>
+        <label>Send rapid commit</label>
+        <type>checkbox</type>
+        <style>type6 type6_dhcp6</style>
+        <help>Send a rapid-commit option in solicit messages and wait for an immediate reply instead of advertisements.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6-prefix-id</id>
+        <label>Optional prefix ID</label>
+        <hint>0x9</hint>
+        <type>text</type>
+        <style>type6 type6_dhcp6</style>
+        <help>The value in this field is the delegated hexadecimal IPv6 prefix ID. This determines the configurable /64 network ID based on the dynamic IPv6 connection.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_ifid</id>
+        <label>Optional interface ID</label>
+        <hint>0xfff</hint>
+        <type>text</type>
+        <style>type6 type6_dhcp6</style>
+        <help>The value in this field is the numeric IPv6 interface ID used to construct the lower part of the resulting IPv6 prefix address. Setting a hex value will use that fixed value in its lower address part. Please note the maximum usable value is 0x7fffffffffffffff due to a PHP integer restriction.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_assoc_pd</id>
+        <label>Optional prefix IAID</label>
+        <type>text</type>
+        <help>The ID to use for prefix request identity association if required to be non-standard.</help>
+        <style>type6 type6_dhcp6</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.prefix-6rd</id>
+        <label>6RD prefix</label>
+        <type>text</type>
+        <style>type6 type6_6rd</style>
+        <hint>2001:db8::/32</hint>
+        <help>The value in this field is the 6RD IPv6 prefix assigned by your ISP. e.g. '2001:db8::/32'</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.gateway-6rd</id>
+        <label>6RD Border Relay</label>
+        <type>text</type>
+        <style>type6 type6_6rd</style>
+        <help>The value in this field is 6RD IPv4 gateway address assigned by your ISP</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.prefix-6rd-v4plen</id>
+        <label>6RD IPv4 Prefix length</label>
+        <type>text</type>
+        <style>type6 type6_6rd</style>
+        <help>The value in this field is the 6RD IPv4 prefix length. A value of 0 means we embed the entire IPv4 address in the 6RD prefix.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.prefix-6rd-v4addr</id>
+        <label> 6RD IPv4 Prefix address</label>
+        <type>text</type>
+        <style>type6 type6_6rd</style>
+        <help>The value in this field is the 6RD IPv4 prefix address. Optionally overrides the automatic detection.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.track6-interface</id>
+        <label>Parent interface</label>
+        <type>dropdown</type>
+        <style>selectpicker type6 type6_track6 type6_idassoc6</style>
+        <help>This selects the dynamic IPv6 WAN interface to track for configuration.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.track6-prefix-id</id>
+        <label>Assign prefix ID</label>
+        <type>text</type>
+        <hint>0x9</hint>
+        <style>type6 type6_track6 type6_idassoc6</style>
+        <help>The value in this field is the delegated hexadecimal IPv6 prefix ID. This determines the configurable /64 network ID based on the dynamic IPv6 connection.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.track6_prefix_range</id>
+        <label>Reserved prefix range</label>
+        <type>text</type>
+        <style>type6 type6_track6 type6_idassoc6</style>
+        <help>The value in this field is the length of the reserved prefix range for downstream prefix delegation. The range starts at the given prefix ID. The default is to only reserve the given prefix ID.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.track6_ifid</id>
+        <label>Optional interface ID</label>
+        <type>text</type>
+        <hint>0xfff</hint>
+        <style>type6 type6_track6 type6_idassoc6</style>
+        <help>The value in this field is the numeric IPv6 interface ID used to construct the lower part of the resulting IPv6 prefix address. Setting a hex value will use that fixed value in its lower address part. Please note the maximum usable value is 0x7fffffffffffffff due to a PHP integer restriction.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.track6_assoc_pd</id>
+        <label>Optional prefix IAID</label>
+        <type>text</type>
+        <style>type6 type6_track6 type6_idassoc6</style>
+        <help>The ID to use for prefix request identity association if required to be non-standard.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcpd6track6allowoverride</id>
+        <label>Manual configuration</label>
+        <type>checkbox</type>
+        <style>type6 type6_track6 type6_idassoc6</style>
+        <help>If this option is set, you will be able to manually set the DHCPv6 and Router Advertisements service for this interface. Use with care.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Gateway configuration</label>
+    </field>
+    <field>
+        <id>interface.gateway_interface</id>
+        <label>Dynamic gateway policy</label>
+        <type>checkbox</type>
+        <help>If the destination is directly reachable via an interface requiring no intermediary system to act as a gateway, you can select this option which allows dynamic gateways to be created without direct target addresses. Some tunnel types support this.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.gateway</id>
+        <label>IPv4 gateway rules</label>
+        <type>dropdown</type>
+        <style>selectpicker type4 type4_staticv4</style>
+        <help>Select a gateway from the list to reply the incoming packets to the proper next hop on their way back and apply source NAT when configured. This is typically disabled for LAN type interfaces.</help>
+    </field>
+    <field>
+        <id>interface.gatewayv6</id>
+        <label>IPv6 gateway rules</label>
+        <type>dropdown</type>
+        <style>selectpicker type6 type6_staticv6</style>
+        <help>Select a gateway from the list to reply the incoming packets to the proper next hop on their way back. This is typically disabled for LAN type interfaces.</help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/GatewayField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/GatewayField.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Routing\Gateways;
+
+
+class GatewayField extends BaseListField
+{
+    protected $protocol = 'inet';
+    private static $gateways = [];
+
+    protected function actionPostLoadingEvent()
+    {
+        if (empty(self::$gateways)) {
+            foreach ((new Gateways())->gatewayIterator() as $gateway) {
+                if (!isset(self::$gateways[$gateway['ipprotocol']])) {
+                    self::$gateways[$gateway['ipprotocol']] = [];
+                }
+                self::$gateways[$gateway['ipprotocol']][$gateway['name']] = $gateway['name'];
+            }
+        }
+        $this->internalOptionList = self::$gateways[$this->protocol] ?? [];
+        return parent::actionPostLoadingEvent();
+    }
+
+    public function setProtocol($value)
+    {
+        $this->protocol = $value;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\ArrayField;
+use OPNsense\Base\FieldTypes\BooleanField;
+use OPNsense\Base\FieldTypes\ContainerField;
+use OPNsense\Core\Config;
+use OPNsense\Firewall\Util;
+
+class NetworkInterfaceContainerField extends ContainerField
+{
+    static $pppDevices = null;
+
+    public function toLegacy()
+    {
+        $result = [];
+        if ($this->type4->isEqual('staticv4')) {
+            $result['ipaddr'] = explode('/', $this->ipaddr->getValue())[0];
+            $result['subnet'] = explode('/', $this->ipaddr->getValue())[1];
+        } else {
+            $result['ipaddr'] = $this->type4->getValue();
+        }
+        if ($this->type6->isEqual('staticv6')) {
+            $result['ipaddrv6'] = explode('/', $this->ipaddrv6->getValue())[0];
+            $result['subnetv6'] = explode('/', $this->ipaddrv6->getValue())[1];
+        } else {
+            $result['ipaddrv6'] = $this->type6->getValue();
+        }
+        /* standard copy->paste */
+        $skiplist = [
+            'type6',
+            'type4',
+            'ipaddr',
+            'ipaddrv6',
+            'identifier',
+            'pending_action',
+            'icon',
+            'optgroup',
+            'dhcp6_request_dns',
+            'dhcp6-prefix-id',
+            'dhcp6_ifid'
+        ];
+        foreach ($this->iterateItems() as $key => $node) {
+            if (in_array($key, $skiplist)) {
+                continue; /* skip otherwise processed */
+            }
+            $result[$key] = $node->getValue();
+        }
+        $result['dhcp6_norequest_dns'] = $this->dhcp6_request_dns->isEmpty() ? '1' : '0';
+        foreach (['dhcp6-prefix-id', 'dhcp6_ifid', 'track6-prefix-id', 'track6_ifid'] as $fld) {
+            if (!$this->$fld->isEmpty()) {
+                $result[$fld] = intval($this->$fld->getValue(), 16);
+            }
+        }
+        return $result;
+    }
+
+    public function fromLegacy($data)
+    {
+        foreach ($this->iterateItems() as $key => $node) {
+            if ($node instanceof BooleanField) {
+                $this->$key = empty($data[$key]) ? '0' : '1';
+            } elseif (in_array($key, ['ipaddr', 'ipaddrv6'])) {
+                /* ignore addresses, processed below, only ensure fields exist */
+                $data[$key] = !empty($data[$key]) ? $data[$key] : '';
+            } elseif (isset($data[$key])) {
+                $this->$key = $data[$key];
+            }
+        }
+        $this->type4 = Util::isIpv4Address($data['ipaddr']) ? 'staticv4' : $data['ipaddr'];
+        $this->type6 = Util::isIpv6Address($data['ipaddrv6']) ? 'staticv6' : $data['ipaddrv6'];
+        if (Util::isIpv4Address($data['ipaddr'])) {
+            $this->ipaddr = $data['ipaddr'] . '/' . $data['subnet'];
+        }
+        if (Util::isIpv6Address($data['ipaddrv6'])) {
+            $this->ipaddrv6 = $data['ipaddrv6'] . '/' . $data['subnetv6'];
+        }
+        $this->dhcp6_request_dns = empty($data['dhcp6_norequest_dns']) ? '1' : '0';
+        foreach (['dhcp6-prefix-id', 'dhcp6_ifid', 'track6-prefix-id', 'track6_ifid'] as $fld) {
+            if (!empty($data[$fld])) {
+                $this->$fld = sprintf("0x%x", $data[$fld]);
+            }
+        }
+    }
+
+    /**
+     * PPP interfaces should be constraint to their configured type
+     */
+    public function pppType()
+    {
+        if (self::$pppDevices === null) {
+            self::$pppDevices = [];
+            foreach (Config::getInstance()->object()->ppps->children() as $intf) {
+                if (!empty((string)$intf->if)) {
+                    self::$pppDevices[(string)$intf->if] = (string)$intf->type;
+                }
+            }
+        }
+
+        if (isset(self::$pppDevices[$this->if->getValue()])) {
+            return self::$pppDevices[$this->if->getValue()];
+        }
+        return null;
+    }
+}
+
+
+class NetworkInterfaceField extends ArrayField
+{
+    /**
+     * @inheritDoc
+     */
+    public function newContainerField($ref, $tagname)
+    {
+        $container_node = new NetworkInterfaceContainerField($ref, $tagname);
+        $pmodel = $this->getParentModel();
+        $container_node->setParentModel($pmodel);
+        return $container_node;
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -29,9 +29,12 @@
 namespace OPNsense\Interfaces;
 
 use OPNsense\Base\BaseModel;
+use OPNsense\Base\FieldTypes\BooleanField;
 use OPNsense\Base\Messages\Message;
 use OPNsense\Core\Config;
 use OPNsense\Core\FileObject;
+use OPNsense\Routing\Gateways;
+
 
 class NetworkInterface extends BaseModel
 {
@@ -97,14 +100,16 @@ class NetworkInterface extends BaseModel
                 continue;
             }
             $node = $this->interface->add($key);
-            $node->descr = (string)$intf->descr;
             $node->identifier = $key;
-            $node->lock = empty((string)$intf->lock) ? '0' : '1';
-            if (isset($iftodo['pending_if'])) {
-                $node->if = $iftodo['pending_if'];
-            } else {
-                $node->if = (string)$intf->if;
+            $node->pending_action = $iftodo['pending_action'] ?? '';
+            $data = !empty($iftodo['pending']) ? $iftodo['pending'] : [];
+            if (empty($data)) {
+                /* just copy all legacy formatted data in, we're only mapping what we need */
+                foreach ($intf as $akey => $ifvalue) {
+                    $data[$akey] = (string)$ifvalue;
+                }
             }
+            $node->fromLegacy($data); /* map the data */
         }
     }
 
@@ -123,10 +128,30 @@ class NetworkInterface extends BaseModel
                 $this->store_if_todo($key, ['pending_action' => 'delete']);
             } else {
                 $intf->descr = $interfaces[$key]['descr'];
-                $intf->lock = $interfaces[$key]['lock'];
-                /* flush actions that need to be applied, for which we need history */
+                /* flush actions that need to be applied, for which we need history (config reflects running config) */
+                $todo = [
+                    'pending' => $this->interface->$key->toLegacy(),
+                    'pending_action' => 'update'
+                ];
+                $changed = false;
                 if ($intf->if != $interfaces[$key]['if']) {
-                    $this->store_if_todo($key, ['pending_action' => 'relink', 'pending_if' => $interfaces[$key]['if']]);
+                    $todo['pending_action'] = 'relink';
+                }
+                foreach ($todo['pending'] as $prop => $value) {
+                    if ($prop === 'dhcp6_norequest_dns' && !isset($intf->$prop)) {
+                        $curval = '0'; /* actually stored as dhcp6_request_dns in our model */
+                    } elseif (!isset($intf->$prop)) {
+                        $curval = $this->interface->$key->$prop instanceof BooleanField  ? '0' : '';
+                    } else {
+                        $curval = $intf->$prop;
+                    }
+                    if ($curval != $value) {
+                        $changed = true;
+                        break;
+                    }
+                }
+                if ($changed) {
+                    $this->store_if_todo($key, $todo);
                 }
             }
             $existing_ifnames[] = $key;
@@ -139,16 +164,24 @@ class NetworkInterface extends BaseModel
         foreach ($interfaces as $key => $intf) {
             $newIdentifier = 'opt' . $next_if;
             if (!isset(Config::getInstance()->object()->interfaces->$key)) {
+                /* register anchor with description, the rest of the data is stored in pending */
                 $newif = Config::getInstance()->object()->interfaces->addChild($newIdentifier);
                 $newif->if = $intf['if'];
                 $newif->descr = $intf['descr'];
-                $newif->lock = $intf['lock'];
                 $next_if++;
 
-                /* We want the node to return the new network identifier as the uuid not
-                the internal random generated uuid by the ArrayField.
-                Assignments use identifier as the uuid in the config.xml */
-                $this->getNodeByReference('interface.' . $key)?->setAttributeValue('uuid', $newIdentifier);
+                $node = $this->interface->$key;
+                if ($node !== null) {
+                    $this->store_if_todo($newIdentifier, [
+                        'pending' => $node->toLegacy(),
+                        'pending_action' => 'update'
+                    ]);
+
+                    /* We want the node to return the new network identifier as the uuid not
+                    the internal random generated uuid by the ArrayField.
+                    Assignments use identifier as the uuid in the config.xml */
+                    $node->setAttributeValue('uuid', $newIdentifier);
+                }
             }
         }
         return true;
@@ -157,6 +190,7 @@ class NetworkInterface extends BaseModel
     public function performValidation($validateFullModel = false)
     {
         $messages = parent::performValidation($validateFullModel);
+        $gateways = new Gateways();
         foreach ($this->interface->iterateItems() as $ifname => $if) {
             if (!$validateFullModel && !$if->isFieldChanged()) {
                 continue;
@@ -172,6 +206,74 @@ class NetworkInterface extends BaseModel
                         );
                         $messages->appendMessage(new Message($msg, $key . ".if"));
                     }
+                }
+            }
+            if ($if->type4->isEqual('staticv4')) {
+                if ($if->ipaddr->isEmpty()) {
+                    $messages->appendMessage(new Message(
+                        gettext('An address is required when configuring static mode'),
+                        $key . ".ipaddr"
+                    ));
+                }
+                if (!$if->gateway->isEmpty() && $gateways->getInterfaceName($if->gateway->getValue()) != $ifname) {
+                    $messages->appendMessage(new Message(
+                        gettext('This gateway belongs to a different interface.'),
+                        $key . ".gateway"
+                    ));
+                }
+            }
+            if (!empty($if->pppType()) && !in_array($if->type4->getValue(), ['none', $if->pppType()])) {
+                $messages->appendMessage(new Message(
+                    sprintf(gettext('This device only supports "%s" as type'), $if->pppType()),
+                    $key . ".type4"
+                ));
+            } elseif (empty($if->pppType()) && in_array($if->type4->getValue(), ['ppp', 'pppoe', 'pptp', 'l2tp'])) {
+                $messages->appendMessage(new Message(
+                    gettext('PPP types belong to their respective devices'),
+                    $key . ".type4"
+                ));
+            }
+            if (!empty($if->pppType()) && !in_array($if->type6->getValue(), ['none', 'pppoev6'])) {
+                $messages->appendMessage(new Message(
+                    sprintf(gettext('This device only supports "%s" as type'), 'pppoev6'),
+                    $key . ".type6"
+                ));
+            } elseif (empty($if->pppType()) && in_array($if->type6->getValue(), ['pppoev6'])) {
+                $messages->appendMessage(new Message(
+                    gettext('PPP types belong to their respective devices'),
+                    $key . ".type6"
+                ));
+            }
+
+            if ($if->type6->isEqual('dhcp6')) {
+                $pdlen = $if->{'dhcp6-ia-pd-len'}->getValue();
+                $ipv6_num_prefix_ids = $pdlen < 0 ? 0 : pow(2, $pdlen);
+                $dhcp6_prefix_id = intval($if->{'dhcp6-prefix-id'}->getValue(), 16);
+                if ($dhcp6_prefix_id < 0 || $dhcp6_prefix_id >= $ipv6_num_prefix_ids) {
+                    $messages->appendMessage(new Message(
+                        gettext('You specified an IPv6 prefix ID that is out of range.'),
+                        $key . ".dhcp6-prefix-id"
+                    ));
+                }
+            } elseif ($if->type6->isEqual('idassoc6') || $if->type6->isEqual('track6')) {
+                if ($if->{'track6-interface'}->isEmpty()) {
+                    $messages->appendMessage(new Message(
+                        gettext('A parent interface is required for this type.'),
+                        $key . ".track6-interface"
+                    ));
+                }
+            } elseif ($if->type6->isEqual('staticv6')) {
+                if ($if->ipaddrv6->isEmpty()) {
+                    $messages->appendMessage(new Message(
+                        gettext('An address is required when configuring static mode'),
+                        $key . ".ipaddrv6"
+                    ));
+                }
+                if (!$if->gatewayv6->isEmpty() && $gateways->getInterfaceName($if->gatewayv6->getValue()) != $ifname) {
+                    $messages->appendMessage(new Message(
+                        gettext('This gateway belongs to a different interface.'),
+                        $key . ".gatewayv6"
+                    ));
                 }
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -3,11 +3,12 @@
     <version>0.0.1</version>
     <description>Interface assignments</description>
     <items>
-        <interface type="ArrayField">
+        <interface type=".\NetworkInterfaceField">
             <descr type=".\IfDescField">
                 <Mask>/^[a-z_0-9]{0,255}$/i</Mask>
             </descr>
             <identifier type="TextField"/>
+            <pending_action type="TextField"/>
             <!-- backref from if field, read-only data -->
             <icon type="TextField" volatile="true"/>
             <optgroup type="TextField" volatile="true"/>
@@ -24,6 +25,180 @@
                 <Default>1</Default>
                 <Required>Y</Required>
             </lock>
+            <enable type="BooleanField">
+                <Default>1</Default>
+                <Required>Y</Required>
+            </enable>
+            <blockpriv type="BooleanField"/>
+            <blockbogons type="BooleanField"/>
+            <promisc type="BooleanField"/>
+            <gateway_interface type="BooleanField"/>
+            <mtu type="IntegerField">
+                <MinimumValue>576</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+                <ValidationMessage>The MTU must be greater than 576 bytes and less than 65535.</ValidationMessage>
+            </mtu>
+            <mss type="IntegerField">
+                <MinimumValue>576</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+                <ValidationMessage>The MSS must be greater than 576 bytes.</ValidationMessage>
+            </mss>
+            <type4 type="OptionField">
+                <Required>Y</Required>
+                <Default>none</Default>
+                <OptionValues>
+                    <none>None</none>
+                    <staticv4>Static IPv4</staticv4>
+                    <dhcp>DHCP</dhcp>
+                    <!-- Require PPP type-->
+                    <ppp>PPP</ppp>
+                    <pppoe>PPPoE</pppoe>
+                    <pptp>PPTP</pptp>
+                    <l2tp>L2TP</l2tp>
+                </OptionValues>
+            </type4>
+            <type6 type="OptionField">
+                <Required>Y</Required>
+                <Default>none</Default>
+                <OptionValues>
+                    <none>None</none>
+                    <staticv6>Static IPv6</staticv6>
+                    <dhcp6>DHCPv6</dhcp6>
+                    <linklocal>Link-local</linklocal>
+                    <slaac>SLAAC</slaac>
+                    <_6rd value="6rd">6rd Tunnel</_6rd>
+                    <_6to4 value="6to4">6to4 Tunnel</_6to4>
+                    <idassoc6>Identity association</idassoc6>
+                    <track6>Track Interface (legacy)</track6>
+                    <!-- Require PPP type-->
+                    <pppoev6>PPPoEv6</pppoev6>
+                </OptionValues>
+            </type6>
+            <ipaddr type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskRequired>Y</NetMaskRequired>
+            </ipaddr>
+            <ipaddrv6 type="NetworkField">
+                <AddressFamily>ipv6</AddressFamily>
+                <NetMaskRequired>Y</NetMaskRequired>
+            </ipaddrv6>
+            <!-- DHCPv4 client settings-->
+            <alias-address type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+            </alias-address>
+            <alias-subnet type="IntegerField">
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>32</MaximumValue>
+                <ValidationMessage>A valid IPv4 CIDR must be provided.</ValidationMessage>
+            </alias-subnet>
+            <dhcprejectfrom type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <AsList>Y</AsList>
+            </dhcprejectfrom>
+            <dhcphostname type="HostnameField">
+                <IsDNSName>Y</IsDNSName>
+                <IpAllowed>N</IpAllowed>
+            </dhcphostname>
+            <dhcphonourmtu type="BooleanField"/>
+            <dhcpvlanprio type="OptionField">
+                <BlankDesc>Disabled</BlankDesc>
+                <OptionValues>
+                    <pcp1 value="1">Background (1, lowest)</pcp1>
+                    <pcp0 value="0">Best Effort (0, default)</pcp0>
+                    <pcp2 value="2">Excellent Effort (2)</pcp2>
+                    <pcp3 value="3">Critical Applications (3)</pcp3>
+                    <pcp4 value="4">Video (4)</pcp4>
+                    <pcp5 value="5">Voice (5)</pcp5>
+                    <pcp6 value="6">Internetwork Control (6)</pcp6>
+                    <pcp7 value="7">Network Control (7, highest)</pcp7>
+                </OptionValues>
+            </dhcpvlanprio>
+            <!-- DHCPv6 client settings-->
+            <dhcp6vlanprio type="OptionField">
+                <BlankDesc>Disabled</BlankDesc>
+                <OptionValues>
+                    <pcp1 value="1">Background (1, lowest)</pcp1>
+                    <pcp0 value="0">Best Effort (0, default)</pcp0>
+                    <pcp2 value="2">Excellent Effort (2)</pcp2>
+                    <pcp3 value="3">Critical Applications (3)</pcp3>
+                    <pcp4 value="4">Video (4)</pcp4>
+                    <pcp5 value="5">Voice (5)</pcp5>
+                    <pcp6 value="6">Internetwork Control (6)</pcp6>
+                    <pcp7 value="7">Network Control (7, highest)</pcp7>
+                </OptionValues>
+            </dhcp6vlanprio>
+            <dhcp6-ia-pd-len type="IntegerField">
+                <MinimumValue>48</MinimumValue>
+                <MaximumValue>64</MaximumValue>
+            </dhcp6-ia-pd-len>
+            <dhcp6prefixonly type="BooleanField"/>
+            <dhcp6_request_dns type="BooleanField"/>
+            <dhcp6-ia-pd-send-hint type="BooleanField"/>
+            <dhcp6_rapid_commit type="BooleanField"/>
+            <dhcp6-prefix-id type="TextField">
+                <Mask>/^0x([a-f,0-9]){0,30}$/i</Mask>
+                <ValidationMessage>Should be a hex value within range.</ValidationMessage>
+            </dhcp6-prefix-id>
+            <dhcp6_ifid type="TextField">
+                <Mask>/^0x([a-f,0-9]){0,30}$/i</Mask>
+                <ValidationMessage>Should be a hex value within range.</ValidationMessage>
+            </dhcp6_ifid>
+            <dhcp6_assoc_pd type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <ValidationMessage>Requires a valid positive number</ValidationMessage>
+            </dhcp6_assoc_pd>
+            <!-- 6rd settings-->
+            <prefix-6rd type="NetworkField">
+                <AddressFamily>ipv6</AddressFamily>
+                <NetMaskRequired>Y</NetMaskRequired>
+            </prefix-6rd>
+            <gateway-6rd type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+            </gateway-6rd>
+            <prefix-6rd-v4plen type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <MaximumValue>32</MaximumValue>
+                <ValidationMessage>6RD IPv4 prefix length must be a number.</ValidationMessage>
+            </prefix-6rd-v4plen>
+            <prefix-6rd-v4addr type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+            </prefix-6rd-v4addr>
+            <!-- idassoc6/track6 settings-->
+            <track6-interface type="InterfaceField">
+                <filters>
+                    <enable>/^(?!0).*$/</enable>
+                    <ipaddrv6>/^6rd|6to4|dhcp6$/</ipaddrv6>
+                </filters>
+            </track6-interface>
+            <track6-prefix-id type="TextField">
+                <Mask>/^0x([a-f,0-9]){0,30}$/i</Mask>
+                <ValidationMessage>Should be a hex value within range.</ValidationMessage>
+            </track6-prefix-id>
+            <track6_ifid type="TextField">
+                <Mask>/^0x([a-f,0-9]){0,30}$/i</Mask>
+                <ValidationMessage>Should be a hex value within range.</ValidationMessage>
+            </track6_ifid>
+            <track6_prefix_range type="IntegerField">
+                <MinimumValue>1</MinimumValue>
+                <ValidationMessage>You specified an IPv6 prefix range that is not valid.</ValidationMessage>
+            </track6_prefix_range>
+            <track6_assoc_pd type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </track6_assoc_pd>
+            <dhcpd6track6allowoverride type="BooleanField"/>
+            <!-- gateway -->
+            <gateway type=".\GatewayField">
+                <Protocol>inet</Protocol>
+                <ValidationMessage>Specify a valid gateway from the list matching the networks ip protocol.</ValidationMessage>
+            </gateway>
+            <gatewayv6 type=".\GatewayField">
+                <Protocol>inet6</Protocol>
+                <ValidationMessage>Specify a valid gateway from the list matching the networks ip protocol.</ValidationMessage>
+            </gatewayv6>
         </interface>
     </items>
 </model>

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
@@ -36,12 +36,31 @@
                     formatters: {
                         statusformatter: function (column, row) {
                             return $("<div/>").addClass(row[column.id])[0];
-                        }
+                        },
+                        ipv4typeformatter: function (column, row) {
+                            return row.type4 === 'staticv4' ? row.ipaddr : row['%type4'];
+                        },
+                        ipv6typeformatter: function (column, row) {
+                            return row.type6 === 'staticv6' ? row.ipaddrv6 : row['%type6'];
+                        },
                     }
                 }
             }
         );
         $("#reconfigureAct").SimpleActionButton();
+
+        $('select.ipoption').change(function(){
+            let this_id = $(this).attr('id').split('.')[1];
+            let this_value =  $(this).val();
+            let show_advanced = $("#show_advanced_formDialogdialog_dialogAssignment").hasClass('fa-toggle-on');
+            $("."+this_id).closest('tr').hide();
+            $("."+this_id + '_' + $(this).val()).each(function(){
+                let tr = $(this).closest("tr");
+                if ((tr.data('advanced') && show_advanced) || !tr.data('advanced')) {
+                    tr.show();
+                }
+            });
+        });
 
     });
 </script>

--- a/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
+++ b/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
@@ -50,11 +50,33 @@ if (is_array($config['interfaces'])) {
             if ($pending_act == 'relink') {
                 $to_configure[] = $id;
             }
+        } else {
+            $to_configure[] = $id;
+            /* suspend only when we're changing the enabled status */
+            interface_reset($id, false, !empty($ifcfg['enable']) && !empty($todos[$id]['enable']));
+        }
+    }
+    foreach (array_keys($todos) as $id) {
+        if (!isset($config['interfaces'][$id])) {
+            $to_configure[] = $id; /* new interface */
         }
     }
 
     foreach ($to_configure as $ifname) {
-        $config['interfaces'][$ifname]['if'] = $todos[$ifname]['pending_if'];
+        $pending = $todos[$ifname]['pending'];
+        foreach ($pending as $key => $value) {
+            if ($value !== '') {
+                $config['interfaces'][$ifname][$key] = $value;
+            } elseif (isset($config['interfaces'][$ifname][$key])) {
+                unset($config['interfaces'][$ifname][$key]);
+            }
+
+        }
+        foreach (['enable', 'lock'] as $legacybool) {
+            if (empty($pending[$legacybool])) {
+                unset($config['interfaces'][$ifname][$legacybool]);
+            }
+        }
         /* Reload all for the interface. */
         interface_configure(false, $ifname, true);
     }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

This is part of a larger challenge, started with https://github.com/opnsense/core/issues/9945, the assignment of interfaces. Eventually we plan to merge the configuration pages with the assignments, which overs a more uniform user experience, API support and better support for larger sets of interfaces (due to not polluting the menu).

---

**Describe the proposed solution**

Refactor NetworkInterface model to reuse existing property names as much as possible, move from/to legacy logic into a custom fieldtype and store all legacy settings in a container named "pending" to ease reconfiguration and updating legacy configurations.

Skip wireless and other advanced settings for now, only implement a minimal set of validations.


---

**Related issue**

https://github.com/opnsense/core/issues/10568