### PR TITLE
VPN: Wireguard: Revamp peer generator to optionally store private key and open existing peers

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
@@ -182,6 +182,7 @@ class ClientController extends ApiMutableModelControllerBase
                     $peers = array_filter(explode(',', (string)$node->peers));
                     $result['endpoint'] = (string)$node->endpoint;
                     $result['peer_dns'] = (string)$node->peer_dns;
+                    $result['allowed_ips'] = (string)$node->allowed_ips;
                     $result['mtu'] = (string)$node->mtu;
                     $result['pubkey'] = (string)$node->pubkey;
                     foreach (array_filter(explode(',', (string)$node->tunneladdress)) as $addr) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
@@ -24,10 +24,16 @@
         <help>Public key of this peer. You can generate the key using the private key piped to "wg pubkey".</help>
     </field>
     <field>
+        <id>configbuilder.store_privkey</id>
+        <label>Store private key on this firewall</label>
+        <type>checkbox</type>
+        <help>Store the generated private key with this peer so its configuration can be shown again later.</help>
+    </field>
+    <field>
         <id>configbuilder.privkey</id>
         <label>Private key</label>
         <type>text</type>
-        <help>Private key of this peer, not stored on this host, only used for the configuration below.</help>
+        <help>Private key of this peer. It is only used for the configuration below.</help>
     </field>
     <field>
         <id>configbuilder.address</id>
@@ -68,6 +74,6 @@
         <label>Store and generate next</label>
         <id>configbuilder.store_btn</id>
         <type>info</type>
-        <help>Store the public parts of this peer and generate a keypair for the next.</help>
+        <help>Store this peer and generate a keypair for the next.</help>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -26,6 +26,16 @@
         </grid_view>
     </field>
     <field>
+        <id>client.privkey</id>
+        <label>Private key</label>
+        <type>text</type>
+        <help>Private key of this peer. It is optional and not used for any service configuration. Please keep this key safe.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
         <id>client.psk</id>
         <label>Pre-shared key</label>
         <type>text</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -75,14 +75,14 @@
     </field>
     <field>
         <type>header</type>
-        <label>Peer Generator</label>
+        <label>Peer generator</label>
         <collapse>true</collapse>
     </field>
     <field>
         <id>client.privkey</id>
         <label>Private key</label>
         <type>text</type>
-        <help>Private key of this peer, only used by the Peer Generator. Please keep this key safe.</help>
+        <help>Private key of this peer, only used by the Peer generator. Please keep this key safe.</help>
         <grid_view>
             <ignore>true</ignore>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -1,5 +1,9 @@
 <form>
     <field>
+        <type>header</type>
+        <label>Peer</label>
+    </field>
+    <field>
         <id>client.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
@@ -23,16 +27,6 @@
         <help>Public key of this peer. You can generate the key using the private key piped to "wg pubkey".</help>
         <grid_view>
             <visible>false</visible>
-        </grid_view>
-    </field>
-    <field>
-        <id>client.privkey</id>
-        <label>Private key</label>
-        <type>text</type>
-        <help>Private key of this peer. It is optional and not used for any service configuration. Please keep this key safe.</help>
-        <advanced>true</advanced>
-        <grid_view>
-            <ignore>true</ignore>
         </grid_view>
     </field>
     <field>
@@ -77,6 +71,20 @@
         <help>Set persistent keepalive interval in seconds.</help>
         <grid_view>
             <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Peer Generator</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>client.privkey</id>
+        <label>Private key</label>
+        <type>text</type>
+        <help>Private key of this peer, only used by the Peer Generator. Please keep this key safe.</help>
+        <grid_view>
+            <ignore>true</ignore>
         </grid_view>
     </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -132,14 +132,14 @@
     </field>
     <field>
         <type>header</type>
-        <label>Peer Generator</label>
+        <label>Peer generator</label>
         <collapse>true</collapse>
     </field>
     <field>
         <id>server.endpoint</id>
         <label>Endpoint</label>
         <type>text</type>
-        <help>The endpoint that the instance will be reachable at, only used by the Peer Generator.</help>
+        <help>The endpoint that the instance will be reachable at, only used by the Peer generator.</help>
         <grid_view>
             <ignore>true</ignore>
         </grid_view>
