### PR TITLE
system: handle missing language setting

### DIFF
--- a/src/www/system_general.php
+++ b/src/www/system_general.php
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $pconfig['dnssearchdomain'] = !empty($config['system']['dnssearchdomain']) ? explode(',', $config['system']['dnssearchdomain']) : [];
     $pconfig['domain'] = $config['system']['domain'];
     $pconfig['hostname'] = $config['system']['hostname'];
-    $pconfig['language'] = $config['system']['language'];
+    $pconfig['language'] = $config['system']['language'] ?? 'en_US';
     $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
     $pconfig['theme'] = $config['theme'] ?? '';
     $pconfig['timezone'] = empty($config['system']['timezone']) ? 'Etc/UTC' : $config['system']['timezone'];


### PR DESCRIPTION
## TL;DR

Use the existing `en_US` GUI default when the optional system language setting is absent.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting. Reviewed by a human before submission.

---

**Describe the problem**

Tracked in #10768.

---

**Describe the proposed solution**

Fall back to the established `en_US` GUI default when `system.language` is absent.

Tested by loading the General Settings page on the affected system, verifying that `en_US` is selected and that no PHP warning is recorded. PHP syntax and diff checks also pass.

---

**Related issue**

Fixes #10768