### PR TITLE
VPN: Wireguard: Reposition peer generator QR code into own field

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogConfigBuilder.xml
@@ -71,6 +71,11 @@
         <type>textbox</type>
     </field>
     <field>
+        <id>configbuilder.qrcode</id>
+        <label>QR code</label>
+        <type>info</type>
+    </field>
+    <field>
         <id>configbuilder.actions</id>
         <type>buttons</type>
         <parent>configbuilder</parent>

--- a/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -256,12 +256,10 @@
                 }
             });
         })
-        let tmp = $("#configbuilder\\.output").closest('tr');
-        tmp.find('td:eq(2)').empty().append($("<div id='qrcode'/>"));
         $("#configbuilder\\.output").css('max-width', '100%');
         $("#configbuilder\\.output").css('height', '256px');
         $("#configbuilder\\.output").on('input', function() {
-            $('#qrcode').empty().qrcode($(this).val());
+            $("#configbuilder\\.qrcode").empty().qrcode($(this).val());
         });
 
         $("#configbuilder\\.servers").change(function(){


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

For consistency add QR code into an own info field below the config output.