### PR TITLE
widget: add ZFS pool status API and dashboard widget

### DIFF
--- a/plist
+++ b/plist
@@ -2310,6 +2310,7 @@
 /usr/local/opnsense/www/js/widgets/ThermalSensors.js
 /usr/local/opnsense/www/js/widgets/Traffic.js
 /usr/local/opnsense/www/js/widgets/Wireguard.js
+/usr/local/opnsense/www/js/widgets/Zfs.js
 /usr/local/opnsense/www/themes/opnsense-auto/build/css
 /usr/local/opnsense/www/themes/opnsense-auto/build/fonts
 /usr/local/opnsense/www/themes/opnsense-auto/build/images

--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
@@ -217,6 +217,13 @@ class SystemController extends ApiControllerBase
         return $result;
     }
 
+    public function zfsStatusAction()
+    {
+        $result = json_decode((new Backend())->configdRun('zfs status'), true);
+
+        return is_array($result) ? $result : [];
+    }
+
     public function systemMbufAction()
     {
         return json_decode((new Backend())->configdRun('system show mbuf'), true);

--- a/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Core/ACL/ACL.xml
@@ -23,6 +23,7 @@
             <pattern>api/diagnostics/system/system_time</pattern>
             <pattern>api/diagnostics/system/system_mbuf</pattern>
             <pattern>api/diagnostics/system/system_swap</pattern>
+            <pattern>api/diagnostics/system/zfs_status</pattern>
         </patterns>
     </page-system-login-logout>
     <page-all>

--- a/src/opnsense/service/conf/actions.d/actions_zfs.conf
+++ b/src/opnsense/service/conf/actions.d/actions_zfs.conf
@@ -13,8 +13,8 @@ message:Scrubbing ZFS Pool %s
 description:ZFS pool scrub
 
 [status]
-command:/sbin/zpool
-parameters:status -j --json-int
+command:/sbin/zpool status -j --json-int
+parameters:
 type:script_output
 message:Reading ZFS pool status
 description:ZFS pool status

--- a/src/opnsense/service/conf/actions.d/actions_zfs.conf
+++ b/src/opnsense/service/conf/actions.d/actions_zfs.conf
@@ -12,6 +12,13 @@ type:script
 message:Scrubbing ZFS Pool %s
 description:ZFS pool scrub
 
+[status]
+command:/sbin/zpool
+parameters:status -j --json-int
+type:script_output
+message:Reading ZFS pool status
+description:ZFS pool status
+
 [snapshot.list]
 command:/usr/local/opnsense/scripts/system/bectl.py
 parameters:list

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -104,6 +104,27 @@
             <free>Free</free>
         </translations>
     </disk>
+    <zfs>
+        <filename>Zfs.js</filename>
+        <endpoints>
+            <endpoint>/api/diagnostics/system/zfs_status</endpoint>
+        </endpoints>
+        <translations>
+            <title>ZFS Status</title>
+            <errors>Errors</errors>
+            <none>None</none>
+            <device>device</device>
+            <devices>devices</devices>
+            <dataerror>data error</dataerror>
+            <dataerrors>data errors</dataerrors>
+            <scan>Scan</scan>
+            <never>Never</never>
+            <running>Running</running>
+            <scrub>Scrub</scrub>
+            <resilver>Resilver</resilver>
+            <nopools>No ZFS pools found.</nopools>
+        </translations>
+    </zfs>
     <firewall>
         <filename>Firewall.js</filename>
         <link>/ui/diagnostics/firewall/log</link>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -120,8 +120,8 @@
             <devices>devices</devices>
             <dataerror>data error</dataerror>
             <dataerrors>data errors</dataerrors>
-            <scan>Scan</scan>
-            <never>Never</never>
+            <action>Action</action>
+            <none>None</none>
             <running>Running</running>
             <scrub>Scrub</scrub>
             <resilver>Resilver</resilver>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -121,7 +121,6 @@
             <dataerror>data error</dataerror>
             <dataerrors>data errors</dataerrors>
             <action>Action</action>
-            <none>None</none>
             <running>Running</running>
             <scrub>Scrub</scrub>
             <resilver>Resilver</resilver>

--- a/src/opnsense/www/js/widgets/Metadata/Core.xml
+++ b/src/opnsense/www/js/widgets/Metadata/Core.xml
@@ -111,6 +111,9 @@
         </endpoints>
         <translations>
             <title>ZFS Status</title>
+            <state>State</state>
+            <healthy>Healthy</healthy>
+            <attention>Attention required</attention>
             <errors>Errors</errors>
             <none>None</none>
             <device>device</device>

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -29,39 +29,56 @@ export default class Zfs extends BaseTableWidget {
         super();
 
         this.tickTimeout = 60;
-        this.compactBreakpoint = 320;
     }
 
     getMarkup() {
         return this.createTable('zfs-table', {
             headerPosition: 'left',
-            headerBreakpoint: this.compactBreakpoint,
+            headerBreakpoint: 320,
         });
     }
 
-    poolField(name, state) {
-        const value = state || 'UNKNOWN';
+    poolField(name, pool) {
+        const state = pool.state || 'UNKNOWN';
+        const errors = this.getErrorSummary(pool);
 
-        let color = 'text-danger';
-        if (value === 'ONLINE') {
-            color = 'text-success';
-        } else if (value === 'DEGRADED') {
-            color = 'text-warning';
-        }
+        const healthy =
+            state === 'ONLINE' &&
+            errors.devices === 0 &&
+            errors.data === 0;
+
+        const color = healthy
+            ? 'text-success'
+            : 'text-warning';
+
+        const title = healthy
+            ? this.translations.healthy
+            : this.translations.attention;
 
         const $status = $('<i>')
-            .addClass(`fa fa-circle text-muted ${color} zfs-status-icon`)
+            .addClass(`fa fa-circle text-muted ${color} zfs-health-icon`)
             .css({
                 'font-size': '11px',
                 'cursor': 'pointer',
             })
             .attr('data-toggle', 'tooltip')
-            .attr('title', value);
+            .attr('title', title);
 
         return $('<div>')
+            .css('margin-bottom', '5px')
             .append($status)
             .append('&nbsp;')
             .append($('<span>').text(name))
+            .prop('outerHTML');
+    }
+
+    stateField(pool) {
+        const state = pool.state || 'UNKNOWN';
+
+        return $('<div>')
+            .append($('<b>').text(this.translations.state))
+            .append('<br>')
+            .append($('<span>').text(state))
             .prop('outerHTML');
     }
 
@@ -214,55 +231,30 @@ export default class Zfs extends BaseTableWidget {
             );
         }
 
-        const $value = $('<span>').text(
-            parts.length > 0
-                ? parts.join(' / ')
-                : this.translations.none
-        );
-
-        if (errors.data > 0) {
-            $value.addClass('text-danger');
-        } else if (errors.devices > 0) {
-            $value.addClass('text-warning');
-        }
-
         return $('<div>')
             .append($('<b>').text(this.translations.errors))
             .append('<br>')
-            .append($value)
-            .prop('outerHTML');
-    }
-
-    detailsField(pool) {
-        const $poolDivider = $('<hr>')
-            .addClass('zfs-pool-divider')
-            .css({
-                'margin': '0 0 0.5em',
-            })
-            .hide();
-
-        const $detailDivider = $('<hr>')
-            .addClass('zfs-detail-divider')
-            .css({
-                'margin': '0.5em 0',
-            });
-
-        return $('<div>')
-            .addClass('zfs-details')
-            .append($poolDivider)
-            .append(this.errorField(pool))
-            .append($detailDivider)
-            .append(this.scanField(pool.scan_stats))
+            .append(
+                $('<span>').text(
+                    parts.length > 0
+                        ? parts.join(' / ')
+                        : this.translations.none
+                )
+            )
             .prop('outerHTML');
     }
 
     renderPools(pools) {
-        const statusSelector = '#zfs-table .zfs-status-icon';
+        const statusSelector = '#zfs-table .zfs-health-icon';
         $(statusSelector).tooltip('hide');
 
         const rows = Object.entries(pools).map(([name, pool]) => [
-            this.poolField(pool.name || name, pool.state),
-            this.detailsField(pool),
+            this.poolField(pool.name || name, pool),
+            [
+                this.stateField(pool),
+                this.errorField(pool),
+                this.scanField(pool.scan_stats),
+            ],
         ]);
 
         if (rows.length === 0) {
@@ -276,14 +268,6 @@ export default class Zfs extends BaseTableWidget {
 
         this.updateTable('zfs-table', rows);
         $(statusSelector).tooltip({container: 'body'});
-    }
-
-    onWidgetResize(elem, width, height) {
-        $(elem)
-            .find('.zfs-pool-divider')
-            .toggle(width < this.compactBreakpoint);
-
-        return super.onWidgetResize(elem, width, height);
     }
 
     async onWidgetTick() {

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -29,30 +29,14 @@ export default class Zfs extends BaseTableWidget {
         super();
 
         this.tickTimeout = 60;
+        this.compactBreakpoint = 320;
     }
 
     getMarkup() {
-        const $table = this.createTable('zfs-table', {
+        return this.createTable('zfs-table', {
             headerPosition: 'left',
+            headerBreakpoint: this.compactBreakpoint,
         });
-
-        /*
-         * Separate the pool header from its details when the native
-         * left-header layout stacks vertically.
-         */
-        Object.assign(this.sizeStates[0]['.column'], {
-            'border-top': 'inherit',
-            'margin-top': '0.5em',
-            'padding-top': '0.5em',
-        });
-
-        Object.assign(this.sizeStates[this.headerBreakpoint]['.column'], {
-            'border-top': '',
-            'margin-top': '',
-            'padding-top': '',
-        });
-
-        return $table;
     }
 
     poolField(name, state) {
@@ -249,16 +233,36 @@ export default class Zfs extends BaseTableWidget {
             .prop('outerHTML');
     }
 
+    detailsField(pool) {
+        const $poolDivider = $('<hr>')
+            .addClass('zfs-pool-divider')
+            .css({
+                'margin': '0 0 0.5em',
+            })
+            .hide();
+
+        const $detailDivider = $('<hr>')
+            .addClass('zfs-detail-divider')
+            .css({
+                'margin': '0.5em 0',
+            });
+
+        return $('<div>')
+            .addClass('zfs-details')
+            .append($poolDivider)
+            .append(this.errorField(pool))
+            .append($detailDivider)
+            .append(this.scanField(pool.scan_stats))
+            .prop('outerHTML');
+    }
+
     renderPools(pools) {
         const statusSelector = '#zfs-table .zfs-status-icon';
         $(statusSelector).tooltip('hide');
 
         const rows = Object.entries(pools).map(([name, pool]) => [
             this.poolField(pool.name || name, pool.state),
-            [
-                this.errorField(pool),
-                this.scanField(pool.scan_stats),
-            ],
+            this.detailsField(pool),
         ]);
 
         if (rows.length === 0) {
@@ -272,6 +276,14 @@ export default class Zfs extends BaseTableWidget {
 
         this.updateTable('zfs-table', rows);
         $(statusSelector).tooltip({container: 'body'});
+    }
+
+    onWidgetResize(elem, width, height) {
+        $(elem)
+            .find('.zfs-pool-divider')
+            .toggle(width < this.compactBreakpoint);
+
+        return super.onWidgetResize(elem, width, height);
     }
 
     async onWidgetTick() {

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Deciso B.V.
+ * Copyright (C) 2026 TuEye
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -270,5 +270,10 @@ export default class Zfs extends BaseTableWidget {
         const status = await this.ajaxCall('/api/diagnostics/system/zfs_status');
 
         this.renderPools(status?.pools ?? {});
+    }
+
+    onWidgetClose() {
+        $('#zfs-table .zfs-health-icon').tooltip('hide');
+        super.onWidgetClose();
     }
 }

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -95,13 +95,11 @@ export default class Zfs extends BaseTableWidget {
     }
 
     formatTimestamp(timestamp) {
-        const value = Number(timestamp);
-
-        if (!Number.isFinite(value) || value <= 0) {
+        if (!Number.isFinite(timestamp) || timestamp <= 0) {
             return '';
         }
 
-        return new Date(value * 1000).toLocaleString([], {
+        return new Date(timestamp * 1000).toLocaleString([], {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',
@@ -127,8 +125,8 @@ export default class Zfs extends BaseTableWidget {
         const state = scan.state || 'UNKNOWN';
 
         if (state === 'SCANNING') {
-            const total = Number(scan.to_examine ?? 0);
-            const issued = Number(scan.issued ?? 0);
+            const total = scan.to_examine ?? 0;
+            const issued = scan.issued ?? 0;
 
             let value = `${func}: ${this.translations.running}`;
 
@@ -137,7 +135,7 @@ export default class Zfs extends BaseTableWidget {
                 total > 0 &&
                 Number.isFinite(issued)
             ) {
-                const progress = Math.max(0, (issued / total) * 100);
+                const progress = (issued / total) * 100;
                 value = `${func}: ${progress.toFixed(1)}%`;
             }
 
@@ -181,9 +179,9 @@ export default class Zfs extends BaseTableWidget {
 
         if (hasErrorCounters && children.length === 0) {
             return (
-                Number(node.read_errors ?? 0) > 0 ||
-                Number(node.write_errors ?? 0) > 0 ||
-                Number(node.checksum_errors ?? 0) > 0
+                (node.read_errors ?? 0) > 0 ||
+                (node.write_errors ?? 0) > 0 ||
+                (node.checksum_errors ?? 0) > 0
             ) ? 1 : 0;
         }
 
@@ -199,11 +197,9 @@ export default class Zfs extends BaseTableWidget {
     }
 
     getErrorSummary(pool) {
-        const dataErrors = Number(pool.error_count ?? 0);
-
         return {
             devices: this.countDeviceErrors(pool),
-            data: Number.isFinite(dataErrors) ? dataErrors : 0,
+            data: pool.error_count ?? 0,
         };
     }
 

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export default class Zfs extends BaseTableWidget {
+    constructor() {
+        super();
+
+        this.tickTimeout = 60;
+    }
+
+    getMarkup() {
+        const $table = this.createTable('zfs-table', {
+            headerPosition: 'left',
+        });
+
+        /*
+         * Separate the pool header from its details when the native
+         * left-header layout stacks vertically.
+         */
+        Object.assign(this.sizeStates[0]['.column'], {
+            'border-top': 'inherit',
+            'margin-top': '0.5em',
+            'padding-top': '0.5em',
+        });
+
+        Object.assign(this.sizeStates[this.headerBreakpoint]['.column'], {
+            'border-top': '',
+            'margin-top': '',
+            'padding-top': '',
+        });
+
+        return $table;
+    }
+
+    poolField(name, state) {
+        const value = state || 'UNKNOWN';
+
+        let color = 'text-danger';
+        if (value === 'ONLINE') {
+            color = 'text-success';
+        } else if (value === 'DEGRADED') {
+            color = 'text-warning';
+        }
+
+        const $status = $('<i>')
+            .addClass(`fa fa-circle text-muted ${color} zfs-status-icon`)
+            .css({
+                'font-size': '11px',
+                'cursor': 'pointer',
+            })
+            .attr('data-toggle', 'tooltip')
+            .attr('title', value);
+
+        return $('<div>')
+            .append($status)
+            .append('&nbsp;')
+            .append($('<span>').text(name))
+            .prop('outerHTML');
+    }
+
+    scanFunction(value) {
+        if (value === 'SCRUB') {
+            return this.translations.scrub;
+        }
+
+        if (value === 'RESILVER') {
+            return this.translations.resilver;
+        }
+
+        return value || this.translations.scan;
+    }
+
+    formatTimestamp(timestamp) {
+        const value = Number(timestamp);
+
+        if (!Number.isFinite(value) || value <= 0) {
+            return '';
+        }
+
+        return new Date(value * 1000).toLocaleString([], {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'UTC',
+            timeZoneName: 'short',
+        });
+    }
+
+    scanField(scan) {
+        const $field = $('<div>')
+            .append($('<b>').text(this.translations.scan));
+
+        if (!scan) {
+            return $field
+                .append('<br>')
+                .append($('<span>').text(this.translations.never))
+                .prop('outerHTML');
+        }
+
+        const func = this.scanFunction(scan.function);
+        const state = scan.state || 'UNKNOWN';
+
+        if (state === 'SCANNING') {
+            const total = Number(scan.to_examine ?? 0);
+            const issued = Number(scan.issued ?? 0);
+
+            let value = `${func}: ${this.translations.running}`;
+
+            if (
+                Number.isFinite(total) &&
+                total > 0 &&
+                Number.isFinite(issued)
+            ) {
+                const progress = Math.max(0, (issued / total) * 100);
+                value = `${func}: ${progress.toFixed(1)}%`;
+            }
+
+            return $field
+                .append('<br>')
+                .append($('<span>').text(value))
+                .prop('outerHTML');
+        }
+
+        const value = state === 'FINISHED'
+            ? func
+            : `${func}: ${state}`;
+
+        $field
+            .append('<br>')
+            .append($('<span>').text(value));
+
+        if (state === 'FINISHED') {
+            const finished = this.formatTimestamp(scan.end_time);
+
+            if (finished) {
+                $field
+                    .append('<br>')
+                    .append($('<span>').text(finished));
+            }
+        }
+
+        return $field.prop('outerHTML');
+    }
+
+    countDeviceErrors(node) {
+        if (!node || typeof node !== 'object') {
+            return 0;
+        }
+
+        const children = Object.values(node.vdevs ?? {});
+        const hasErrorCounters =
+            'read_errors' in node ||
+            'write_errors' in node ||
+            'checksum_errors' in node;
+
+        if (hasErrorCounters && children.length === 0) {
+            return (
+                Number(node.read_errors ?? 0) > 0 ||
+                Number(node.write_errors ?? 0) > 0 ||
+                Number(node.checksum_errors ?? 0) > 0
+            ) ? 1 : 0;
+        }
+
+        let count = 0;
+
+        for (const value of Object.values(node)) {
+            if (value && typeof value === 'object') {
+                count += this.countDeviceErrors(value);
+            }
+        }
+
+        return count;
+    }
+
+    getErrorSummary(pool) {
+        const dataErrors = Number(pool.error_count ?? 0);
+
+        return {
+            devices: this.countDeviceErrors(pool),
+            data: Number.isFinite(dataErrors) ? dataErrors : 0,
+        };
+    }
+
+    errorField(pool) {
+        const errors = this.getErrorSummary(pool);
+        const parts = [];
+
+        if (errors.devices > 0) {
+            parts.push(
+                `${errors.devices} ${
+                    errors.devices === 1
+                        ? this.translations.device
+                        : this.translations.devices
+                }`
+            );
+        }
+
+        if (errors.data > 0) {
+            parts.push(
+                `${errors.data} ${
+                    errors.data === 1
+                        ? this.translations.dataerror
+                        : this.translations.dataerrors
+                }`
+            );
+        }
+
+        const $value = $('<span>').text(
+            parts.length > 0
+                ? parts.join(' / ')
+                : this.translations.none
+        );
+
+        if (errors.data > 0) {
+            $value.addClass('text-danger');
+        } else if (errors.devices > 0) {
+            $value.addClass('text-warning');
+        }
+
+        return $('<div>')
+            .append($('<b>').text(this.translations.errors))
+            .append('<br>')
+            .append($value)
+            .prop('outerHTML');
+    }
+
+    renderPools(pools) {
+        const statusSelector = '#zfs-table .zfs-status-icon';
+        $(statusSelector).tooltip('hide');
+
+        const rows = Object.entries(pools).map(([name, pool]) => [
+            this.poolField(pool.name || name, pool.state),
+            [
+                this.errorField(pool),
+                this.scanField(pool.scan_stats),
+            ],
+        ]);
+
+        if (rows.length === 0) {
+            rows.push([
+                $('<span>')
+                    .text(this.translations.nopools)
+                    .prop('outerHTML'),
+                '',
+            ]);
+        }
+
+        this.updateTable('zfs-table', rows);
+        $(statusSelector).tooltip({container: 'body'});
+    }
+
+    async onWidgetTick() {
+        const status = await this.ajaxCall(
+            '/api/diagnostics/system/zfs_status'
+        );
+
+        this.renderPools(status?.pools ?? {});
+    }
+}

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -275,9 +275,7 @@ export default class Zfs extends BaseTableWidget {
     }
 
     async onWidgetTick() {
-        const status = await this.ajaxCall(
-            '/api/diagnostics/system/zfs_status'
-        );
+        const status = await this.ajaxCall('/api/diagnostics/system/zfs_status');
 
         this.renderPools(status?.pools ?? {});
     }

--- a/src/opnsense/www/js/widgets/Zfs.js
+++ b/src/opnsense/www/js/widgets/Zfs.js
@@ -27,7 +27,6 @@
 export default class Zfs extends BaseTableWidget {
     constructor() {
         super();
-
         this.tickTimeout = 60;
     }
 
@@ -39,59 +38,32 @@ export default class Zfs extends BaseTableWidget {
     }
 
     poolField(name, pool) {
-        const state = pool.state || 'UNKNOWN';
         const errors = this.getErrorSummary(pool);
-
-        const healthy =
-            state === 'ONLINE' &&
-            errors.devices === 0 &&
-            errors.data === 0;
-
-        const color = healthy
-            ? 'text-success'
-            : 'text-warning';
-
-        const title = healthy
-            ? this.translations.healthy
-            : this.translations.attention;
+        const healthy = (pool.state || 'UNKNOWN') === 'ONLINE' && errors.devices === 0 && errors.data === 0;
+        const color = healthy ? 'text-success' : 'text-warning';
+        const title = healthy ? this.translations.healthy : this.translations.attention;
 
         const $status = $('<i>')
             .addClass(`fa fa-circle text-muted ${color} zfs-health-icon`)
-            .css({
-                'font-size': '11px',
-                'cursor': 'pointer',
-            })
-            .attr('data-toggle', 'tooltip')
-            .attr('title', title);
+            .css({ 'font-size': '11px', 'cursor': 'pointer' })
+            .attr({ 'data-toggle': 'tooltip', 'title': title });
 
         return $('<div>')
             .css('margin-bottom', '5px')
-            .append($status)
-            .append('&nbsp;')
-            .append($('<span>').text(name))
+            .append($status, '&nbsp;', $('<span>').text(name))
             .prop('outerHTML');
     }
 
     stateField(pool) {
-        const state = pool.state || 'UNKNOWN';
-
         return $('<div>')
-            .append($('<b>').text(this.translations.state))
-            .append('<br>')
-            .append($('<span>').text(state))
+            .append($('<b>').text(this.translations.state), '<br>', $('<span>').text(pool.state || 'UNKNOWN'))
             .prop('outerHTML');
     }
 
     scanFunction(value) {
-        if (value === 'SCRUB') {
-            return this.translations.scrub;
-        }
-
-        if (value === 'RESILVER') {
-            return this.translations.resilver;
-        }
-
-        return value || this.translations.scan;
+        if (value === 'SCRUB') return this.translations.scrub;
+        if (value === 'RESILVER') return this.translations.resilver;
+        return value || this.translations.action;
     }
 
     formatTimestamp(timestamp) {
@@ -111,14 +83,10 @@ export default class Zfs extends BaseTableWidget {
     }
 
     scanField(scan) {
-        const $field = $('<div>')
-            .append($('<b>').text(this.translations.scan));
+        const $div = $('<div>').append($('<b>').text(this.translations.action), '<br>');
 
         if (!scan) {
-            return $field
-                .append('<br>')
-                .append($('<span>').text(this.translations.never))
-                .prop('outerHTML');
+            return $div.append($('<span>').text(this.translations.none)).prop('outerHTML');
         }
 
         const func = this.scanFunction(scan.function);
@@ -127,43 +95,24 @@ export default class Zfs extends BaseTableWidget {
         if (state === 'SCANNING') {
             const total = scan.to_examine ?? 0;
             const issued = scan.issued ?? 0;
+            const progress = (Number.isFinite(total) && total > 0 && Number.isFinite(issued))
+                ? `${((issued / total) * 100).toFixed(1)}%`
+                : this.translations.running;
 
-            let value = `${func}: ${this.translations.running}`;
-
-            if (
-                Number.isFinite(total) &&
-                total > 0 &&
-                Number.isFinite(issued)
-            ) {
-                const progress = (issued / total) * 100;
-                value = `${func}: ${progress.toFixed(1)}%`;
-            }
-
-            return $field
-                .append('<br>')
-                .append($('<span>').text(value))
-                .prop('outerHTML');
+            return $div.append($('<span>').text(`${func}: ${progress}`)).prop('outerHTML');
         }
 
-        const value = state === 'FINISHED'
-            ? func
-            : `${func}: ${state}`;
-
-        $field
-            .append('<br>')
-            .append($('<span>').text(value));
+        const value = state === 'FINISHED' ? func : `${func}: ${state}`;
+        $div.append($('<span>').text(value));
 
         if (state === 'FINISHED') {
             const finished = this.formatTimestamp(scan.end_time);
-
             if (finished) {
-                $field
-                    .append('<br>')
-                    .append($('<span>').text(finished));
+                $div.append('<br>', $('<span>').text(finished));
             }
         }
 
-        return $field.prop('outerHTML');
+        return $div.prop('outerHTML');
     }
 
     countDeviceErrors(node) {
@@ -172,27 +121,18 @@ export default class Zfs extends BaseTableWidget {
         }
 
         const children = Object.values(node.vdevs ?? {});
-        const hasErrorCounters =
-            'read_errors' in node ||
-            'write_errors' in node ||
-            'checksum_errors' in node;
+        const hasErrorCounters = 'read_errors' in node || 'write_errors' in node || 'checksum_errors' in node;
 
         if (hasErrorCounters && children.length === 0) {
-            return (
-                (node.read_errors ?? 0) > 0 ||
-                (node.write_errors ?? 0) > 0 ||
-                (node.checksum_errors ?? 0) > 0
-            ) ? 1 : 0;
+            return ((node.read_errors ?? 0) > 0 || (node.write_errors ?? 0) > 0 || (node.checksum_errors ?? 0) > 0) ? 1 : 0;
         }
 
         let count = 0;
-
         for (const value of Object.values(node)) {
             if (value && typeof value === 'object') {
                 count += this.countDeviceErrors(value);
             }
         }
-
         return count;
     }
 
@@ -208,35 +148,15 @@ export default class Zfs extends BaseTableWidget {
         const parts = [];
 
         if (errors.devices > 0) {
-            parts.push(
-                `${errors.devices} ${
-                    errors.devices === 1
-                        ? this.translations.device
-                        : this.translations.devices
-                }`
-            );
+            parts.push(`${errors.devices} ${errors.devices === 1 ? this.translations.device : this.translations.devices}`);
         }
-
         if (errors.data > 0) {
-            parts.push(
-                `${errors.data} ${
-                    errors.data === 1
-                        ? this.translations.dataerror
-                        : this.translations.dataerrors
-                }`
-            );
+            parts.push(`${errors.data} ${errors.data === 1 ? this.translations.dataerror : this.translations.dataerrors}`);
         }
 
+        const content = parts.length > 0 ? parts.join(' / ') : this.translations.none;
         return $('<div>')
-            .append($('<b>').text(this.translations.errors))
-            .append('<br>')
-            .append(
-                $('<span>').text(
-                    parts.length > 0
-                        ? parts.join(' / ')
-                        : this.translations.none
-                )
-            )
+            .append($('<b>').text(this.translations.errors), '<br>', $('<span>').text(content))
             .prop('outerHTML');
     }
 
@@ -254,12 +174,7 @@ export default class Zfs extends BaseTableWidget {
         ]);
 
         if (rows.length === 0) {
-            rows.push([
-                $('<span>')
-                    .text(this.translations.nopools)
-                    .prop('outerHTML'),
-                '',
-            ]);
+            rows.push([$('<span>').text(this.translations.nopools).prop('outerHTML'), '']);
         }
 
         this.updateTable('zfs-table', rows);
@@ -268,7 +183,11 @@ export default class Zfs extends BaseTableWidget {
 
     async onWidgetTick() {
         const status = await this.ajaxCall('/api/diagnostics/system/zfs_status');
-
         this.renderPools(status?.pools ?? {});
+    }
+
+    onWidgetClose() {
+        $('#zfs-table .zfs-health-icon').tooltip('hide');
+        super.onWidgetClose();
     }
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used: GPT-5.6 Sol / Codex
- Extent of AI involvement:
AI was heavily used during development and code review of the dashboard widget. I tested all changes on my own virtual OpnSense 26.7 box (including "make lint", "make style" and "make lint-plist").

---

**Describe the problem**

Currently the dashboard has no widget to show the status of ZFS pools. Additionally, there is also no API endpoint to fetch this information. For monitoring purposes it would be useful to include both: the widget as an easy way to see if a ZFS pool is healthy, and the API endpoint for this widget and external monitoring.

---

**Describe the proposed solution**

Add a simple ZFS status with "zpool status -j --json-int" and expose it through the diagnostics API, similar to other system information such as "system_disk". Then the ZFS widget can use this endpoint to show the following information:
- pool health/state
- number of errors in the pool
- the date of the last scrub or resilver

<img width="218" height="423" alt="ZFS Status" src="https://github.com/user-attachments/assets/edca38a9-c2f7-4d6d-b00a-b74e023d9457" />


---

**Related issue**

Closes #10833