@@ -148,7 +148,7 @@
         <id>server.peer_dns</id>
         <label>DNS Servers</label>
         <type>text</type>
-        <help>The DNS Servers to use when peers connect, only used by the Peer Generator.</help>
+        <help>The DNS Servers to use when peers connect, only used by the Peer generator.</help>
         <grid_view>
             <ignore>true</ignore>
         </grid_view>
@@ -157,7 +157,7 @@
         <id>server.allowed_ips</id>
         <label>Allowed IPs</label>
         <type>text</type>
-        <help>The Allowed IPs to use when peers connect, only used by the Peer Generator.</help>
+        <help>The Allowed IPs to use when peers connect, only used by the Peer generator.</help>
         <grid_view>
             <ignore>true</ignore>
         </grid_view>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -1,5 +1,9 @@
 <form>
     <field>
+        <type>header</type>
+        <label>Instance</label>
+    </field>
+    <field>
         <id>server.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
@@ -124,6 +128,38 @@
             <visible>false</visible>
             <type>boolean</type>
             <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Peer Generator</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>server.endpoint</id>
+        <label>Endpoint</label>
+        <type>text</type>
+        <help>The endpoint that the instance will be reachable at, only used by the Peer Generator.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>server.peer_dns</id>
+        <label>DNS Servers</label>
+        <type>text</type>
+        <help>The DNS Servers to use when peers connect, only used by the Peer Generator.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>server.allowed_ips</id>
+        <label>Allowed IPs</label>
+        <type>text</type>
+        <help>The Allowed IPs to use when peers connect, only used by the Peer Generator.</help>
+        <grid_view>
+            <ignore>true</ignore>
         </grid_view>
     </field>
 </form>

--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -27,6 +27,8 @@
                         </check001>
                     </Constraints>
                 </pubkey>
+                <!-- The client privkey is not used for any service configuration -->
+                <privkey type="Base64Field"/>
                 <psk type="Base64Field"/>
                 <tunneladdress type="NetworkField">
                     <NetMaskRequired>Y</NetMaskRequired>

--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -27,8 +27,6 @@
                         </check001>
                     </Constraints>
                 </pubkey>
-                <!-- The client privkey is not used for any service configuration -->
-                <privkey type="Base64Field"/>
                 <psk type="Base64Field"/>
                 <tunneladdress type="NetworkField">
                     <NetMaskRequired>Y</NetMaskRequired>
@@ -68,6 +66,8 @@
                     </Model>
                     <Multiple>Y</Multiple>
                 </servers>
+                <!-- Peer generator storage [client specific] -->
+                <privkey type="Base64Field"/>
             </client>
         </clients>
     </items>

--- a/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -76,6 +76,7 @@
                 <!-- Peer generator storage [default values] -->
                 <endpoint type="TextField"/>
                 <peer_dns type="TextField"/>
