### PR TITLE
dnsmasq: include expire and lease type in leases search fields

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/Api/LeasesController.php
@@ -115,7 +115,7 @@ class LeasesController extends ApiControllerBase
 
         $response = $this->searchRecordsetBase(
             $records,
-            ['if_descr', 'address', 'hwaddr', 'mac_info', 'iaid', 'client_id', 'hostname'],
+            ['if_descr', 'address', 'hwaddr', 'mac_info', 'iaid', 'client_id', 'expire', 'hostname', 'lease_type'],
             'sort_address',
             function ($record) use ($selected_interfaces, $selected_protocol) {
                 $interfaceMatch = empty($selected_interfaces)


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The specific search list in #10790 missed a search field previously available via `null`.

---

**Describe the proposed solution**

Add the field in (plus the new `lease_type` field).

---

**Related issue**

N/A