### PR TITLE
Firewall: Rules: emit gateway debug message in block rules only when gateway was not empty

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/FilterRule.php
@@ -212,8 +212,10 @@ class FilterRule extends Rule
                 $this->log("Gateway protocol mismatch");
             }
             if (!empty($rule['type']) && $rule['type'] != 'pass') {
+                if (!empty($rule['gateway']) || !empty($rule['reply'])) {
+                    $this->log("Gateway not allowed for block rules");
+                }
                 unset($rule['gateway'], $rule['reply']);
-                $this->log("Gateway not allowed for block rules");
             }
             if (!isset($rule['quick'])) {
                 // all rules are quick by default except floating


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

I wondered why my rules.debug was full of these messages for each of my block rules even though they didn't have a gateway or reply-to set.

---

**Describe the proposed solution**

Only emit these when something was removed from a block rule.

---

**Related issue**

None
