### PR TITLE
rc: add watchdog to shutdown, reboot and reload_all cases

### DIFF
--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -79,10 +79,34 @@ rc_enabled()
 	esac
 }
 
+get_service_pid()
+{
+	rc_filename="$1"
+	service_name="$2"
+
+	status="$(${rc_filename} status 2>/dev/null)" || return 1
+
+	pid="$(printf '%s\n' "${status}" |
+	    sed -n "s/^${service_name} is running as pid \([0-9][0-9]*\)\.$/\1/p")"
+
+	case "${pid}" in
+		''|*[!0-9]*)
+			return 1
+			;;
+	esac
+
+	# Make sure it actually exists right now.
+	kill -0 "${pid}" 2>/dev/null || return 1
+
+	printf '%s\n' "${pid}"
+	return 0
+}
+
 rc_filenames="$(${RCORDER} /etc/rc.d/* /usr/local/etc/rc.d/* 2> /dev/null)"
 rc_filenames_defer=
 rc_filenames_reverse=
 rc_filenames_skip=
+service_stop_timeout="${service_stop_timeout:-15}"
 
 for rc_filename in ${rc_filenames}; do
 	eval "$(grep "^name[[:blank:]]*=" ${rc_filename})"
@@ -121,5 +145,42 @@ for rc_filename in ${rc_filenames}; do
 		continue
 	fi
 
-	${rc_filename} ${1}
+	if [ "${1}" != "stop" ]; then
+		${rc_filename} ${1}
+		continue
+	fi
+
+	service_pid="$(get_service_pid "${rc_filename}" "${name}")"
+
+	if [ -z "${service_pid}" ]; then
+		# no valid pid through status, stop without watchdog
+		${rc_filename} stop
+		continue
+	fi
+
+	${rc_filename} stop &
+	stop_pid=$!
+
+	# Watchdog.
+	(
+		sleep "${service_stop_timeout}"
+
+		# If the rc script has already completed, there is nothing to do.
+		kill -0 "${stop_pid}" 2>/dev/null || exit 0
+
+		# Re-query the service before sending SIGKILL to prevent blindly killing a stale/reused PID.
+		current_pid="$(get_service_pid "${rc_filename}" "${name}")"
+
+		if [ "${current_pid}" = "${service_pid}" ]; then
+			echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
+			kill -KILL "${service_pid}" 2>/dev/null
+		fi
+	) &
+	watchdog_pid=$!
+
+	wait "${stop_pid}"
+	stop_result=$?
+
+	kill "${watchdog_pid}" 2>/dev/null
+	wait "${watchdog_pid}" 2>/dev/null
 done

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -81,32 +81,14 @@ rc_enabled()
 
 get_service_pid()
 {
-	rc_filename="$1"
-	service_name="$2"
-
-	status="$(${rc_filename} status 2>/dev/null)" || return 1
-
-	pid="$(printf '%s\n' "${status}" |
-	    sed -n "s/^${service_name} is running as pid \([0-9][0-9]*\)\.$/\1/p")"
-
-	case "${pid}" in
-		''|*[!0-9]*)
-			return 1
-			;;
-	esac
-
-	# Make sure it actually exists right now.
-	kill -0 "${pid}" 2>/dev/null || return 1
-
-	printf '%s\n' "${pid}"
-	return 0
+	${1} status 2>/dev/null | awk '{gsub(/[^0-9]/, "", $NF); print $NF}'
 }
 
 rc_filenames="$(${RCORDER} /etc/rc.d/* /usr/local/etc/rc.d/* 2> /dev/null)"
 rc_filenames_defer=
 rc_filenames_reverse=
 rc_filenames_skip=
-service_stop_timeout="${service_stop_timeout:-15}"
+service_stop_timeout=30
 
 for rc_filename in ${rc_filenames}; do
 	eval "$(grep "^name[[:blank:]]*=" ${rc_filename})"
@@ -139,6 +121,7 @@ fi
 
 # pass all commands to script now
 for rc_filename in ${rc_filenames}; do
+	watchdog_pid=
 	eval "$(grep "^name[[:blank:]]*=" ${rc_filename})"
 
 	if ! rc_enabled ${rc_filename} ${name}; then
@@ -146,14 +129,14 @@ for rc_filename in ${rc_filenames}; do
 	fi
 
 	if [ "${1}" = "stop" ]; then
-		service_pid="$(get_service_pid "${rc_filename}" "${name}")"
+		service_pid="$(get_service_pid "${rc_filename}")"
 
 		if [ -n "${service_pid}" ]; then
 			# Watchdog
 			(
 				sleep "${service_stop_timeout}"
 
-				current_pid="$(get_service_pid "${rc_filename}" "${name}")"
+				current_pid="$(get_service_pid "${rc_filename}")"
 
 				if [ "${current_pid}" = "${service_pid}" ]; then
 					echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
@@ -161,16 +144,13 @@ for rc_filename in ${rc_filenames}; do
 				fi
 			) &
 			watchdog_pid=$!
-
-			${rc_filename} stop
-
-			kill "${watchdog_pid}" 2>/dev/null
-			wait "${watchdog_pid}" 2>/dev/null
-		else
-			# No reliable PID: don't apply watchdog policy.
-			${rc_filename} stop
 		fi
