### PR TITLE
Firewall: NAT: Source NAT: add pool options and source hash key

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
@@ -218,7 +218,7 @@
         <help>Choose how traffic is distributed when multiple translation addresses are used.</help>
         <advanced>true</advanced>
         <grid_view>
-            <ignore>true</ignore>
+            <visible>false</visible>
         </grid_view>
     </field>
     <field>
@@ -228,7 +228,7 @@
         <help>Optionally specify a key to keep Source Hash mappings stable across ruleset reloads. Enter 0x followed by 32 hexadecimal digits.</help>
         <advanced>true</advanced>
         <grid_view>
-            <ignore>true</ignore>
+            <visible>false</visible>
         </grid_view>
     </field>
     <field>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
@@ -212,6 +212,16 @@
         </grid_view>
     </field>
     <field>
+        <id>rule.poolopts</id>
+        <label>Pool Options</label>
+        <type>dropdown</type>
+        <help>Choose how traffic is distributed when multiple translation addresses are used.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
         <id>rule.staticnatport</id>
         <label>Static-port</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
@@ -215,7 +215,7 @@
         <id>rule.poolopts</id>
         <label>Pool Options</label>
         <type>dropdown</type>
-        <help>Choose how traffic is distributed when multiple translation addresses are used.</help>
+        <help>Choose how traffic is distributed when multiple translation addresses are used. When nothing is selected, the current default is round-robin.</help>
         <advanced>true</advanced>
         <grid_view>
             <visible>false</visible>

--- a/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Firewall/forms/dialogSNatRule.xml
@@ -222,6 +222,16 @@
         </grid_view>
     </field>
     <field>
+        <id>rule.poolopts_sourcehashkey</id>
+        <label>Source Hash Key</label>
+        <type>text</type>
+        <help>Optionally specify a key to keep Source Hash mappings stable across ruleset reloads. Enter 0x followed by 32 hexadecimal digits.</help>
+        <advanced>true</advanced>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
         <id>rule.staticnatport</id>
         <label>Static-port</label>
         <type>checkbox</type>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.php
@@ -186,6 +186,15 @@ class Filter extends BaseModel
                                 $rule->{'endpoint-independent'}->__reference
                             ));
                         }
+                        if (
+                            !$rule->poolopts_sourcehashkey->isEmpty() &&
+                            !$rule->poolopts->isEqual('source-hash')
+                        ) {
+                            $messages->appendMessage(new Message(
+                                gettext("Source Hash Key is only valid for Source Hash type."),
+                                $rule->poolopts_sourcehashkey->__reference
+                            ));
+                        }
                     } else {
                         // Additional filter validations
                         if (!$rule->{'received-on'}->isEmpty() && $rule->direction != 'out') {

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -531,6 +531,17 @@
                     <EnableAlias>Y</EnableAlias>
                     <ValidationMessage>Please specify a valid port number, well-known name, alias or range.</ValidationMessage>
                 </target_port>
+                <poolopts type="OptionField">
+                    <BlankDesc>Default</BlankDesc>
+                    <OptionValues>
+                        <rr value="round-robin">Round Robin</rr>
+                        <rrsa value="round-robin sticky-address">Round Robin with Sticky Address</rrsa>
+                        <random>Random</random>
+                        <randomsa value="random sticky-address">Random with Sticky Address</randomsa>
+                        <source-hash>Source Hash</source-hash>
+                        <bitmask>Bitmask</bitmask>
+                    </OptionValues>
+                </poolopts>
                 <staticnatport type="BooleanField"/>
                 <log type="BooleanField">
                     <Default>0</Default>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -534,12 +534,12 @@
                 <poolopts type="OptionField">
                     <BlankDesc>Default</BlankDesc>
                     <OptionValues>
-                        <rr value="round-robin">Round Robin</rr>
-                        <rrsa value="round-robin sticky-address">Round Robin with Sticky Address</rrsa>
-                        <random>Random</random>
-                        <randomsa value="random sticky-address">Random with Sticky Address</randomsa>
-                        <source-hash>Source Hash</source-hash>
-                        <bitmask>Bitmask</bitmask>
+                        <p1 value="round-robin">Round Robin</p1>
+                        <p2 value="round-robin sticky-address">Round Robin with Sticky Address</p2>
+                        <p3 value="random">Random</p3>
+                        <p4 value="random sticky-address">Random with Sticky Address</p4>
+                        <p5 value="source-hash">Source Hash</p5>
+                        <p6 value="bitmask">Bitmask</p6>
                     </OptionValues>
                 </poolopts>
                 <poolopts_sourcehashkey type="StrictTextField">

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -532,7 +532,6 @@
                     <ValidationMessage>Please specify a valid port number, well-known name, alias or range.</ValidationMessage>
                 </target_port>
                 <poolopts type="OptionField">
-                    <BlankDesc>Default</BlankDesc>
                     <OptionValues>
                         <p1 value="round-robin">Round Robin</p1>
                         <p2 value="round-robin sticky-address">Round Robin with Sticky Address</p2>

--- a/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -542,6 +542,10 @@
                         <bitmask>Bitmask</bitmask>
                     </OptionValues>
                 </poolopts>
+                <poolopts_sourcehashkey type="StrictTextField">
+                    <Mask>/^0x[0-9a-fA-F]{32}$/</Mask>
+                    <ValidationMessage>Source Hash Key must be 0x followed by 32 hexadecimal digits.</ValidationMessage>
+                </poolopts_sourcehashkey>
                 <staticnatport type="BooleanField"/>
                 <log type="BooleanField">
                     <Default>0</Default>

--- a/src/opnsense/scripts/filter/list_legacy_outbound_nat.php
+++ b/src/opnsense/scripts/filter/list_legacy_outbound_nat.php
@@ -116,6 +116,7 @@ if (count($nat_rules)) {
             'target' => legacy_target_to_network($rule),
             'target_port' => normalize_port($rule['natport'] ?? ''),
             'poolopts' => $rule['poolopts'] ?? '',
+            'poolopts_sourcehashkey' => $rule['poolopts_sourcehashkey'] ?? '',
             'staticnatport' => !empty($rule['staticnatport']) ? '1' : '0',
             'log' => !empty($rule['log']) ? '1' : '0',
             'categories' => $rule['category'] ?? '',

--- a/src/opnsense/scripts/filter/list_legacy_outbound_nat.php
+++ b/src/opnsense/scripts/filter/list_legacy_outbound_nat.php
@@ -115,6 +115,7 @@ if (count($nat_rules)) {
             'destination_port' => normalize_port($rule['dstport'] ?? ''),
             'target' => legacy_target_to_network($rule),
             'target_port' => normalize_port($rule['natport'] ?? ''),
+            'poolopts' => $rule['poolopts'] ?? '',
             'staticnatport' => !empty($rule['staticnatport']) ? '1' : '0',
             'log' => !empty($rule['log']) ? '1' : '0',
             'categories' => $rule['category'] ?? '',


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Adds missing pool options and source hash key to SNAT

---

**Describe the proposed solution**

Add them. Also to the SNAT migration export.

---

**Related issue**

Fixes: https://github.com/opnsense/core/issues/10814