### PR TITLE
System: High Availability: Settings - Add pfsync version 1500

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Core/Hasync.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/Hasync.xml
@@ -24,10 +24,11 @@
         </pfsyncpeerip>
         <pfsyncversion type="OptionField">
             <Required>Y</Required>
-            <Default>1400</Default>
+            <Default>1500</Default>
             <OptionValues>
                 <v1301 value="1301">OPNsense 24.1 or below</v1301>
-                <v1400 value="1400">OPNsense 24.7 or above</v1400>
+                <v1400 value="1400">OPNsense 24.7 - 26.1</v1400>
+                <v1500 value="1500">OPNsense 26.7 or above</v1500>
             </OptionValues>
         </pfsyncversion>
         <pfsyncdefer type="BooleanField"/>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x ] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x ] I opened an issue first for non-trivial changes and linked it below.


**Describe the proposed solution**

This adds the pfsync version 1500 to the model for HA Settings.

---

**Related issue**

#10829 
