### PR TITLE
interfaces: handle missing DHCPv6 PD size

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2997,7 +2997,7 @@ function DHCP6_Config_File_Basic($interface, $wancfg, $wanif, $default_id)
     } elseif ($wancfg['ipaddrv6'] == 'dhcp6') {
         $assoc_pd = [];
 
-        if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
+        if (is_numeric($wancfg['dhcp6-ia-pd-len'] ?? null)) {
             if (isset($wancfg['dhcp6-prefix-id']) && is_numeric($wancfg['dhcp6-prefix-id'])) {
                 $pd_conf  = "  prefix-interface {$wanif} {\n";
                 $pd_conf .= "    sla-id {$wancfg['dhcp6-prefix-id']};\n";
@@ -3042,7 +3042,7 @@ function DHCP6_Config_File_Basic($interface, $wancfg, $wanif, $default_id)
             $dhcp6cconf .= "  send ia-na {$default_id};\n";
         }
 
-        if (is_numeric($wancfg['dhcp6-ia-pd-len'])) {
+        if (is_numeric($wancfg['dhcp6-ia-pd-len'] ?? null)) {
             /* request prefix delegation */
             foreach (array_keys($assoc_pd) as $id) {
                 $dhcp6cconf .= "  send ia-pd {$id};\n";


### PR DESCRIPTION
## TL;DR

Use a null fallback when checking an optional DHCPv6 prefix delegation size.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10764.

---

**Describe the proposed solution**

Apply a null fallback to both numeric prefix delegation checks. Existing numeric values remain unchanged, while an absent value follows the existing nonnumeric path.

Tested on OPNsense 26.7.2_2 with a DHCPv6 configuration lacking the PD-size field. IA-NA output was preserved, IA-PD remained omitted, and no PHP errors were added. PHP syntax validation also passed.

---

**Related issue**

Fixes #10764