-	else
-		${rc_filename} "${1}"
+	fi
+
+	${rc_filename} "${1}"
+
+	if [ -n "${watchdog_pid}" ]; then
+		kill "${watchdog_pid}" 2>/dev/null
+		wait "${watchdog_pid}" 2>/dev/null
 	fi
 done

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -179,7 +179,6 @@ for rc_filename in ${rc_filenames}; do
 	watchdog_pid=$!
 
 	wait "${stop_pid}"
-	stop_result=$?
 
 	kill "${watchdog_pid}" 2>/dev/null
 	wait "${watchdog_pid}" 2>/dev/null

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -145,41 +145,32 @@ for rc_filename in ${rc_filenames}; do
 		continue
 	fi
 
-	if [ "${1}" != "stop" ]; then
-		${rc_filename} ${1}
-		continue
-	fi
+	if [ "${1}" = "stop" ]; then
+		service_pid="$(get_service_pid "${rc_filename}" "${name}")"
 
-	service_pid="$(get_service_pid "${rc_filename}" "${name}")"
+		if [ -n "${service_pid}" ]; then
+			# Watchdog
+			(
+				sleep "${service_stop_timeout}"
 
-	if [ -z "${service_pid}" ]; then
-		# no valid pid through status, stop without watchdog
-		${rc_filename} stop
-		continue
-	fi
+				current_pid="$(get_service_pid "${rc_filename}" "${name}")"
 
-	${rc_filename} stop &
-	stop_pid=$!
+				if [ "${current_pid}" = "${service_pid}" ]; then
+					echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
+					kill -KILL "${service_pid}" 2>/dev/null
+				fi
+			) &
+			watchdog_pid=$!
 
-	# Watchdog.
-	(
-		sleep "${service_stop_timeout}"
+			${rc_filename} stop
 
-		# If the rc script has already completed, there is nothing to do.
-		kill -0 "${stop_pid}" 2>/dev/null || exit 0
-
-		# Re-query the service before sending SIGKILL to prevent blindly killing a stale/reused PID.
-		current_pid="$(get_service_pid "${rc_filename}" "${name}")"
-
-		if [ "${current_pid}" = "${service_pid}" ]; then
-			echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
-			kill -KILL "${service_pid}" 2>/dev/null
+			kill "${watchdog_pid}" 2>/dev/null
+			wait "${watchdog_pid}" 2>/dev/null
+		else
+			# No reliable PID: don't apply watchdog policy.
+			${rc_filename} stop
 		fi
-	) &
-	watchdog_pid=$!
-
-	wait "${stop_pid}"
-
-	kill "${watchdog_pid}" 2>/dev/null
-	wait "${watchdog_pid}" 2>/dev/null
+	else
+		${rc_filename} "${1}"
+	fi
 done

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -141,6 +141,8 @@ for rc_filename in ${rc_filenames}; do
 				if [ "${current_pid}" = "${service_pid}" ]; then
 					echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
 					kill -KILL "${service_pid}" 2>/dev/null
+				else
+					echo " Service ${name} stop timed out, but pid changed/disappeared; not killing pid ${service_pid}"
 				fi
 			) &
 			watchdog_pid=$!

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -129,20 +129,18 @@ for rc_filename in ${rc_filenames}; do
 	fi
 
 	if [ "${1}" = "stop" ]; then
-		service_pid="$(get_service_pid "${rc_filename}")"
-
-		if [ -n "${service_pid}" ]; then
+		if [ -n "$(get_service_pid "${rc_filename}")" ]; then
 			# Watchdog
 			(
 				sleep "${service_stop_timeout}"
 
 				current_pid="$(get_service_pid "${rc_filename}")"
 
-				if [ "${current_pid}" = "${service_pid}" ]; then
-					echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${service_pid}"
-					kill -KILL "${service_pid}" 2>/dev/null
+				if [ -n "${current_pid}" ]; then
+					echo " Service ${name} did not stop within ${service_stop_timeout}s; killing pid ${current_pid}"
+					kill -KILL "${current_pid}" 2>/dev/null
 				else
-					echo " Service ${name} stop timed out, but pid changed/disappeared; not killing pid ${service_pid}"
+					echo " Service ${name} stop timed out, but pid disappeared"
 				fi
 			) &
 			watchdog_pid=$!

--- a/src/etc/rc.freebsd
+++ b/src/etc/rc.freebsd
@@ -147,7 +147,7 @@ for rc_filename in ${rc_filenames}; do
 		fi
 	fi
 
-	${rc_filename} "${1}"
+	${rc_filename} ${1}
 
 	if [ -n "${watchdog_pid}" ]; then
 		kill "${watchdog_pid}" 2>/dev/null


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: GPT 5.6-Sol
- Extent of AI involvement:

Generating initial code changes based, adjusted as necessary.

---

**Describe the problem**

See https://github.com/opnsense/core/issues/10567

---

**Describe the proposed solution**

Add a simple watchdog that checks service pid validity over the waiting period and kills accordingly. A simple

```
sleep 15
kill -KILL "${service_pid}"
```

is also possible and would simplify it greatly, but obviously has the race of possible reclaimed pid.

Then there's also the default timeout value, which is set to 15 here.

---

**Related issue**

https://github.com/opnsense/core/issues/10567
