### PR TITLE
interfaces: handle missing PPP item ID

### DIFF
--- a/src/www/interfaces_ppps.php
+++ b/src/www/interfaces_ppps.php
@@ -49,7 +49,7 @@ $a_ppps = &config_read_array('ppps', 'ppp');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $input_errors = array();
-    if (!empty($a_ppps[$_POST['id']])) {
+    if (isset($_POST['id']) && !empty($a_ppps[$_POST['id']])) {
         $id = $_POST['id'];
     }
 


### PR DESCRIPTION
## TL;DR

Validate that the PPP item ID exists before using it as a configuration array offset.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10776.

---

**Describe the proposed solution**

Check that the POST field exists before looking up the PPP item. Valid item IDs, including index `0`, retain their existing behavior.

Tested on OPNsense 26.7.2_2 with an authenticated POST lacking `id`: the page returned HTTP 200 without changing the configuration or adding PHP messages. PHP syntax and diff checks also pass.

---

**Related issue**

Fixes #10776