### PR TITLE
interfaces: handle basic DHCP mode fields

### DIFF
--- a/src/www/interfaces.php
+++ b/src/www/interfaces.php
@@ -763,7 +763,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 if ((!empty($pconfig['adv_dhcp_config_advanced']) || !empty($pconfig['adv_dhcp_config_file_override'])) && !userIsAdmin($_SESSION['Username'])) {
                     $input_errors[] = gettext('Advanced options may only be edited by system administrators due to the increased possibility of privilege escalation.');
                 }
-                if (!empty($pconfig['adv_dhcp_config_file_override'] && !file_exists($pconfig['adv_dhcp_config_file_override_path']))) {
+                if (!empty($pconfig['adv_dhcp_config_file_override']) && !file_exists($pconfig['adv_dhcp_config_file_override_path'])) {
                     $input_errors[] = sprintf(gettext('The DHCP override file "%s" does not exist.'), $pconfig['adv_dhcp_config_file_override_path']);
                 }
                 break;
@@ -1118,8 +1118,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                     $new_config['adv_dhcp_request_options'] = $pconfig['adv_dhcp_request_options'];
                     $new_config['adv_dhcp_required_options'] = $pconfig['adv_dhcp_required_options'];
                     $new_config['adv_dhcp_option_modifiers'] = $pconfig['adv_dhcp_option_modifiers'];
-                    $new_config['adv_dhcp_config_advanced'] = $pconfig['adv_dhcp_config_advanced'];
-                    $new_config['adv_dhcp_config_file_override'] = $pconfig['adv_dhcp_config_file_override'];
+                    $new_config['adv_dhcp_config_advanced'] = $pconfig['adv_dhcp_config_advanced'] ?? null;
+                    $new_config['adv_dhcp_config_file_override'] = $pconfig['adv_dhcp_config_file_override'] ?? null;
                     $new_config['adv_dhcp_config_file_override_path'] = $pconfig['adv_dhcp_config_file_override_path'];
                     /* flipped in GUI on purpose */
                     if (empty($pconfig['dhcpoverridemtu'])) {


### PR DESCRIPTION
## TL;DR

Handle omitted Basic-mode fields safely and correct the DHCP override-path validation condition.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10762.

---

**Describe the proposed solution**

Use null-coalescing reads when storing the omitted Advanced and Override mode fields. Also separate the Override-mode check from its file existence test so short-circuit evaluation works as intended.

Tested with PHP syntax validation and representative Basic and Override mode inputs on OPNsense 26.7.2_2. Basic mode retained null defaults, Override mode retained path validation, and no PHP errors were added.

---

**Related issue**

Fixes #10762