### PR TITLE
ux: widget bottom gap

### DIFF
--- a/src/opnsense/www/css/dashboard.css
+++ b/src/opnsense/www/css/dashboard.css
@@ -263,7 +263,7 @@ div {
 
 .flextable-container {
     display: block;
-    margin: 2em auto;
+    margin: 0.5em auto;
     width: 95%;
     max-width: 1200px;
 }

--- a/src/opnsense/www/themes/opnsense-dark/assets/stylesheets/dashboard.scss
+++ b/src/opnsense/www/themes/opnsense-dark/assets/stylesheets/dashboard.scss
@@ -264,7 +264,7 @@ div {
 
 .flextable-container {
     display: block;
-    margin: 2em auto;
+    margin: 0.5em auto;
     width: 95%;
     max-width: 1200px;
 }

--- a/src/opnsense/www/themes/opnsense-dark/build/css/dashboard.css
+++ b/src/opnsense/www/themes/opnsense-dark/build/css/dashboard.css
@@ -262,7 +262,7 @@ div {
 
 .flextable-container {
   display: block;
-  margin: 2em auto;
+  margin: 0.5em auto;
   width: 95%;
   max-width: 1200px;
 }

--- a/src/opnsense/www/themes/opnsense/assets/stylesheets/dashboard.scss
+++ b/src/opnsense/www/themes/opnsense/assets/stylesheets/dashboard.scss
@@ -264,7 +264,7 @@ div {
 
 .flextable-container {
     display: block;
-    margin: 2em auto;
+    margin: 0.5em auto;
     width: 95%;
     max-width: 1200px;
 }

--- a/src/opnsense/www/themes/opnsense/build/css/dashboard.css
+++ b/src/opnsense/www/themes/opnsense/build/css/dashboard.css
@@ -262,7 +262,7 @@ div {
 
 .flextable-container {
   display: block;
-  margin: 2em auto;
+  margin: 0.5em auto;
   width: 95%;
   max-width: 1200px;
 }


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/core/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code and text submitted herewith.

**Describe the problem**

The gap under the content of some widgets is excessive.

Before:

<img width="264" height="268" alt="image" src="https://github.com/user-attachments/assets/e41ee899-40ae-44dc-bdfc-a3c7d206e9df" />
<img width="252" height="212" alt="image" src="https://github.com/user-attachments/assets/f08b67ae-bb8d-43d1-b4ff-0638f19618fc" />
<img width="270" height="168" alt="image" src="https://github.com/user-attachments/assets/7aacb175-8563-4f2e-8149-a51c504cafcd" />


After:

<img width="258" height="181" alt="image" src="https://github.com/user-attachments/assets/dd1e7555-25fb-4d0d-8ade-bfabb67462d5" />
<img width="255" height="158" alt="image" src="https://github.com/user-attachments/assets/a56e97ad-81c3-444d-8a50-44199304573e" />
<img width="258" height="141" alt="image" src="https://github.com/user-attachments/assets/ede7cfce-6ad3-442f-a5b8-3a70d91c6eec" />
