### PR TITLE
system: handle missing user during deletion

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/UserController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/UserController.php
@@ -228,18 +228,18 @@ class UserController extends ApiMutableModelControllerBase
         if ($this->request->isPost()) {
             Config::getInstance()->lock();
             $node = $this->getModel()->getNodeByReference('user.' . $uuid);
-            if ($node->scope == 'system') {
-                throw new UserException(
-                    sprintf(gettext("Not allowed to delete system user %s"), $node->name),
-                    gettext("Usermanager")
-                );
-            } elseif ($node->name == $this->getUserName()) {
-                throw new UserException(
-                    sprintf(gettext("Not allowed to remove logged in user %s"), $node->name),
-                    gettext("Usermanager")
-                );
-            }
-            if (!empty($node)) {
+            if ($node !== null) {
+                if ($node->scope == 'system') {
+                    throw new UserException(
+                        sprintf(gettext("Not allowed to delete system user %s"), $node->name),
+                        gettext("Usermanager")
+                    );
+                } elseif ($node->name == $this->getUserName()) {
+                    throw new UserException(
+                        sprintf(gettext("Not allowed to remove logged in user %s"), $node->name),
+                        gettext("Usermanager")
+                    );
+                }
                 $username = (string)$node->name;
             }
         }


### PR DESCRIPTION
## TL;DR

Run user-specific deletion safeguards only when the requested user exists, allowing the generic deletion handler to return `not found` for unknown UUIDs.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10760.

---

**Describe the proposed solution**

Guard the existing system-user and current-user checks with a null check. Existing users retain the same deletion protections, while unknown UUIDs reach the standard `delBase()` handling.

Tested on OPNsense 26.7.2_2: an unknown UUID returned `{"result":"not found"}` without changing the configuration or adding PHP errors. PHP syntax validation also passed.

---

**Related issue**

Fixes #10760