### PR TITLE
Interfaces: Assignments - next round of attributes,  closes https://github.com/opnsense/core/issues/10568

### DIFF
--- a/plist
+++ b/plist
@@ -835,10 +835,15 @@
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/BridgeMemberField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/DUIDField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/DeviceField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4RequestOptionsField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4SendOptionsField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6RequestOptionsField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6SendOptionsField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/GatewayField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/IfDescField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/LaggInterfaceField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/LinkAddressField.php
+/usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/MediaTypesField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NeighborField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VipField.php

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2930,6 +2930,10 @@ function DHCP6_Config_File_Basic($interface, $wancfg, $wanif, $default_id)
 
         $dhcp6cconf .= "interface {$wanif} {\n";
 
+        if (!empty($wancfg['dhcp6-information-only'])) {
+            $dhcp6cconf .= "  information-only;\n";
+        }
+
         if (!isset($wancfg['dhcp6prefixonly'])) {
             /* request non-temporary address */
             $dhcp6cconf .= "  send ia-na {$default_id};\n";
@@ -2949,6 +2953,17 @@ function DHCP6_Config_File_Basic($interface, $wancfg, $wanif, $default_id)
         if (empty($wancfg['dhcp6_norequest_dns'])) {
             $dhcp6cconf .= "  request domain-name-servers;\n";
             $dhcp6cconf .= "  request domain-name;\n";
+        }
+
+        if (!empty($wancfg['dhcp6_send_options'])) {
+            foreach (explode("\n", $wancfg['dhcp6_send_options']) as $line) {
+                $dhcp6cconf .= sprintf("  send %s;\n", $line);
+            }
+        }
+        if (!empty($wancfg['dhcp6_request_options'])) {
+            foreach (explode("\n", $wancfg['dhcp6_request_options']) as $line) {
+                $dhcp6cconf .= sprintf("  request %s;\n", $line);
+            }
         }
 
         $dhcp6cconf .= "  script \"/usr/local/opnsense/scripts/interfaces/dhcp6c_script.sh\";\n";
@@ -3238,6 +3253,14 @@ function interface_dhcp_configure($interface = 'wan')
     $conf .= interfaces_dhcp_safe('  supersede interface-mtu %s;', 0, empty($wancfg['dhcphonourmtu']));
     $conf .= interfaces_dhcp_safe('  reject %s;', $wancfg['dhcprejectfrom'], !empty($wancfg['dhcprejectfrom']));
     $conf .= interfaces_dhcp_safe('  vlan-pcp %s;', $wancfg['dhcpvlanprio'] ?? '', isset($wancfg['dhcpvlanprio']));
+    foreach (['dhcp_send_options' => 'send' , 'dhcp_request_options' => 'request'] as $prop => $tag) {
+        if (!empty($wancfg[$prop])) {
+            foreach (explode("\n", $wancfg[$prop]) as $line) {
+                $option = interfaces_dhcp_split($line)[0]; /* only one per line */
+                $conf .= interfaces_dhcp_safe(sprintf('  %s %s;', $tag, implode(' ', $option['frmt'])), $option['args']);
+            }
+        }
+    }
     $conf .= interfaces_dhcp_safe('}');
 
     // DHCP Config File Advanced

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
@@ -139,6 +139,13 @@ class AssignmentController extends ApiMutableModelControllerBase
 
     public function reconfigureAction()
     {
+        $legacybools = [
+            'enable',
+            'lock',
+            'disablechecksumoffloading',
+            'disablesegmentationoffloading',
+            'disablelargereceiveoffloading'
+        ];
         if ($this->request->isPost()) {
             $backend = new Backend();
             /***
@@ -164,9 +171,20 @@ class AssignmentController extends ApiMutableModelControllerBase
                                 unset(Config::getInstance()->object()->interfaces->$key->$akey);
                             }
                         }
-                        foreach (['enable', 'lock'] as $legacybool) {
+                        foreach ($legacybools as $legacybool) {
                             if (empty($pending[$legacybool])) {
                                 unset(Config::getInstance()->object()->interfaces->$key->$legacybool);
+                            }
+                        }
+                        /* advanced dhcp settings not supported, prevent settings being used */
+                        foreach ([
+                            'adv_dhcp6_config_file_override',
+                            'adv_dhcp6_config_advanced',
+                            'adv_dhcp_config_advanced',
+                            'adv_dhcp_config_file_override'
+                        ] as $unset) {
+                            if (isset(Config::getInstance()->object()->interfaces->$key->$unset)) {
+                                unset(Config::getInstance()->object()->interfaces->$key->$unset);
                             }
                         }
                     }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
@@ -76,6 +76,17 @@
         </grid_view>
     </field>
     <field>
+        <id>interface.spoofmac</id>
+        <label>MAC address (spoof)</label>
+        <advanced>true</advanced>
+        <type>text</type>
+        <help>This field can be used to spoof the MAC address of the interface. Enter a MAC address in the following format: xx:xx:xx:xx:xx:xx or leave blank if unsure. This may only be required e.g. with certain cable connections on a WAN interface.
+When used on a single VLAN interface the setting "Promiscuous mode" is required for this to work. Alternatively, the parent interface MAC can be spoofed applying the MAC address to all attached VLAN children automatically.</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <id>interface.mtu</id>
         <label>MTU</label>
         <type>text</type>
@@ -89,6 +100,75 @@
         <label>MSS</label>
         <type>text</type>
         <help>If you enter a value in this field, then MSS clamping for TCP connections to the value entered above minus 40 (IPv4) or 60 (IPv6) will be in effect (TCP/IP header size).</help>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Hardware settings</label>
+    </field>
+    <field>
+        <id>interface.media</id>
+        <label>Media (speed and duplex)</label>
+        <type>dropdown</type>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.hw_settings_overwrite</id>
+        <label>Overwrite global settings</label>
+        <type>checkbox</type>
+        <help>Overwrite custom interface hardware settings with settings specified below</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.disablechecksumoffloading</id>
+        <label>Hardware CRC</label>
+        <type>checkbox</type>
+        <style>hw_settings_overwrite</style>
+        <help>Checking this option will disable hardware checksum offloading. Checksum offloading is broken in some hardware, particularly some Realtek cards. Rarely, drivers may have problems with checksum offloading and some specific NICs.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.disablesegmentationoffloading</id>
+        <label>Hardware TSO</label>
+        <style>hw_settings_overwrite</style>
+        <type>checkbox</type>
+        <help>Checking this option will disable hardware TCP segmentation offloading (TSO, TSO4, TSO6). This offloading is broken in some hardware drivers, and may impact performance with some specific NICs.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.disablelargereceiveoffloading</id>
+        <label>Hardware LRO</label>
+        <style>hw_settings_overwrite</style>
+        <type>checkbox</type>
+        <help>Checking this option will disable hardware large receive offloading (LRO). This offloading is broken in some hardware drivers, and may impact performance with some specific NICs.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.disablevlanhwfilter</id>
+        <label>VLAN Hardware Filtering</label>
+        <style>selectpicker hw_settings_overwrite</style>
+        <type>dropdown</type>
+        <help>Set usage of VLAN hardware filtering. This hardware acceleration may be broken in a particular device driver, or may impact performance.</help>
         <grid_view>
             <visible>false</visible>
         </grid_view>
@@ -209,6 +289,28 @@
         </grid_view>
     </field>
     <field>
+        <id>interface.dhcp_send_options</id>
+        <label>Send Options</label>
+        <advanced>true</advanced>
+        <type>textbox</type>
+        <help>Options to send to the server, one per line.</help>
+        <style>type4 type4_dhcp</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp_request_options</id>
+        <label>Request Options</label>
+        <advanced>true</advanced>
+        <type>textbox</type>
+        <help>Options to request from the server, one per line.</help>
+        <style>type4 type4_dhcp</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
         <type>header</type>
         <label>Address configuration [IPv6]</label>
     </field>
@@ -233,7 +335,6 @@
             <visible>false</visible>
         </grid_view>
     </field>
-
     <field>
         <id>interface.dhcp6vlanprio</id>
         <label>Use VLAN priority</label>
@@ -247,8 +348,8 @@
     <field>
         <id>interface.dhcp6-ia-pd-len</id>
         <label>Prefix delegation size</label>
-        <type>text</type>
-        <style>type6 type6_dhcp6</style>
+        <type>dropdown</type>
+        <style>selectpicker type6 type6_dhcp6</style>
         <help>The value in this field is the delegated prefix length provided by the DHCPv6 server.</help>
         <grid_view>
             <visible>false</visible>
@@ -260,6 +361,19 @@
         <type>checkbox</type>
         <style>type6 type6_dhcp6</style>
         <help>Only request an IPv6 prefix; do not request an IPv6 address.</help>
+        <grid_view>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6-information-only</id>
+        <label>Information Only</label>
+        <type>checkbox</type>
+        <style>type6 type6_dhcp6</style>
+        <advanced>true</advanced>
+        <help>Prevent asking for an IPv6 address, only request configuration parameters like DNS etc. </help>
         <grid_view>
             <type>boolean</type>
             <formatter>boolean</formatter>
@@ -329,6 +443,28 @@
         <label>Optional prefix IAID</label>
         <type>text</type>
         <help>The ID to use for prefix request identity association if required to be non-standard.</help>
+        <style>type6 type6_dhcp6</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_send_options</id>
+        <label>Send Options</label>
+        <advanced>true</advanced>
+        <type>textbox</type>
+        <help>Options to send to the server, one per line.</help>
+        <style>type6 type6_dhcp6</style>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
+    </field>
+    <field>
+        <id>interface.dhcp6_request_options</id>
+        <label>Request Options</label>
+        <advanced>true</advanced>
+        <type>textbox</type>
+        <help>Options to send to the server, one per line.</help>
         <style>type6 type6_dhcp6</style>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4RequestOptionsField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4RequestOptionsField.php
@@ -1,0 +1,323 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\TextField;
+use OPNsense\Base\Validators\CallbackValidator;
+
+class Dhcp4RequestOptionsField extends TextField
+{
+    static $validoptions = [
+        'subnet-mask',
+        'time-offset',
+        'routers',
+        'time-servers',
+        'ien116-name-servers',
+        'domain-name-servers',
+        'log-servers',
+        'cookie-servers',
+        'lpr-servers',
+        'impress-servers',
+        'resource-location-servers',
+        'host-name',
+        'boot-size',
+        'merit-dump',
+        'domain-name',
+        'swap-server',
+        'root-path',
+        'extensions-path',
+        'ip-forwarding',
+        'non-local-source-routing',
+        'policy-filter',
+        'max-dgram-reassembly',
+        'default-ip-ttl',
+        'path-mtu-aging-timeout',
+        'path-mtu-plateau-table',
+        'interface-mtu',
+        'all-subnets-local',
+        'broadcast-address',
+        'perform-mask-discovery',
+        'mask-supplier',
+        'router-discovery',
+        'router-solicitation-address',
+        'static-routes',
+        'trailer-encapsulation',
+        'arp-cache-timeout',
+        'ieee802-3-encapsulation',
+        'default-tcp-ttl',
+        'tcp-keepalive-interval',
+        'tcp-keepalive-garbage',
+        'nis-domain',
+        'nis-servers',
+        'ntp-servers',
+        'vendor-encapsulated-options',
+        'netbios-name-servers',
+        'netbios-dd-server',
+        'netbios-node-type',
+        'netbios-scope',
+        'font-servers',
+        'x-display-manager',
+        'dhcp-requested-address',
+        'dhcp-lease-time',
+        'dhcp-option-overload',
+        'dhcp-message-type',
+        'dhcp-server-identifier',
+        'dhcp-parameter-request-list',
+        'dhcp-message',
+        'dhcp-max-message-size',
+        'dhcp-renewal-time',
+        'dhcp-rebinding-time',
+        'dhcp-class-identifier',
+        'dhcp-client-identifier',
+        'option-62',
+        'option-63',
+        'nisplus-domain',
+        'nisplus-servers',
+        'tftp-server-name',
+        'bootfile-name',
+        'mobile-ip-home-agent',
+        'smtp-server',
+        'pop-server',
+        'nntp-server',
+        'www-server',
+        'finger-server',
+        'irc-server',
+        'streettalk-server',
+        'streettalk-directory-assistance-server',
+        'user-class',
+        'option-78',
+        'option-79',
+        'option-80',
+        'option-81',
+        'option-82',
+        'option-83',
+        'option-84',
+        'nds-servers',
+        'nds-tree-name',
+        'nds-context',
+        'option-88',
+        'option-89',
+        'option-90',
+        'option-91',
+        'option-92',
+        'option-93',
+        'option-94',
+        'option-95',
+        'option-96',
+        'option-97',
+        'option-98',
+        'option-99',
+        'option-100',
+        'option-101',
+        'option-102',
+        'option-103',
+        'option-104',
+        'option-105',
+        'option-106',
+        'option-107',
+        'option-108',
+        'option-109',
+        'option-110',
+        'option-111',
+        'option-112',
+        'option-113',
+        'url',
+        'option-115',
+        'option-116',
+        'option-117',
+        'option-118',
+        'domain-search',
+        'option-120',
+        'classless-routes',
+        'option-122',
+        'option-123',
+        'option-124',
+        'option-125',
+        'option-126',
+        'option-127',
+        'option-128',
+        'option-129',
+        'option-130',
+        'option-131',
+        'option-132',
+        'option-133',
+        'option-134',
+        'option-135',
+        'option-136',
+        'option-137',
+        'option-138',
+        'option-139',
+        'option-140',
+        'option-141',
+        'option-142',
+        'option-143',
+        'option-144',
+        'option-145',
+        'option-146',
+        'option-147',
+        'option-148',
+        'option-149',
+        'option-150',
+        'option-151',
+        'option-152',
+        'option-153',
+        'option-154',
+        'option-155',
+        'option-156',
+        'option-157',
+        'option-158',
+        'option-159',
+        'option-160',
+        'option-161',
+        'option-162',
+        'option-163',
+        'option-164',
+        'option-165',
+        'option-166',
+        'option-167',
+        'option-168',
+        'option-169',
+        'option-170',
+        'option-171',
+        'option-172',
+        'option-173',
+        'option-174',
+        'option-175',
+        'option-176',
+        'option-177',
+        'option-178',
+        'option-179',
+        'option-180',
+        'option-181',
+        'option-182',
+        'option-183',
+        'option-184',
+        'option-185',
+        'option-186',
+        'option-187',
+        'option-188',
+        'option-189',
+        'option-190',
+        'option-191',
+        'option-192',
+        'option-193',
+        'option-194',
+        'option-195',
+        'option-196',
+        'option-197',
+        'option-198',
+        'option-199',
+        'option-200',
+        'option-201',
+        'option-202',
+        'option-203',
+        'option-204',
+        'option-205',
+        'option-206',
+        'option-207',
+        'option-208',
+        'option-209',
+        'option-210',
+        'option-211',
+        'option-212',
+        'option-213',
+        'option-214',
+        'option-215',
+        'option-216',
+        'option-217',
+        'option-218',
+        'option-219',
+        'option-220',
+        'option-221',
+        'option-222',
+        'option-223',
+        'option-224',
+        'option-225',
+        'option-226',
+        'option-227',
+        'option-228',
+        'option-229',
+        'option-230',
+        'option-231',
+        'option-232',
+        'option-233',
+        'option-234',
+        'option-235',
+        'option-236',
+        'option-237',
+        'option-238',
+        'option-239',
+        'option-240',
+        'option-241',
+        'option-242',
+        'option-243',
+        'option-244',
+        'option-245',
+        'option-246',
+        'option-247',
+        'option-248',
+        'option-249',
+        'option-250',
+        'option-251',
+        'option-252',
+        'option-253',
+        'option-254',
+    ];
+    public function getValidators()
+    {
+
+        $validators = parent::getValidators();
+        $validators[] = new CallbackValidator(["callback" => function ($data) {
+            $messages = [];
+            if (empty($data)) {
+                return $messages;
+            }
+            foreach (explode("\n", $data) as $line) {
+                $parts = explode(" ", rtrim($line), 2);
+                if (!empty($parts)) {
+                    if (!in_array($parts[0], self::$validoptions) || count($parts) > 1) {
+                        $messages[] = sprintf(
+                            gettext('Invalid option or parameters "%s".'),
+                            $line
+                        );
+                    }
+                }
+            }
+            return $messages;
+        }
+        ]);
+
+        return $validators;
+    }
+}
+
+
+
+
+

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4SendOptionsField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp4SendOptionsField.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\TextField;
+use OPNsense\Base\Validators\CallbackValidator;
+
+class Dhcp4SendOptionsField extends TextField
+{
+    /**
+     * All known options from dhclient
+     * https://github.com/opnsense/src/blob/10516aac41659315e7081ebdd34b24ec2b9dc953/sbin/dhclient/tables.c#L67
+     */
+    static $validoptions = [
+        'subnet-mask' => 'I',
+        'time-offset' => 'l',
+        'routers' => 'IA',
+        'time-servers' => 'IA',
+        'ien116-name-servers' => 'IA',
+        'domain-name-servers' => 'IA',
+        'log-servers' => 'IA',
+        'cookie-servers' => 'IA',
+        'lpr-servers' => 'IA',
+        'impress-servers' => 'IA',
+        'resource-location-servers' => 'IA',
+        'host-name' => 't',
+        'boot-size' => 'S',
+        'merit-dump' => 't',
+        'domain-name' => 't',
+        'swap-server' => 'I',
+        'root-path' => 't',
+        'extensions-path' => 't',
+        'ip-forwarding' => 'f',
+        'non-local-source-routing' => 'f',
+        'policy-filter' => 'IIA',
+        'max-dgram-reassembly' => 'S',
+        'default-ip-ttl' => 'B',
+        'path-mtu-aging-timeout' => 'L',
+        'path-mtu-plateau-table' => 'SA',
+        'interface-mtu' => 'S',
+        'all-subnets-local' => 'f',
+        'broadcast-address' => 'I',
+        'perform-mask-discovery' => 'f',
+        'mask-supplier' => 'f',
+        'router-discovery' => 'f',
+        'router-solicitation-address' => 'I',
+        'static-routes' => 'IIA',
+        'trailer-encapsulation' => 'f',
+        'arp-cache-timeout' => 'L',
+        'ieee802-3-encapsulation' => 'f',
+        'default-tcp-ttl' => 'B',
+        'tcp-keepalive-interval' => 'L',
+        'tcp-keepalive-garbage' => 'f',
+        'nis-domain' => 't',
+        'nis-servers' => 'IA',
+        'ntp-servers' => 'IA',
+        'vendor-encapsulated-options' => 'X',
+        'netbios-name-servers' => 'IA',
+        'netbios-dd-server' => 'IA',
+        'netbios-node-type' => 'B',
+        'netbios-scope' => 't',
+        'font-servers' => 'IA',
+        'x-display-manager' => 'IA',
+        'dhcp-requested-address' => 'I',
+        'dhcp-lease-time' => 'L',
+        'dhcp-option-overload' => 'B',
+        'dhcp-message-type' => 'B',
+        'dhcp-server-identifier' => 'I',
+        'dhcp-parameter-request-list' => 'BA',
+        'dhcp-message' => 't',
+        'dhcp-max-message-size' => 'S',
+        'dhcp-renewal-time' => 'L',
+        'dhcp-rebinding-time' => 'L',
+        'dhcp-class-identifier' => 't',
+        'dhcp-client-identifier' => 'X',
+        'option-62' => 'X',
+        'option-63' => 'X',
+        'nisplus-domain' => 't',
+        'nisplus-servers' => 'IA',
+        'tftp-server-name' => 't',
+        'bootfile-name' => 't',
+        'mobile-ip-home-agent' => 'IA',
+        'smtp-server' => 'IA',
+        'pop-server' => 'IA',
+        'nntp-server' => 'IA',
+        'www-server' => 'IA',
+        'finger-server' => 'IA',
+        'irc-server' => 'IA',
+        'streettalk-server' => 'IA',
+        'streettalk-directory-assistance-server' => 'IA',
+        'user-class' => 't',
+        'option-78' => 'X',
+        'option-79' => 'X',
+        'option-80' => 'X',
+        'option-81' => 'X',
+        'option-82' => 'X',
+        'option-83' => 'X',
+        'option-84' => 'X',
+        'nds-servers' => 'IA',
+        'nds-tree-name' => 'X',
+        'nds-context' => 'X',
+        'option-88' => 'X',
+        'option-89' => 'X',
+        'option-90' => 'X',
+        'option-91' => 'X',
+        'option-92' => 'X',
+        'option-93' => 'X',
+        'option-94' => 'X',
+        'option-95' => 'X',
+        'option-96' => 'X',
+        'option-97' => 'X',
+        'option-98' => 'X',
+        'option-99' => 'X',
+        'option-100' => 'X',
+        'option-101' => 'X',
+        'option-102' => 'X',
+        'option-103' => 'X',
+        'option-104' => 'X',
+        'option-105' => 'X',
+        'option-106' => 'X',
+        'option-107' => 'X',
+        'option-108' => 'X',
+        'option-109' => 'X',
+        'option-110' => 'X',
+        'option-111' => 'X',
+        'option-112' => 'X',
+        'option-113' => 'X',
+        'url' => 't',
+        'option-115' => 'X',
+        'option-116' => 'X',
+        'option-117' => 'X',
+        'option-118' => 'X',
+        'domain-search' => 't',
+        'option-120' => 'X',
+        'classless-routes' => 'BA',
+        'option-122' => 'X',
+        'option-123' => 'X',
+        'option-124' => 'X',
+        'option-125' => 'X',
+        'option-126' => 'X',
+        'option-127' => 'X',
+        'option-128' => 'X',
+        'option-129' => 'X',
+        'option-130' => 'X',
+        'option-131' => 'X',
+        'option-132' => 'X',
+        'option-133' => 'X',
+        'option-134' => 'X',
+        'option-135' => 'X',
+        'option-136' => 'X',
+        'option-137' => 'X',
+        'option-138' => 'X',
+        'option-139' => 'X',
+        'option-140' => 'X',
+        'option-141' => 'X',
+        'option-142' => 'X',
+        'option-143' => 'X',
+        'option-144' => 'X',
+        'option-145' => 'X',
+        'option-146' => 'X',
+        'option-147' => 'X',
+        'option-148' => 'X',
+        'option-149' => 'X',
+        'option-150' => 'X',
+        'option-151' => 'X',
+        'option-152' => 'X',
+        'option-153' => 'X',
+        'option-154' => 'X',
+        'option-155' => 'X',
+        'option-156' => 'X',
+        'option-157' => 'X',
+        'option-158' => 'X',
+        'option-159' => 'X',
+        'option-160' => 'X',
+        'option-161' => 'X',
+        'option-162' => 'X',
+        'option-163' => 'X',
+        'option-164' => 'X',
+        'option-165' => 'X',
+        'option-166' => 'X',
+        'option-167' => 'X',
+        'option-168' => 'X',
+        'option-169' => 'X',
+        'option-170' => 'X',
+        'option-171' => 'X',
+        'option-172' => 'X',
+        'option-173' => 'X',
+        'option-174' => 'X',
+        'option-175' => 'X',
+        'option-176' => 'X',
+        'option-177' => 'X',
+        'option-178' => 'X',
+        'option-179' => 'X',
+        'option-180' => 'X',
+        'option-181' => 'X',
+        'option-182' => 'X',
+        'option-183' => 'X',
+        'option-184' => 'X',
+        'option-185' => 'X',
+        'option-186' => 'X',
+        'option-187' => 'X',
+        'option-188' => 'X',
+        'option-189' => 'X',
+        'option-190' => 'X',
+        'option-191' => 'X',
+        'option-192' => 'X',
+        'option-193' => 'X',
+        'option-194' => 'X',
+        'option-195' => 'X',
+        'option-196' => 'X',
+        'option-197' => 'X',
+        'option-198' => 'X',
+        'option-199' => 'X',
+        'option-200' => 'X',
+        'option-201' => 'X',
+        'option-202' => 'X',
+        'option-203' => 'X',
+        'option-204' => 'X',
+        'option-205' => 'X',
+        'option-206' => 'X',
+        'option-207' => 'X',
+        'option-208' => 'X',
+        'option-209' => 'X',
+        'option-210' => 'X',
+        'option-211' => 'X',
+        'option-212' => 'X',
+        'option-213' => 'X',
+        'option-214' => 'X',
+        'option-215' => 'X',
+        'option-216' => 'X',
+        'option-217' => 'X',
+        'option-218' => 'X',
+        'option-219' => 'X',
+        'option-220' => 'X',
+        'option-221' => 'X',
+        'option-222' => 'X',
+        'option-223' => 'X',
+        'option-224' => 'X',
+        'option-225' => 'X',
+        'option-226' => 'X',
+        'option-227' => 'X',
+        'option-228' => 'X',
+        'option-229' => 'X',
+        'option-230' => 'X',
+        'option-231' => 'X',
+        'option-232' => 'X',
+        'option-233' => 'X',
+        'option-234' => 'X',
+        'option-235' => 'X',
+        'option-236' => 'X',
+        'option-237' => 'X',
+        'option-238' => 'X',
+        'option-239' => 'X',
+        'option-240' => 'X',
+        'option-241' => 'X',
+        'option-242' => 'X',
+        'option-243' => 'X',
+        'option-244' => 'X',
+        'option-245' => 'X',
+        'option-246' => 'X',
+        'option-247' => 'X',
+        'option-248' => 'X',
+        'option-249' => 'X',
+        'option-250' => 'X',
+        'option-251' => 'X',
+        'option-252' => 'X',
+        'option-253' => 'X',
+        'option-254' => 'X',
+    ];
+
+
+    public function getValidators()
+    {
+        $validators = parent::getValidators();
+        $validators[] = new CallbackValidator(["callback" => function ($data) {
+            $options = self::$validoptions;
+            $messages = [];
+            if (empty($data)) {
+                return $messages;
+            }
+            foreach (explode("\n", $data) as $line) {
+                $parts = explode(" ", $line, 2);
+                if (!empty($parts)) {
+                    /* very basic input validation, ignoring the actual types specified in the option list */
+                    $payload = trim($parts[1] ?? '');
+                    $match_regex = '/^[a-zA-Z0-9 .,:\_+\-\\\\]*$/D';
+                    if (str_starts_with($payload, '"') && str_ends_with($payload, '"')) {
+                        $payload = substr($payload, 1, -1); /* only single quote wrapping is allowed  (str)*/
+                    }
+                    if (!isset($options[$parts[0]]) || !preg_match($match_regex, $payload)) {
+                        $messages[] = sprintf(
+                            gettext('Invalid option or parameters "%s".'),
+                            $line
+                        );
+                    }
+                }
+            }
+            return $messages;
+        }
+        ]);
+
+        return $validators;
+    }
+}
+
+
+
+
+

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6RequestOptionsField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6RequestOptionsField.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\TextField;
+use OPNsense\Base\Validators\CallbackValidator;
+
+class Dhcp6RequestOptionsField extends TextField
+{
+    static $validoptions = [
+        'domain-name-servers' => '/^$/D',
+        'domain-name' => '/^$/D',
+        'ntp-servers' => '/^$/D',
+        'refreshtime' => '/^$/D',
+        'sip-server-address' => '/^$/D',
+        'sip-server-domain-name' => '/^$/D',
+        'nis-server-address' => '/^$/D',
+        'nis-domain-name' => '/^$/D',
+        'nisp-server-address' => '/^$/D',
+        'nisp-domain-name' => '/^$/D',
+        'bcmcs-server-address' => '/^$/D',
+        'bcmcs-server-domain-name' => '/^$/D',
+        'refreshtime' => '/^$/D',
+    ];
+
+    public function getValidators()
+    {
+
+        $validators = parent::getValidators();
+        $validators[] = new CallbackValidator(["callback" => function ($data) {
+            $options = self::$validoptions;
+            $messages = [];
+            if (empty($data)) {
+                return $messages;
+            }
+            foreach (explode("\n", $data) as $line) {
+                $parts = explode(" ", $line, 2);
+                if (!empty($parts)) {
+                    if (!isset($options[$parts[0]]) || !preg_match($options[$parts[0]], $parts[1] ?? '')) {
+                        $messages[] = sprintf(
+                            gettext('Invalid option or parameters "%s".'),
+                            $line
+                        );
+                    }
+                }
+            }
+            return $messages;
+        }
+        ]);
+
+        return $validators;
+    }
+}
+
+
+
+
+

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6SendOptionsField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/Dhcp6SendOptionsField.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\TextField;
+use OPNsense\Base\Validators\CallbackValidator;
+
+class Dhcp6SendOptionsField extends TextField
+{
+    static $validoptions = [
+        'authentication' => '/^[a-z0-9_-]+$/i',
+        'ia-pd' => '/^[0-9]+$/i',
+        'ia-na' => '/^[0-9]+$/i',
+        'raw-option' => '/^[0-9]+\s+([0-9a-f]{2}:)+([0-9a-f]{2})$/i',
+        'sip-server-address' => '/^$/D',
+        'sip-server-domain-name' => '/^$/D',
+        'rapid-commit' => '/^$/D',
+        'domain-name-servers' => '/^$/D',
+        'domain-name' => '/^$/D',
+        'ntp-servers' => '/^$/D',
+        'refreshtime' => '/^$/D',
+        'nis-server-address' => '/^$/D',
+        'nis-domain-name' => '/^$/D',
+        'nisp-server-address' => '/^$/D',
+        'nisp-domain-name' => '/^$/D',
+        'bcmcs-server-address' => '/^$/D',
+        'bcmcs-server-domain-name' => '/^$/D',
+    ];
+
+    public function getValidators()
+    {
+
+        $validators = parent::getValidators();
+        $validators[] = new CallbackValidator(["callback" => function ($data) {
+            $options = self::$validoptions;
+            $messages = [];
+            if (empty($data)) {
+                return $messages;
+            }
+            foreach (explode("\n", $data) as $line) {
+                $parts = explode(" ", $line, 2);
+                if (!empty($parts)) {
+                    if (!isset($options[$parts[0]]) || !preg_match($options[$parts[0]], $parts[1] ?? '')) {
+                        $messages[] = sprintf(
+                            gettext('Invalid option or parameters "%s".'),
+                            $line
+                        );
+                    }
+                }
+            }
+            return $messages;
+        }
+        ]);
+
+        return $validators;
+    }
+}
+
+
+
+
+

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/MediaTypesField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/MediaTypesField.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Interfaces\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Core\Backend;
+
+
+class MediaTypesField extends BaseListField
+{
+    private static $known_types = [];
+
+    protected function actionPostLoadingEvent()
+    {
+        if (empty(self::$known_types)) {
+            $opts = json_decode((new Backend())->configdRun('interface list media-opts'), true);
+            foreach (array_keys($opts) as $opt) {
+                self::$known_types[$opt] = $opt;
+            }
+        }
+        $this->internalOptionList = self::$known_types;
+        return parent::actionPostLoadingEvent();
+    }
+}

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/NetworkInterfaceField.php
@@ -34,6 +34,7 @@ use OPNsense\Base\FieldTypes\ContainerField;
 use OPNsense\Core\Config;
 use OPNsense\Firewall\Util;
 
+
 class NetworkInterfaceContainerField extends ContainerField
 {
     static $pppDevices = null;
@@ -65,7 +66,8 @@ class NetworkInterfaceContainerField extends ContainerField
             'optgroup',
             'dhcp6_request_dns',
             'dhcp6-prefix-id',
-            'dhcp6_ifid'
+            'dhcp6_ifid',
+            'media',
         ];
         foreach ($this->iterateItems() as $key => $node) {
             if (in_array($key, $skiplist)) {
@@ -75,9 +77,14 @@ class NetworkInterfaceContainerField extends ContainerField
         }
         $result['dhcp6_norequest_dns'] = $this->dhcp6_request_dns->isEmpty() ? '1' : '0';
         foreach (['dhcp6-prefix-id', 'dhcp6_ifid', 'track6-prefix-id', 'track6_ifid'] as $fld) {
-            if (!$this->$fld->isEmpty()) {
+            if (!$this->$fld->isSet()) {
                 $result[$fld] = intval($this->$fld->getValue(), 16);
             }
+        }
+        if (!$this->media->isEmpty()) {
+            $parts = explode("\t", $this->media->getValue());
+            $result['media'] = $parts[0];
+            $result['mediaopt'] = $parts[1] ?? '';
         }
         return $result;
     }
@@ -104,9 +111,12 @@ class NetworkInterfaceContainerField extends ContainerField
         }
         $this->dhcp6_request_dns = empty($data['dhcp6_norequest_dns']) ? '1' : '0';
         foreach (['dhcp6-prefix-id', 'dhcp6_ifid', 'track6-prefix-id', 'track6_ifid'] as $fld) {
-            if (!empty($data[$fld])) {
+            if (isset($data[$fld]) && $data[$fld] !== '') {
                 $this->$fld = sprintf("0x%x", $data[$fld]);
             }
+        }
+        if (!empty($data['media']) && !empty($data['mediaopt'])) {
+            $this->media = sprintf("%s\t%s", $data['media'], $data['mediaopt']);
         }
     }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -31,6 +31,7 @@ namespace OPNsense\Interfaces;
 use OPNsense\Base\BaseModel;
 use OPNsense\Base\FieldTypes\BooleanField;
 use OPNsense\Base\Messages\Message;
+use OPNsense\Core\Backend;
 use OPNsense\Core\Config;
 use OPNsense\Core\FileObject;
 use OPNsense\Routing\Gateways;
@@ -190,6 +191,7 @@ class NetworkInterface extends BaseModel
     {
         $messages = parent::performValidation($validateFullModel);
         $gateways = new Gateways();
+        $mediaopts = json_decode((new Backend())->configdRun('interface list media-opts'), true) ?? [];
         foreach ($this->interface->iterateItems() as $ifname => $if) {
             if (!$validateFullModel && !$if->isFieldChanged()) {
                 continue;
@@ -274,6 +276,25 @@ class NetworkInterface extends BaseModel
                         $key . ".gatewayv6"
                     ));
                 }
+            }
+
+            if (!$if->media->isEmpty() && (
+                !isset($mediaopts[$if->media->getValue()]) ||
+                !in_array($if->if->getValue(), $mediaopts[$if->media->getValue()]['ifs'])
+            )) {
+                $tmp = [];
+                foreach ($mediaopts as $val => $opt) {
+                    if (in_array($if->if->getValue(), $opt['ifs'])) {
+                        $tmp[] = $val;
+                    }
+                }
+                $messages->appendMessage(new Message(
+                    sprintf(
+                        gettext('Selected media type not valid for this interface (available: %s).'),
+                        implode(",", $tmp)
+                    ),
+                    $key . ".media"
+                ));
             }
         }
 

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -31,7 +31,24 @@
             </enable>
             <blockpriv type="BooleanField"/>
             <blockbogons type="BooleanField"/>
