### PR TITLE
ipsec: add hybrid post-quantum variants as a first additional key exchange

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -112,7 +112,6 @@ class IPsecProposalField extends BaseListField
             gettext('Internal') => [
                 'default' => gettext('default')
             ],
-
             /* Non-AEAD algorithms */
             gettext('Commonly used AES') => [
                 'aes256-sha256-modp2048' => null,
@@ -124,12 +123,10 @@ class IPsecProposalField extends BaseListField
                 'aes256-sha256-ecp521' => null,
                 'aes256-sha512-ecp521' => null,
             ],
-
             /* AEAD algorithms */
             gettext('Commonly used combined-mode (AEAD) ciphers') => [
                 ...$this->AeadAlgorithms()
             ],
-
             gettext('Commonly used, but insecure cipher suites') => [
                 'aes256-sha1-modp2048' => 'aes256-sha1-modp2048 [DH14]',
                 'aes192-sha1-modp2048' => 'aes192-sha1-modp2048 [DH14]',

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -105,28 +105,93 @@ class IPsecProposalField extends BaseListField
         return $this->phase == '1' ? $this->AeadPhase1() : $this->AeadPhase2();
     }
 
+    private function addPostQuantumKeOptions(array $ciphers)
+    {
+       /*
+        * Add hybrid post-quantum key exchange options using a single additional
+        * key exchange (KE1). ML-KEM is deliberately not offered as
+        * the primary key exchange to prevent a larger cartesian product in our UI.
+        *
+        * We only offer the post-quantum variants on top of classical primary key exchanges,
+        * see https://www.rfc-editor.org/rfc/rfc9370.html#section-1.1-2 and only within our
+        * "Commonly used" section.
+        */
+
+        $dhgroups = [
+            'modp2048',
+            'modp3072',
+            'modp4096',
+            'modp6144',
+            'modp8192',
+            'ecp224',
+            'ecp256',
+            'ecp384',
+            'ecp521',
+            'ecp224bp',
+            'ecp256bp',
+            'ecp384bp',
+            'ecp512bp',
+            'x25519',
+            'x448',
+        ];
+
+        $postQuantumKe = [
+            'mlkem512' => 'ML-KEM-512 (ID 35)',
+            'mlkem768' => 'ML-KEM-768 (ID 36)',
+            'mlkem1024' => 'ML-KEM-1024 (ID 37)',
+        ];
+
+        $result = $ciphers;
+
+        foreach ($ciphers as $cipher => $description) {
+            foreach ($dhgroups as $dhgroup) {
+                if (substr($cipher, -strlen("-{$dhgroup}")) !== "-{$dhgroup}") {
+                    continue;
+                }
+
+                foreach ($postQuantumKe as $pqKe => $pqDescription) {
+                    $pqCipher = "{$cipher}-ke1_{$pqKe}";
+
+                    $result[$pqCipher] = "{$pqCipher} [{$pqDescription}]";
+                }
+
+                break;
+            }
+        }
+
+        return $result;
+    }
+
     private function commonOptions()
     {
+        $commonAes = [
+            'aes256-sha256-modp2048' => null,
+            'aes256-sha512-modp2048' => null,
+            'aes128-sha256-modp2048' => null,
+            'aes128-sha512-modp2048' => null,
+            'aes256-sha256-modp4096' => null,
+            'aes256-sha512-modp4096' => null,
+            'aes256-sha256-ecp521' => null,
+            'aes256-sha512-ecp521' => null,
+        ];
+
+        $commonAead = $this->AeadAlgorithms();
+
+        $commonAes = $this->addPostQuantumKeOptions($commonAes);
+        $commonAead = $this->addPostQuantumKeOptions($commonAead);
+
         /* group and cipher order, when set to null an auto generated description will be used */
         return [
             gettext('Internal') => [
                 'default' => gettext('default')
             ],
+
             /* Non-AEAD algorithms */
-            gettext('Commonly used AES') => [
-                'aes256-sha256-modp2048' => null,
-                'aes256-sha512-modp2048' => null,
-                'aes128-sha256-modp2048' => null,
-                'aes128-sha512-modp2048' => null,
-                'aes256-sha256-modp4096' => null,
-                'aes256-sha512-modp4096' => null,
-                'aes256-sha256-ecp521' => null,
-                'aes256-sha512-ecp521' => null,
-            ],
+            gettext('Commonly used AES') => $commonAes,
+
             /* AEAD algorithms */
-            gettext('Commonly used combined-mode (AEAD) ciphers') => [
-                ...$this->AeadAlgorithms()
-            ],
+            gettext('Commonly used combined-mode (AEAD) ciphers') => $commonAead,
+
             gettext('Commonly used, but insecure cipher suites') => [
                 'aes256-sha1-modp2048' => 'aes256-sha1-modp2048 [DH14]',
                 'aes192-sha1-modp2048' => 'aes192-sha1-modp2048 [DH14]',
@@ -208,53 +273,6 @@ class IPsecProposalField extends BaseListField
                 }
             }
             self::$internalCacheOptionList[$this->internalCacheKey] = self::$internalCacheOptionList[$this->internalCacheKey] + $gcm_prf_options;
-
-            /*
-             * Add hybrid post-quantum variants using a single additional
-             * key exchange (KE1). ML-KEM is deliberately not offered as
-             * the primary key exchange to prevent a larger cartesian product in our UI.
-             *
-             * We only offer the post-quantum variants on top of classical primary key exchanges,
-             * see https://www.rfc-editor.org/rfc/rfc9370.html#section-1.1-2
-             *
-             * For example:
-             *
-             * aes256-sha384-x25519
-             *
-             * additionally produces:
-             *
-             * aes256-sha384-x25519-ke1_mlkem512
-             * aes256-sha384-x25519-ke1_mlkem768
-             * aes256-sha384-x25519-ke1_mlkem1024
-             */
-            $pqOptions = [];
-
-            foreach (self::$internalCacheOptionList[$this->internalCacheKey] as $cipher => $option) {
-                foreach ($dhgroups as $dhgroup => $dhDescription) {
-                    if (
-                        $cipher === $dhgroup ||
-                        substr($cipher, -strlen("-{$dhgroup}")) === "-{$dhgroup}"
-                    ) {
-                        foreach ($postQuantumKe as $pqKe => $pqDescription) {
-                            $pqCipher = "{$cipher}-ke1_{$pqKe}";
-
-                            $description = $option['value'];
-                            if (empty($description)) {
-                                $description = $cipher . " [{$dhDescription}]";
-                            }
-
-                            $pqOptions[$pqCipher] = [
-                                'value' => $pqCipher . " [{$dhDescription} + {$pqDescription}]",
-                                'optgroup' => $option['optgroup']
-                            ];
-                        }
-
-                        break;
-                    }
-                }
-            }
-
-            self::$internalCacheOptionList[$this->internalCacheKey] = self::$internalCacheOptionList[$this->internalCacheKey] + $pqOptions;
         }
 
         $this->internalOptionList = self::$internalCacheOptionList[$this->internalCacheKey];

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -176,6 +176,13 @@ class IPsecProposalField extends BaseListField
                 'x25519' => 'DH31, Modern EC',
                 'x448' => 'DH32, Modern EC'
             ];
