### PR TITLE
hostwatch: emit discovered hosts sorted by last_seen, which helps callers like kea_prefix_watcher to use the most recent address

### DIFF
--- a/src/opnsense/scripts/captiveportal/lib/arp.py
+++ b/src/opnsense/scripts/captiveportal/lib/arp.py
@@ -67,16 +67,7 @@ class ARP(object):
         source = out.get("source")
         rows = out.get("rows", [])
 
-        if source == "discovery":
-            rows_iter = sorted(
-                rows,
-                key=lambda row: datetime.strptime(row[5], "%Y-%m-%dT%H:%M:%SZ"),
-                reverse=True
-            )
-        else:
-            rows_iter = rows
-
-        for row in rows_iter:
+        for row in rows:
             ip = row[2]
 
             entry = {

--- a/src/opnsense/scripts/interfaces/list_hosts.py
+++ b/src/opnsense/scripts/interfaces/list_hosts.py
@@ -84,6 +84,10 @@ if __name__ == '__main__':
             """
             params.append(inputargs.last_seen_window)
 
+        query += """
+            ORDER BY last_seen ASC
+        """
+
         for row in con.execute(query, params):
             record = [row['interface_name'], row['ether_address'], row['ip_address']]
             if inputargs.verbose:

--- a/src/opnsense/scripts/interfaces/list_hosts.py
+++ b/src/opnsense/scripts/interfaces/list_hosts.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
             params.append(inputargs.last_seen_window)
 
         query += """
-            ORDER BY last_seen ASC
+            ORDER BY last_seen DESC
         """
 
         for row in con.execute(query, params):

--- a/src/opnsense/scripts/kea/kea_prefix_watcher.py
+++ b/src/opnsense/scripts/kea/kea_prefix_watcher.py
@@ -95,8 +95,9 @@ class Hostwatch:
         for row in ujson.loads(out).get("rows", []):
             # [ifname, mac, ip]
             if ipaddress.ip_address(row[2]).is_link_local:
-                # link local requires scope ID here, otherwise route add will fail
-                self._def_local_db[(row[0], row[1])] = f"{row[2]}%{row[0]}"
+                # Results are newest first, retain the first link-local address per host.
+                # Link-local addresses require a scope ID here, otherwise route add will fail.
+                self._def_local_db.setdefault((row[0], row[1]), f"{row[2]}%{row[0]}")
 
     def get(self, ifname, mac):
         if (ifname, mac) not in self._def_local_db:


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10736