+            <spoofmac type="MacAddressField"/>
             <promisc type="BooleanField"/>
+            <media type=".\MediaTypesField">
+                <BlankDesc>Default (no preference, typically autoselect)</BlankDesc>
+            </media>
+            <hw_settings_overwrite type="BooleanField"/>
+            <disablechecksumoffloading type="BooleanField"/>
+            <disablesegmentationoffloading type="BooleanField"/>
+            <disablelargereceiveoffloading type="BooleanField"/>
+            <disablevlanhwfilter type="OptionField">
+                <Required>Y</Required>
+                <Default>0</Default>
+                <OptionValues>
+                    <p0 value="0">Enable VLAN Hardware Filtering</p0>
+                    <p1 value="1">Disable VLAN Hardware Filtering</p1>
+                    <p2 value="2">Leave default</p2>
+                </OptionValues>
+            </disablevlanhwfilter>
             <gateway_interface type="BooleanField"/>
             <mtu type="IntegerField">
                 <MinimumValue>576</MinimumValue>
@@ -115,6 +132,8 @@
                     <pcp7 value="7">Network Control (7, highest)</pcp7>
                 </OptionValues>
             </dhcpvlanprio>
+            <dhcp_send_options type=".\Dhcp4SendOptionsField"/>
+            <dhcp_request_options type=".\Dhcp4RequestOptionsField"/>
             <!-- DHCPv6 client settings-->
             <dhcp6vlanprio type="OptionField">
                 <BlankDesc>Disabled</BlankDesc>
