### PR TITLE
diagnostics: handle missing authentication fields

### DIFF
--- a/src/www/diag_authentication.php
+++ b/src/www/diag_authentication.php
@@ -31,17 +31,16 @@ require_once("guiconfig.inc");
 require_once("interfaces.inc");
 
 $input_errors = array();
-if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    $pconfig = array("authmode" => "", "username" => "", "password" => "");
-} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $pconfig = $_POST;
+$pconfig = array("authmode" => "", "username" => "", "password" => "");
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $pconfig = array_merge($pconfig, $_POST);
 
-    $authcfg = auth_get_authserver($_POST['authmode']);
+    $authcfg = auth_get_authserver($pconfig['authmode']);
     if (!$authcfg) {
-        $input_errors[] = $_POST['authmode'] . " " . gettext("is not a valid authentication server");
+        $input_errors[] = $pconfig['authmode'] . " " . gettext("is not a valid authentication server");
     }
 
-    if (empty($_POST['username']) || empty($_POST['password'])) {
+    if (empty($pconfig['username']) || empty($pconfig['password'])) {
         $input_errors[] = gettext("A username and password must be specified.");
     }
 
@@ -54,12 +53,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
         $authFactory = new OPNsense\Auth\AuthenticationFactory();
         $authenticator = $authFactory->get($authName);
-        if ($authenticator->authenticate($_POST['username'], $_POST['password'])) {
-            $savemsg = gettext("User") . ": " . $_POST['username'] . " " . gettext("authenticated successfully.");
+        if ($authenticator->authenticate($pconfig['username'], $pconfig['password'])) {
+            $savemsg = gettext("User") . ": " . $pconfig['username'] . " " . gettext("authenticated successfully.");
             OPNsense\Core\Config::getInstance()->forceReload();
             $config = parse_config();
             $userindex = index_users();
-            $groups = getUserGroups($authenticator->getUserName($_POST['username']));
+            $groups = getUserGroups($authenticator->getUserName($pconfig['username']));
             $savemsg .= "<br /><br/><strong>" . gettext("This user is a member of these groups") . ": </strong> <br />";
             foreach ($groups as $group) {
                 $savemsg .= "{$group} ";
@@ -67,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $savemsg .= "<br /><br/><strong>" . gettext("May access the following locations, depending on source address") . ":</strong> <br />";
             $savemsg .= "<table style='width:700px;' class='alert-info'>";
             $savemsg .= sprintf("<tr><td>%s</td><td>%s</td></tr>", gettext('Uri'), gettext('Networks'));
-            foreach ((new \OPNsense\Core\ACL())->userUrlMasks($_POST['username']) as $item) {
+            foreach ((new \OPNsense\Core\ACL())->userUrlMasks($pconfig['username']) as $item) {
                 $savemsg .= sprintf("<tr><td>%s</td><td>%s</td></tr>", $item[0], implode(',', $item[1]));
             }
             $savemsg .= "</table>";


### PR DESCRIPTION
## TL;DR

Normalize Authentication Tester input with the existing empty form defaults before validation and authentication.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: OpenAI Codex (GPT-5)
- Extent of AI involvement: AI-assisted diagnosis, implementation, testing, and drafting; reviewed by the human contributor before submission.

---

**Describe the problem**

Tracked in #10778.

---

**Describe the proposed solution**

Merge submitted data with the existing empty defaults and consistently use the normalized form configuration.

Tested on OPNsense 26.7.2_2: both GET and an authenticated empty POST returned HTTP 200 without changing the configuration or adding PHP messages. PHP syntax and diff checks also pass.

---

**Related issue**

Fixes #10778