### PR TITLE
system: handle missing group during deletion

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/GroupController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Auth/Api/GroupController.php
@@ -95,10 +95,10 @@ class GroupController extends ApiMutableModelControllerBase
             Config::getInstance()->lock();
             foreach (!empty($uuids) ? explode(",", $uuids) : [] as $uuid) {
                 $node = $this->getModel()->getNodeByReference('group.' . $uuid);
-                if ($node->scope == 'system') {
-                    throw new UserException(sprintf(gettext("Not allowed to delete system group %s"), $node->name));
-                }
-                if (!empty($node)) {
+                if ($node !== null) {
+                    if ($node->scope == 'system') {
+                        throw new UserException(sprintf(gettext("Not allowed to delete system group %s"), $node->name));
+                    }
                     $groupnames[] = (string)$node->name;
                 }
             }


### PR DESCRIPTION
## TL;DR

Run group-specific deletion safeguards only when the requested group exists, allowing the generic deletion handler to return `not found` for unknown UUIDs.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10770.

---

**Describe the proposed solution**

Guard the existing system-group check and name collection with a null check. Existing groups retain the same deletion protection, while unknown UUIDs reach the standard `delBase()` handling.

Tested on OPNsense 26.7.2_2: an unknown UUID returned `{"result":"not found"}` without changing the configuration or adding PHP errors. PHP syntax and diff checks also pass.

---

**Related issue**

Fixes #10770