### PR TITLE
system: handle missing sudo setting

### DIFF
--- a/src/www/system_advanced_admin.php
+++ b/src/www/system_advanced_admin.php
@@ -64,7 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['httpaccesslog'] = isset($config['system']['webgui']['httpaccesslog']);
     $pconfig['disableconsolemenu'] = isset($config['system']['disableconsolemenu']);
     $pconfig['usevirtualterminal'] = isset($config['system']['usevirtualterminal']);
-    $pconfig['sudo_allow_wheel'] = $config['system']['sudo_allow_wheel'];
+    $pconfig['sudo_allow_wheel'] = $config['system']['sudo_allow_wheel'] ?? null;
     $pconfig['sudo_allow_group'] = isset($config['system']['sudo_allow_group']) ? $config['system']['sudo_allow_group'] : null;
     $pconfig['user_allow_gen_token'] = isset($config['system']['user_allow_gen_token']) ? explode(",", $config['system']['user_allow_gen_token']) : [];
     $pconfig['nodnsrebindcheck'] = isset($config['system']['webgui']['nodnsrebindcheck']);


### PR DESCRIPTION
## TL;DR

Default the optional Sudo setting to disabled when it is absent from the configuration.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10766.

---

**Describe the proposed solution**

Use a null fallback when loading `sudo_allow_wheel`, matching the existing disabled state and Sudoers template default.

Tested on OPNsense 26.7.2_2 by rendering the complete Administration page without the configuration entry. The page selected **Disallow**, added no PHP errors, and passed PHP syntax validation.

---

**Related issue**

Fixes #10766