### PR TITLE
system: handle missing authentication plugin fields

### DIFF
--- a/src/www/system_authservers.php
+++ b/src/www/system_authservers.php
@@ -133,7 +133,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         }
         if (!empty($authCNFOptions[$pconfig['type']])) {
             foreach ($authCNFOptions[$pconfig['type']]['additionalFields'] as $fieldname => $field) {
-                $pconfig[$fieldname] = $a_server[$id][$fieldname];
+                $pconfig[$fieldname] = $a_server[$id][$fieldname] ?? null;
             }
         }
     }
@@ -196,7 +196,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       if (!empty($authCNFOptions[$pconfig['type']])) {
           foreach ($authCNFOptions[$pconfig['type']]['additionalFields'] as $fieldname => $field) {
               if (!empty($field['validate'])) {
-                  foreach ($field['validate']($pconfig[$fieldname]) as $input_error) {
+                  foreach ($field['validate']($pconfig[$fieldname] ?? null) as $input_error) {
                       $input_errors[] = $input_error;
                   }
               }
@@ -310,7 +310,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
           }
           if (!empty($authCNFOptions[$server['type']])) {
               foreach ($authCNFOptions[$server['type']]['additionalFields'] as $fieldname => $field) {
-                  $server[$fieldname] = $pconfig[$fieldname];
+                  $server[$fieldname] = $pconfig[$fieldname] ?? null;
               }
           }
 


### PR DESCRIPTION
## TL;DR

Treat omitted pluggable authentication fields as `null` when loading, validating, and storing authentication server configuration.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10758.

---

**Describe the proposed solution**

Use null-coalescing reads for pluggable authentication fields when loading an existing server, invoking connector validators, and storing submitted settings.

Tested with PHP syntax validation and an OPNsense 26.7.2_2 POST validation run with omitted plugin fields; no new PHP errors were logged.

---

**Related issue**

Fixes #10758