### PR TITLE
dnsmasq: leases sorting fixes

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
@@ -88,7 +88,8 @@ class ApiControllerBase extends ControllerRoot
         $defaultSort = null,
         $filter_funct = null,
         $sort_flags = SORT_NATURAL | SORT_FLAG_CASE,
-        $search_clauses = null
+        $search_clauses = null,
+        $sort_transforms = []
     ) {
         $records = is_array($records) ? $records : []; // safeguard input, we are only able to search arrays.
         $itemsPerPage = intval($this->request->getPost('rowCount', 'int', 9999));
@@ -121,6 +122,10 @@ class ApiControllerBase extends ControllerRoot
                 }
             }
             $keys = array_column($records, $sortKey);
+            if (isset($sort_transforms[$sortKey])) {
+                $keys = array_map($sort_transforms[$sortKey], $keys);
+                $sort_flags = SORT_STRING; // a transform yields a directly comparable key
+            }
             array_multisort($keys, $sortOrder, $sort_flags, $records);
         }
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Base/ApiControllerBase.php
@@ -88,8 +88,7 @@ class ApiControllerBase extends ControllerRoot
         $defaultSort = null,
         $filter_funct = null,
         $sort_flags = SORT_NATURAL | SORT_FLAG_CASE,
-        $search_clauses = null,
-        $sort_transforms = []
+        $search_clauses = null
     ) {
         $records = is_array($records) ? $records : []; // safeguard input, we are only able to search arrays.
         $itemsPerPage = intval($this->request->getPost('rowCount', 'int', 9999));
@@ -122,10 +121,6 @@ class ApiControllerBase extends ControllerRoot
                 }
             }
             $keys = array_column($records, $sortKey);
-            if (isset($sort_transforms[$sortKey])) {
-                $keys = array_map($sort_transforms[$sortKey], $keys);
-                $sort_flags = SORT_STRING; // a transform yields a directly comparable key
-            }
             array_multisort($keys, $sortOrder, $sort_flags, $records);
         }
 

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
@@ -91,6 +91,11 @@ class LeasesController extends ApiControllerBase
             }
         }
 
+        /* fixed-width decimal-per-byte keys so the grid's natural sort orders
+         * the address and hex fields numerically instead of as text */
+        $byteSortKey = fn($bin) => $bin === false ? ''
+            : implode('.', array_map(fn($b) => sprintf('%03d', $b), unpack('C*', $bin)));
+
         foreach ($records as &$record) {
             $reservedBy = [];
             foreach (['client_id', 'hwaddr'] as $reservedType) {
@@ -100,21 +105,18 @@ class LeasesController extends ApiControllerBase
                 }
             }
             $record['is_reserved'] = $reservedBy;
+            $record['lease_type'] = empty($reservedBy) ? 'dynamic' : 'static';
+            /* length prefix groups IPv4 before IPv6 instead of interleaving */
+            $addressBin = @inet_pton($record['address']);
+            $record['sort_address'] = sprintf('%02d.', strlen((string)$addressBin)) . $byteSortKey($addressBin);
+            $record['sort_hwaddr'] = $byteSortKey(@hex2bin(str_replace(':', '', $record['hwaddr'])));
+            $record['sort_client_id'] = $byteSortKey(@hex2bin(str_replace(':', '', $record['client_id'])));
         }
 
-        /* Sort keys that compare byte-for-byte rather than as text (which
-         * mis-orders IPv6 and hex fields): pack the address to bytes, and
-         * normalise MAC/DUID hex. */
-        $addressSortKey = function ($address) {
-            /* length prefix groups IPv4 before IPv6 */
-            $bin = @inet_pton($address);
-            return $bin === false ? $address : sprintf('%02x', strlen($bin)) . bin2hex($bin);
-        };
-        $hexSortKey = fn($value) => strtolower(str_replace(':', '', (string)$value));
         $response = $this->searchRecordsetBase(
             $records,
-            null,
-            'address',
+            ['if_descr', 'address', 'hwaddr', 'mac_info', 'iaid', 'client_id', 'hostname'],
+            'sort_address',
             function ($record) use ($selected_interfaces, $selected_protocol) {
                 $interfaceMatch = empty($selected_interfaces)
                     || in_array($record['if_name'], $selected_interfaces, true);
@@ -129,16 +131,7 @@ class LeasesController extends ApiControllerBase
                 }
 
                 return $interfaceMatch && $protocolMatch;
-            },
-            SORT_NATURAL | SORT_FLAG_CASE,
-            null,
-            [
-                'address' => $addressSortKey,
-                'hwaddr' => $hexSortKey,
-                'client_id' => $hexSortKey,
-                /* is_reserved is an array; sort by the derived lease type */
-                'is_reserved' => fn($reserved) => empty($reserved) ? 'dynamic' : 'static',
-            ]
+            }
         );
 
         $response['interfaces'] = $interfaces;

