### PR TITLE
trust: Fix server certificate purpose detection

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -249,10 +249,11 @@ function cert_get_purpose($str_crt, $decode = true)
     }
     $purpose['ca'] = in_array('CA:TRUE', $purpose['basicConstraints']) ? 'Yes' : 'No';
     $purpose['server'] = in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) ? 'Yes' : 'No';
-    // rfc3280 extended key usage
+    // RFC 5280, section 4.2.1.12: serverAuth permits digitalSignature, keyEncipherment, or keyAgreement.
     if (
-        in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) &&
-        in_array('Digital Signature', $purpose['keyUsage']) && (
+        in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) && (
+            empty($purpose['keyUsage']) ||
+            in_array('Digital Signature', $purpose['keyUsage']) ||
             in_array('Key Encipherment', $purpose['keyUsage']) ||
             in_array('Key Agreement', $purpose['keyUsage'])
         )

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -249,7 +249,7 @@ function cert_get_purpose($str_crt, $decode = true)
     }
     $purpose['ca'] = in_array('CA:TRUE', $purpose['basicConstraints']) ? 'Yes' : 'No';
     $purpose['server'] = in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) ? 'Yes' : 'No';
-    // RFC 5280, section 4.2.1.12: serverAuth permits digitalSignature, keyEncipherment, or keyAgreement.
+    // RFC 5280, section 4.2.1.12 lists these key usage bits as consistent with serverAuth
     if (
         in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) && (
             empty($purpose['keyUsage']) ||

--- a/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
@@ -415,7 +415,7 @@ class Store
         // Extended key usage purpose definitions (+ cert_type derivative field)
         $result['rfc3280_purpose'] = '';
         $result['cert_type'] = '';
-        // RFC 5280, section 4.2.1.12: serverAuth permits digitalSignature, keyEncipherment, or keyAgreement.
+        // RFC 5280, section 4.2.1.12 lists these key usage bits as consistent with serverAuth
         if (
             in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) && (
                 empty($purpose['keyUsage']) ||

--- a/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
@@ -412,12 +412,17 @@ class Store
             }
         }
 
-        // rfc3280 purpose definitions (+ cert_type derivative field)
+        // Extended key usage purpose definitions (+ cert_type derivative field)
         $result['rfc3280_purpose'] = '';
         $result['cert_type'] = '';
+        // RFC 5280, section 4.2.1.12: serverAuth permits digitalSignature, keyEncipherment, or keyAgreement.
         if (
-            in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) &&
-            in_array('Digital Signature', $purpose['keyUsage'])
+            in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) && (
+                empty($purpose['keyUsage']) ||
+                in_array('Digital Signature', $purpose['keyUsage']) ||
+                in_array('Key Encipherment', $purpose['keyUsage']) ||
+                in_array('Key Agreement', $purpose['keyUsage'])
+            )
         ) {
             $result['rfc3280_purpose'] = 'id-kp-serverAuth';
             $both = in_array('TLS Web Client Authentication', $purpose['extendedKeyUsage']);

--- a/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Trust/Store.php
@@ -417,10 +417,7 @@ class Store
         $result['cert_type'] = '';
         if (
             in_array('TLS Web Server Authentication', $purpose['extendedKeyUsage']) &&
-            in_array('Digital Signature', $purpose['keyUsage']) && (
-                in_array('Key Encipherment', $purpose['keyUsage']) ||
-                in_array('Key Agreement', $purpose['keyUsage'])
-            )
+            in_array('Digital Signature', $purpose['keyUsage'])
         ) {
             $result['rfc3280_purpose'] = 'id-kp-serverAuth';
             $both = in_array('TLS Web Client Authentication', $purpose['extendedKeyUsage']);


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT Codex 5.6 Sol Medium
- Extent of AI involvement: Finding the RFC and implementing the condition

---

**Describe the problem**

Create a certificate like this for testing:

```
openssl ecparam -name secp384r1 -genkey -noout -out server.key

openssl req -new -x509 \
    -key server.key \
    -out server.crt \
    -days 365 \
    -subj "/CN=test.example.com" \
    -addext "subjectAltName=DNS:test.example.com" \
    -addext "extendedKeyUsage=serverAuth" \
    -addext "keyUsage=digitalSignature"
```

---

**Describe the proposed solution**

Allow ECDSA TLS server certificates that only require digital signatures, without requiring key encipherment or key agreement.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10749