@@ -129,12 +148,33 @@
                     <pcp7 value="7">Network Control (7, highest)</pcp7>
                 </OptionValues>
             </dhcp6vlanprio>
-            <dhcp6-ia-pd-len type="IntegerField">
-                <MinimumValue>48</MinimumValue>
-                <MaximumValue>64</MaximumValue>
+            <dhcp6-ia-pd-len type="OptionField">
+                <Required>Y</Required>
+                <Default>0</Default>
+                <OptionValues>
+                    <pcp0 value="0">64</pcp0>
+                    <pcp1 value="1">63</pcp1>
+                    <pcp2 value="2">62</pcp2>
+                    <pcp3 value="3">61</pcp3>
+                    <pcp4 value="4">60</pcp4>
+                    <pcp5 value="5">59</pcp5>
+                    <pcp6 value="6">58</pcp6>
+                    <pcp7 value="7">57</pcp7>
+                    <pcp8 value="8">56</pcp8>
+                    <pcp9 value="9">55</pcp9>
+                    <pcp10 value="10">54</pcp10>
+                    <pcp11 value="11">53</pcp11>
+                    <pcp12 value="12">52</pcp12>
+                    <pcp13 value="13">51</pcp13>
+                    <pcp14 value="14">50</pcp14>
+                    <pcp15 value="15">49</pcp15>
+                    <pcp16 value="16">48</pcp16>
+                    <none>None</none>
+                </OptionValues>
             </dhcp6-ia-pd-len>
             <dhcp6prefixonly type="BooleanField"/>
             <dhcp6_request_dns type="BooleanField"/>