--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
@@ -102,6 +102,15 @@ class LeasesController extends ApiControllerBase
             $record['is_reserved'] = $reservedBy;
         }
 
+        /* Sort keys that compare byte-for-byte rather than as text (which
+         * mis-orders IPv6 and hex fields): pack the address to bytes, and
+         * normalise MAC/DUID hex. */
+        $addressSortKey = function ($address) {
+            /* length prefix groups IPv4 before IPv6 */
+            $bin = @inet_pton($address);
+            return $bin === false ? $address : sprintf('%02x', strlen($bin)) . bin2hex($bin);
+        };
+        $hexSortKey = fn($value) => strtolower(str_replace(':', '', (string)$value));
         $response = $this->searchRecordsetBase(
             $records,
             null,
@@ -120,7 +129,16 @@ class LeasesController extends ApiControllerBase
                 }
 
                 return $interfaceMatch && $protocolMatch;
-            }
+            },
+            SORT_NATURAL | SORT_FLAG_CASE,
+            null,
+            [
+                'address' => $addressSortKey,
+                'hwaddr' => $hexSortKey,
+                'client_id' => $hexSortKey,
+                /* is_reserved is an array; sort by the derived lease type */
+                'is_reserved' => fn($reserved) => empty($reserved) ? 'dynamic' : 'static',
+            ]
         );
 
         $response['interfaces'] = $interfaces;

--- a/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Dnsmasq/leases.volt
@@ -70,6 +70,12 @@
                     "overflowformatter": function (column, row) {
                         return '<span class="overflow">' + row[column.id] + '</span><br/>'
                     },
+                    "addressformatter": function (column, row) {
+                        return '<span class="overflow">' + row.address + '</span><br/>'
+                    },
+                    "duidformatter": function (column, row) {
+                        return '<span class="overflow">' + row.client_id + '</span><br/>'
+                    },
                     "macformatter": function (column, row) {
                         let mac = '<span class="overflow">' + row.hwaddr + '</span>';
                         if (row.mac_info != '') {
@@ -167,13 +173,13 @@
         <thead>
             <tr>
                 <th data-column-id="if_descr" data-type="string">{{ lang._('Interface') }}</th>
-                <th data-column-id="address" data-identifier="true" data-type="string" data-formatter="overflowformatter">{{ lang._('IP Address') }}</th>
-                <th data-column-id="hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
+                <th data-column-id="sort_address" data-identifier="true" data-type="string" data-formatter="addressformatter">{{ lang._('IP Address') }}</th>
+                <th data-column-id="sort_hwaddr" data-type="string" data-formatter="macformatter" data-width="9em">{{ lang._('MAC Address') }}</th>
                 <th data-column-id="iaid" data-type="string" data-width="9em">{{ lang._('IAID') }}</th>
-                <th data-column-id="client_id" data-type="string" data-formatter="overflowformatter">{{ lang._('DUID') }}</th>
+                <th data-column-id="sort_client_id" data-type="string" data-formatter="duidformatter">{{ lang._('DUID') }}</th>
                 <th data-column-id="expire" data-type="string" data-formatter="timestamp">{{ lang._('Expire') }}</th>
                 <th data-column-id="hostname" data-type="string" data-formatter="overflowformatter">{{ lang._('Hostname') }}</th>
-                <th data-column-id="is_reserved" data-type="string" data-formatter="reservation" data-width="6em">{{ lang._('Lease Type') }}</th>
+                <th data-column-id="lease_type" data-type="string" data-formatter="reservation" data-width="6em">{{ lang._('Lease Type') }}</th>
                 <th data-column-id="commands" data-formatter="commands" data-sortable="false" data-width="6em">{{ lang._('Commands') }}</th>
             </tr>
         </thead>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.8
- Extent of AI involvement: Identified the source of the issues and suggested solutions.

---

**Describe the problem**

Ordering of various Dnsmasq lease fields (IP Address, MAC Address, DUID, Lease Type) currently does not work properly since the existing code does not take proper account of the underlying data structure (array) or type (hex numbers).

---

**Describe the proposed solution**

Ensure proper ordering.

(Note that the same issues likely affect the KEA leases sorting, however I am focusing this PR on Dnsmasq for the time being.)

---

**Related issue**

https://forum.opnsense.org/index.php?topic=52794.0