+
+            $postQuantumKe = [
+                'mlkem512' => 'ML-KEM-512 (ID 35)',
+                'mlkem768' => 'ML-KEM-768 (ID 36)',
+                'mlkem1024' => 'ML-KEM-1024 (ID 37)',
+            ];
+
             $gcm_prf_options = [];
             foreach (['aes128', 'aes192', 'aes256', 'aes128gcm16', 'aes192gcm16', 'aes256gcm16'] as $encalg) {
                 foreach (['sha256', 'sha384', 'sha512', 'aesxcbc'] as $intalg) {
@@ -201,6 +208,53 @@ class IPsecProposalField extends BaseListField
                 }
             }
             self::$internalCacheOptionList[$this->internalCacheKey] = self::$internalCacheOptionList[$this->internalCacheKey] + $gcm_prf_options;
+
+            /*
+             * Add hybrid post-quantum variants using a single additional
+             * key exchange (KE1). ML-KEM is deliberately not offered as
+             * the primary key exchange to prevent a larger cartesian product in our UI.
+             *
+             * We only offer the post-quantum variants on top of classical primary key exchanges,
+             * see https://www.rfc-editor.org/rfc/rfc9370.html#section-1.1-2
+             *
+             * For example:
+             *
+             * aes256-sha384-x25519
+             *
+             * additionally produces:
+             *
+             * aes256-sha384-x25519-ke1_mlkem512
+             * aes256-sha384-x25519-ke1_mlkem768
+             * aes256-sha384-x25519-ke1_mlkem1024
+             */
+            $pqOptions = [];
+
+            foreach (self::$internalCacheOptionList[$this->internalCacheKey] as $cipher => $option) {
+                foreach ($dhgroups as $dhgroup => $dhDescription) {
+                    if (
+                        $cipher === $dhgroup ||
+                        substr($cipher, -strlen("-{$dhgroup}")) === "-{$dhgroup}"
+                    ) {
+                        foreach ($postQuantumKe as $pqKe => $pqDescription) {
+                            $pqCipher = "{$cipher}-ke1_{$pqKe}";
+
+                            $description = $option['value'];
+                            if (empty($description)) {
+                                $description = $cipher . " [{$dhDescription}]";
+                            }
+
+                            $pqOptions[$pqCipher] = [
+                                'value' => $pqCipher . " [{$dhDescription} + {$pqDescription}]",
+                                'optgroup' => $option['optgroup']
+                            ];
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            self::$internalCacheOptionList[$this->internalCacheKey] = self::$internalCacheOptionList[$this->internalCacheKey] + $pqOptions;
         }
 
         $this->internalOptionList = self::$internalCacheOptionList[$this->internalCacheKey];

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -53,6 +53,27 @@ class IPsecProposalField extends BaseListField
         $this->internalCacheKey = $this->phase;
     }
 
+    private function DHGroups()
+    {
+        return [
+            'modp2048' => 'DH14',
+            'modp3072' => 'DH15',
+            'modp4096' => 'DH16',
+            'modp6144' => 'DH17',
+            'modp8192' => 'DH18',
+            'ecp224' => 'DH26, NIST EC',
+            'ecp256' => 'DH19, NIST EC',
+            'ecp384' => 'DH20, NIST EC',
+            'ecp521' => 'DH21, NIST EC',
+            'ecp224bp' => 'DH27, Brainpool EC',
+            'ecp256bp' => 'DH28, Brainpool EC',
+            'ecp384bp' => 'DH29, Brainpool EC',
+            'ecp512bp' => 'DH30, Brainpool EC',
+            'x25519' => 'DH31, Modern EC',
+            'x448' => 'DH32, Modern EC'
+        ];
+    }
+
     private function AeadPhase1()
     {
         /* a PRF is mandatory for IKE proposals containing AEAD algorithms, e.g. GCM and ChaCha20-Poly1305 */
@@ -117,24 +138,6 @@ class IPsecProposalField extends BaseListField
         * "Commonly used" section.
         */
 
-        $dhgroups = [
-            'modp2048',
-            'modp3072',
-            'modp4096',
-            'modp6144',
-            'modp8192',
-            'ecp224',
-            'ecp256',
-            'ecp384',
-            'ecp521',
-            'ecp224bp',
-            'ecp256bp',
-            'ecp384bp',
-            'ecp512bp',
-            'x25519',
-            'x448',
-        ];
-
         $postQuantumKe = [
             'mlkem512' => 'ML-KEM-512 (ID 35)',
             'mlkem768' => 'ML-KEM-768 (ID 36)',
@@ -144,7 +147,7 @@ class IPsecProposalField extends BaseListField
         $result = $ciphers;
 
         foreach ($ciphers as $cipher => $description) {
-            foreach ($dhgroups as $dhgroup) {
+            foreach ($this->DHGroups() as $dhgroup => $dhdescr) {
                 if (substr($cipher, -strlen("-{$dhgroup}")) !== "-{$dhgroup}") {
                     continue;
                 }
@@ -224,34 +227,10 @@ class IPsecProposalField extends BaseListField
                 }
             }
 
-            $dhgroups = [
-                'modp2048' => 'DH14',
-                'modp3072' => 'DH15',
-                'modp4096' => 'DH16',
-                'modp6144' => 'DH17',
-                'modp8192' => 'DH18',
-                'ecp224' => 'DH26, NIST EC',
-                'ecp256' => 'DH19, NIST EC',
-                'ecp384' => 'DH20, NIST EC',
-                'ecp521' => 'DH21, NIST EC',
-                'ecp224bp' => 'DH27, Brainpool EC',
-                'ecp256bp' => 'DH28, Brainpool EC',
-                'ecp384bp' => 'DH29, Brainpool EC',
-                'ecp512bp' => 'DH30, Brainpool EC',
-                'x25519' => 'DH31, Modern EC',
-                'x448' => 'DH32, Modern EC'
-            ];
-
-            $postQuantumKe = [
-                'mlkem512' => 'ML-KEM-512 (ID 35)',
-                'mlkem768' => 'ML-KEM-768 (ID 36)',
-                'mlkem1024' => 'ML-KEM-1024 (ID 37)',
-            ];
-
             $gcm_prf_options = [];
             foreach (['aes128', 'aes192', 'aes256', 'aes128gcm16', 'aes192gcm16', 'aes256gcm16'] as $encalg) {
                 foreach (['sha256', 'sha384', 'sha512', 'aesxcbc'] as $intalg) {
-                    foreach ($dhgroups as $dhgroup => $descr) {
+                    foreach ($this->DHGroups() as $dhgroup => $descr) {
                         $cipher = "{$encalg}-{$intalg}-{$dhgroup}";
                         if (strpos($encalg, 'gcm') !== false && $this->phase != '1') {
                             /* only relevant for phase 2 entries, see comment in AeadPhase1() */

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -53,27 +53,6 @@ class IPsecProposalField extends BaseListField
         $this->internalCacheKey = $this->phase;
     }
 
-    private function DHGroups()
-    {
-        return [
-            'modp2048' => 'DH14',
-            'modp3072' => 'DH15',
-            'modp4096' => 'DH16',
-            'modp6144' => 'DH17',
-            'modp8192' => 'DH18',
-            'ecp224' => 'DH26, NIST EC',
-            'ecp256' => 'DH19, NIST EC',
-            'ecp384' => 'DH20, NIST EC',
-            'ecp521' => 'DH21, NIST EC',
-            'ecp224bp' => 'DH27, Brainpool EC',
-            'ecp256bp' => 'DH28, Brainpool EC',
-            'ecp384bp' => 'DH29, Brainpool EC',
-            'ecp512bp' => 'DH30, Brainpool EC',
-            'x25519' => 'DH31, Modern EC',
-            'x448' => 'DH32, Modern EC'
-        ];
-    }
-
     private function AeadPhase1()
     {
         /* a PRF is mandatory for IKE proposals containing AEAD algorithms, e.g. GCM and ChaCha20-Poly1305 */
@@ -214,10 +193,27 @@ class IPsecProposalField extends BaseListField
                 self::$internalCacheOptionList[$this->internalCacheKey][$cipher] = ['value' => $description, 'optgroup' => gettext('Post-quantum options')];
             }
 
+            $dhgroups = [
+                'modp2048' => 'DH14',
+                'modp3072' => 'DH15',
+                'modp4096' => 'DH16',
+                'modp6144' => 'DH17',
+                'modp8192' => 'DH18',
+                'ecp224' => 'DH26, NIST EC',
+                'ecp256' => 'DH19, NIST EC',
+                'ecp384' => 'DH20, NIST EC',
+                'ecp521' => 'DH21, NIST EC',
+                'ecp224bp' => 'DH27, Brainpool EC',
+                'ecp256bp' => 'DH28, Brainpool EC',
+                'ecp384bp' => 'DH29, Brainpool EC',
+                'ecp512bp' => 'DH30, Brainpool EC',
+                'x25519' => 'DH31, Modern EC',
+                'x448' => 'DH32, Modern EC'
+            ];
             $gcm_prf_options = [];
             foreach (['aes128', 'aes192', 'aes256', 'aes128gcm16', 'aes192gcm16', 'aes256gcm16'] as $encalg) {
                 foreach (['sha256', 'sha384', 'sha512', 'aesxcbc'] as $intalg) {
-                    foreach ($this->DHGroups() as $dhgroup => $descr) {
+                    foreach ($dhgroups as $dhgroup => $descr) {
                         $cipher = "{$encalg}-{$intalg}-{$dhgroup}";
                         if (strpos($encalg, 'gcm') !== false && $this->phase != '1') {
                             /* only relevant for phase 2 entries, see comment in AeadPhase1() */

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -160,14 +160,14 @@ class IPsecProposalField extends BaseListField
         if ($this->phase == '1') {
             return [
                 'aes256gcm16-sha256-x25519-ke1_mlkem768' => 'aes256gcm16-sha256-x25519-ke1_mlkem768 [DH31, ML-KEM-768 (ID 36)]',
-                'aes256gcm16-sha256-ecp256-ke1_mlkem768' => 'aes256gcm16-sha256-ecp256-ke1_mlkem768 [DH19, NIST EC, ML-KEM-768 (ID 36)]',
-                'aes256gcm16-sha384-ecp384-ke1_mlkem1024' => 'aes256gcm16-sha384-ecp384-ke1_mlkem1024 [DH20, NIST EC, ML-KEM-1024 (ID 37)]',
+                'aes256gcm16-sha256-ecp256-ke1_mlkem768' => 'aes256gcm16-sha256-ecp256-ke1_mlkem768 [DH19, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-sha384-ecp384-ke1_mlkem1024' => 'aes256gcm16-sha384-ecp384-ke1_mlkem1024 [DH20, ML-KEM-1024 (ID 37)]',
             ];
         } else {
             return [
                 'aes256gcm16-x25519-ke1_mlkem768' => 'aes256gcm16-x25519-ke1_mlkem768 [DH31, ML-KEM-768 (ID 36)]',
-                'aes256gcm16-ecp256-ke1_mlkem768' => 'aes256gcm16-ecp256-ke1_mlkem768 [DH19, NIST EC, ML-KEM-768 (ID 36)]',
-                'aes256gcm16-ecp384-ke1_mlkem1024' => 'aes256gcm16-ecp384-ke1_mlkem1024 [DH20, NIST EC, ML-KEM-1024 (ID 37)]',
+                'aes256gcm16-ecp256-ke1_mlkem768' => 'aes256gcm16-ecp256-ke1_mlkem768 [DH19, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-ecp384-ke1_mlkem1024' => 'aes256gcm16-ecp384-ke1_mlkem1024 [DH20, ML-KEM-1024 (ID 37)]',
             ];
         }
     }

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/FieldTypes/IPsecProposalField.php
@@ -126,63 +126,8 @@ class IPsecProposalField extends BaseListField
         return $this->phase == '1' ? $this->AeadPhase1() : $this->AeadPhase2();
     }
 
-    private function addPostQuantumKeOptions(array $ciphers)
-    {
-       /*
-        * Add hybrid post-quantum key exchange options using a single additional
-        * key exchange (KE1). ML-KEM is deliberately not offered as
-        * the primary key exchange to prevent a larger cartesian product in our UI.
-        *
-        * We only offer the post-quantum variants on top of classical primary key exchanges,
-        * see https://www.rfc-editor.org/rfc/rfc9370.html#section-1.1-2 and only within our
-        * "Commonly used" section.
-        */
-
-        $postQuantumKe = [
-            'mlkem512' => 'ML-KEM-512 (ID 35)',
-            'mlkem768' => 'ML-KEM-768 (ID 36)',
-            'mlkem1024' => 'ML-KEM-1024 (ID 37)',
-        ];
-
-        $result = $ciphers;
-
-        foreach ($ciphers as $cipher => $description) {
-            foreach ($this->DHGroups() as $dhgroup => $dhdescr) {
-                if (substr($cipher, -strlen("-{$dhgroup}")) !== "-{$dhgroup}") {
-                    continue;
-                }
-
-                foreach ($postQuantumKe as $pqKe => $pqDescription) {
-                    $pqCipher = "{$cipher}-ke1_{$pqKe}";
-
-                    $result[$pqCipher] = "{$pqCipher} [{$pqDescription}]";
-                }
-
-                break;
-            }
-        }
-
-        return $result;
-    }
-
     private function commonOptions()
     {
-        $commonAes = [
-            'aes256-sha256-modp2048' => null,
-            'aes256-sha512-modp2048' => null,
-            'aes128-sha256-modp2048' => null,
-            'aes128-sha512-modp2048' => null,
-            'aes256-sha256-modp4096' => null,
-            'aes256-sha512-modp4096' => null,
-            'aes256-sha256-ecp521' => null,
-            'aes256-sha512-ecp521' => null,
-        ];
-
-        $commonAead = $this->AeadAlgorithms();
-
-        $commonAes = $this->addPostQuantumKeOptions($commonAes);
-        $commonAead = $this->addPostQuantumKeOptions($commonAead);
-
         /* group and cipher order, when set to null an auto generated description will be used */
         return [
             gettext('Internal') => [
@@ -190,10 +135,21 @@ class IPsecProposalField extends BaseListField
             ],
 
             /* Non-AEAD algorithms */
-            gettext('Commonly used AES') => $commonAes,
+            gettext('Commonly used AES') => [
+                'aes256-sha256-modp2048' => null,
+                'aes256-sha512-modp2048' => null,
+                'aes128-sha256-modp2048' => null,
+                'aes128-sha512-modp2048' => null,
+                'aes256-sha256-modp4096' => null,
+                'aes256-sha512-modp4096' => null,
+                'aes256-sha256-ecp521' => null,
+                'aes256-sha512-ecp521' => null,
+            ],
 
             /* AEAD algorithms */
-            gettext('Commonly used combined-mode (AEAD) ciphers') => $commonAead,
+            gettext('Commonly used combined-mode (AEAD) ciphers') => [
+                ...$this->AeadAlgorithms()
+            ],
 
             gettext('Commonly used, but insecure cipher suites') => [
                 'aes256-sha1-modp2048' => 'aes256-sha1-modp2048 [DH14]',
@@ -213,6 +169,33 @@ class IPsecProposalField extends BaseListField
         ];
     }
 
+    private function postQuantumCiphers()
+    {
+       /*
+        * Add hybrid post-quantum key exchange options using a single additional
+        * key exchange (KE1). ML-KEM is deliberately not offered as
+        * the primary key exchange since including a classical primitive is encouraged
+        * (see https://www.rfc-editor.org/rfc/rfc9370.html#section-1.1-2).
+        *
+        * Also limit to just a couple of sensible options
+        * (see https://www.rfc-editor.org/info/rfc10024/#name-motivation).
+        */
+
+        if ($this->phase == '1') {
+            return [
+                'aes256gcm16-sha256-x25519-ke1_mlkem768' => 'aes256gcm16-sha256-x25519-ke1_mlkem768 [DH31, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-sha256-ecp256-ke1_mlkem768' => 'aes256gcm16-sha256-ecp256-ke1_mlkem768 [DH19, NIST EC, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-sha384-ecp384-ke1_mlkem1024' => 'aes256gcm16-sha384-ecp384-ke1_mlkem1024 [DH20, NIST EC, ML-KEM-1024 (ID 37)]',
+            ];
+        } else {
+            return [
+                'aes256gcm16-x25519-ke1_mlkem768' => 'aes256gcm16-x25519-ke1_mlkem768 [DH31, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-ecp256-ke1_mlkem768' => 'aes256gcm16-ecp256-ke1_mlkem768 [DH19, NIST EC, ML-KEM-768 (ID 36)]',
+                'aes256gcm16-ecp384-ke1_mlkem1024' => 'aes256gcm16-ecp384-ke1_mlkem1024 [DH20, NIST EC, ML-KEM-1024 (ID 37)]',
+            ];
+        }
+    }
+
     protected function actionPostLoadingEvent()
     {
         if (empty(self::$internalCacheOptionList[$this->internalCacheKey])) {
@@ -225,6 +208,10 @@ class IPsecProposalField extends BaseListField
                 foreach ($ciphers as $cipher => $description) {
                     self::$internalCacheOptionList[$this->internalCacheKey][$cipher] = ['value' => $description, 'optgroup' => $group];
                 }
+            }
+
+            foreach ($this->postQuantumCiphers() as $cipher => $description) {
+                self::$internalCacheOptionList[$this->internalCacheKey][$cipher] = ['value' => $description, 'optgroup' => gettext('Post-quantum options')];
             }
 
             $gcm_prf_options = [];

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
@@ -177,7 +177,7 @@ class Swanctl extends BaseModel
             }
             $key = $node->__reference;
             $conn = $this->getNodeByReference('Connections.Connection.' . $node->connection->getValue());
-            if (str_contains($node->esp_proposals->getValue(), 'mlkem') && $conn->version->getValue() != '2') {
+            if ($conn != null && str_contains($node->esp_proposals->getValue(), 'mlkem') && $conn->version->getValue() != '2') {
                 $messages->appendMessage(
                     new Message(
                         gettext("A post-quantum key exchange method (mlkem) can only be used with IKEv2"),

--- a/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
+++ b/src/opnsense/mvc/app/models/OPNsense/IPsec/Swanctl.php
@@ -82,6 +82,23 @@ class Swanctl extends BaseModel
                 }
             }
         }
+
+        foreach ($this->Connections->Connection->iterateItems() as $node) {
+            if (!$validateFullModel && !$node->isFieldChanged()) {
+                continue;
+            }
+
+            $key = $node->__reference;
+            if (str_contains($node->proposals->getValue(), 'mlkem') && $node->version->getValue() != '2') {
+                $messages->appendMessage(
+                    new Message(
+                        gettext("A post-quantum key exchange method (mlkem) can only be used with IKEv2"),
+                        $key . ".proposals"
+                    )
+                );
+            }
+        }
+
         foreach ($this->VTIs->VTI->iterateItems() as $node) {
             if (!$validateFullModel && !$node->isFieldChanged()) {
                 continue;
@@ -151,6 +168,22 @@ class Swanctl extends BaseModel
                  $messages->appendMessage(
                      new Message(gettext("Either match on a certificate or an autority, but not both."), $key . ".certs")
                  );
+            }
+        }
+
+        foreach ($this->children->child->iterateItems() as $node) {
+            if (!$validateFullModel && !$node->isFieldChanged()) {
+                continue;
+            }
+            $key = $node->__reference;
+            $conn = $this->getNodeByReference('Connections.Connection.' . $node->connection->getValue());
+            if (str_contains($node->esp_proposals->getValue(), 'mlkem') && $conn->version->getValue() != '2') {
+                $messages->appendMessage(
+                    new Message(
+                        gettext("A post-quantum key exchange method (mlkem) can only be used with IKEv2"),
+                        $key . ".esp_proposals"
+                    )
+                );
             }
         }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: GPT-5.6 Sol
- Extent of AI involvement:

Scoping requirements based on StrongSwan algorithm proposals documentation, discussing possible extension strategies to fit current model, initial code changes based on requirements.

---

**Describe the problem**

This proposes a middle ground to the problem as described in https://github.com/opnsense/core/issues/10792#issuecomment-5424776148

---

**Describe the proposed solution**

For every valid combination of `<encryption algorithm>-<PRF>-<Primary key exchange>`, add each post-quantum variant on top as an additional key exchange (made possible through RFC9370):

`<encryption algorithm>-<PRF>-<Primary key exchange>-<Additional key exchange>`.

for example:

`aes256-sha384-x25519-ke1_mlkem768`.

This significantly increases the selectpicker list, but it remains logically structured and adheres to security recommendations.

<img width="942" height="309" alt="afbeelding" src="https://github.com/user-attachments/assets/847c8fb9-d79d-4c11-96f0-42efa2a370a0" />


---

**Related issue**

If this pull request relates to an issue, link it here.

https://github.com/opnsense/core/issues/10792