### PR TITLE
mvc: advanced marker for fields POC

### DIFF
--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -83,7 +83,7 @@
                         <tr>
                             <td colspan="3">
                                 <span>
-                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}</td>
+                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}
                                 </span>
                                 <span class="pull-right">
                                     {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-sm fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -81,9 +81,13 @@
                         <tbody {%if not (section['static']|default(false)) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
                         {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
                         <tr>
-                            <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
-                            <td colspan="2" style="text-align:right;">
-                                {% if fields['help']|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}
+                            <td colspan="3">
+                                <span>
+                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cogs fa-fw text-info"></i>{% endif %}</td>
+                                </span>
+                                <span class="pull-right">
+                                    {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}
+                                </span>
                             </td>
                         </tr>
                         {% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -83,7 +83,7 @@
                         <tr>
                             <td colspan="3">
                                 <span>
-                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}
+                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-warning"></i>{% endif %}
                                 </span>
                                 <span class="pull-right">
                                     {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-sm fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_dialog.volt
@@ -83,10 +83,10 @@
                         <tr>
                             <td colspan="3">
                                 <span>
-                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cogs fa-fw text-info"></i>{% endif %}</td>
+                                    {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}</td>
                                 </span>
                                 <span class="pull-right">
-                                    {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}
+                                    {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-sm fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_dialog_id}}"></i></a>{% endif %}
                                 </span>
                             </td>
                         </tr>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -73,9 +73,13 @@
             <tbody {%if not (section['static']|default(false)) %}class="collapsible" {% if section['collapse']|default(false) %}style="display: none;"{%endif%}{%endif%}>
             {%  if not section['type'] and (fields['advanced']|default(false) or fields['help']|default(false)) %}
             <tr>
-                <td>{% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
-                <td colspan="2" style="text-align:right;">
-                    {% if fields['help']|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
+                <td colspan="3">
+                    <span>
+                        {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cogs fa-fw text-info"></i>{% endif %}
+                    </span>
+                    <span class="pull-right">
+                        {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i><small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
+                    </span>
                 </td>
             </tr>
             {% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -78,7 +78,7 @@
                         {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cogs fa-fw text-info"></i>{% endif %}
                     </span>
                     <span class="pull-right">
-                        {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i><small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
+                        {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
                     </span>
                 </td>
             </tr>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -75,10 +75,10 @@
             <tr>
                 <td colspan="3">
                     <span>
-                        {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cogs fa-fw text-info"></i>{% endif %}
+                        {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}
                     </span>
                     <span class="pull-right">
-                        {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
+                        {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-sm fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}
                     </span>
                 </td>
             </tr>

--- a/src/opnsense/mvc/app/views/layout_partials/base_form.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/base_form.volt
@@ -75,7 +75,7 @@
             <tr>
                 <td colspan="3">
                     <span>
-                        {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-info"></i>{% endif %}
+                        {% if fields['advanced']|default(false) %}<a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_advanced_{{base_form_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small> <i class="fa fa-cog fa-sm fa-fw text-warning"></i>{% endif %}
                     </span>
                     <span class="pull-right">
                         {% if fields['help']|default(false) %}<i class="fa fa-info-circle fa-sm fa-fw text-primary"></i> <small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off fa-fw text-danger" id="show_all_help_{{base_form_id}}"></i></a>{% endif %}

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -80,9 +80,12 @@
     <td>
         <div class="control-label" id="control_label_{{ id }}">
             {% if help|default(false) %}
-                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a>
+                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle" data-toggle="tooltip" title="{{ lang._('Help') }}"></i></a>
             {% elseif help|default(false) == false %}
                 <i class="fa fa-info-circle text-muted"></i>
+            {% endif %}
+            {% if advanced|default(false)=='true' %}
+                <i class="text-warning fa fa-exclamation-triangle" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
             {% endif %}
             <b>{{label}}</b>
         </div>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -80,13 +80,13 @@
     <td>
         <div class="control-label" id="control_label_{{ id }}">
             {% if help|default(false) %}
-                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle fa-fw" data-toggle="tooltip" title="{{ lang._('Help') }}"></i></a>
+                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle fa-fw"></i></a>
             {% elseif help|default(false) == false %}
                 <i class="fa fa-info-circle fa-fw text-muted"></i>
             {% endif %}
             <b>{{label}}</b>
             {% if advanced|default(false)=='true' %}
-                <i class="fa fa-cogs fa-fw text-info" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
+                <i class="fa fa-cogs fa-fw text-info"></i>
             {% endif %}
         </div>
     </td>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -86,7 +86,7 @@
             {% endif %}
             <b>{{label}}</b>
             {% if advanced|default(false)=='true' %}
-                <i class="fa fa-cogs fa-fw text-info"></i>
+                <i class="fa fa-cog fa-sm fa-fw text-info"></i>
             {% endif %}
         </div>
     </td>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -86,7 +86,7 @@
             {% endif %}
             <b>{{label}}</b>
             {% if advanced|default(false)=='true' %}
-                <i class="fa fa-cog fa-fw text-muted" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
+                <i class="fa fa-cogs fa-fw text-info" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
             {% endif %}
         </div>
     </td>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -86,7 +86,7 @@
             {% endif %}
             <b>{{label}}</b>
             {% if advanced|default(false)=='true' %}
-                <i class="fa fa-cog fa-sm fa-fw text-info"></i>
+                <i class="fa fa-cog fa-sm fa-fw text-warning"></i>
             {% endif %}
         </div>
     </td>

--- a/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
+++ b/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt
@@ -80,14 +80,14 @@
     <td>
         <div class="control-label" id="control_label_{{ id }}">
             {% if help|default(false) %}
-                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle" data-toggle="tooltip" title="{{ lang._('Help') }}"></i></a>
+                <a id="help_for_{{ id }}" href="#" class="showhelp"><i class="fa fa-info-circle fa-fw" data-toggle="tooltip" title="{{ lang._('Help') }}"></i></a>
             {% elseif help|default(false) == false %}
-                <i class="fa fa-info-circle text-muted"></i>
-            {% endif %}
-            {% if advanced|default(false)=='true' %}
-                <i class="text-warning fa fa-exclamation-triangle" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
+                <i class="fa fa-info-circle fa-fw text-muted"></i>
             {% endif %}
             <b>{{label}}</b>
+            {% if advanced|default(false)=='true' %}
+                <i class="fa fa-cog fa-fw text-muted" data-toggle="tooltip" title="{{ lang._('Advanced') }}"></i>
+            {% endif %}
         </div>
     </td>
     <td>


### PR DESCRIPTION
Also adds tooltip for it and help button.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Advanced fields are hard to spot in larger forms.

---

**Describe the proposed solution**

Show a marker next to them. Might even help people treating them with a bit more respect. ;)

Left:

<img width="737" height="176" alt="Screenshot 2026-08-25 at 15 00 17" src="https://github.com/user-attachments/assets/8a27ba80-56f7-4d40-8b02-a23bd84bf43b" />

Right:

<img width="785" height="175" alt="Screenshot 2026-08-25 at 14 59 53" src="https://github.com/user-attachments/assets/d173c3b0-fcf8-4018-b304-20ca3ed2cb9b" />

Tooltip:

<img width="307" height="108" alt="Screenshot 2026-08-25 at 15 00 27" src="https://github.com/user-attachments/assets/d56c7f91-09dd-4311-9f51-42eda84a0b4c" />

I kinda like the right one, but left works also. Tooltips might be a bit annoying for general help but I included it for discussion.