### PR TITLE
system: use created user name for change event

### DIFF
--- a/src/opnsense/scripts/auth/add_user.php
+++ b/src/opnsense/scripts/auth/add_user.php
@@ -70,7 +70,7 @@ if (isset($opts['h']) || empty($opts['u'])) {
         if ($usermdl->serializeToConfig(false, true)) {
             Config::getInstance()->save();
         }
-        configdp_run('auth user changed', [$userent['name']]);
+        configdp_run('auth user changed', [(string)$user->name]);
         echo json_encode(["status" => "ok", "uid" => (string)$user->uid, "name" => (string)$user->name]);
     } else {
         echo json_encode(["status" => "failed", "messages" => $input_errors]);


### PR DESCRIPTION
## TL;DR

Use the created user model node's name when triggering the existing user change event.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, operational testing, and PR drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10756.

---

**Describe the proposed solution**

Pass `(string)$user->name` to the existing `auth user changed` event after the user model has been saved.

Tested on OPNsense 26.7.2_2: user creation returned valid JSON, the event completed, and the PHP error log remained unchanged.

---

**Related issue**

Fixes: #10756