### PR TITLE
VPN: Wireguard: Give peer generator standard save and cancel buttons

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
@@ -70,10 +70,4 @@
         <label>Config</label>
         <type>textbox</type>
     </field>
-    <field>
-        <label>Store and generate next</label>
-        <id>configbuilder.store_btn</id>
-        <type>info</type>
-        <help>Store this peer and generate a keypair for the next.</help>
-    </field>
 </form>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
@@ -70,4 +70,10 @@
         <label>Config</label>
         <type>textbox</type>
     </field>
+    <field>
+        <id>configbuilder.actions</id>
+        <type>buttons</type>
+        <parent>configbuilder</parent>
+        <cancel>true</cancel>
+    </field>
 </form>

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -268,10 +268,15 @@
             configbuilder_load_server($(this).val());
         });
 
+        const $actions_row = $(
+            '<tr id="row_configbuilder_actions">' +
+                '<td></td><td></td><td></td>' +
+            '</tr>'
+        ).insertAfter($("#frm_config_builder tr:last"));
+
         $("#configbuilder_actions")
             .detach()
-            .appendTo($("#row_configbuilder\\.output td:eq(1)"))
-            .css({"text-align": "left", "margin-top": "10px"})
+            .appendTo($actions_row.find("td:eq(1)"))
             .show();
 
         $("#btn_configbuilder_cancel").click(function() {

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -202,6 +202,7 @@
         function configbuilder_set_reference_mode(enabled)
         {
             $("#configbuilder\\.name").prop("disabled", enabled);
+            $("#configbuilder_actions").toggle(!enabled);
 
             [
                 "servers",
@@ -213,8 +214,7 @@
                 "privkey",
                 "psk",
                 "address",
-                "store_privkey",
-                "store_btn"
+                "store_privkey"
             ].forEach(function(field) {
                 $("#row_configbuilder\\." + field).toggle(!enabled);
             });
@@ -268,7 +268,15 @@
             configbuilder_load_server($(this).val());
         });
 
-        $("#configbuilder\\.store_btn").replaceWith($("#btn_configbuilder_save"));
+        $("#configbuilder_actions")
+            .detach()
+            .appendTo($("#row_configbuilder\\.output td:eq(1)"))
+            .css({"text-align": "left", "margin-top": "10px"})
+            .show();
+
+        $("#btn_configbuilder_cancel").click(function() {
+            $('a[href="#peers"]').tab('show');
+        });
 
         $("#btn_configbuilder_save").click(function(){
             if (configbuilder_reference !== null) {
@@ -367,20 +375,26 @@
             $("#configbuilder\\.output").val(config).trigger('input');
         }
 
+        const $apply_container = $("#reconfigureAct").closest(".alert.content-box");
+
         $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
             if (e.target.id == 'tab_configbuilder') {
                 if (configbuilder_reference !== null) {
                     configbuilder_load_reference(configbuilder_reference);
+                    $apply_container.hide();
                 } else {
                     configbuilder_new();
+                    $apply_container.show();
                 }
                 $('#frm_general_settings').hide();
             } else if (e.target.id == 'tab_peers') {
                 configbuilder_reference = null;
+                $apply_container.show();
                 $('#{{formGridWireguardClient['table_id']}}').bootgrid('reload');
                 $('#frm_general_settings').show();
             } else if (e.target.id == 'tab_instances') {
                 configbuilder_reference = null;
+                $apply_container.show();
                 $('#{{formGridWireguardServer['table_id']}}').bootgrid('reload');
                 $('#frm_general_settings').show();
             }
@@ -436,11 +450,15 @@
               <i class="fa fa-fw fa-gear"></i>
             </button>
         </span>
-        <span id="configbuilder_div" style="display:none">
-            <button id="btn_configbuilder_save" type="button" class="btn btn-primary">
-                <i class="fa fa-fw fa-check"></i>
-              </button>
-        </span>
+        <div id="configbuilder_actions" style="display:none;">
+            <button type="button" class="btn btn-primary" id="btn_configbuilder_save">
+                {{ lang._('Save') }}
+                <i id="btn_configbuilder_save_progress" class=""></i>
+            </button>
+            <button type="button" class="btn btn-default" id="btn_configbuilder_cancel">
+                {{ lang._('Cancel') }}
+            </button>
+        </div>
         {{ partial("layout_partials/base_form",['fields':formDialogConfigBuilder,'id':'frm_config_builder'])}}
     </div>
     {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -202,7 +202,6 @@
         function configbuilder_set_reference_mode(enabled)
         {
             $("#configbuilder\\.name").prop("disabled", enabled);
-            $("#configbuilder_actions").toggle(!enabled);
 
             [
                 "servers",
@@ -214,7 +213,8 @@
                 "privkey",
                 "psk",
                 "address",
-                "store_privkey"
+                "store_privkey",
+                "actions"
             ].forEach(function(field) {
                 $("#row_configbuilder\\." + field).toggle(!enabled);
             });
@@ -267,17 +267,6 @@
         $("#configbuilder\\.servers").change(function(){
             configbuilder_load_server($(this).val());
         });
-
-        const $actions_row = $(
-            '<tr id="row_configbuilder_actions">' +
-                '<td></td><td></td><td></td>' +
-            '</tr>'
-        ).insertAfter($("#frm_config_builder tr:last"));
-
-        $("#configbuilder_actions")
-            .detach()
-            .appendTo($actions_row.find("td:eq(1)"))
-            .show();
 
         $("#btn_configbuilder_cancel").click(function() {
             $('a[href="#peers"]').tab('show');
@@ -455,15 +444,6 @@
               <i class="fa fa-fw fa-gear"></i>
             </button>
         </span>
-        <div id="configbuilder_actions" style="display:none;">
-            <button type="button" class="btn btn-primary" id="btn_configbuilder_save">
-                {{ lang._('Save') }}
-                <i id="btn_configbuilder_save_progress" class=""></i>
-            </button>
-            <button type="button" class="btn btn-default" id="btn_configbuilder_cancel">
-                {{ lang._('Cancel') }}
-            </button>
-        </div>
         {{ partial("layout_partials/base_form",['fields':formDialogConfigBuilder,'id':'frm_config_builder'])}}
     </div>
     {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

base_form doesn't have standard save/cancel buttons. The current button used by wireguard is not the easiest to discover.

---

**Describe the proposed solution**

Make the form look like all other forms with save and cancel buttons

Hide Apply button when peer generator is opened in reference mode

---

**Related issue**

None
