### PR TITLE
interfaces: handle missing GRE and GIF during deletion

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GifSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GifSettingsController.php
@@ -139,8 +139,8 @@ class GifSettingsController extends ApiMutableModelControllerBase
                         );
                     }
                 }
+                $nodes[] = $node;
             }
-            $nodes[] = $node;
         }
         $result = $this->delBase("gif", $uuids);
         if ($result['result'] != 'failed' && !empty($nodes)) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GreSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/GreSettingsController.php
@@ -139,8 +139,8 @@ class GreSettingsController extends ApiMutableModelControllerBase
                         );
                     }
                 }
+                $nodes[] = $node;
             }
-            $nodes[] = $node;
         }
         $result = $this->delBase("gre", $uuids);
         if ($result['result'] != 'failed' && !empty($nodes)) {


### PR DESCRIPTION
## TL;DR

Keep only existing GRE and GIF nodes in the post-deletion update list so unknown UUIDs return `not found`.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10774.

---

**Describe the proposed solution**

Add GRE and GIF nodes to the post-deletion update list only when they exist. Existing-item safeguards and interface updates remain unchanged.

Tested on OPNsense 26.7.2_2: both unknown UUIDs returned `{"result":"not found"}` without changing the configuration or adding PHP errors. PHP syntax and diff checks also pass.

---

**Related issue**

Fixes #10774