+            <dhcp6-information-only type="BooleanField"/>
             <dhcp6-ia-pd-send-hint type="BooleanField"/>
             <dhcp6_rapid_commit type="BooleanField"/>
             <dhcp6-prefix-id type="TextField">
@@ -149,6 +189,8 @@
                 <MinimumValue>0</MinimumValue>
                 <ValidationMessage>Requires a valid positive number</ValidationMessage>
             </dhcp6_assoc_pd>
+            <dhcp6_send_options type=".\Dhcp6SendOptionsField"/>
+            <dhcp6_request_options type=".\Dhcp6RequestOptionsField"/>
             <!-- 6rd settings-->
             <prefix-6rd type="NetworkField">
                 <AddressFamily>ipv6</AddressFamily>

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
@@ -62,6 +62,14 @@
             });
         });
 
+        $("#interface\\.hw_settings_overwrite").change(function(){
+            if ($(this).is(':checked')) {
+                $(".hw_settings_overwrite").closest('tr').show();
+            } else {
+                $(".hw_settings_overwrite").closest('tr').hide();
+            }
+        });
+
     });
 </script>
 <div class="tab-content content-box">

--- a/src/opnsense/service/conf/actions.d/actions_interface.conf
+++ b/src/opnsense/service/conf/actions.d/actions_interface.conf
@@ -79,6 +79,13 @@ type:script_output
 cache_ttl:60
 message:show assignable interfaces
 
+[list.media-opts]
+command:/usr/local/opnsense/scripts/interfaces/list_mediaopts.php
+parameters:
+type:script_output
+cache_ttl:60
+message:show media options for installed interfaces
+
 [list.wlan-adapters]
 command: sysctl -n net.wlan.devices | jq -R 'split(" ") | map({key: ., value: .}) | from_entries'
 parameters:


### PR DESCRIPTION
o add media type and options
o most common ipv6 dhcp advanced options
o support "raw", but validated, send and receive options for both dhcp and dhcp6

This should complete the interfaces configuration section.
