### PR TITLE
Firewall: NAT: Source NAT: fix port alias and well known port usage in target_port

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
@@ -204,7 +204,7 @@
         <label>Translate Source Port</label>
         <type>text</type>
         <style>port_selector</style>
-        <help>Source port number or well known name (imap, imaps, http, https, ...)</help>
+        <help>Source port number, well-known name, range, or alias containing a single port or range.</help>
         <grid_view>
             <formatter>alias</formatter>
             <sequence>95</sequence>

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
@@ -102,13 +102,29 @@ class SNatRule extends Rule
             }
             foreach (array("sourceport", "dstport", "natport") as $fieldname) {
                 if (!empty($rule[$fieldname]) && Util::isAlias($rule[$fieldname])) {
-                    if (!Util::isAlias($rule[$fieldname], true)) {
-                        // unable to map port
-                        $this->log("SNAT / unable to map port " . $rule[$fieldname] . ", empty?");
-                        $rule['disabled'] = true;
+                    if ($fieldname == 'natport') {
+                        // PF translation ports accept one port or range, not an alias macro containing a list.
+                        $ports = Util::getPortAlias($rule[$fieldname]);
+                        if (count($ports) == 1) {
+                            $rule[$fieldname] = $ports[0];
+                        } else {
+                            $this->log(
+                                "SNAT / target port alias " . $rule[$fieldname] .
+                                " must resolve to exactly one port or range"
+                            );
+                            $rule['disabled'] = true;
+                            $rule[$fieldname] = '';
+                        }
+                    } else {
+                        if (!Util::isAlias($rule[$fieldname], true)) {
+                            // unable to map port
+                            $this->log("SNAT / unable to map port " . $rule[$fieldname] . ", empty?");
+                            $rule['disabled'] = true;
+                        }
+                        $rule[$fieldname] = "$" . $rule[$fieldname];
                     }
-                    $rule[$fieldname] = "$" . $rule[$fieldname];
-                } elseif (!empty($rule[$fieldname])) {
+                }
+                if (!empty($rule[$fieldname]) && !str_starts_with((string)$rule[$fieldname], '$')) {
                     $rule[$fieldname] = str_replace('-', ':', $rule[$fieldname]); // range interpretation
                 }
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
@@ -30,6 +30,7 @@ namespace OPNsense\Firewall\FieldTypes;
 
 use OPNsense\Base\FieldTypes\ArrayField;
 use OPNsense\Base\FieldTypes\ContainerField;
+use OPNsense\Base\FieldTypes\PortField;
 use OPNsense\Core\Config;
 
 /**
@@ -66,6 +67,8 @@ class SourceNatRuleContainerField extends ContainerField
                     if ((string)$node != 'any') {
                         $result[$target_fieldname] = (string)$node;
                     }
+                } elseif ($key == 'target_port' && is_a($node, PortField::class) && $node->getValue() != '') {
+                    $result[$target_fieldname] = (string)$node->normalizedPort();
                 } elseif ((string)$node != '') {
                     /*
                      * XXX: Omit empty values to allow array_merge() to overlay default values in Plugin.php.

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/FieldTypes/SourceNatRuleField.php
@@ -29,8 +29,10 @@
 namespace OPNsense\Firewall\FieldTypes;
 
 use OPNsense\Base\FieldTypes\ArrayField;
+use OPNsense\Base\FieldTypes\BooleanField;
 use OPNsense\Base\FieldTypes\ContainerField;
 use OPNsense\Base\FieldTypes\PortField;
+use OPNsense\Base\FieldTypes\ProtocolField;
 use OPNsense\Core\Config;
 
 /**
@@ -61,9 +63,9 @@ class SourceNatRuleContainerField extends ContainerField
         foreach ($this->iterateItems() as $key => $node) {
             $target_fieldname = isset($source_mapper[$key]) ? $source_mapper[$key] : $key;
             if ($target_fieldname) {
-                if (is_a($node, "OPNsense\\Base\\FieldTypes\\BooleanField")) {
+                if (is_a($node, BooleanField::class)) {
                     $result[$target_fieldname] = !empty((string)$node);
-                } elseif (is_a($node, "OPNsense\\Base\\FieldTypes\\ProtocolField")) {
+                } elseif (is_a($node, ProtocolField::class)) {
                     if ((string)$node != 'any') {
                         $result[$target_fieldname] = (string)$node;
                     }

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
@@ -163,9 +163,20 @@ class Filter extends BaseModel
                                 $rule->target->__reference
                             ));
                         }
-                        if (!empty((string)$rule->target_port) && !in_array($rule->protocol, $port_protos)) {
+                        $target_port = $rule->target_port->getValue();
+                        if (!empty($target_port) && !in_array($rule->protocol, $port_protos)) {
                             $messages->appendMessage(new Message(
                                 gettext("Target ports are only valid for tcp or udp type rules."),
+                                $rule->target_port->__reference
+                            ));
+                        }
+                        if (
+                            !empty($target_port) &&
+                            Util::isAlias($target_port) &&
+                            count(Util::getPortAlias($target_port)) != 1
+                        ) {
+                            $messages->appendMessage(new Message(
+                                gettext("Target port aliases must resolve to exactly one port or port range."),
                                 $rule->target_port->__reference
                             ));
                         }

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -517,6 +517,8 @@
                 <target_port type="PortField">
                     <EnableWellKnown>Y</EnableWellKnown>
                     <EnableRanges>Y</EnableRanges>
+                    <EnableAlias>Y</EnableAlias>
+                    <ValidationMessage>Please specify a valid port number, well-known name, alias or range.</ValidationMessage>
                 </target_port>
                 <staticnatport type="BooleanField"/>
                 <log type="BooleanField">


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT Codex Sol 5.6 medium
- Extent of AI involvement: Took the existing DNAT fix for the same issue and converted it to SNAT

---

**Describe the problem**

Fixes: https://github.com/opnsense/core/issues/10788

This also adds the capability to use a port alias, not only a well known port, because it is normalized now anyway. This also adds a new validation to prevent most invalid port aliases