+                <allowed_ips type="TextField"/>
             </server>
         </servers>
     </items>

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -1,5 +1,5 @@
 {#
- # Copyright (c) 2014-2023 Deciso B.V.
+ # Copyright (c) 2014-2026 Deciso B.V.
  # Copyright (c) 2018 Michael Muenz <m.muenz@gmail.com>
  # All rights reserved.
  #
@@ -28,27 +28,40 @@
  <script>
     $( document ).ready(function() {
         const data_get_map = {'frm_general_settings':"/api/wireguard/general/get"};
+        let configbuilder_reference = null;
         mapDataToFormUI(data_get_map).done(function(data){
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
         });
 
         const grid_peers = $("#{{formGridWireguardClient['table_id']}}").UIBootgrid({
-                search: '/api/wireguard/client/search_client',
-                get: '/api/wireguard/client/get_client/',
-                set: '/api/wireguard/client/set_client/',
-                add: '/api/wireguard/client/add_client/',
-                del: '/api/wireguard/client/del_client/',
-                toggle: '/api/wireguard/client/toggle_client/',
-                options:{
-                    initialSearchPhrase: getUrlHash('search'),
-                    requestHandler: function(request){
-                        if ( $('#server_filter').val().length > 0) {
-                            request['servers'] = $('#server_filter').val();
-                        }
-                        return request;
+            search: '/api/wireguard/client/search_client',
+            get: '/api/wireguard/client/get_client/',
+            set: '/api/wireguard/client/set_client/',
+            add: '/api/wireguard/client/add_client/',
+            del: '/api/wireguard/client/del_client/',
+            toggle: '/api/wireguard/client/toggle_client/',
+            options: {
+                initialSearchPhrase: getUrlHash('search'),
+                requestHandler: function(request){
+                    if ( $('#server_filter').val().length > 0) {
+                        request['servers'] = $('#server_filter').val();
                     }
-            }
+                    return request;
+                }
+            },
+            commands: {
+                show_peer: {
+                    filter: (cell) => !!cell.getData().privkey,
+                    classname: "fa fa-fw fa-qrcode",
+                    title: "{{ lang._('Open in peer generator') }}",
+                    sequence: 10,
+                    method: function(event, cell) {
+                        configbuilder_reference = cell.getData();
+                        $('a[href="#configbuilder"]').tab('show');
+                    }
+                }
+            },
         });
         grid_peers.on("loaded.rs.jquery.bootgrid", function (e){
             // reload servers before grid load
@@ -114,6 +127,117 @@
         });
 
         /**
+         * Build the peer config for the peer generator
+         */
+        function buildPeerConfig(data)
+        {
+            let rows = [];
+            rows.push('[Interface]');
+            rows.push('PrivateKey = ' + data.privkey);
+            if (data.address) {
+                rows.push('Address = ' + data.address);
+            }
+            if (data.peer_dns) {
+                rows.push('DNS = ' + data.peer_dns);
+            }
+            if (data.mtu) {
+                rows.push('MTU = ' + data.mtu);
+            }
+            rows.push('');
+            rows.push('[Peer]');
+            rows.push('PublicKey = ' + data.pubkey);
+            if (data.psk) {
+                rows.push('PresharedKey = ' + data.psk);
+            }
+            rows.push('Endpoint = ' + data.endpoint);
+            rows.push('AllowedIPs = ' + data.allowedips);
+            if (data.keepalive) {
+                rows.push('PersistentKeepalive = ' + data.keepalive);
+            }
+            return rows.join("\n");
+        }
+
+        /**
+         * Load instance information for the peer generator
+         */
+        function configbuilder_load_server(server_id, callback, update_address = true)
+        {
+            ajaxGet('/api/wireguard/client/get_server_info/' + server_id, {}, function(data, status) {
+                if (data.status === 'ok') {
+                    let endpoint = $("#configbuilder\\.endpoint");
+                    let peer_dns = $("#configbuilder\\.peer_dns");
+
+                    if (update_address) {
+                        $("#configbuilder\\.address").val(data.address);
+                    }
+
+                    peer_dns
+                        .val(data.peer_dns)
+                        .data('org-value', data.peer_dns);
+
+                    endpoint
+                        .val(data.endpoint)
+                        .data('org-value', data.endpoint)
+                        .data('mtu', data.mtu)
+                        .data('pubkey', data.pubkey);
+
+                    if (callback) {
+                        callback();
+                    }
+
+                    endpoint.change();
+                }
+            });
+        }
+
+        /**
+         * Toggle peer generator reference mode
+         */
+        function configbuilder_set_reference_mode(enabled)
+        {
+            $("#configbuilder\\.name").prop("disabled", enabled);
+
+            [
+                "servers",
+                "pubkey",
+                "privkey",
+                "psk",
+                "address",
+                "store_privkey",
+                "store_btn"
+            ].forEach(function(field) {
+                $("#row_configbuilder\\." + field).toggle(!enabled);
+            });
+
+            $("#row_general\\.enabled").toggle(!enabled);
+            $("#pskgen_cb").toggle(!enabled);
+        }
+
+        /**
+         * Load an existing peer into the peer generator
+         */
+        function configbuilder_load_reference(row)
+        {
+            const server_id = row.servers;
+
+            $("#configbuilder\\.servers")
+                .val(server_id)
+                .selectpicker('refresh');
+
+            $("#configbuilder\\.name").val(row.name);
+            $("#configbuilder\\.pubkey").val(row.pubkey);
+            $("#configbuilder\\.privkey").val(row.privkey);
+            $("#configbuilder\\.psk").val(row.psk);
+            $("#configbuilder\\.address").val(row.tunneladdress);
+            $("#configbuilder\\.tunneladdress").val("0.0.0.0/0,::/0");
+            $("#configbuilder\\.keepalive").val(row.keepalive);
+
+            configbuilder_load_server(server_id, function() {
+                configbuilder_set_reference_mode(true);
+            }, false);
+        }
+
+        /**
          * Peer generator tab hooks
          */
         $("#control_label_configbuilder\\.psk").append($("#pskgen_cb_div").detach().show());
@@ -133,28 +257,15 @@
         });
 
         $("#configbuilder\\.servers").change(function(){
-            ajaxGet('/api/wireguard/client/get_server_info/' + $(this).val(), {}, function(data, status) {
-                if (data.status === 'ok') {
-                    let endpoint = $("#configbuilder\\.endpoint");
-                    let peer_dns = $("#configbuilder\\.peer_dns");
-                    $("#configbuilder\\.address").val(data.address);
-                    peer_dns
-                        .val(data.peer_dns)
-                        .data('org-value', data.peer_dns);
-
-                    endpoint
-                        .val(data.endpoint)
-                        .data('org-value', data.endpoint)
-                        .data('mtu', data.mtu)
-                        .data('pubkey', data.pubkey)
-                        .change();
-                }
-            });
+            configbuilder_load_server($(this).val());
         });
 
         $("#configbuilder\\.store_btn").replaceWith($("#btn_configbuilder_save"));
 
         $("#btn_configbuilder_save").click(function(){
+            if (configbuilder_reference !== null) {
+                return;
+            }
             let instance_id = $("#configbuilder\\.servers").val();
             let endpoint = $("#configbuilder\\.endpoint");
             let peer_dns = $("#configbuilder\\.peer_dns");
@@ -163,8 +274,12 @@
                     enabled: '1',
                     name: $("#configbuilder\\.name").val(),
                     pubkey: $("#configbuilder\\.pubkey").val(),
+                    privkey: $("#configbuilder\\.store_privkey").prop("checked")
+                        ? $("#configbuilder\\.privkey").val()
+                        : '',
                     psk: $("#configbuilder\\.psk").val(),
                     tunneladdress: $("#configbuilder\\.address").val(),
+                    allowedips: $("#configbuilder\\.tunneladdress").val(),
                     keepalive: $("#configbuilder\\.keepalive").val(),
                     server: instance_id,
                     endpoint: endpoint.val()
@@ -174,9 +289,9 @@
                 if (data.validations) {
                     if (data.validations['configbuilder.tunneladdress']) {
                         /*
-                            tunnel address for the client is this peers address, since we remap these
-                            in the form, we should remap the errors as well.
-                        */
+                         * tunnel address for the client is this peers address, since we remap these
+                         * in the form, we should remap the errors as well.
+                         */
                         data.validations['configbuilder.address'] = data.validations['configbuilder.tunneladdress'];
                         delete data.validations['configbuilder.tunneladdress'];
                     }
@@ -203,54 +318,54 @@
 
         function configbuilder_new()
         {
+            configbuilder_reference = null;
+            configbuilder_set_reference_mode(false);
+
             mapDataToFormUI({'frm_config_builder':"/api/wireguard/client/get_client_builder"}).done(function(data){
-                    formatTokenizersUI();
-                    $('.selectpicker').selectpicker('refresh');
-                    ajaxGet("/api/wireguard/server/key_pair", {}, function(data, status){
+                formatTokenizersUI();
+                $('.selectpicker').selectpicker('refresh');
+                // Private key storage is intentionally opt-in to preserve existing behavior.
+                $("#configbuilder\\.store_privkey").prop("checked", false);
+                $("#configbuilder\\.tunneladdress").val("0.0.0.0/0,::/0");
+                ajaxGet("/api/wireguard/server/key_pair", {}, function(data, status){
                     if (data.status && data.status === 'ok') {
-                            $("#configbuilder\\.pubkey").val(data.pubkey);
-                            $("#configbuilder\\.privkey").val(data.privkey).change();
-                        }
-                    });
-                    $("#configbuilder\\.tunneladdress").val("0.0.0.0/0,::/0");
-                    clearFormValidation("frm_config_builder");
+                        $("#configbuilder\\.pubkey").val(data.pubkey);
+                        $("#configbuilder\\.privkey").val(data.privkey).change();
+                    }
                 });
+                clearFormValidation("frm_config_builder");
+            });
         }
 
         function configbuilder_update_config()
         {
-            let rows = [];
-            rows.push('[Interface]');
-            rows.push('PrivateKey = ' + $("#configbuilder\\.privkey").val());
-            if ($("#configbuilder\\.address").val()) {
-                rows.push('Address = ' + $("#configbuilder\\.address").val());
-            }
-            if ($("#configbuilder\\.peer_dns").val()) {
-                rows.push('DNS = ' + $("#configbuilder\\.peer_dns").val());
-            }
-            if ($("#configbuilder\\.endpoint").data('mtu')) {
-                rows.push('MTU = ' + $("#configbuilder\\.endpoint").data('mtu'));
-            }
-            rows.push('');
-            rows.push('[Peer]');
-            rows.push('PublicKey = ' + $("#configbuilder\\.endpoint").data('pubkey'));
-            if ($("#configbuilder\\.psk").val()) {
-                rows.push('PresharedKey = ' + $("#configbuilder\\.psk").val());
-            }
-            rows.push('Endpoint = ' + $("#configbuilder\\.endpoint").val());
-            rows.push('AllowedIPs = ' + $("#configbuilder\\.tunneladdress").val());
-            if ($("#configbuilder\\.keepalive").val()) {
-                rows.push('PersistentKeepalive = ' + $("#configbuilder\\.keepalive").val());
-            }
-            $("#configbuilder\\.output").val(rows.join("\n")).change();
+            const config = buildPeerConfig({
+                privkey: $("#configbuilder\\.privkey").val(),
+                address: $("#configbuilder\\.address").val(),
+                peer_dns: $("#configbuilder\\.peer_dns").val(),
+                mtu: $("#configbuilder\\.endpoint").data('mtu'),
+                pubkey: $("#configbuilder\\.endpoint").data('pubkey'),
+                psk: $("#configbuilder\\.psk").val(),
+                endpoint: $("#configbuilder\\.endpoint").val(),
+                allowedips: $("#configbuilder\\.tunneladdress").val(),
+                keepalive: $("#configbuilder\\.keepalive").val()
+            });
+
+            $("#configbuilder\\.output").val(config).change();
         }
 
         $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-            if (e.target.id == 'tab_configbuilder'){
-                configbuilder_new();
+            if (e.target.id == 'tab_configbuilder') {
+                if (configbuilder_reference !== null) {
+                    configbuilder_load_reference(configbuilder_reference);
+                } else {
+                    configbuilder_new();
+                }
             } else if (e.target.id == 'tab_peers') {
+                configbuilder_reference = null;
                 $('#{{formGridWireguardClient['table_id']}}').bootgrid('reload');
             } else if (e.target.id == 'tab_instances') {
+                configbuilder_reference = null;
                 $('#{{formGridWireguardServer['table_id']}}').bootgrid('reload');
             }
         });
@@ -289,7 +404,7 @@
                 </select>
             </div>
         </div>
-        {{ partial('layout_partials/base_bootgrid_table', formGridWireguardClient)}}
+        {{ partial('layout_partials/base_bootgrid_table', formGridWireguardClient + {'command_width':'120'}) }}
     </div>
     <div id="instances" class="tab-pane fade in active">
         <span id="keygen_div" style="display:none" class="pull-right">

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
- <script>
+<script>
     $( document ).ready(function() {
         const data_get_map = {'frm_general_settings':"/api/wireguard/general/get"};
         let configbuilder_reference = null;
@@ -166,6 +166,7 @@
                 if (data.status === 'ok') {
                     let endpoint = $("#configbuilder\\.endpoint");
                     let peer_dns = $("#configbuilder\\.peer_dns");
+                    let allowed_ips = $("#configbuilder\\.tunneladdress");
 
                     if (update_address) {
                         $("#configbuilder\\.address").val(data.address);
@@ -180,6 +181,11 @@
                         .data('org-value', data.endpoint)
                         .data('mtu', data.mtu)
                         .data('pubkey', data.pubkey);
+
+                    const allowed_ips_value = data.allowed_ips || "0.0.0.0/0,::/0";
+                    allowed_ips
+                        .val(allowed_ips_value)
+                        .data('org-value', allowed_ips_value);
 
                     if (callback) {
                         callback();
@@ -199,6 +205,10 @@
 
             [
                 "servers",
+                "endpoint",
+                "peer_dns",
+                "tunneladdress",
+                "keepalive",
                 "pubkey",
                 "privkey",
                 "psk",
@@ -229,7 +239,6 @@
             $("#configbuilder\\.privkey").val(row.privkey);
             $("#configbuilder\\.psk").val(row.psk);
             $("#configbuilder\\.address").val(row.tunneladdress);
-            $("#configbuilder\\.tunneladdress").val("0.0.0.0/0,::/0");
             $("#configbuilder\\.keepalive").val(row.keepalive);
 
             configbuilder_load_server(server_id, function() {
@@ -269,6 +278,7 @@
             let instance_id = $("#configbuilder\\.servers").val();
             let endpoint = $("#configbuilder\\.endpoint");
             let peer_dns = $("#configbuilder\\.peer_dns");
+            let allowed_ips = $("#configbuilder\\.tunneladdress");
             let peer = {
                 configbuilder: {
                     enabled: '1',
@@ -279,7 +289,6 @@
                         : '',
                     psk: $("#configbuilder\\.psk").val(),
                     tunneladdress: $("#configbuilder\\.address").val(),
-                    allowedips: $("#configbuilder\\.tunneladdress").val(),
                     keepalive: $("#configbuilder\\.keepalive").val(),
                     server: instance_id,
                     endpoint: endpoint.val()
@@ -297,11 +306,16 @@
                     }
                     handleFormValidation("frm_config_builder", data.validations);
                 } else {
-                    if (endpoint.val() != endpoint.data('org-value') || peer_dns.val() != peer_dns.data('org-value')) {
+                    if (
+                        endpoint.val() != endpoint.data('org-value') ||
+                        peer_dns.val() != peer_dns.data('org-value') ||
+                        allowed_ips.val() != allowed_ips.data('org-value')
+                    ) {
                         let param = {
                             'server': {
                                 'endpoint': endpoint.val(),
-                                'peer_dns': peer_dns.val()
+                                'peer_dns': peer_dns.val(),
+                                'allowed_ips': allowed_ips.val()
                             }
                         };
                         ajaxCall('/api/wireguard/server/set_server/' + instance_id, param, function(data, status){
@@ -326,7 +340,6 @@
                 $('.selectpicker').selectpicker('refresh');
                 // Private key storage is intentionally opt-in to preserve existing behavior.
                 $("#configbuilder\\.store_privkey").prop("checked", false);
-                $("#configbuilder\\.tunneladdress").val("0.0.0.0/0,::/0");
                 ajaxGet("/api/wireguard/server/key_pair", {}, function(data, status){
                     if (data.status && data.status === 'ok') {
                         $("#configbuilder\\.pubkey").val(data.pubkey);

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -55,7 +55,7 @@
                     filter: (cell) => !!cell.getData().privkey,
                     classname: "fa fa-fw fa-qrcode",
                     title: "{{ lang._('Open in peer generator') }}",
-                    sequence: 10,
+                    sequence: 1000,
                     method: function(event, cell) {
                         configbuilder_reference = cell.getData();
                         $('a[href="#configbuilder"]').tab('show');


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Chatgpt 5.5
- Extent of AI involvement: Brainstorming and testing a few different ideas before coming to the current design

---

**Describe the problem**

Generated peers were one shot and the configuration could never be shown again.

---

**Describe the proposed solution**

Private key can now optionlly be stored which enables a new command that can reopen the peer in the generator in a reference mode where the QR code and config exists again.

Some indentation cleanups were also made to clean up the code.

---

**Related issue**

It was requested a lot over the years.
