### PR TITLE
interfaces: interface_configure() should tear down a disabled interface

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2326,6 +2326,7 @@ function interface_configure($verbose = false, $interface = 'wan', $reload = fal
     $loaded = [];
 
     if (!isset($wancfg['enable'])) {
+        interface_reset($interface);
         return $loaded;
     }
 


### PR DESCRIPTION
## Summary

`interface_configure()` returns immediately when an interface's `enable` flag is unset, without ever calling `interface_reset()`:

```php
if (!isset($wancfg['enable'])) {
    return $loaded;
}
```

This means disabling an interface via the API (unset `enable`, `write_config()`) and then running `configctl interface reconfigure <if>` — the only reconfigure action exposed by configd for interfaces — does nothing to actually tear the interface down. `interface_reset()` is the function that stops `dhclient`/`dhcp6c` and flushes addresses, but it is apparently only ever invoked from `interfaces.php`'s own GUI save handler, not from any standalone configd action or REST API path.

## Impact

Anything driving interface state through the API/configd path instead of the GUI (Ansible, Terraform, custom automation) can disable an interface in config.xml, call the exposed reconfigure action, and have the interface appear disabled in config while `dhclient`/`dhcp6c`/`dpinger` keep running underneath, still holding the old lease/delegation indefinitely.

## Testing

Confirmed live on 26.7, on a real dual-WAN router:
1. Interface `wan1` (DHCPv4 + DHCPv6-PD) was up with an active lease and PD delegation, `dhclient` and `dhcp6c` running.
2. Unset `interfaces.wan1.enable` in config.xml via the API, `write_config()`, then `configctl interface reconfigure wan1` (returns `OK`).
3. `ifconfig igc1` still showed the leased IPv4 address; `ps aux` showed `dhclient: igc1` and `dhcp6c` both still running, untouched.
4. Applied this patch. Re-ran step 2 with the fix in place; `interface_configure()` now reaches the new `interface_reset($interface)` call in the disabled branch — confirmed via direct invocation that the patched function executes cleanly with no error and correctly detects the current `enable` state.
5. Did not repeat the full end-to-end "disable an interface holding a real live upstream ISP lease and confirm the lease is actually released" reproduction a second time against production WAN hardware, to avoid a second live disruption to the same production link in one session — the fix itself calls the exact same `interface_reset()` codepath already used (and already verified correct) by the GUI's own disable-via-save-handler flow, just now reachable from the API/configd path too.

This is a minimal, surgical one-line fix — no behavior changes for the already-enabled path, and disabling an interface via the GUI is unaffected (it already reaches `interface_reset()` through a different path in `interfaces.php`).