### PR TITLE
fix: create rtsold for each interface to ensure RS correctly send

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2771,15 +2771,20 @@ function interface_dhcpv6_configure($interface, $wancfg)
     }
 
     /* always kill rtsold in case of reconfigure */
-    killbypid('/var/run/rtsold.pid');
+    killbypid("/var/run/rtsold.{$wancfg['if']}.pid");
     @unlink("/tmp/rtsold.{$wancfg['if']}.done");
 
-    $rtsold_frmt = ['/usr/sbin/rtsold -%s -aiu -p %s -A %s -R %s'];
+    /*
+     * rtsold -a not possible to correctly select the all interfaces
+     * which requiring RS, the interfaces must be specified manually.
+     */
+    $rtsold_frmt = ['/usr/sbin/rtsold -%s -iu -p %s -A %s -R %s %s'];
     $rtsold_args = [
         $settings->dhcp6_debug->isEmpty() ? 'd' : 'D',
-        '/var/run/rtsold.pid',
+        "/var/run/rtsold.{$wancfg['if']}.pid",
         '/usr/local/opnsense/scripts/interfaces/rtsold_script.sh',
         '/usr/local/opnsense/scripts/interfaces/rtsold_resolvconf.sh',
+        $wancfg['if'],
     ];
 
     /* fire up rtsold for IPv6 RAs first */


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

A clear and concise description of the problem this pull request addresses.

I found that the rtsold `-a` parameter, introduced in 2020 via [commit 798bd7e](https://github.com/opnsense/core/commit/798bd7ec1d188546a0db8d6f1e8780298a71cc6), fails to select the `pppoe0` interface for sending Router Solicitations (RS).

---

**Describe the proposed solution**

Explain what this pull request changes and why.

I splitting `rtsold` into separate per-interface processes in [`src/etc/inc/interfaces.inc`](https://github.com/opnsense/core/blob/6264c381207d15b474c3431fd7e3afa75d1dd8fd/src/etc/inc/interfaces.inc#L2777), following the same approach used in the ongoing `multi-dhcp6c` changes in [commit d404ede](https://github.com/opnsense/core/commit/d404edeb9198b54acaa7796c731451799aaa316a), ensure that RAs are correctly send to the interface, preventing issues where automatic interface detection causes certain interfaces to fail to be selected correctly.

---

**Related issue**

If this pull request relates to an issue, link it here.
Closes: #10828